### PR TITLE
Bust Docker layer cache to rebuild dev nightly image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 # SoulSync requirements
 # Web application dependencies only
+# (cache-bust 2026-05-02: dev nightly image was serving a poisoned layer
+#  with missing dependencies; touching this comment forces the GHA Docker
+#  layer cache to invalidate the pip-install step on the next build.)
 
 # Core web framework
 Flask>=3.0.0


### PR DESCRIPTION
User reported the dev nightly Docker image fails to start with ``ModuleNotFoundError: No module named 'requests'`` despite ``requests>=2.31.0`` being correctly listed in requirements.txt. Local Docker builds + python imports both work — the issue is a poisoned GHA Docker layer cache: the ``pip install -r requirements.txt`` step is cached based on the file's content hash, so once a bad layer (e.g. an aborted/incomplete pip install from a previous run) makes it into the cache, every subsequent build reuses it.

Touching this comment changes the requirements.txt hash, which forces ``cache-from: type=gha`` in dev-nightly.yml to skip the poisoned layer and run a fresh ``pip install``. The next dev nightly build (or push-to-dev triggered build) will produce a clean image.

No functional change.