### PR TITLE
Skip Docker/publish workflows on forks

### DIFF
--- a/.github/workflows/cleanup-dev-images.yml
+++ b/.github/workflows/cleanup-dev-images.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   cleanup:
+    if: github.repository == 'Nezreka/SoulSync'
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/dev-nightly.yml
+++ b/.github/workflows/dev-nightly.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   nightly:
+    if: github.repository == 'Nezreka/SoulSync'
     runs-on: ubuntu-latest
     # Skip scheduled runs if dev branch has no new commits in the last 24h
     # (pushes and manual triggers always run)

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   build-and-push:
+    if: github.repository == 'Nezreka/SoulSync'
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Skip Docker/publish workflows on forks

Adds a repository guard (github.repository == Nezreka/SoulSync) to three workflows so they silently skip when running on a fork:

- cleanup-dev-images.yml
- dev-nightly.yml
- docker-publish.yml

build-and-test.yml is left unchanged so fork contributors can still run linting, compilation checks, and unit tests on their branches.

Without this change, forking the repo triggers a flood of failed Actions notifications from workflows that try to push Docker images or manage GHCR packages without the required secrets or permissions.

Previous PR accidentally targeted main.