### PR TITLE
Fix/wishlist album bundle postprocess

### DIFF
--- a/core/downloads/staging.py
+++ b/core/downloads/staging.py
@@ -167,15 +167,32 @@ def try_staging_match(task_id, batch_id, track, deps: StagingDeps):
 
     Returns True if a match was found and the file was moved to the transfer folder.
     Returns False to fall through to normal download.
+
+    Every silent-False exit point logs at INFO with the rejection reason
+    so #706 / #708-class "track staged but never imported, ends up
+    re-added to wishlist" loops can be diagnosed from app.log without
+    a re-instrumentation round-trip. Per-candidate skips log at DEBUG
+    so the noise stays out of INFO unless explicitly turned up.
     """
+    track_title = (track.name or '').strip() if hasattr(track, 'name') else ''
+    track_artist = (track.artists[0] if (hasattr(track, 'artists') and track.artists) else '').strip()
+    # Compact identifier for the log lines below so a multi-batch
+    # wishlist run can be greppable per-track.
+    _track_label = f"'{track_title}' by '{track_artist}'"
+
     staging_files = deps.get_staging_file_cache(batch_id or task_id)
     if not staging_files:
+        logger.info(
+            "[Staging] No match attempted for %s — staging cache empty for batch %s",
+            _track_label, batch_id or task_id,
+        )
         return False
 
-    track_title = track.name or ''
-    track_artist = track.artists[0] if track.artists else ''
-
     if not track_title:
+        logger.info(
+            "[Staging] No match attempted for task %s — track has empty title",
+            task_id,
+        )
         return False
 
     from difflib import SequenceMatcher
@@ -186,12 +203,20 @@ def try_staging_match(task_id, batch_id, track, deps: StagingDeps):
 
     best_match = None
     best_score = 0.0
+    # Track per-candidate scoring so the rejection log can show the
+    # near-miss that DID exist (useful when title-sim is 0.79 — one
+    # point below the threshold).
+    candidate_scores: list = []
 
     for sf in staging_files:
         sf_title_variants = _staging_title_variants(sf['title'], normalize)
         sf_norm_artist = normalize(sf['artist'])
 
         if not sf_title_variants:
+            logger.debug(
+                "[Staging] Skip candidate %s — no usable title variants",
+                os.path.basename(sf.get('full_path', '?')),
+            )
             continue
 
         # Title similarity (primary)
@@ -201,6 +226,12 @@ def try_staging_match(task_id, batch_id, track, deps: StagingDeps):
             for candidate in sf_title_variants
         )
         if title_sim < 0.80:
+            logger.debug(
+                "[Staging] Skip candidate %s — title_sim=%.2f below 0.80 threshold (%s vs %s)",
+                os.path.basename(sf.get('full_path', '?')),
+                title_sim, norm_title, '|'.join(sf_title_variants[:3]),
+            )
+            candidate_scores.append((sf, title_sim, None, 0.0))
             continue
 
         # Artist similarity (secondary)
@@ -221,12 +252,37 @@ def try_staging_match(task_id, batch_id, track, deps: StagingDeps):
         else:
             combined = (title_sim * 0.80) + (artist_sim * 0.20)
 
+        candidate_scores.append((sf, title_sim, artist_sim, combined))
+
         if combined > best_score:
             best_score = combined
             best_match = sf
 
     # Require high confidence to avoid false positives
     if not best_match or best_score < 0.75:
+        # Log the rejection with the best near-miss so we can see why
+        # the staged files didn't claim this wishlist track. Pre-fix
+        # this returned False silently and the loop "download album,
+        # stage files, never claim them, re-add to wishlist" was
+        # impossible to debug from logs alone.
+        if candidate_scores:
+            near_miss = max(candidate_scores, key=lambda c: c[3])
+            sf, title_sim, artist_sim, combined = near_miss
+            logger.info(
+                "[Staging] No match for %s in batch %s — best candidate %s "
+                "(title_sim=%.2f, artist_sim=%s, combined=%.2f) below 0.75 threshold",
+                _track_label, batch_id or task_id,
+                os.path.basename(sf.get('full_path', '?')),
+                title_sim,
+                f"{artist_sim:.2f}" if artist_sim is not None else 'n/a',
+                combined,
+            )
+        else:
+            logger.info(
+                "[Staging] No match for %s in batch %s — %d staging files "
+                "but none had usable title variants",
+                _track_label, batch_id or task_id, len(staging_files),
+            )
         return False
 
     logger.info(f"[Staging] Match found for '{track_title}' by '{track_artist}': "

--- a/core/imports/context.py
+++ b/core/imports/context.py
@@ -418,8 +418,12 @@ def detect_album_info_web(context, artist_context=None):
             context,
             album_info={
                 "album_name": album_name,
-                "track_number": track_info.get("track_number", 1),
-                "disc_number": track_info.get("disc_number", 1),
+                # Preserve missing numbers as None so the import pipeline
+                # can fall through to ``extract_track_number_from_filename``
+                # at ``core/imports/pipeline.py:652`` instead of locking
+                # to track/disc 01 for every wishlist re-attempt.
+                "track_number": track_info.get("track_number"),
+                "disc_number": track_info.get("disc_number"),
                 "album_image_url": album_ctx.get("image_url", ""),
                 "confidence": 0.5,
             },

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -642,7 +642,15 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
             album_info=album_info,
             default=original_search.get('title', 'Unknown Track'),
         )
-        track_number = album_info.get('track_number', 1)
+        # Read with explicit None default — the upstream payload helpers
+        # (``core/wishlist/payloads.py``) now preserve missing track
+        # numbers as None instead of pre-filling 1. That lets the
+        # filename-extract fallback below actually fire on wishlist
+        # re-attempts whose source payload lost the position. Pre-fix,
+        # ``.get('track_number', 1)`` filled 1, the None-check below
+        # never matched, and every wishlist re-try imported as ``01 -``
+        # regardless of the source file's real track number.
+        track_number = album_info.get('track_number')
         logger.debug(
             "Final track_number processing: source=%s album_info_track_number=%s track_number=%s",
             album_info.get('source', 'unknown'),

--- a/core/wishlist/payloads.py
+++ b/core/wishlist/payloads.py
@@ -118,8 +118,15 @@ def ensure_wishlist_track_format(track_info):
         'artists': artists_list,
         'album': album,
         'duration_ms': track_info.get('duration_ms', 0),
-        'track_number': track_info.get('track_number', 1),
-        'disc_number': track_info.get('disc_number', 1),
+        # track/disc numbers preserved as-is (no default-to-1 fallback).
+        # Defaulting to 1 here poisons the downstream chain — the import
+        # pipeline at ``core/imports/pipeline.py:645`` only runs its
+        # ``extract_track_number_from_filename`` fallback when this
+        # value is None, so a pre-filled 1 would lock every wishlist
+        # re-attempt to track 01 regardless of source filename. Leave
+        # missing values explicit so the pipeline can detect-and-recover.
+        'track_number': track_info.get('track_number'),
+        'disc_number': track_info.get('disc_number'),
         'preview_url': track_info.get('preview_url'),
         'external_urls': track_info.get('external_urls', {}),
         'popularity': track_info.get('popularity', 0),
@@ -156,18 +163,33 @@ def build_cancelled_task_wishlist_payload(task, profile_id: int = 1):
 
     album_raw = track_info.get('album', {})
     if isinstance(album_raw, dict):
+        # Full-dict shape — copy as-is so release_date / id / total_tracks
+        # / artists survive the round-trip. Earlier this only ``setdefault``ed
+        # name/album_type/images, but ``dict(album_raw)`` already
+        # preserves every other key the source carries; the setdefaults
+        # only fill blanks. release_date in particular MUST survive so
+        # the import path-template renders the year in the folder name.
         album_data = dict(album_raw)
         album_data.setdefault('name', 'Unknown Album')
         album_data.setdefault('album_type', track_info.get('album_type', 'album'))
         if 'images' not in album_data and track_info.get('album_image_url'):
             album_data['images'] = [{'url': track_info.get('album_image_url')}]
     else:
+        # String-shape album — preserve every adjacent track_info field
+        # we know about so the constructed dict is still usable
+        # downstream. Pre-fix this only set name + album_type, dropping
+        # release_date / total_tracks / id even when the caller had them.
         album_data = {
             'name': str(album_raw) if album_raw else 'Unknown Album',
             'album_type': track_info.get('album_type', 'album'),
         }
         if track_info.get('album_image_url'):
             album_data['images'] = [{'url': track_info.get('album_image_url')}]
+        if track_info.get('album_release_date') or track_info.get('release_date'):
+            album_data['release_date'] = (
+                track_info.get('album_release_date')
+                or track_info.get('release_date')
+            )
 
     track_data = {
         'id': track_info.get('id'),
@@ -175,6 +197,13 @@ def build_cancelled_task_wishlist_payload(task, profile_id: int = 1):
         'artists': formatted_artists,
         'album': album_data,
         'duration_ms': track_info.get('duration_ms'),
+        # Preserve track / disc position so a cancellation→re-add doesn't
+        # lock the next attempt to track 01. ``None`` is intentional —
+        # downstream ``core/imports/pipeline.py:645`` reads None as
+        # "extract from filename instead", which is what we want when
+        # the position genuinely isn't known.
+        'track_number': track_info.get('track_number'),
+        'disc_number': track_info.get('disc_number'),
     }
 
     source_context = {
@@ -279,8 +308,11 @@ def track_object_to_dict(track_object) -> Dict[str, Any]:
             "preview_url": getattr(track_object, "preview_url", None),
             "external_urls": getattr(track_object, "external_urls", {}),
             "popularity": getattr(track_object, "popularity", 0),
-            "track_number": getattr(track_object, "track_number", 1),
-            "disc_number": getattr(track_object, "disc_number", 1),
+            # See ``ensure_wishlist_track_format`` — preserve missing
+            # values as None so the import pipeline's filename fallback
+            # can fire instead of locking to track/disc 01.
+            "track_number": getattr(track_object, "track_number", None),
+            "disc_number": getattr(track_object, "disc_number", None),
         }
 
         logger.debug(

--- a/tests/wishlist/test_payloads.py
+++ b/tests/wishlist/test_payloads.py
@@ -106,6 +106,92 @@ def test_extract_spotify_track_from_modal_info_reconstructs_from_slskd_result():
     assert out["album"]["name"] == "Album Three"
 
 
+# ---------------------------------------------------------------------------
+# track_number / disc_number preservation through the wishlist payload
+# helpers — pins the bug A fix from PR 2/4. Pre-fix the helpers
+# defaulted missing numbers to 1, which locked every wishlist retry
+# to track 01 because the import pipeline's filename-extract fallback
+# only fires when the value is None (not the pre-filled 1).
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_wishlist_track_format_preserves_real_track_number():
+    """Real track positions must survive the format helper. Pre-fix
+    the helper read ``track_info.get('track_number', 1)`` which always
+    returned 1 if the upstream payload had dropped the key — the
+    desired number was lost on every round-trip."""
+    track = {
+        "name": "No Sleep Till Brooklyn",
+        "artist": "Beastie Boys",
+        "album": {"name": "Licensed to Ill", "release_date": "1986-11-15"},
+        "track_number": 8,
+        "disc_number": 1,
+    }
+    out = payloads.ensure_wishlist_track_format(track)
+    assert out["track_number"] == 8
+    assert out["disc_number"] == 1
+
+
+def test_ensure_wishlist_track_format_keeps_missing_track_number_as_none():
+    """When the upstream payload doesn't carry a track number, the
+    helper must NOT pre-fill 1 — that poisons the chain and locks the
+    file to track 01. Leave None so the import pipeline's filename
+    fallback at ``core/imports/pipeline.py:652`` can fire."""
+    track = {
+        "name": "Mystery Track",
+        "artist": "Artist",
+        "album": {"name": "Album"},
+    }
+    out = payloads.ensure_wishlist_track_format(track)
+    assert out["track_number"] is None
+    assert out["disc_number"] is None
+
+
+def test_build_cancelled_task_wishlist_payload_preserves_track_number():
+    """Cancellation→re-add path was the worst offender — the payload
+    builder dropped track_number from the saved data entirely (didn't
+    even include the key). Next wishlist cycle saw missing key →
+    helper defaulted to 1 → file imported as 01. Now both the
+    cancellation payload AND the helper preserve real positions."""
+    task = {
+        "track_info": {
+            "id": "trk-1", "name": "Brass Monkey",
+            "artists": [{"name": "Beastie Boys"}],
+            "album": {"name": "Licensed to Ill", "release_date": "1986-11-15"},
+            "track_number": 11,
+            "disc_number": 1,
+        },
+        "playlist_name": "Wishlist",
+        "playlist_id": "p1",
+    }
+    out = payloads.build_cancelled_task_wishlist_payload(task)
+    td = out["track_data"]
+    assert td["track_number"] == 11
+    assert td["disc_number"] == 1
+    # Album release_date survives the round-trip so the path template
+    # renders the year in the folder name.
+    assert td["album"]["release_date"] == "1986-11-15"
+
+
+def test_build_cancelled_task_wishlist_payload_string_album_pulls_release_date_from_track_info():
+    """When the source ``album`` field is a bare string, the payload
+    builder constructs an album dict from scratch — it must pull
+    release_date / album_image_url / etc. from the adjacent
+    track_info fields rather than dropping them silently."""
+    task = {
+        "track_info": {
+            "id": "trk-2", "name": "Song",
+            "artists": [{"name": "Artist"}],
+            "album": "Bare String Album",
+            "release_date": "2020-06-01",
+        },
+    }
+    out = payloads.build_cancelled_task_wishlist_payload(task)
+    album = out["track_data"]["album"]
+    assert album["name"] == "Bare String Album"
+    assert album["release_date"] == "2020-06-01"
+
+
 def test_ensure_wishlist_track_format_defaults_non_dict_album_to_album_type():
     """When ``album`` arrives as a non-dict (legacy/reconstruction path) we
     must not stamp ``album_type='single'`` — that lies about the origin


