### PR TITLE
Fix Socket.IO client fallback order

### DIFF
--- a/tests/test_websocket_client_transport.py
+++ b/tests/test_websocket_client_transport.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_websocket_client_prefers_polling_before_websocket():
+    script_path = Path(__file__).resolve().parents[1] / "webui" / "static" / "script.js"
+    script = script_path.read_text()
+
+    assert "transports: ['polling', 'websocket']" in script

--- a/webui/static/script.js
+++ b/webui/static/script.js
@@ -274,7 +274,7 @@ function initializeWebSocket() {
     }
 
     socket = io({
-        transports: ['websocket', 'polling'],
+        transports: ['polling', 'websocket'],
         reconnection: true,
         reconnectionAttempts: Infinity,
         reconnectionDelay: 1000,


### PR DESCRIPTION
## Summary
- prefer polling before websocket in the web UI Socket.IO client
- add a regression test to lock in the client transport order
- reduce the impact of failing websocket upgrades on the live UI

## Why
The current client forces websocket first. In the deployed app, websocket upgrade attempts can fail under the current Flask-SocketIO/Werkzeug runtime, which makes the UI feel stuck or constantly reconnecting even though the HTTP app stays healthy.

## Verification
- added a regression test for the transport order in 
- built and deployed the patched image privately on my instance
- verified the app stays healthy and the UI feels smoother with polling-first fallback