### PR TITLE
fix(webui): recover artist detail deep links in legacy startup

### DIFF
--- a/webui/static/init.js
+++ b/webui/static/init.js
@@ -2171,6 +2171,20 @@ function buildArtistDetailPath(artistId, source = null) {
     return '/artist-detail/' + encodeURIComponent(normalizedSource) + '/' + encodeURIComponent(String(artistId));
 }
 
+function parseArtistDetailPath(pathname = window.location.pathname) {
+    const segs = String(pathname || '').split('/').filter(Boolean);
+    if (segs[0] !== 'artist-detail' || segs.length < 3) return null;
+
+    const source = decodeURIComponent(segs[1] || '');
+    const artistId = decodeURIComponent(segs.slice(2).join('/'));
+    if (!source || !artistId) return null;
+
+    return {
+        artistId,
+        source: source.toLowerCase() === 'library' ? null : source,
+    };
+}
+
 // ===============================
 // MOBILE NAVIGATION
 // ===============================

--- a/webui/static/search.js
+++ b/webui/static/search.js
@@ -1175,6 +1175,14 @@ async function loadInitialData() {
             return;
         }
 
+        if (targetPage === 'artist-detail') {
+            const artistRoute = typeof parseArtistDetailPath === 'function' ? parseArtistDetailPath() : null;
+            if (artistRoute && typeof navigateToArtistDetail === 'function') {
+                navigateToArtistDetail(artistRoute.artistId, '', artistRoute.source);
+            }
+            return;
+        }
+
         // Always apply the target page to the legacy shell chrome.
         const router = getWebRouter();
         const route = router?.routeManifest?.find((entry) => entry.pageId === targetPage);


### PR DESCRIPTION
Parse /artist-detail/<source>/<id> during legacy initial navigation so Python/git-pull installs without a fresh React handoff bundle still call the existing artist detail loader instead of leaving the shell blank.