### PR TITLE
Pin yt-dlp in requirements.txt, drop pip install from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,10 +69,6 @@ chown -R soulsync:soulsync /app/config /app/data /app/logs /app/downloads /app/T
 
 echo "✅ Configuration initialized successfully"
 
-# Auto-update yt-dlp — YouTube changes their API frequently and stale versions break downloads
-echo "🔄 Updating yt-dlp..."
-pip install -U yt-dlp --quiet --no-cache-dir 2>/dev/null && echo "   ✅ yt-dlp updated" || echo "   ⚠️ yt-dlp update failed (will use existing version)"
-
 # Display final user info
 echo "👤 Running as:"
 echo "   User: $(id -u soulsync):$(id -g soulsync) ($(id -un soulsync):$(id -gn soulsync))"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,12 @@ beautifulsoup4>=4.12.0
 psutil>=6.0.0
 
 # YouTube support
-yt-dlp>=2024.12.13
+# Pinned to an exact version for reproducible builds. The Docker
+# entrypoint used to `pip install -U yt-dlp` on every container start,
+# which made startup non-deterministic and depended on PyPI being
+# reachable. Bump this pin in a SoulSync release when yt-dlp ships a
+# YouTube-fix update — that's the supported upgrade path now.
+yt-dlp==2026.3.17
 
 # Lyrics support
 lrclibapi>=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,12 +27,7 @@ beautifulsoup4>=4.12.0
 # System monitoring
 psutil>=6.0.0
 
-# YouTube support
-# Pinned to an exact version for reproducible builds. The Docker
-# entrypoint used to `pip install -U yt-dlp` on every container start,
-# which made startup non-deterministic and depended on PyPI being
-# reachable. Bump this pin in a SoulSync release when yt-dlp ships a
-# YouTube-fix update — that's the supported upgrade path now.
+# YouTube support — pinned for reproducible builds; bump per release. See #367.
 yt-dlp==2026.3.17
 
 # Lyrics support

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3444,7 +3444,7 @@ const WHATS_NEW = {
     '2.4.1': [
         // --- post-2.4.0 dev work — entries hidden by _getLatestWhatsNewVersion until the build version bumps ---
         { date: 'Unreleased — 2.4.1 dev cycle' },
-        { title: 'Faster Docker Startup — yt-dlp Pinned', desc: 'docker startup used to run `pip install -U yt-dlp` on every container start. removed that — yt-dlp is now pinned in requirements.txt so startup is fast and reproducible. tradeoff: youtube fixes ship via soulsync releases now instead of next container restart.', page: 'settings' },
+        { title: 'Faster Docker Startup — yt-dlp Pinned', desc: 'docker startup used to run `pip install -U yt-dlp` on every container start. removed that — yt-dlp is now pinned in requirements.txt so startup is fast and reproducible. tradeoff: youtube fixes ship via soulsync releases now instead of next container restart.' },
     ],
     '2.4.0': [
         // --- April 26, 2026 — Search & Artists unification + reorganize queue ---

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3441,6 +3441,11 @@ function closeHelperSearch() {
 // projects that span multiple commits before shipping. Strip the flag at
 // release time and add a real `date:` line at the top of the version block.
 const WHATS_NEW = {
+    '2.4.1': [
+        // --- post-2.4.0 dev work — entries hidden by _getLatestWhatsNewVersion until the build version bumps ---
+        { date: 'Unreleased — 2.4.1 dev cycle' },
+        { title: 'Faster Docker Startup — yt-dlp Pinned', desc: 'docker startup used to run `pip install -U yt-dlp` on every container start. removed that — yt-dlp is now pinned in requirements.txt so startup is fast and reproducible. tradeoff: youtube fixes ship via soulsync releases now instead of next container restart.', page: 'settings' },
+    ],
     '2.4.0': [
         // --- April 26, 2026 — Search & Artists unification + reorganize queue ---
         { date: 'April 26, 2026 — 2.4.0 release' },


### PR DESCRIPTION
Closes #367 (reported by JohnBaumb).

The Docker entrypoint ran `pip install -U yt-dlp --quiet --no-cache-dir` on every container start. Three problems with that:

- Non-deterministic startup: each restart could pick up a different yt-dlp version, making "works on my machine" debugging harder.
- Network dependency at boot: PyPI being slow/unreachable gated the app coming up.
- In-place upgrades inside running containers can race with active yt-dlp invocations and aren't a great pattern.

Picked Option A from the issue: pin to an exact version in requirements.txt (`yt-dlp==2026.3.17`) and remove the entrypoint install entirely. yt-dlp comes baked into the image now via the existing `pip install -r requirements.txt` in the Dockerfile.

Tradeoff: YouTube fixes ship via SoulSync releases now instead of "next container restart". The pin is documented inline with how to bump it.

Net change: -3 entrypoint lines, requirements.txt pin tightened, WHATS_NEW '2.4.1' block opened (entries hidden until version bumps).

553 tests pass.