### PR TITLE
feat: raise discography limit to 500 and paginate Discogs artist releases

### DIFF
--- a/core/artist_source_detail.py
+++ b/core/artist_source_detail.py
@@ -126,7 +126,7 @@ def build_source_only_artist_detail(
             allow_fallback=True,
             skip_cache=False,
             max_pages=0,
-            limit=50,
+            limit=500,
             artist_source_ids={source: artist_id},
             dedup_variants=False,
         ),

--- a/core/discogs_client.py
+++ b/core/discogs_client.py
@@ -656,16 +656,32 @@ class DiscogsClient:
 
         return result
 
-    def get_artist_albums(self, artist_id: str, album_type: str = 'album,single', limit: int = 50) -> List[Album]:
+    def get_artist_albums(self, artist_id: str, album_type: str = 'album,single', limit: int = 500) -> List[Album]:
         """Get releases by an artist. Prefers master releases, filters features."""
         # First get the artist name for feature filtering
         artist_data = self._api_get(f'/artists/{artist_id}')
         artist_name = artist_data.get('name', '').lower() if artist_data else ''
 
-        data = self._api_get(f'/artists/{artist_id}/releases', {
-            'sort': 'year', 'sort_order': 'desc', 'per_page': min(limit * 3, 200),
-        })
-        if not data or not data.get('releases'):
+        # Paginate through all release pages (Discogs max per_page=100).
+        # Collect everything before filtering so the limit applies to
+        # qualified albums, not raw API rows.
+        PAGE_SIZE = 100
+        all_items: list = []
+        page = 1
+        while True:
+            data = self._api_get(f'/artists/{artist_id}/releases', {
+                'sort': 'year', 'sort_order': 'desc',
+                'per_page': PAGE_SIZE, 'page': page,
+            })
+            if not data or not data.get('releases'):
+                break
+            all_items.extend(data['releases'])
+            pagination = data.get('pagination', {})
+            if page >= pagination.get('pages', 1):
+                break
+            page += 1
+
+        if not all_items:
             return []
 
         # Separate masters from individual releases — prefer masters (canonical versions)
@@ -673,7 +689,7 @@ class DiscogsClient:
         releases_no_master = []
         master_titles = set()
 
-        for item in data['releases']:
+        for item in all_items:
             # Skip non-main roles
             role = item.get('role', 'Main').lower()
             if role not in ('main', ''):
@@ -726,7 +742,7 @@ class DiscogsClient:
                 if album.album_type in allowed_types:
                     albums.append(album)
 
-                if len(albums) >= limit:
+                if limit and len(albums) >= limit:
                     break
             except Exception as e:
                 logger.debug(f"Error parsing Discogs artist release: {e}")

--- a/web_server.py
+++ b/web_server.py
@@ -8662,7 +8662,7 @@ def get_artist_detail(artist_id):
                     allow_fallback=True,
                     skip_cache=False,
                     max_pages=0,
-                    limit=50,
+                    limit=500,
                     artist_source_ids=artist_source_ids,
                 ),
             )
@@ -9046,7 +9046,7 @@ def get_artist_discography(artist_id):
                 allow_fallback=True,
                 skip_cache=False,
                 max_pages=0,
-                limit=50,
+                limit=500,
                 artist_source_ids=artist_source_ids or None,
             ),
         )


### PR DESCRIPTION
## Summary

- Raises the discography album fetch limit from 50 → 500 across all three call sites: artist-detail page, discography download modal, and source-detail view
- Deezer, iTunes, and Spotify already paginate internally — no changes needed there
- Discogs is updated to paginate through **all pages** (100 results/request, the API max) before filtering, so the 500-album limit applies to qualified albums rather than raw API rows

## Changes

- `core/discogs_client.py` — `get_artist_albums()` now loops through all Discogs pages, collecting items before the dedup/filter pass; early-exit guard handles `limit=0` (unlimited) correctly
- `web_server.py` — both the artist-detail and discography-modal endpoints: `limit=50` → `limit=500`
- `core/artist_source_detail.py` — same lift for the source-detail view

## Notes

This is part of a refactor of my previous PR (#433, now set to draft) — splitting the original combined branch into focused, individually reviewable PRs. This is the first of those.

## Testing

Tested in situ on my own server via a locally-built Docker image — confirmed artists with large catalogs now return well beyond the previous 50-release cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)