### PR TITLE
Fix GHCR tags: lowercase repository owner for Docker compatibility

### DIFF
--- a/.github/workflows/dev-nightly.yml
+++ b/.github/workflows/dev-nightly.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           ref: dev
 
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Check for recent commits (scheduled only)
         if: github.event_name == 'schedule'
         id: recent
@@ -72,7 +75,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate build tag
@@ -95,6 +98,6 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
           tags: |
-            ghcr.io/${{ github.repository_owner }}/soulsync:dev
-            ghcr.io/${{ github.repository_owner }}/soulsync:dev-${{ steps.tag.outputs.date }}-${{ steps.tag.outputs.short_sha }}
-            ${{ github.event_name == 'schedule' && format('ghcr.io/{0}/soulsync:nightly', github.repository_owner) || '' }}
+            ghcr.io/${{ env.OWNER }}/soulsync:dev
+            ghcr.io/${{ env.OWNER }}/soulsync:dev-${{ steps.tag.outputs.date }}-${{ steps.tag.outputs.short_sha }}
+            ${{ github.event_name == 'schedule' && format('ghcr.io/{0}/soulsync:nightly', env.OWNER) || '' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set lowercase owner
+        run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
@@ -41,7 +44,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ env.OWNER }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
@@ -57,9 +60,9 @@ jobs:
             COMMIT_SHA=${{ github.sha }}
           tags: |
             boulderbadgedad/soulsync:latest
-            ghcr.io/${{ github.repository_owner }}/soulsync:latest
+            ghcr.io/${{ env.OWNER }}/soulsync:latest
             ${{ inputs.version_tag && format('boulderbadgedad/soulsync:{0}', inputs.version_tag) || '' }}
-            ${{ inputs.version_tag && format('ghcr.io/{0}/soulsync:{1}', github.repository_owner, inputs.version_tag) || '' }}
+            ${{ inputs.version_tag && format('ghcr.io/{0}/soulsync:{1}', env.OWNER, inputs.version_tag) || '' }}
 
       - name: Announce release to Discord
         if: success() && inputs.version_tag


### PR DESCRIPTION
Fixes the build failure introduced in #340 where docker buildx rejects GHCR tags containing uppercase characters in the repository owner name.

github.repository_owner returns "Nezreka" but OCI/Docker tags require all-lowercase. Both docker-publish and dev-nightly workflows now lowercase the owner via bash before using it in image tags.