### PR TITLE
Improve shutdown procedures so that the application can close gracefully

### DIFF
--- a/core/audiodb_worker.py
+++ b/core/audiodb_worker.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.audiodb_client import AudioDBClient
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("audiodb_worker")
 
@@ -24,6 +25,7 @@ class AudioDBWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -52,6 +54,7 @@ class AudioDBWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("AudioDB background worker started")
@@ -64,9 +67,10 @@ class AudioDBWorker:
         logger.info("Stopping AudioDB worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("AudioDB worker stopped")
 
@@ -115,7 +119,7 @@ class AudioDBWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 self.current_item = None
@@ -124,7 +128,7 @@ class AudioDBWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -143,11 +147,11 @@ class AudioDBWorker:
 
                 self._process_item(item)
 
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("AudioDB worker thread finished")
 

--- a/core/deezer_worker.py
+++ b/core/deezer_worker.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.deezer_client import DeezerClient
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("deezer_worker")
 
@@ -24,6 +25,7 @@ class DeezerWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -52,6 +54,7 @@ class DeezerWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Deezer background worker started")
@@ -64,9 +67,10 @@ class DeezerWorker:
         logger.info("Stopping Deezer worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Deezer worker stopped")
 
@@ -115,7 +119,7 @@ class DeezerWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 self.current_item = None
@@ -124,7 +128,7 @@ class DeezerWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -143,11 +147,11 @@ class DeezerWorker:
 
                 self._process_item(item)
 
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Deezer worker thread finished")
 

--- a/core/discogs_worker.py
+++ b/core/discogs_worker.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.discogs_client import DiscogsClient
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("discogs_worker")
 
@@ -34,6 +35,7 @@ class DiscogsWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -62,6 +64,7 @@ class DiscogsWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Discogs background worker started")
@@ -73,8 +76,9 @@ class DiscogsWorker:
         logger.info("Stopping Discogs worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("Discogs worker stopped")
 
     def pause(self):
@@ -113,14 +117,14 @@ class DiscogsWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 self.current_item = None
                 item = self._get_next_item()
 
                 if not item:
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item.get('name', '')
@@ -132,11 +136,11 @@ class DiscogsWorker:
                     continue
 
                 self._process_item(item)
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
             except Exception as e:
                 logger.error(f"Error in Discogs worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Discogs worker thread finished")
 

--- a/core/genius_worker.py
+++ b/core/genius_worker.py
@@ -9,6 +9,7 @@ from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.genius_client import GeniusClient
 from config.settings import config_manager
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("genius_worker")
 
@@ -31,6 +32,7 @@ class GeniusWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -64,6 +66,7 @@ class GeniusWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Genius background worker started")
@@ -76,9 +79,10 @@ class GeniusWorker:
         logger.info("Stopping Genius worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Genius worker stopped")
 
@@ -123,14 +127,14 @@ class GeniusWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Check if access token is configured
                 if not self.client.access_token:
                     self._init_client()
                     if not self.client.access_token:
-                        time.sleep(30)
+                        interruptible_sleep(self._stop_event, 30)
                         continue
 
                 self.current_item = None
@@ -138,7 +142,7 @@ class GeniusWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -157,11 +161,11 @@ class GeniusWorker:
                 self._process_item(item)
 
                 # Genius rate limiting is conservative (500ms per call) + lyrics scraping
-                time.sleep(1)
+                interruptible_sleep(self._stop_event, 1)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Genius worker thread finished")
 

--- a/core/hydrabase_worker.py
+++ b/core/hydrabase_worker.py
@@ -15,6 +15,7 @@ import time
 import uuid
 
 logger = logging.getLogger(__name__)
+from core.worker_utils import interruptible_sleep
 
 
 class HydrabaseWorker:
@@ -31,6 +32,7 @@ class HydrabaseWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Queue with cap
         self.queue = queue.Queue(maxsize=1000)
@@ -47,6 +49,7 @@ class HydrabaseWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Hydrabase P2P mirror worker started")
@@ -56,8 +59,9 @@ class HydrabaseWorker:
             return
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("Hydrabase P2P mirror worker stopped")
 
     def pause(self):
@@ -102,7 +106,7 @@ class HydrabaseWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Non-blocking dequeue with timeout
@@ -112,12 +116,12 @@ class HydrabaseWorker:
                     continue
 
                 self._process_item(item)
-                time.sleep(0.5)  # Rate limit
+                interruptible_sleep(self._stop_event, 0.5)  # Rate limit
 
             except Exception as e:
                 logger.error(f"Error in Hydrabase worker loop: {e}")
                 self.stats['errors'] += 1
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
     def _process_item(self, item):
         ws, lock = self.get_ws_and_lock()

--- a/core/itunes_worker.py
+++ b/core/itunes_worker.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.itunes_client import iTunesClient
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("itunes_worker")
 
@@ -34,6 +35,7 @@ class iTunesWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -66,6 +68,7 @@ class iTunesWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("iTunes background worker started")
@@ -76,8 +79,9 @@ class iTunesWorker:
         logger.info("Stopping iTunes worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("iTunes worker stopped")
 
     def pause(self):
@@ -116,7 +120,7 @@ class iTunesWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # No auth check needed — iTunes API requires no authentication
@@ -126,7 +130,7 @@ class iTunesWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -147,13 +151,13 @@ class iTunesWorker:
                 # Sleep depends on item type — search items need more delay
                 item_type = item.get('type', '')
                 if item_type in ('album_batch', 'track_batch'):
-                    time.sleep(self.batch_inter_item_sleep)
+                    interruptible_sleep(self._stop_event, self.batch_inter_item_sleep)
                 else:
-                    time.sleep(self.inter_item_sleep)
+                    interruptible_sleep(self._stop_event, self.inter_item_sleep)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         self.current_item = None
         logger.info("iTunes worker thread finished")
@@ -444,7 +448,7 @@ class iTunesWorker:
                 self._mark_status('album', db_id, 'not_found')
                 self.stats['not_found'] += 1
 
-            time.sleep(self.batch_inter_item_sleep)
+            interruptible_sleep(self._stop_event, self.batch_inter_item_sleep)
 
         logger.info(f"Album batch for '{artist_name}': {matched_count}/{len(db_albums)} matched")
 
@@ -516,7 +520,7 @@ class iTunesWorker:
                 self._mark_status('track', db_id, 'not_found')
                 self.stats['not_found'] += 1
 
-            time.sleep(self.batch_inter_item_sleep)
+            interruptible_sleep(self._stop_event, self.batch_inter_item_sleep)
 
         logger.info(f"Track batch for '{album_name}': {matched_count}/{len(db_tracks)} matched")
 

--- a/core/lastfm_worker.py
+++ b/core/lastfm_worker.py
@@ -9,6 +9,7 @@ from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.lastfm_client import LastFMClient
 from config.settings import config_manager
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("lastfm_worker")
 
@@ -31,6 +32,7 @@ class LastFMWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -65,6 +67,7 @@ class LastFMWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Last.fm background worker started")
@@ -77,9 +80,10 @@ class LastFMWorker:
         logger.info("Stopping Last.fm worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Last.fm worker stopped")
 
@@ -124,14 +128,14 @@ class LastFMWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Check if API key is configured
                 if not self.client.api_key:
                     self._init_client()
                     if not self.client.api_key:
-                        time.sleep(30)
+                        interruptible_sleep(self._stop_event, 30)
                         continue
 
                 self.current_item = None
@@ -139,7 +143,7 @@ class LastFMWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -158,11 +162,11 @@ class LastFMWorker:
                 self._process_item(item)
 
                 # Last.fm allows 5 req/sec but we use multiple calls per item
-                time.sleep(1)
+                interruptible_sleep(self._stop_event, 1)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Last.fm worker thread finished")
 

--- a/core/listening_stats_worker.py
+++ b/core/listening_stats_worker.py
@@ -11,6 +11,7 @@ import time
 from typing import Dict, Any
 
 from utils.logging_config import get_logger
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("listening_stats_worker")
 
@@ -32,6 +33,7 @@ class ListeningStatsWorker:
         self.should_stop = False
         self.thread = None
         self.current_item = None
+        self._stop_event = threading.Event()
 
         # Stats
         self.stats = {
@@ -52,6 +54,7 @@ class ListeningStatsWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Listening stats worker started")
@@ -61,8 +64,9 @@ class ListeningStatsWorker:
             return
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("Listening stats worker stopped")
 
     def pause(self):
@@ -86,7 +90,7 @@ class ListeningStatsWorker:
         logger.info("Listening stats worker thread started")
 
         # Build cache from existing data immediately (before first poll)
-        time.sleep(5)
+        interruptible_sleep(self._stop_event, 5)
         try:
             self._build_stats_cache()
             logger.info("Initial stats cache built from existing data")
@@ -94,17 +98,17 @@ class ListeningStatsWorker:
             logger.debug(f"Initial cache build skipped: {e}")
 
         # Wait before first poll
-        time.sleep(10)
+        interruptible_sleep(self._stop_event, 10)
 
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(5)
+                    interruptible_sleep(self._stop_event, 5)
                     continue
 
                 # Check if enabled
                 if not self.config_manager.get('listening_stats.enabled', True):
-                    time.sleep(30)
+                    interruptible_sleep(self._stop_event, 30)
                     continue
 
                 # Update poll interval from config
@@ -119,12 +123,13 @@ class ListeningStatsWorker:
                 for _ in range(int(self.poll_interval)):
                     if self.should_stop:
                         break
-                    time.sleep(1)
+                    if interruptible_sleep(self._stop_event, 1):
+                        break
 
             except Exception as e:
                 logger.error(f"Error in listening stats worker: {e}", exc_info=True)
                 self.stats['errors'] += 1
-                time.sleep(60)
+                interruptible_sleep(self._stop_event, 60)
 
         self.current_item = None
         logger.info("Listening stats worker thread finished")

--- a/core/listening_stats_worker.py
+++ b/core/listening_stats_worker.py
@@ -90,15 +90,20 @@ class ListeningStatsWorker:
         logger.info("Listening stats worker thread started")
 
         # Build cache from existing data immediately (before first poll)
-        interruptible_sleep(self._stop_event, 5)
+        if interruptible_sleep(self._stop_event, 5):
+            return
         try:
             self._build_stats_cache()
             logger.info("Initial stats cache built from existing data")
         except Exception as e:
             logger.debug(f"Initial cache build skipped: {e}")
 
+        if self.should_stop:
+            return
+
         # Wait before first poll
-        interruptible_sleep(self._stop_event, 10)
+        if interruptible_sleep(self._stop_event, 10):
+            return
 
         while not self.should_stop:
             try:

--- a/core/media_scan_manager.py
+++ b/core/media_scan_manager.py
@@ -256,6 +256,8 @@ class MediaScanManager:
             if is_scanning:
                 # Still scanning - trigger database update and continue periodic updates
                 logger.info(f"{server_type.upper()} still scanning - triggering database update")
+                if self._shutting_down:
+                    return
                 self._call_completion_callbacks()
                 
                 # Schedule next periodic update
@@ -268,6 +270,8 @@ class MediaScanManager:
             else:
                 # Scanning stopped - final update and cleanup
                 logger.info(f"{server_type.upper()} scanning completed - doing final database update")
+                if self._shutting_down:
+                    return
                 self._call_completion_callbacks()
                 self._stop_periodic_updates()
                 

--- a/core/media_scan_manager.py
+++ b/core/media_scan_manager.py
@@ -39,6 +39,7 @@ class MediaScanManager:
         self._periodic_update_timer = None  # Timer for 5-minute periodic updates
         self._periodic_update_interval = 300  # 5 minutes in seconds
         self._is_doing_periodic_updates = False  # Track if we're in periodic update mode
+        self._shutting_down = False
         
         logger.info(f"MediaScanManager initialized with {delay_seconds}s debounce delay")
     
@@ -119,6 +120,9 @@ class MediaScanManager:
         """
         logger.info(f"DEBUG: Media scan requested - reason: {reason}")
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Media scan request ignored during shutdown")
+                return
             if self._scan_in_progress:
                 # Server is currently scanning - mark that we need another scan later
                 self._downloads_during_scan = True
@@ -134,6 +138,7 @@ class MediaScanManager:
             
             # Start the debounce timer
             self._timer = threading.Timer(self.delay, self._execute_scan)
+            self._timer.daemon = True
             self._timer.start()
     
     def add_scan_completion_callback(self, callback):
@@ -164,6 +169,9 @@ class MediaScanManager:
     def _execute_scan(self):
         """Execute the actual media library scan"""
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Media scan execution skipped during shutdown")
+                return
             if self._scan_in_progress:
                 logger.warning("Scan already in progress - skipping duplicate execution")
                 return
@@ -211,6 +219,7 @@ class MediaScanManager:
             
             # Schedule first periodic update after 5 minutes
             self._periodic_update_timer = threading.Timer(self._periodic_update_interval, self._do_periodic_update)
+            self._periodic_update_timer.daemon = True
             self._periodic_update_timer.start()
             
         except Exception as e:
@@ -250,8 +259,11 @@ class MediaScanManager:
                 self._call_completion_callbacks()
                 
                 # Schedule next periodic update
+                if self._shutting_down:
+                    return
                 logger.info(f"Scheduling next periodic update in {self._periodic_update_interval//60} minutes")
                 self._periodic_update_timer = threading.Timer(self._periodic_update_interval, self._do_periodic_update)
+                self._periodic_update_timer.daemon = True
                 self._periodic_update_timer.start()
             else:
                 # Scanning stopped - final update and cleanup
@@ -360,6 +372,7 @@ class MediaScanManager:
     def shutdown(self):
         """Clean shutdown - cancel any pending timers"""
         with self._lock:
+            self._shutting_down = True
             if self._timer:
                 self._timer.cancel()
                 self._timer = None

--- a/core/musicbrainz_worker.py
+++ b/core/musicbrainz_worker.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.musicbrainz_service import MusicBrainzService
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("musicbrainz_worker")
 
@@ -20,6 +21,7 @@ class MusicBrainzWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -45,6 +47,7 @@ class MusicBrainzWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("MusicBrainz background worker started")
@@ -57,9 +60,10 @@ class MusicBrainzWorker:
         logger.info("Stopping MusicBrainz worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Music Brainz worker stopped")
 
@@ -112,7 +116,7 @@ class MusicBrainzWorker:
             try:
                 # Check if paused
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Clear previous item before getting next
@@ -124,7 +128,7 @@ class MusicBrainzWorker:
                 if not item:
                     # No more items - sleep for a bit
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 # Set current item for UI tracking
@@ -147,11 +151,11 @@ class MusicBrainzWorker:
 
                 # Keep current_item set during sleep so UI can see what was just processed
                 # Rate limit: 1 request per second
-                time.sleep(1)
+                interruptible_sleep(self._stop_event, 1)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)  # Back off on errors
+                interruptible_sleep(self._stop_event, 5)  # Back off on errors
 
         logger.info("MusicBrainz worker thread finished")
 

--- a/core/plex_scan_manager.py
+++ b/core/plex_scan_manager.py
@@ -39,6 +39,7 @@ class PlexScanManager:
         self._periodic_update_timer = None  # Timer for 5-minute periodic updates
         self._periodic_update_interval = 300  # 5 minutes in seconds
         self._is_doing_periodic_updates = False  # Track if we're in periodic update mode
+        self._shutting_down = False
         
         logger.info(f"PlexScanManager initialized with {delay_seconds}s debounce delay")
     
@@ -51,6 +52,9 @@ class PlexScanManager:
         """
         logger.info(f"DEBUG: Plex scan requested - reason: {reason}")
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Plex scan request ignored during shutdown")
+                return
             if self._scan_in_progress:
                 # Plex is currently scanning - mark that we need another scan later
                 self._downloads_during_scan = True
@@ -66,6 +70,7 @@ class PlexScanManager:
             
             # Start the debounce timer
             self._timer = threading.Timer(self.delay, self._execute_scan)
+            self._timer.daemon = True
             self._timer.start()
     
     def add_scan_completion_callback(self, callback):
@@ -96,6 +101,9 @@ class PlexScanManager:
     def _execute_scan(self):
         """Execute the actual Plex library scan"""
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Plex scan execution skipped during shutdown")
+                return
             if self._scan_in_progress:
                 logger.warning("Scan already in progress - skipping duplicate execution")
                 return
@@ -136,6 +144,7 @@ class PlexScanManager:
             
             # Schedule first periodic update after 5 minutes
             self._periodic_update_timer = threading.Timer(self._periodic_update_interval, self._do_periodic_update)
+            self._periodic_update_timer.daemon = True
             self._periodic_update_timer.start()
             
         except Exception as e:
@@ -168,8 +177,11 @@ class PlexScanManager:
                 self._call_completion_callbacks()
                 
                 # Schedule next periodic update
+                if self._shutting_down:
+                    return
                 logger.info(f"Scheduling next periodic update in {self._periodic_update_interval//60} minutes")
                 self._periodic_update_timer = threading.Timer(self._periodic_update_interval, self._do_periodic_update)
+                self._periodic_update_timer.daemon = True
                 self._periodic_update_timer.start()
             else:
                 # Scanning stopped - final update and cleanup
@@ -218,7 +230,9 @@ class PlexScanManager:
             if is_scanning:
                 # Still scanning, poll again in 30 seconds
                 logger.info("DEBUG: Plex library still scanning, will check again in 30 seconds")
-                threading.Timer(30, self._poll_scan_status).start()
+                timer = threading.Timer(30, self._poll_scan_status)
+                timer.daemon = True
+                timer.start()
             else:
                 # Scan completed!
                 elapsed_time = time.time() - self._scan_start_time if self._scan_start_time else 0
@@ -311,6 +325,7 @@ class PlexScanManager:
     def shutdown(self):
         """Clean shutdown - cancel any pending timers"""
         with self._lock:
+            self._shutting_down = True
             if self._timer:
                 self._timer.cancel()
                 self._timer = None

--- a/core/plex_scan_manager.py
+++ b/core/plex_scan_manager.py
@@ -174,6 +174,8 @@ class PlexScanManager:
             if is_scanning:
                 # Still scanning - trigger database update and continue periodic updates
                 logger.info("Plex still scanning - triggering database update")
+                if self._shutting_down:
+                    return
                 self._call_completion_callbacks()
                 
                 # Schedule next periodic update
@@ -186,6 +188,8 @@ class PlexScanManager:
             else:
                 # Scanning stopped - final update and cleanup
                 logger.info("Plex scanning completed - doing final database update")
+                if self._shutting_down:
+                    return
                 self._call_completion_callbacks()
                 self._stop_periodic_updates()
                 

--- a/core/qobuz_worker.py
+++ b/core/qobuz_worker.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.qobuz_client import _qobuz_is_rate_limited
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("qobuz_worker")
 
@@ -24,6 +25,7 @@ class QobuzWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -52,6 +54,7 @@ class QobuzWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Qobuz background worker started")
@@ -64,9 +67,10 @@ class QobuzWorker:
         logger.info("Stopping Qobuz worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Qobuz worker stopped")
 
@@ -120,24 +124,24 @@ class QobuzWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Auth guard: sleep if not authenticated
                 try:
                     if not self.client or not self.client.is_authenticated():
                         self.current_item = None
-                        time.sleep(30)
+                        interruptible_sleep(self._stop_event, 30)
                         continue
                 except Exception:
-                    time.sleep(30)
+                    interruptible_sleep(self._stop_event, 30)
                     continue
 
                 # Rate limit guard: back off if globally rate limited
                 if _qobuz_is_rate_limited():
                     self.current_item = None
                     logger.debug("Qobuz rate limited, backing off...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = None
@@ -146,7 +150,7 @@ class QobuzWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -166,11 +170,11 @@ class QobuzWorker:
                 self._process_item(item)
 
                 # Throttle between API calls
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Qobuz worker thread finished")
 
@@ -351,7 +355,7 @@ class QobuzWorker:
             error_str = str(e).lower()
             if '429' in error_str or 'rate limit' in error_str:
                 logger.warning(f"Rate limited while processing {item['type']} #{item['id']}, backing off 30s")
-                time.sleep(30)
+                interruptible_sleep(self._stop_event, 30)
                 return
             logger.error(f"Error processing {item['type']} #{item['id']}: {e}")
             self.stats['errors'] += 1

--- a/core/repair_jobs/acoustid_scanner.py
+++ b/core/repair_jobs/acoustid_scanner.py
@@ -141,7 +141,8 @@ class AcoustIDScannerJob(RepairJob):
             if batch_count >= batch_size:
                 batch_count = 0
                 self._save_checkpoint(context, fpath)
-                time.sleep(2)
+                if context.sleep_or_stop(2):
+                    return result
 
             if context.update_progress and (i + 1) % 10 == 0:
                 context.update_progress(i + 1, total)

--- a/core/repair_jobs/base.py
+++ b/core/repair_jobs/base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+import threading
 from typing import Any, Callable, Dict, List, Optional
 
 
@@ -29,6 +30,7 @@ class JobContext:
     mb_client: Any = None
     acoustid_client: Any = None
     metadata_cache: Any = None
+    stop_event: Optional[threading.Event] = None
 
     # Callbacks
     create_finding: Optional[Callable] = None
@@ -39,6 +41,8 @@ class JobContext:
 
     def check_stop(self) -> bool:
         """Return True if the worker should stop."""
+        if self.stop_event and self.stop_event.is_set():
+            return True
         return self.should_stop() if self.should_stop else False
 
     def is_spotify_rate_limited(self) -> bool:
@@ -55,11 +59,31 @@ class JobContext:
 
     def wait_if_paused(self):
         """Block until unpaused or stopped. Returns True if should stop."""
-        import time
         while self.is_paused and self.is_paused():
             if self.check_stop():
                 return True
-            time.sleep(1)
+            if self.stop_event:
+                self.stop_event.wait(0.2)
+            else:
+                import time
+                time.sleep(0.2)
+        return self.check_stop()
+
+    def sleep_or_stop(self, seconds: float, step: float = 0.2) -> bool:
+        """Sleep in small increments so stop requests can interrupt quickly."""
+        if seconds <= 0:
+            return self.check_stop()
+        remaining = seconds
+        while remaining > 0:
+            if self.check_stop():
+                return True
+            chunk = min(step, remaining)
+            if self.stop_event:
+                self.stop_event.wait(chunk)
+            else:
+                import time
+                time.sleep(chunk)
+            remaining -= chunk
         return self.check_stop()
 
 

--- a/core/repair_jobs/library_reorganize.py
+++ b/core/repair_jobs/library_reorganize.py
@@ -821,7 +821,8 @@ class LibraryReorganizeJob(RepairJob):
                                 years[key] = year_str
                                 break
                 import time
-                time.sleep(0.1)  # Rate limit courtesy
+                if context.sleep_or_stop(0.1):  # Rate limit courtesy
+                    break
             except Exception as e:
                 logger.debug("API year lookup failed for %s - %s: %s", artist, album, e)
 

--- a/core/repair_jobs/mbid_mismatch_detector.py
+++ b/core/repair_jobs/mbid_mismatch_detector.py
@@ -294,7 +294,8 @@ class MbidMismatchDetectorJob(RepairJob):
 
             try:
                 # Rate limit: MusicBrainz allows ~1 req/sec
-                time.sleep(1.1)
+                if context.sleep_or_stop(1.1):
+                    return result
 
                 recording = mb_client.get_recording(mbid, includes=['artist-credits'])
                 if not recording:

--- a/core/repair_jobs/metadata_gap_filler.py
+++ b/core/repair_jobs/metadata_gap_filler.py
@@ -173,7 +173,8 @@ class MetadataGapFillerJob(RepairJob):
 
             # Rate limit API calls
             if spotify_track_id:
-                time.sleep(0.5)
+                if context.sleep_or_stop(0.5):
+                    return result
 
             if context.update_progress and (i + 1) % 10 == 0:
                 context.update_progress(i + 1, total)

--- a/core/repair_jobs/unknown_artist_fixer.py
+++ b/core/repair_jobs/unknown_artist_fixer.py
@@ -337,7 +337,8 @@ class UnknownArtistFixerJob(RepairJob):
             except Exception as e:
                 logger.debug(f"Title search failed for '{title}': {e}")
             # Rate limit courtesy
-            time.sleep(0.2)
+            if context.sleep_or_stop(0.2):
+                return None
 
         return None
 

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -67,6 +67,7 @@ class RepairWorker:
         self.running = False
         self.enabled = False  # Master toggle (replaces 'paused')
         self.should_stop = False
+        self._stop_event = threading.Event()
         self.thread = None
 
         # Current job being executed
@@ -293,6 +294,7 @@ class RepairWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Repair worker started")
@@ -303,8 +305,9 @@ class RepairWorker:
         logger.info("Stopping repair worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=2)
         logger.info("Repair worker stopped")
 
     def toggle(self) -> bool:
@@ -418,7 +421,7 @@ class RepairWorker:
         logger.info("Repair worker thread started")
         self._ensure_jobs_loaded()
 
-        while not self.should_stop:
+        while not self._stop_event.is_set():
             try:
                 # Check force-run queue even when disabled (user explicitly requested)
                 forced_job = None
@@ -428,13 +431,15 @@ class RepairWorker:
 
                 if forced_job:
                     self._run_job(forced_job)
-                    time.sleep(2)
+                    if self._sleep_or_stop(2):
+                        break
                     continue
 
                 if not self.enabled:
                     self._current_job_id = None
                     self._current_job_name = None
-                    time.sleep(2)
+                    if self._sleep_or_stop(2):
+                        break
                     continue
 
                 # Find the next job to run based on staleness
@@ -444,20 +449,23 @@ class RepairWorker:
                     # Nothing due — sleep and re-check
                     self._current_job_id = None
                     self._current_job_name = None
-                    time.sleep(10)
+                    if self._sleep_or_stop(10):
+                        break
                     continue
 
                 # Run the selected job
                 self._run_job(next_job)
 
                 # Brief pause between jobs
-                time.sleep(5)
+                if self._sleep_or_stop(5):
+                    break
 
             except Exception as e:
                 logger.error("Error in repair worker loop: %s", e, exc_info=True)
                 self._current_job_id = None
                 self._current_job_name = None
-                time.sleep(30)
+                if self._sleep_or_stop(30):
+                    break
 
         logger.info("Repair worker thread finished")
 
@@ -552,6 +560,7 @@ class RepairWorker:
             metadata_cache=self.metadata_cache,
             create_finding=self._create_finding,
             should_stop=lambda: self.should_stop,
+            stop_event=self._stop_event,
             is_paused=lambda: not self.enabled,
             update_progress=self._update_progress,
             report_progress=_report_progress,
@@ -594,6 +603,17 @@ class RepairWorker:
         self._current_job_id = None
         self._current_job_name = None
         self._current_progress = {'scanned': 0, 'total': 0, 'percent': 0}
+
+    def _sleep_or_stop(self, seconds: float, step: float = 0.2) -> bool:
+        """Sleep in small chunks so shutdown interrupts quickly."""
+        if seconds <= 0:
+            return self._stop_event.is_set()
+        remaining = seconds
+        while remaining > 0 and not self._stop_event.is_set():
+            chunk = min(step, remaining)
+            self._stop_event.wait(chunk)
+            remaining -= chunk
+        return self._stop_event.is_set()
 
     def run_job_now(self, job_id: str):
         """Queue a job for immediate execution by the main worker loop.

--- a/core/soulid_worker.py
+++ b/core/soulid_worker.py
@@ -24,6 +24,7 @@ import unicodedata
 from typing import Dict, Any, List, Optional
 
 from utils.logging_config import get_logger
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("soulid_worker")
 
@@ -79,6 +80,7 @@ class SoulIDWorker:
         self.should_stop = False
         self.thread = None
         self.current_item = None
+        self._stop_event = threading.Event()
 
         # API clients (lazy-initialized)
         self._itunes_client = None
@@ -135,6 +137,7 @@ class SoulIDWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("SoulID worker started")
@@ -144,8 +147,9 @@ class SoulIDWorker:
             return
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("SoulID worker stopped")
 
     def pause(self):
@@ -178,7 +182,7 @@ class SoulIDWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 processed = 0
@@ -188,16 +192,16 @@ class SoulIDWorker:
 
                 if processed == 0:
                     self.current_item = None
-                    time.sleep(self.idle_sleep)
+                    interruptible_sleep(self._stop_event, self.idle_sleep)
                 else:
                     # Albums/tracks get inter_batch_sleep, artists get their
                     # own sleep inside _process_next_artist
-                    time.sleep(self.inter_batch_sleep)
+                    interruptible_sleep(self._stop_event, self.inter_batch_sleep)
 
             except Exception as e:
                 logger.error(f"Error in SoulID worker loop: {e}", exc_info=True)
                 self.stats['errors'] += 1
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         self.current_item = None
         logger.info("SoulID worker thread finished")
@@ -267,7 +271,7 @@ class SoulIDWorker:
             logger.info(f"Generated soul ID for artist: {name}" + (f" (canonical id: {canonical_id})" if canonical_id else ""))
 
             # Rate limit courtesy for API calls
-            time.sleep(self.artist_sleep)
+            interruptible_sleep(self._stop_event, self.artist_sleep)
             return 1
 
         except Exception as e:
@@ -324,7 +328,7 @@ class SoulIDWorker:
                                 deezer_artist_id = int(raw_id)
                                 logger.debug(f"Deezer artist ID for '{artist_name}': {deezer_artist_id}")
                             break
-                time.sleep(0.3)
+                interruptible_sleep(self._stop_event, 0.3)
             except Exception as e:
                 logger.debug(f"Deezer track search failed for '{artist_name}': {e}")
 
@@ -344,7 +348,7 @@ class SoulIDWorker:
                                 itunes_artist_id = int(raw_id)
                                 logger.debug(f"iTunes artist ID for '{artist_name}': {itunes_artist_id}")
                             break
-                time.sleep(0.3)
+                interruptible_sleep(self._stop_event, 0.3)
             except Exception as e:
                 logger.debug(f"iTunes track search failed for '{artist_name}': {e}")
 

--- a/core/spotify_worker.py
+++ b/core/spotify_worker.py
@@ -8,6 +8,7 @@ from datetime import datetime, date, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.spotify_client import SpotifyClient, SpotifyRateLimitError
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("spotify_worker")
 
@@ -31,6 +32,7 @@ class SpotifyWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -66,6 +68,7 @@ class SpotifyWorker:
             return
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Spotify background worker started")
@@ -76,8 +79,9 @@ class SpotifyWorker:
         logger.info("Stopping Spotify worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
         logger.info("Spotify worker stopped")
 
     def pause(self):
@@ -167,7 +171,7 @@ class SpotifyWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Rate limit guard — if globally rate limited, sleep until ban expires
@@ -175,7 +179,7 @@ class SpotifyWorker:
                     info = self.client.get_rate_limit_info()
                     remaining = info['remaining_seconds'] if info else 60
                     logger.debug(f"Spotify globally rate limited, sleeping {remaining}s...")
-                    time.sleep(min(remaining, 60))  # Check again every 60s max
+                    interruptible_sleep(self._stop_event, min(remaining, 60))  # Check again every 60s max
                     continue
 
                 # Daily budget guard — worker-only cap to avoid saturating Spotify rate limits
@@ -184,7 +188,7 @@ class SpotifyWorker:
                     resets_in = budget['resets_in_seconds']
                     logger.info(f"Daily enrichment budget exhausted ({budget['used']}/{budget['limit']}), "
                                 f"resets in {resets_in // 3600}h {(resets_in % 3600) // 60}m")
-                    time.sleep(min(resets_in, 300))  # Check every 5 min max
+                    interruptible_sleep(self._stop_event, min(resets_in, 300))  # Check every 5 min max
                     continue
 
                 # Post-ban cooldown guard — after ban expires, wait before resuming
@@ -192,7 +196,7 @@ class SpotifyWorker:
                 cooldown = self.client.get_post_ban_cooldown_remaining()
                 if cooldown > 0:
                     logger.debug(f"Post-ban cooldown active ({cooldown}s left), sleeping...")
-                    time.sleep(min(cooldown, 60))
+                    interruptible_sleep(self._stop_event, min(cooldown, 60))
                     continue
 
                 # Auth guard — check if Spotify client is configured (no API call).
@@ -203,7 +207,7 @@ class SpotifyWorker:
                     self.client.reload_config()
                     if not self.client.is_spotify_authenticated():
                         logger.debug("Spotify not authenticated, sleeping 30s...")
-                        time.sleep(30)
+                        interruptible_sleep(self._stop_event, 30)
                         continue
 
                 self.current_item = None
@@ -211,7 +215,7 @@ class SpotifyWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -229,14 +233,14 @@ class SpotifyWorker:
 
                 self._process_item(item)
                 self._increment_daily_budget()
-                time.sleep(self.inter_item_sleep)
+                interruptible_sleep(self._stop_event, self.inter_item_sleep)
 
             except SpotifyRateLimitError:
                 logger.debug("Spotify rate limit hit in worker loop, will retry after ban expires")
-                time.sleep(10)
+                interruptible_sleep(self._stop_event, 10)
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         self.current_item = None
         logger.info("Spotify worker thread finished")
@@ -541,7 +545,7 @@ class SpotifyWorker:
                 self._mark_status('album', db_id, 'not_found')
                 self.stats['not_found'] += 1
 
-            time.sleep(self.batch_inter_item_sleep)
+            interruptible_sleep(self._stop_event, self.batch_inter_item_sleep)
 
         logger.info(f"Album batch for '{artist_name}': {matched_count}/{len(db_albums)} matched")
 
@@ -614,7 +618,7 @@ class SpotifyWorker:
                 self._mark_status('track', db_id, 'not_found')
                 self.stats['not_found'] += 1
 
-            time.sleep(self.batch_inter_item_sleep)
+            interruptible_sleep(self._stop_event, self.batch_inter_item_sleep)
 
         logger.info(f"Track batch for '{album_name}': {matched_count}/{len(db_tracks)} matched")
 

--- a/core/tidal_worker.py
+++ b/core/tidal_worker.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.tidal_client import TidalClient
+from core.worker_utils import interruptible_sleep
 
 logger = get_logger("tidal_worker")
 
@@ -45,6 +46,7 @@ class TidalWorker:
         self.paused = False
         self.should_stop = False
         self.thread = None
+        self._stop_event = threading.Event()
 
         # Current item being processed (for UI tooltip)
         self.current_item = None
@@ -73,6 +75,7 @@ class TidalWorker:
 
         self.running = True
         self.should_stop = False
+        self._stop_event.clear()
         self.thread = threading.Thread(target=self._run, daemon=True)
         self.thread.start()
         logger.info("Tidal background worker started")
@@ -85,9 +88,10 @@ class TidalWorker:
         logger.info("Stopping Tidal worker...")
         self.should_stop = True
         self.running = False
+        self._stop_event.set()
 
         if self.thread:
-            self.thread.join(timeout=5)
+            self.thread.join(timeout=1)
 
         logger.info("Tidal worker stopped")
 
@@ -140,17 +144,17 @@ class TidalWorker:
         while not self.should_stop:
             try:
                 if self.paused:
-                    time.sleep(1)
+                    interruptible_sleep(self._stop_event, 1)
                     continue
 
                 # Auth guard: sleep if not authenticated
                 try:
                     if not self.client.is_authenticated():
                         self.current_item = None
-                        time.sleep(30)
+                        interruptible_sleep(self._stop_event, 30)
                         continue
                 except Exception:
-                    time.sleep(30)
+                    interruptible_sleep(self._stop_event, 30)
                     continue
 
                 self.current_item = None
@@ -159,7 +163,7 @@ class TidalWorker:
 
                 if not item:
                     logger.debug("No pending items, sleeping...")
-                    time.sleep(10)
+                    interruptible_sleep(self._stop_event, 10)
                     continue
 
                 self.current_item = item
@@ -178,11 +182,11 @@ class TidalWorker:
 
                 self._process_item(item)
 
-                time.sleep(2)
+                interruptible_sleep(self._stop_event, 2)
 
             except Exception as e:
                 logger.error(f"Error in worker loop: {e}")
-                time.sleep(5)
+                interruptible_sleep(self._stop_event, 5)
 
         logger.info("Tidal worker thread finished")
 
@@ -364,7 +368,7 @@ class TidalWorker:
             if '429' in error_str or 'rate limit' in error_str:
                 # Rate limit — don't mark as error, back off then retry
                 logger.warning(f"Rate limited while processing {item['type']} #{item['id']}, backing off 30s")
-                time.sleep(30)
+                interruptible_sleep(self._stop_event, 30)
                 return
             logger.error(f"Error processing {item['type']} #{item['id']}: {e}")
             self.stats['errors'] += 1

--- a/core/web_scan_manager.py
+++ b/core/web_scan_manager.py
@@ -38,6 +38,8 @@ class WebScanManager:
         self._max_scan_time = 1800  # 30 minutes maximum
         self._current_server_type = None
         self._scan_progress = {}
+        self._completion_check_timer = None
+        self._shutting_down = False
 
         logger.info(f"WebScanManager initialized with {delay_seconds}s debounce delay")
 
@@ -84,6 +86,14 @@ class WebScanManager:
         logger.info(f"Web scan requested - reason: {reason}")
 
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Web scan request ignored during shutdown")
+                return {
+                    "status": "ignored",
+                    "message": "Server is shutting down",
+                    "delay_seconds": 0,
+                    "reason": reason,
+                }
             # Add callback if provided
             if callback and callback not in self._scan_completion_callbacks:
                 self._scan_completion_callbacks.append(callback)
@@ -107,6 +117,7 @@ class WebScanManager:
 
             # Start the debounce timer
             self._timer = threading.Timer(self.delay, self._execute_scan)
+            self._timer.daemon = True
             self._timer.start()
 
             return {
@@ -169,6 +180,9 @@ class WebScanManager:
     def _execute_scan(self):
         """Execute the actual media library scan"""
         with self._lock:
+            if self._shutting_down:
+                logger.debug("Web scan execution skipped during shutdown")
+                return
             if self._scan_in_progress:
                 logger.warning("Web scan already in progress - skipping duplicate execution")
                 return
@@ -231,6 +245,9 @@ class WebScanManager:
         """Start periodic checking for scan completion"""
         def check_completion():
             try:
+                if self._shutting_down:
+                    logger.debug("Web scan completion check aborted during shutdown")
+                    return
                 # Check for timeout
                 if self._scan_start_time and (time.time() - self._scan_start_time) > self._max_scan_time:
                     logger.warning(f"Web scan timed out after {self._max_scan_time} seconds")
@@ -254,14 +271,22 @@ class WebScanManager:
                     self._handle_scan_completion()
                 else:
                     # Continue checking
-                    threading.Timer(30, check_completion).start()  # Check every 30 seconds
+                    if self._shutting_down:
+                        return
+                    timer = threading.Timer(30, check_completion)  # Check every 30 seconds
+                    timer.daemon = True
+                    self._completion_check_timer = timer
+                    timer.start()
 
             except Exception as e:
                 logger.error(f"Error during web scan completion check: {e}")
                 self._reset_scan_state()
 
         # Start first check after 30 seconds
-        threading.Timer(30, check_completion).start()
+        timer = threading.Timer(30, check_completion)
+        timer.daemon = True
+        self._completion_check_timer = timer
+        timer.start()
 
     def _handle_scan_completion(self):
         """Handle scan completion and trigger callbacks"""
@@ -296,3 +321,23 @@ class WebScanManager:
             self._scan_start_time = None
             self._scan_progress = {}
             # Don't clear callbacks - they might be reused
+
+    def shutdown(self):
+        """Cancel any pending timers and stop scheduling new work."""
+        with self._lock:
+            self._shutting_down = True
+            self._scan_in_progress = False
+            self._current_server_type = None
+            self._scan_start_time = None
+            self._scan_progress = {}
+
+            if self._timer:
+                self._timer.cancel()
+                self._timer = None
+
+            if self._completion_check_timer:
+                self._completion_check_timer.cancel()
+                self._completion_check_timer = None
+
+            self._downloads_during_scan = False
+            logger.info("WebScanManager shutdown - cancelled all pending timers")

--- a/core/web_scan_manager.py
+++ b/core/web_scan_manager.py
@@ -290,12 +290,19 @@ class WebScanManager:
 
     def _handle_scan_completion(self):
         """Handle scan completion and trigger callbacks"""
-        logger.info(f"Web {self._current_server_type.upper()} library scan completed")
-
-        # Call completion callbacks
-        callbacks_to_call = []
         with self._lock:
+            if self._shutting_down:
+                return
+            server_type = self._current_server_type
             callbacks_to_call = self._scan_completion_callbacks.copy()
+            downloads_during_scan = self._downloads_during_scan
+
+        if not server_type:
+            logger.debug("Skipping web scan completion: no active server type")
+            self._reset_scan_state()
+            return
+
+        logger.info(f"Web {server_type.upper()} library scan completed")
 
         for callback in callbacks_to_call:
             try:
@@ -308,10 +315,9 @@ class WebScanManager:
         self._reset_scan_state()
 
         # Check if we need another scan due to downloads during this scan
-        with self._lock:
-            if self._downloads_during_scan:
-                logger.info("Web scan follow-up needed for downloads during scan")
-                self.request_scan("Follow-up scan for downloads during previous scan")
+        if downloads_during_scan:
+            logger.info("Web scan follow-up needed for downloads during scan")
+            self.request_scan("Follow-up scan for downloads during previous scan")
 
     def _reset_scan_state(self):
         """Reset internal scan state"""

--- a/core/worker_utils.py
+++ b/core/worker_utils.py
@@ -1,0 +1,17 @@
+"""Shared helpers for background workers."""
+
+import threading
+
+
+def interruptible_sleep(stop_event: threading.Event, seconds: float, step: float = 0.5) -> bool:
+    """Sleep in chunks so shutdown can interrupt long waits."""
+    if seconds <= 0:
+        return stop_event.is_set()
+
+    remaining = float(seconds)
+    while remaining > 0 and not stop_event.is_set():
+        wait_for = min(step, remaining)
+        if stop_event.wait(wait_for):
+            break
+        remaining -= wait_for
+    return stop_event.is_set()

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -16,6 +16,7 @@ from utils.logging_config import get_logger
 logger = get_logger("music_database")
 
 _database_initialized_paths = set()
+_database_sidecar_warnings = set()
 _database_initialization_lock = threading.Lock()
 
 # Import matching engine for enhanced similarity logic
@@ -170,9 +171,56 @@ class MusicDatabase:
             database_path = os.environ.get('DATABASE_PATH', 'database/music_library.db')
         self.database_path = Path(database_path)
         self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        self._warn_about_stale_sqlite_sidecars()
         
         # Initialize database once per process for this path
         self._initialize_database_once()
+
+    def _warn_about_stale_sqlite_sidecars(self):
+        """Warn if SQLite sidecars are present and the database looks unhealthy."""
+        db_key = str(self.database_path.resolve())
+        with _database_initialization_lock:
+            if db_key in _database_sidecar_warnings:
+                return
+            _database_sidecar_warnings.add(db_key)
+
+        wal_path = Path(f"{self.database_path}-wal")
+        shm_path = Path(f"{self.database_path}-shm")
+        existing = [p.name for p in (wal_path, shm_path) if p.exists()]
+
+        if existing:
+            check_result = None
+            try:
+                conn = sqlite3.connect(f"file:{self.database_path}?mode=ro", uri=True, timeout=5.0)
+                try:
+                    row = conn.execute("PRAGMA quick_check").fetchone()
+                    check_result = row[0] if row else None
+                finally:
+                    conn.close()
+            except Exception as e:
+                logger.warning(
+                    "SQLite sidecar files detected for %s: %s, and database health check could not be run (%s). "
+                    "This usually means the previous shutdown was not clean.",
+                    self.database_path,
+                    ", ".join(existing),
+                    e,
+                )
+                return
+
+            if check_result != "ok":
+                logger.warning(
+                    "SQLite sidecar files detected for %s: %s, and quick_check returned %r. "
+                    "This usually means the previous shutdown was not clean.",
+                    self.database_path,
+                    ", ".join(existing),
+                    check_result,
+                )
+            else:
+                logger.debug(
+                    "SQLite sidecar files present for %s (%s) but quick_check returned ok.",
+                    self.database_path,
+                    ", ".join(existing),
+                )
 
     def _initialize_database_once(self):
         """Run schema setup and migrations once per database path per process."""

--- a/web_server.py
+++ b/web_server.py
@@ -2638,6 +2638,8 @@ class WebUIDownloadMonitor:
                                 completed_tasks.append((batch_id, task_id))
 
         # ---- All work below runs WITHOUT tasks_lock held ----
+        if globals().get('IS_SHUTTING_DOWN', False) or not self.monitoring:
+            return
 
         # Execute deferred operations from _should_retry_task (network calls, nested locks)
         for op in deferred_ops:
@@ -3459,6 +3461,11 @@ def _shutdown_runtime_components():
         print("API call history saved")
     except Exception as e:
         print(f"Error saving API call history: {e}")
+
+    # Stop the active DB update worker before tearing down the executor it runs on.
+    # This lets an in-flight update observe should_stop and exit cleanly.
+    _stop_component(db_update_worker, "db update worker")
+    _stop_component(metadata_update_runtime_worker, "metadata update worker")
 
     # Stop long-lived worker components in parallel so shutdown waits for the
     # slowest worker instead of serially burning the timeout for each one.
@@ -40789,6 +40796,7 @@ metadata_update_state = {
 }
 
 metadata_update_worker = None
+metadata_update_runtime_worker = None
 metadata_update_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="metadata_update")
 
 # ===============================
@@ -44903,7 +44911,7 @@ def _old_get_listenbrainz_playlist_tracks_DEPRECATED(playlist_mbid):
 @app.route('/api/metadata/start', methods=['POST'])
 def start_metadata_update():
     """Start the metadata update process - EXACT copy of dashboard.py logic"""
-    global metadata_update_worker, metadata_update_state
+    global metadata_update_worker, metadata_update_runtime_worker, metadata_update_state
     
     try:
         # Check if already running
@@ -44971,6 +44979,7 @@ def start_metadata_update():
         
         # Start the metadata update worker - EXACTLY like dashboard.py
         def run_metadata_update():
+            global metadata_update_runtime_worker
             try:
                 metadata_worker = WebMetadataUpdateWorker(
                     None,  # Artists will be loaded in the worker thread - EXACTLY like dashboard.py
@@ -44979,12 +44988,15 @@ def start_metadata_update():
                     active_server,
                     refresh_interval_days
                 )
+                metadata_update_runtime_worker = metadata_worker
                 metadata_worker.run()
             except Exception as e:
                 print(f"Error in metadata update worker: {e}")
                 metadata_update_state['status'] = 'error'
                 metadata_update_state['error'] = str(e)
                 add_activity_item("", "Metadata Error", str(e), "Now")
+            finally:
+                metadata_update_runtime_worker = None
         
         metadata_update_worker = metadata_update_executor.submit(run_metadata_update)
         

--- a/web_server.py
+++ b/web_server.py
@@ -22830,7 +22830,7 @@ def _simple_monitor_task():
     Search cleanup and download cleanup are now handled by system automations."""
     print("Simple background monitor started")
 
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         try:
             with matched_context_lock:
                 pending_count = len(matched_downloads_context)
@@ -22856,6 +22856,8 @@ def _simple_monitor_task():
         except Exception as e:
             print(f"Simple monitor error: {e}")
             time.sleep(10)
+
+    print("Simple background monitor stopped")
 
 def start_simple_background_monitor():
     """Starts the simple background monitor thread."""
@@ -52130,7 +52132,7 @@ def _hydrabase_reconnect_loop():
     global _hydrabase_ws
     _consecutive_failures = 0
 
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(30)
         try:
             # Only attempt reconnect if auto_connect is enabled
@@ -52180,7 +52182,7 @@ def _hydrabase_reconnect_loop():
 
 def _emit_service_status_loop():
     """Background thread that pushes service status every 5 seconds."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(5)
         try:
             socketio.emit('status:update', _build_status_payload())
@@ -52189,7 +52191,7 @@ def _emit_service_status_loop():
 
 def _emit_watchlist_count_loop():
     """Background thread that pushes watchlist count every 10 seconds to each profile room."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(10)
         try:
             database = get_database()
@@ -52202,7 +52204,7 @@ def _emit_watchlist_count_loop():
 
 def _emit_download_status_loop():
     """Background thread that pushes download batch status every 2 seconds to subscribed rooms."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(2)
         try:
             live_transfers_lookup = get_cached_transfer_data()
@@ -52263,7 +52265,7 @@ def handle_profile_join(data):
 
 def _emit_system_stats_loop():
     """Background thread that pushes system stats every 10 seconds."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(10)
         try:
             socketio.emit('dashboard:stats', _build_system_stats())
@@ -52272,7 +52274,7 @@ def _emit_system_stats_loop():
 
 def _emit_activity_feed_loop():
     """Background thread that pushes activity feed every 2 seconds."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(2)
         try:
             with activity_feed_lock:
@@ -52283,7 +52285,7 @@ def _emit_activity_feed_loop():
 
 def _emit_db_stats_loop():
     """Background thread that pushes database stats every 10 seconds."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(10)
         try:
             db = get_database()
@@ -52294,7 +52296,7 @@ def _emit_db_stats_loop():
 
 def _emit_wishlist_count_loop():
     """Background thread that pushes wishlist count every 10 seconds to each profile room."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(10)
         try:
             from core.wishlist_service import get_wishlist_service
@@ -52340,7 +52342,7 @@ def _emit_rate_monitor_loop():
         'tidal': 'tidal_enrichment', 'qobuz': 'qobuz_enrichment',
     }
 
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         try:
             from core.api_call_tracker import api_call_tracker
@@ -52410,7 +52412,7 @@ def _emit_enrichment_status_loop():
         'genius-enrichment': lambda: genius_worker,
     }
 
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(2)
 
         # Auto-pause/resume rate-limited workers during downloads
@@ -52448,7 +52450,7 @@ def _emit_enrichment_status_loop():
 
 def _emit_tool_progress_loop():
     """Background thread that pushes all tool progress statuses every 1 second."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         # Stream status
         try:
@@ -52536,7 +52538,7 @@ def handle_discovery_unsubscribe(data):
 
 def _emit_sync_progress_loop():
     """Push sync progress to subscribed rooms every 1 second."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         try:
             with sync_lock:
@@ -52560,7 +52562,7 @@ def _emit_discovery_progress_loop():
         'listenbrainz': lambda: listenbrainz_playlist_states,
         'spotify_public': lambda: spotify_public_discovery_states,
     }
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         for platform, get_states in platform_states.items():
             try:
@@ -52590,7 +52592,7 @@ def _emit_discovery_progress_loop():
 
 def _emit_scan_status_loop():
     """Push watchlist and media scan status every 2 seconds."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(2)
         # Watchlist scan
         try:
@@ -52622,7 +52624,7 @@ def _emit_scan_status_loop():
 
 def _emit_automation_progress_loop():
     """Push automation:progress events every 1 second for running automations."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         try:
             with automation_progress_lock:
@@ -52666,7 +52668,7 @@ def _emit_automation_progress_loop():
 
 def _emit_repair_progress_loop():
     """Push repair:progress events every 1 second for running repair jobs."""
-    while True:
+    while not globals().get('IS_SHUTTING_DOWN', False):
         socketio.sleep(1)
         try:
             if repair_worker is None:

--- a/web_server.py
+++ b/web_server.py
@@ -2517,27 +2517,41 @@ class WebUIDownloadMonitor:
         self.monitoring = False
         self.monitor_thread = None
         self.monitored_batches = set()
+        self._lock = threading.Lock()
         
     def start_monitoring(self, batch_id):
         """Start monitoring a download batch"""
-        self.monitored_batches.add(batch_id)
-        if not self.monitoring:
-            self.monitoring = True
-            self.monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
-            self.monitor_thread.start()
-            print(f"Started download monitor for batch {batch_id}")
+        with self._lock:
+            self.monitored_batches.add(batch_id)
+            if not self.monitoring:
+                self.monitoring = True
+                self.monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
+                self.monitor_thread.start()
+                print(f"Started download monitor for batch {batch_id}")
     
     def stop_monitoring(self, batch_id):
         """Stop monitoring a specific batch"""
-        self.monitored_batches.discard(batch_id)
-        if not self.monitored_batches:
+        with self._lock:
+            self.monitored_batches.discard(batch_id)
+            if not self.monitored_batches:
+                self.monitoring = False
+                print(f"Stopped download monitor (no active batches)")
+
+    def shutdown(self):
+        """Stop the monitor loop and clear active batch tracking."""
+        with self._lock:
             self.monitoring = False
-            print(f"Stopped download monitor (no active batches)")
+            self.monitored_batches.clear()
+            self.monitor_thread = None
+        print("Download monitor shutdown requested")
     
     def _monitor_loop(self):
         """Main monitoring loop - checks downloads every 1 second for responsive web UX"""
         while self.monitoring and self.monitored_batches:
             try:
+                if globals().get('IS_SHUTTING_DOWN', False):
+                    self.monitoring = False
+                    break
                 self._check_all_downloads()
                 time.sleep(1)  # 1-second polling for fast web UI updates
             except Exception as e:
@@ -3206,6 +3220,8 @@ def validate_and_heal_batch_states():
     This is the server-side equivalent of the frontend's worker count validation.
     """
     try:
+        if globals().get('IS_SHUTTING_DOWN', False):
+            return
         import time
         current_time = time.time()
 
@@ -3310,15 +3326,41 @@ def validate_and_heal_batch_states():
 
 # Start periodic batch healing (every 30 seconds)
 import threading
+_batch_healing_timer = None
+_batch_healing_timer_lock = threading.Lock()
+
+def _schedule_batch_healing_timer(delay_seconds=30.0):
+    """Schedule the next batch healing cycle."""
+    global _batch_healing_timer
+    if globals().get('IS_SHUTTING_DOWN', False):
+        return
+
+    timer = threading.Timer(delay_seconds, start_batch_healing_timer)
+    timer.daemon = True
+    with _batch_healing_timer_lock:
+        _batch_healing_timer = timer
+    timer.start()
+
+def _cancel_batch_healing_timer():
+    """Cancel the current batch healing timer if one exists."""
+    global _batch_healing_timer
+    with _batch_healing_timer_lock:
+        timer = _batch_healing_timer
+        _batch_healing_timer = None
+    if timer:
+        timer.cancel()
+
 def start_batch_healing_timer():
     """Start periodic batch state validation and healing"""
     try:
+        if globals().get('IS_SHUTTING_DOWN', False):
+            return
         validate_and_heal_batch_states()
     except Exception as e:
         print(f"[Batch Healing Timer] Error: {e}")
     finally:
         # Schedule next healing cycle
-        threading.Timer(30.0, start_batch_healing_timer).start()
+        _schedule_batch_healing_timer(30.0)
 
 # Start the healing timer when the server starts
 start_batch_healing_timer()
@@ -3332,35 +3374,85 @@ def cleanup_monitor():
     """Clean up background monitor on shutdown"""
     if download_monitor.monitoring:
         print("Flask shutdown detected, stopping download monitor...")
-        download_monitor.monitoring = False
-        download_monitor.monitored_batches.clear()
+        download_monitor.shutdown()
         # Give the thread a moment to exit cleanly
         time.sleep(0.5)
         
     # Clean up batch locks to prevent memory leaks
-    with tasks_lock:
-        batch_locks.clear()
-        print("Cleaned up batch locks")
+    try:
+        acquired = tasks_lock.acquire(timeout=1.0)
+        if acquired:
+            try:
+                batch_locks.clear()
+                print("Cleaned up batch locks")
+            finally:
+                tasks_lock.release()
+        else:
+            print("Skipped batch lock cleanup - tasks_lock busy")
+    except Exception as e:
+        print(f"Error cleaning up batch locks: {e}")
 
 # Global shutdown flag
 IS_SHUTTING_DOWN = False
 
-def signal_handler(signum, frame):
-    """Handle SIGINT (Ctrl+C) and SIGTERM"""
-    global IS_SHUTTING_DOWN
-    print(f"Signal {signum} received, cleaning up...")
-    IS_SHUTTING_DOWN = True
-    cleanup_monitor()
-    
-    # Stop automation engine
+def _shutdown_executor(executor, name):
+    """Shut down a ThreadPoolExecutor without waiting for long-running tasks."""
+    if executor is None:
+        return
     try:
-        if automation_engine:
-            print("Stopping automation engine...")
-            automation_engine.stop()
+        print(f"Shutting down {name}...")
+        executor.shutdown(wait=False, cancel_futures=True)
     except Exception as e:
-        print(f"Error stopping automation engine: {e}")
+        print(f"Error shutting down {name}: {e}")
 
-    # Persist API call history
+def _stop_component(component, name, method_names=("stop", "shutdown")):
+    """Call a best-effort stop method on a component if it has one."""
+    if component is None:
+        return
+    for method_name in method_names:
+        method = getattr(component, method_name, None)
+        if callable(method):
+            try:
+                print(f"Stopping {name}...")
+                method()
+            except Exception as e:
+                print(f"Error stopping {name}: {e}")
+            return
+
+def _stop_components_parallel(components):
+    """Stop multiple components concurrently and wait for all stop calls to finish."""
+    stop_threads = []
+
+    for component, name in components:
+        if component is None:
+            continue
+
+        thread = threading.Thread(
+            target=_stop_component,
+            args=(component, name),
+            name=f"shutdown-{name.replace(' ', '-')}",
+        )
+        thread.start()
+        stop_threads.append((name, thread))
+
+    for name, thread in stop_threads:
+        thread.join()
+
+def _shutdown_runtime_components():
+    """Best-effort shutdown for timers, monitors, workers, and executors."""
+    global IS_SHUTTING_DOWN
+    if IS_SHUTTING_DOWN:
+        return
+
+    IS_SHUTTING_DOWN = True
+    _cancel_batch_healing_timer()
+
+    cleanup_monitor()
+
+    _stop_component(web_scan_manager, "web scan manager")
+    _stop_component(automation_engine, "automation engine")
+
+    # Persist API call history before shutting down worker pools.
     try:
         from core.api_call_tracker import api_call_tracker
         api_call_tracker.save()
@@ -3368,13 +3460,52 @@ def signal_handler(signum, frame):
     except Exception as e:
         print(f"Error saving API call history: {e}")
 
-    # Shutdown executor to prevent new tasks
-    try:
-        print("Shutting down missing_download_executor...")
-        missing_download_executor.shutdown(wait=False, cancel_futures=True)
-    except Exception as e:
-        print(f"Error shutting down executor: {e}")
+    # Stop long-lived worker components in parallel so shutdown waits for the
+    # slowest worker instead of serially burning the timeout for each one.
+    _stop_components_parallel([
+        (mb_worker, "musicbrainz worker"),
+        (audiodb_worker, "audiodb worker"),
+        (discogs_worker, "discogs worker"),
+        (deezer_worker, "deezer worker"),
+        (spotify_enrichment_worker, "spotify enrichment worker"),
+        (itunes_enrichment_worker, "itunes enrichment worker"),
+        (lastfm_worker, "lastfm worker"),
+        (genius_worker, "genius worker"),
+        (tidal_enrichment_worker, "tidal enrichment worker"),
+        (qobuz_enrichment_worker, "qobuz enrichment worker"),
+        (hydrabase_worker, "hydrabase worker"),
+        (soulid_worker, "soulid worker"),
+        (listening_stats_worker, "listening stats worker"),
+        (repair_worker, "repair worker"),
+    ])
 
+    # Shut down executor pools so their worker threads stop keeping the process alive.
+    for executor, name in [
+        (stream_executor, "stream executor"),
+        (db_update_executor, "db update executor"),
+        (quality_scanner_executor, "quality scanner executor"),
+        (duplicate_cleaner_executor, "duplicate cleaner executor"),
+        (retag_executor, "retag executor"),
+        (sync_executor, "sync executor"),
+        (missing_download_executor, "missing download executor"),
+        (tidal_discovery_executor, "tidal discovery executor"),
+        (deezer_discovery_executor, "deezer discovery executor"),
+        (spotify_public_discovery_executor, "spotify public discovery executor"),
+        (youtube_discovery_executor, "youtube discovery executor"),
+        (beatport_discovery_executor, "beatport discovery executor"),
+        (listenbrainz_discovery_executor, "listenbrainz discovery executor"),
+        (similar_artists_executor, "similar artists executor"),
+        (metadata_update_executor, "metadata update executor"),
+    ]:
+        _shutdown_executor(executor, name)
+
+    # Give daemon cleanup threads a moment to observe the shutdown flag.
+    time.sleep(0.2)
+
+def signal_handler(signum, frame):
+    """Handle SIGINT (Ctrl+C) and SIGTERM"""
+    print(f"Signal {signum} received, cleaning up...")
+    _shutdown_runtime_components()
     sys.exit(0)
 
 # Register cleanup handlers
@@ -3385,7 +3516,14 @@ def _atexit_save_history():
     except Exception:
         pass
 
+def _atexit_shutdown():
+    try:
+        _shutdown_runtime_components()
+    except Exception:
+        pass
+
 atexit.register(_atexit_save_history)
+atexit.register(_atexit_shutdown)
 atexit.register(cleanup_monitor)
 signal.signal(signal.SIGINT, signal_handler)
 signal.signal(signal.SIGTERM, signal_handler)


### PR DESCRIPTION
When running the application locally, I noticed that closing the server gracefully would take an unexpectedly long time (over a minute). The reason ended up being mostly caused by long, uninterruptible sleep calls sprinkled here and there, which would not react to shutdown signals.

This also means that currently when one shuts down / restarts the SoulSync docker container, it basically by default never shuts down gracefully, but instead docker forcefully kills it after [10 seconds](https://docs.docker.com/reference/cli/docker/container/run/#stop-timeout) (unless explicitly configured otherwise). These forceful terminations can end up causing unexpected issues, one of them being a corrupted database due to lingering, incompatible `.db-wal` files for example (had this happen locally).

This PR basically makes it so that most sleeps become interruptible, and they by default are interrupted upon receiving a SIGINT signal. This makes graceful process termination possible, since the application now manages to close within ~a second on average, compared to the previous 1minute+ which would result in a SIGKILL by docker