### PR TITLE
Bump version to 2.6.1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.6.0)'
+        description: 'Version tag (e.g. 2.6.1)'
         required: true
-        default: '2.6.0'
+        default: '2.6.1'
 
 jobs:
   build-and-push:

--- a/web_server.py
+++ b/web_server.py
@@ -40,7 +40,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.6.0"
+_SOULSYNC_BASE_VERSION = "2.6.1"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3413,6 +3413,14 @@ function closeHelperSearch() {
 // projects that span multiple commits before shipping. Strip the flag at
 // release time and add a real `date:` line at the top of the version block.
 const WHATS_NEW = {
+    '2.6.1': [
+        { date: 'May 24, 2026 — 2.6.1 release' },
+        { title: 'React Import page polish', desc: 'Import now runs through the React route stack with album, singles, and auto-import tabs plus the state fixes needed for reliable Vite builds.' },
+        { title: 'Fix: album-bundle track numbering', desc: 'Soulseek-first hybrid and album-level source flows now preserve each track number during staging instead of importing every file as track 01.' },
+        { title: 'Fix: completed downloads stay visible', desc: 'The Downloads view now keeps a bounded completed-history tail so finished downloads remain visible after the live task disappears.' },
+        { title: 'MusicBrainz release variants', desc: 'Manual album search now surfaces concrete MusicBrainz releases with richer variant metadata instead of collapsing everything to the release group.' },
+        { title: 'Artist and radio UI refinements', desc: 'Artist detail actions and the Now Playing radio-mode controls were restyled and aligned for the refreshed artist workflow.' },
+    ],
     '2.6.0': [
         { date: 'May 24, 2026 — 2.6.0 release' },
         { title: 'Qobuz playlist sync', desc: 'new Qobuz tab on the Sync page. Connect Qobuz in Settings → Connections, hit Refresh on the tab, and your Qobuz playlists + Favorite Tracks show up alongside Tidal and Deezer. clicks run the same discovery → sync → download flow as the other sources.', page: 'sync' },
@@ -3906,7 +3914,7 @@ function _getLatestWhatsNewVersion() {
     const versions = Object.keys(WHATS_NEW)
         .filter(v => _compareVersions(v, buildVer) <= 0)
         .sort((a, b) => _compareVersions(b, a));
-    return versions[0] || '2.6.0';
+    return versions[0] || '2.6.1';
 }
 
 function openWhatsNew() {


### PR DESCRIPTION
Update the SoulSync base version, Docker release workflow default, and What's New notes so the next release surfaces as 2.6.1.