### PR TITLE
update suggested spotify callback URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ docker run -d -p 8008:8008 boulderbadgedad/soulsync:latest
    - **App Name**: `SoulSync` (or whatever you want)
    - **App Description**: `Music library sync`
    - **Website**: `http://localhost` (or leave blank)
-   - **Redirect URI**: `http://localhost:8888/callback`
+   - **Redirect URI**: `http://127.0.0.1:8888/callback`
 4. Click **"Save"** 
 5. Click **"Settings"** on your new app
 6. Copy the **Client ID** and **Client Secret**


### PR DESCRIPTION
Spotify's dev site no longer allows http:// protocol callback urls unless their host is exactly 127.0.0.1 (for newly created apps, that is)