### PR TITLE
Bump version to 2.5.3

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.5.2)'
+        description: 'Version tag (e.g. 2.5.3)'
         required: true
-        default: '2.5.2'
+        default: '2.5.3'
 
 jobs:
   build-and-push:

--- a/web_server.py
+++ b/web_server.py
@@ -40,7 +40,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.5.2"
+_SOULSYNC_BASE_VERSION = "2.5.3"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -4349,7 +4349,7 @@ function _getLatestWhatsNewVersion() {
     const versions = Object.keys(WHATS_NEW)
         .filter(v => _compareVersions(v, buildVer) <= 0)
         .sort((a, b) => _compareVersions(b, a));
-    return versions[0] || '2.5.2';
+    return versions[0] || '2.5.3';
 }
 
 function openWhatsNew() {


### PR DESCRIPTION
# Release 2.5.3

dev → main. Brings in every change since 2.4.2 (2.5.0 + 2.5.1 + 2.5.2 + the version bump).

## Highlights

**Tagging & metadata**
- Multi-artist support overhaul — `_artists_list` populated, `artist_separator` + `feat_in_title` settings actually applied, Deezer `/track/<id>` contributor upgrade, Soulseek matched downloads pull full artist list from `track_info`, scanner retag respects `write_multi_artist`
- Cross-script artist aliases — Hiroyuki Sawano ↔ 澤野弘之, Dmitry Yablonsky ↔ Дмитрий Яблонский, etc. MusicBrainz canonical name + sort-name + non-strict search fallback all bridge correctly
- Track number tag no longer writes `"6/0"` when album total is unknown — drops to `"6"` per ID3 spec
- Retag tool now re-embeds LYRICS tag (was clearing without rewriting)
- `$albumtype` folder template fix for non-Spotify sources (EPs / Singles route correctly for Deezer / Tidal / etc)
- Deezer cover art upgraded to 1900×1900 (was 1000×1000)

**AcoustID & verification**
- Multi-candidate scan — scanner now iterates ALL AcoustID candidates instead of trusting `recordings[0]`. Drops false positives when AcoustID returns multiple recordings per fingerprint
- Duration guard catches fingerprint hash collisions (the 17-min mashup → 5-min track case)
- Cross-script alias-aware verification stops quarantining cross-language artist tags
- Compilation albums no longer flag every track (per-track artist column finally read)
- Multi-artist credits no longer flagged as wrong song
- Configurable duration tolerance setting (default 0 = auto 3s/5s, set higher for live/concert albums)
- MTV Unplugged & live-album false-quarantine pipeline fixed at three layers (album-context title normalization, Tidal qualifier filter on primary search, qualifier inspection of `track.album.name`)

**Quarantine management**
- New Quarantine tab in the Library History modal
- Per-row Approve / Recover / Delete actions
- Approve re-runs post-process with only the failing check skipped
- Themed confirm + toast (no native browser dialogs)

**Discover page**
- Section controller refactor — every discover section migrated to a shared `createDiscoverSectionController` lifecycle (~30 sections, no more drift)
- Sharper track selection — diversity caps, source-aware popularity thresholds, library dedup, SQL-pushed genre filter
- Stop showing undownloadable tracks (mandatory id-validity gate on every selection)

**Server playlists**
- Find & Add now persists as a permanent match override in `sync_match_cache` — no more re-downloading the same Spotify track that the user already manually paired
- Sync append-mode added (preserves user-added tracks)

**Tidal**
- Favorite tracks / albums / artists now show up as virtual playlists (parity with Spotify Liked Songs)
- Tidal album-tracks fetch via two-phase cursor walk + batch hydration

**Auto-import**
- Multi-album parallel processing (3 workers default)
- Picard / Beets parity — MBID + ISRC exact-match fast path before fuzzy scoring, duration sanity gate, multi-disc dedup correctness
- SoulSync standalone library writes get full server-quality rows (source IDs populated correctly)
- Falls through to fallback metadata sources when primary returns no match

**Plex / Jellyfin / Navidrome**
- Plex library scan trigger fixed for non-English section names (Música / Musique / Musik / etc)
- Server playlist sync now supports Append mode in addition to Replace
- Artist page "Write Artist Image" button writes `artist.jpg` so Navidrome reads real artist photos

**Library**
- Library reorganize stops leaving orphan audio files behind
- Library history audit trail modal — full per-download lifecycle view + embedded tags grid via live mutagen read
- Discography 50-cap fix (bumped to 200 for non-Spotify sources)
- Discography skips tracks already owned (no double-queue)
- No more cross-artist tracks or unwanted remixes from discography downloads

**Search & downloads**
- Source picker default no longer always sticks to Spotify
- Manual search in failed-track candidates modal
- Manual picks don't auto-retry anymore
- Download Missing modal tracklist polish
- Soulseek min-delay-between-searches knob (fixes ISP anti-abuse trips)
- Auto-import album duration is album total + re-imports fill metadata gaps

**Docker**
- Container restart-loop fix on bind-mounted staging folder
- Writability audit at entrypoint logs missing permissions instead of silently failing

**Misc**
- AudioDB track worker no longer stuck in infinite retry loop (#553)
- Cross-script artist names no longer quarantine files (#442)
- Search for match no longer surfaces karaoke / tribute / "originally performed by" junk
- Deezer ISP/peer integration tweaks
- Multi-artist tag settings (`artist_separator`, `feat_in_title`, `write_multi_artist`) now actually function

## Closed issues (since 2.4.2)

#442, #502, #524, #534, #535, #553, #558, #559, #566, #567, #572, #584, #585, #586, #587, #588, #589, plus several Discord / Reddit reports.
