### PR TITLE
Fix: Load config.json on fresh install & remove redundant loading

### DIFF
--- a/web_server.py
+++ b/web_server.py
@@ -57,16 +57,27 @@ else:
     config_path = os.path.join(project_root, 'config', 'config.json')
 
 if os.path.exists(config_path):
-    print(f"Found config file at: {config_path}")
-    # Load configuration into the existing singleton instance
-    if hasattr(config_manager, 'load_config'):
-        config_manager.load_config(config_path)
+    # Check if we need to reload or if settings.py already handled it
+    current_loaded_path = getattr(config_manager, 'config_path', None)
+    target_path = Path(config_path).resolve()
+
+    # Resolve current loaded path if it's a Path object
+    if isinstance(current_loaded_path, Path):
+        current_loaded_path = current_loaded_path.resolve()
+
+    if current_loaded_path == target_path and config_manager.config_data:
+        print(f"✅ Web server configuration already loaded from: {config_path}")
     else:
-        # Fallback for older settings.py in Docker volumes
-        print("⚠️ Legacy configuration detected: using fallback loading method")
-        config_manager.config_path = Path(config_path)
-        config_manager._load_config()
-    print("✅ Web server configuration loaded successfully.")
+        print(f"Found config file at: {config_path}")
+        # Load configuration into the existing singleton instance
+        if hasattr(config_manager, 'load_config'):
+            config_manager.load_config(config_path)
+        else:
+            # Fallback for older settings.py in Docker volumes
+            print("⚠️ Legacy configuration detected: using fallback loading method")
+            config_manager.config_path = Path(config_path)
+            config_manager._load_config()
+        print("✅ Web server configuration loaded successfully.")
 else:
     print(f"🔴 WARNING: config.json not found at {config_path}. Using default settings.")
 # Correctly point to the 'webui' directory for templates and static files


### PR DESCRIPTION
# Fix: Load config.json on fresh install & remove redundant loading

closes: https://github.com/Nezreka/SoulSync/issues/119

## Summary
This PR fixes a critical initialization issue where `config/config.json` was ignored when creating a new database. It ensures that user configurations are correctly migrated to the SQLite database on the first run. Additionally, it streamlines the startup process by removing redundant configuration loading in the web server.

## Changes

### 1. Robust Configuration Loading (`config/settings.py`)
*   **Path Resolution**: `ConfigManager` now resolves `config.json` relative to the `settings.py` file location. This makes the application robust against being run from different working directories (e.g., Docker containers vs. local dev).
*   **Unified Environment Handling**: Moved the `SOULSYNC_CONFIG_PATH` environment variable check directly into `ConfigManager.__init__`. This ensures the correct config path is used immediately upon instantiation, removing the need for external scripts to patch it later.
*   **Scope Fix**: Fixed a variable scope issue (`UnboundLocalError`) caused by a shadowed `os` import.

### 2. Startup Optimization (`web_server.py`)
*   Refactored the startup logic to check if `ConfigManager` has already loaded the correct configuration.
*   Eliminated the unconditional second reload of the configuration, resulting in cleaner logs and faster startup.

### 3. Enhanced Logging
*   Added clear, emoji-prefixed logs to indicate the configuration state:
    *   `[MIGRATE] 🚀` when moving settings from JSON to DB.
    *   `✅ Web server configuration already loaded` when skipping redundant loads.
    *   Explicit warnings when falling back to defaults.

## Verification
*   **Fresh Install Test**: Verified that deleting `database/music_library.db` and running the app results in a successful migration log (`[MIGRATE] ... [OK]`) and that API keys from JSON are present in the app.
*   **Log Check**: Confirmed that `python web_server.py` no longer prints duplicate "Found config..." debug messages.

## Checklist
- [x] `config/config.json` is loaded on fresh DB creation.
- [x] `SOULSYNC_CONFIG_PATH` is respected.
- [x] Redundant logs removed.
- [x] Verified locally.