### PR DESCRIPTION
# Wishlist post-process: preserve track_number + release_date, instrument staging-match (PR 2 of 4)

Follow-up to PR 1 (#716) which bumped the album-bundle threshold to 2 so single-track wishlist items take the per-track path. PR 2 fixes two post-process bugs that affect BOTH paths (per-track and album-bundle) and instruments the staging-match path so the third bug — silent rejection of album-bundle staged files — can be diagnosed from logs on the user's next reproduction.

## Background

Real-world wishlist of 26 single-track items from 26 different albums was producing three observable bugs:

1. **All imported files numbered `01 - <title>`** regardless of source position (e.g. `08. No Sleep Till Brooklyn.flac` → imported as `01 - No Sleep Till Brooklyn`).
2. **Year missing from folder path** for most imports (only 2 of 7 had year — `sombr - 2024 back to friends` and `Alice Deejay - 2022 Better Off Alone`, the other 5 didn't).
3. **Album-bundle staging-match silently dropping requested wishlist tracks** → infinite re-download loop where the same album is fetched every cycle but its files never claimed.

PR 1 already addressed the worst case (single-track wishlist items now bypass album-bundle entirely). PR 2 fixes the underlying causes of bugs 1+2 and instruments bug 3 for follow-up.

## What changed

### Commit `94ba1d73` — instrument staging-match path

`core/downloads/staging.py:try_staging_match` had three silent `return False` exit points: empty staging cache, empty track title, or no candidate scoring ≥ 0.75. None logged anything when they fired, so the user's repro loop (download album → stage files → never claim them → re-add wishlist track) was impossible to debug from app.log alone.

Now every failure exit logs at INFO with enough context to grep:

```
[Staging] No match attempted for 'X' by 'Y' — staging cache empty for batch <id>
[Staging] No match attempted for task <id> — track has empty title
[Staging] No match for 'X' by 'Y' in batch <id> — best candidate <file> (title_sim=0.74, artist_sim=0.91, combined=0.81) below 0.75 threshold
[Staging] No match for 'X' by 'Y' in batch <id> — N staging files but none had usable title variants
```

Per-candidate skips (`title_sim < 0.80`, no usable variants) log at DEBUG so the noise stays out of INFO unless the user explicitly enables it.

Zero behavior change — pure logging. Sets up the follow-up PR that fixes bug 3 once we have real evidence of WHERE the rejection happens.

### Commit `66d70292` — preserve track_number + release_date end-to-end

**Bug A — `track_number` always 1**

Pre-fix: `.get('track_number', 1)` defaults at four sites poisoned the chain:

| File:line | Context |
|---|---|
| `core/wishlist/payloads.py:121` | `ensure_wishlist_track_format` |
| `core/wishlist/payloads.py:282` | Track-object conversion |
| `core/imports/context.py:421` | Legacy album-info builder |
| `core/imports/pipeline.py:645` | Final processing read |

Each step "filled in" 1 when upstream dropped the key. The downstream filename-extract fallback at `pipeline.py:652` ONLY runs when the value is `None` — pre-filled `1` never matched, so the fallback never fired, so source filename's track number (e.g. `08. No Sleep Till Brooklyn.flac`) was discarded.

Fix: every default changed from `1` to `None` along the chain. Pipeline already has the right detect-and-recover logic — needs the chain to stop poisoning it. Final `< 1` floor at `pipeline.py:660` still defaults to 1 as last resort, so callers that genuinely have nothing still produce a valid number.

**Bug B — `release_date` dropped from cancelled-task payload**

`build_cancelled_task_wishlist_payload` had two album-shape branches:
- **Dict shape**: `dict(album_raw)` copy preserved release_date naturally (load-bearing — a future refactor switching to stricter copy would silently strip it).
- **String shape**: constructed dict had only `name` + `album_type`. No release_date, no total_tracks, no id.

Plus `track_data` itself didn't surface `track_number` / `disc_number` at the top level.

Fix:
- Dict-shape branch gets explicit comment naming the load-bearing copy semantic so future refactors don't break it.
- String-shape branch now pulls `release_date` from `track_info.album_release_date` or `track_info.release_date` when present.
- `track_data` top-level now carries `track_number` + `disc_number` (preserved as `None` if absent, per Bug A's contract).

## Test plan

Code:
- [x] `python -m pytest tests/wishlist/test_payloads.py` — 14 pass (4 new)
- [x] `python -m pytest tests/wishlist/ tests/imports/ tests/downloads/ tests/metadata/` — 1410 pass
- [x] `python -m ruff check core/wishlist/ core/imports/ core/downloads/ tests/wishlist/` — clean
- [x] `python -m pytest tests/downloads/test_downloads_staging.py tests/test_staging_album_provenance.py` — 24 pass (instrumentation doesn't change behavior)

New tests:
- `test_ensure_wishlist_track_format_preserves_real_track_number` — 8 stays 8
- `test_ensure_wishlist_track_format_keeps_missing_track_number_as_none` — missing key produces None, not 1
- `test_build_cancelled_task_wishlist_payload_preserves_track_number` — cancellation→re-add preserves position AND release_date
- `test_build_cancelled_task_wishlist_payload_string_album_pulls_release_date_from_track_info` — string-album branch pulls release_date from adjacent track_info fields

Manual smoke (needed before merge — instrumented commit lights up after one full wishlist cycle):
- [ ] Run auto-wishlist with multi-track-per-album items (test bug A fix end-to-end: import paths should show real track number, not 01)
- [ ] Confirm folder paths render `Artist - YYYY Album` for tracks where Spotify has release_date (test bug B fix)
- [ ] Grep `[Staging]` in app.log after the run to see the new rejection logs — those tell us where bug C lives (low score? empty cache? no title variants?) so the follow-up PR can fix it with evidence.

## Known limits

- **Bug C (staging-match silent drop) NOT fixed in this PR.** Instrumentation lands so the next reproduction generates evidence. Follow-up PR after user's next run.
- **PR 1's threshold bump already sidesteps both A+B for the typical single-track wishlist case** — those items now take the per-track path which already had correct track_number / release_date handling. PR 2's fixes matter for the genuine multi-track-per-album case AND for any per-track flow whose payload had been through a cancellation round-trip.
- **The `< 1` floor at `pipeline.py:660` still exists** as a safety net. If both the wishlist payload AND the source filename lack a track number, we still default to 1 as the last-resort floor. That's correct behavior — better a default than a crash — but means there's still a class of inputs (truly metadata-less + truly unparseable filenames) that imports as 01.

## Files changed

```
core/downloads/staging.py            | +59 / -3   (instrumentation)
core/wishlist/payloads.py            | +30 / -3   (track_number + release_date preservation)
core/imports/context.py              | +5 / -2    (default chain fix)
core/imports/pipeline.py             | +7 / -1    (default chain fix + comment)
tests/wishlist/test_payloads.py      | +97 / 0    (4 new tests)
```

## Sibling PRs queued (TaskCreate)

- **PR 2.5** — bug C staging-match drop fix, after evidence from this PR's instrumentation lands
- **PR 3** — sibling-completion gate firing on first sibling instead of last (log evidence: run a4945c88 finalized 1/26 batches)
- **PR 4** — UI distinguish "Queued" from "Analyzing" for batches waiting on `missing_download_executor` (max_workers=3)

## Closes / refs

- Builds on PR #716 (`fix/wishlist-album-bundle-threshold`)
- Root cause analysis driven by app.log from 2026-05-27 (run id `a4945c88` + sibling runs `ae8b50bc`, `d067c36a`)
- Real-world repro: 26 wishlist tracks → only 7 imports landed in `H:\Test`, all as `01 - <title>`, 5 of 7 missing year
