### PR TITLE
Drop duplicate Download History button from Downloads batch panel header

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -2180,12 +2180,9 @@
                     <div class="adl-batch-panel" id="adl-batch-panel">
                         <div class="adl-batch-panel-header">
                             <h3 class="adl-batch-panel-title">Batches</h3>
-                            <div class="adl-batch-panel-header-actions">
-                                <button class="library-history-btn" onclick="openLibraryHistoryModal()" title="View full download + import history">Download History</button>
-                                <button class="adl-batch-panel-collapse" id="adl-batch-collapse" onclick="adlToggleBatchPanel()" title="Toggle batch panel">
-                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
-                                </button>
-                            </div>
+                            <button class="adl-batch-panel-collapse" id="adl-batch-collapse" onclick="adlToggleBatchPanel()" title="Toggle batch panel">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 18 15 12 9 6"/></svg>
+                            </button>
                         </div>
                         <div class="adl-batch-active" id="adl-batch-active">
                             <!-- Active batch cards rendered by JS -->

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -57129,12 +57129,6 @@ body.reduce-effects *::after {
     margin: 0;
 }
 
-.adl-batch-panel-header-actions {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
 /* Collapse toggle */
 .adl-batch-panel-collapse {
     background: none;


### PR DESCRIPTION
Audit-trail PR added two buttons to the Downloads page — one always visible next to the 'Batches' panel title, one inside the collapsible 'Recent History' header. User wants only the Recent History one.

Removes the panel-header button + the unused
.adl-batch-panel-header-actions style. Recent History button + the original Dashboard button remain.