### PR TITLE
feat: wrap discog modal card titles instead of truncating

### DIFF
--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -45427,7 +45427,7 @@ textarea.enhanced-meta-field-input {
 }
 
 .discog-card {
-    display: flex; align-items: center; gap: 10px;
+    display: flex; align-items: flex-start; gap: 10px;
     padding: 8px 10px; border-radius: 10px;
     background: rgba(255,255,255,0.02); border: 1px solid rgba(255,255,255,0.04);
     cursor: pointer; transition: all 0.15s ease;
@@ -45464,7 +45464,7 @@ textarea.enhanced-meta-field-input {
 
 .discog-card-title {
     font-size: 13px; font-weight: 600; color: #fff;
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    white-space: normal; word-break: break-word;
 }
 
 .discog-card-meta { font-size: 11px; color: rgba(255,255,255,0.35); margin-top: 2px; }
@@ -45473,6 +45473,7 @@ textarea.enhanced-meta-field-input {
     width: 20px; height: 20px; border-radius: 6px; flex-shrink: 0;
     border: 2px solid rgba(255,255,255,0.15); transition: all 0.15s ease;
     display: flex; align-items: center; justify-content: center;
+    margin-top: 2px;
 }
 
 .discog-card-cb:checked ~ .discog-card-check {


### PR DESCRIPTION
## Summary

- Discography modal card titles now wrap to full text instead of being cut off with an ellipsis
- Card artwork and the selection checkbox pin to the top of the card so they align with the first line when titles wrap
- CSS-only change: 3 lines modified in `style.css`

## Changes

| Rule | Before | After |
|---|---|---|
| `.discog-card` | `align-items: center` | `align-items: flex-start` |
| `.discog-card-title` | `white-space: nowrap; overflow: hidden; text-overflow: ellipsis` | `white-space: normal; word-break: break-word` |
| `.discog-card-check` | — | `margin-top: 2px` |

## Test plan

- Tested locally via Docker — long album/EP titles wrap correctly and artwork/checkbox stay top-aligned
- Part of a series of focused PRs refactoring improvements from the previous draft PR #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)