### PR TITLE
perf(webui): fix scroll-container raster jank + make the UI usable with password-manager extensions

### DIFF
--- a/webui/static/api-monitor.js
+++ b/webui/static/api-monitor.js
@@ -65,6 +65,14 @@ function _handleRateMonitorUpdate(data) {
     const grid = document.getElementById('rate-monitor-grid');
     if (!grid) return;
 
+    // Skip DOM writes while the equalizer is off-screen (you're on another page).
+    // All pages stay mounted, so updating a hidden grid still fires every
+    // MutationObserver on the document — including password-manager extensions
+    // that re-scan the WHOLE DOM on each mutation — for zero visible benefit.
+    // offsetParent is null when an ancestor is display:none. The next update that
+    // arrives while the dashboard is visible renders normally.
+    if (grid.offsetParent === null) return;
+
     // The dashboard rate monitor uses the equalizer-bar visual — a
     // vertical-bar VU-meter row that fits any service count without
     // an orphan grid cell. Detail page / mobile breakpoints keep the

--- a/webui/static/pages-extra.js
+++ b/webui/static/pages-extra.js
@@ -1066,18 +1066,24 @@ function explorerFitToView() {
     });
 }
 
-// Scroll wheel zoom (no modifier needed inside viewport)
-document.addEventListener('wheel', (e) => {
+// Scroll wheel zoom (no modifier needed inside viewport).
+// IMPORTANT: attach to the viewport element, NOT document. A non-passive wheel
+// listener on document disables the browser's compositor (async) scrolling for
+// the ENTIRE app — every wheel/trackpad scroll then runs through the main thread.
+// Scoping it to the viewport keeps zoom working while the rest of the app keeps
+// smooth compositor scrolling.
+(function attachExplorerWheelZoom() {
     const viewport = document.getElementById('explorer-viewport');
-    if (!viewport || !viewport.contains(e.target)) return;
-    // Check if we're on the explorer page
-    const page = document.getElementById('playlist-explorer-page');
-    if (!page || !page.classList.contains('active')) return;
+    if (!viewport) return;
+    viewport.addEventListener('wheel', (e) => {
+        const page = document.getElementById('playlist-explorer-page');
+        if (!page || !page.classList.contains('active')) return;
 
-    e.preventDefault();
-    const step = e.deltaY > 0 ? -0.08 : 0.08;
-    explorerZoom(step);
-}, { passive: false });
+        e.preventDefault();
+        const step = e.deltaY > 0 ? -0.08 : 0.08;
+        explorerZoom(step);
+    }, { passive: false });
+})();
 
 // Middle-click / right-click drag to pan
 document.addEventListener('mousedown', (e) => {

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -143,6 +143,25 @@ function handleMetadataSourceChange(event) {
 }
 
 let _settingsInitialized = false;
+// Tell password-manager extensions (Bitwarden / 1Password / LastPass) to ignore
+// this app's credential inputs. The settings page is full of API-key / token /
+// secret fields; password managers treat them as login forms and re-scan the
+// whole (large, constantly-mutating) DOM on every change, which can peg the main
+// thread for seconds. These attributes make them skip the fields entirely.
+function _markCredentialFieldsNoAutofill(root) {
+    const scope = root || document;
+    scope.querySelectorAll('input, textarea').forEach((el) => {
+        if (el.dataset.bwignore !== undefined) return; // already tagged
+        el.setAttribute('data-bwignore', '');          // Bitwarden
+        el.setAttribute('data-1p-ignore', '');         // 1Password
+        el.setAttribute('data-lpignore', 'true');      // LastPass
+        if (!el.getAttribute('autocomplete')) el.setAttribute('autocomplete', 'off');
+    });
+}
+// Run once on load (inputs exist from page load — all pages are mounted).
+if (document.readyState !== 'loading') _markCredentialFieldsNoAutofill();
+else document.addEventListener('DOMContentLoaded', () => _markCredentialFieldsNoAutofill());
+
 function initializeSettings() {
     // This function is called when the settings page is loaded.
     // It attaches event listeners to all interactive elements on the page.
@@ -150,6 +169,9 @@ function initializeSettings() {
     // re-scanning the ~960-node settings subtree on every revisit (scroll jank).
     if (_settingsInitialized) return;
     _settingsInitialized = true;
+
+    // Re-tag in case any inputs were added dynamically since page load.
+    _markCredentialFieldsNoAutofill(document.getElementById('settings-page'));
 
     // Accent color listeners (live preview + custom picker toggle)
     initAccentColorListeners();

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -2970,11 +2970,13 @@ body.helper-mode-active #dashboard-activity-feed:hover {
 
 .main-content {
     flex: 1;
-    /* Opaque dark background (GPU-optimized: no backdrop-filter needed on solid dark body) */
-    background: linear-gradient(135deg,
-            rgba(10, 10, 10, 1) 0%,
-            rgba(15, 15, 15, 1) 50%,
-            rgba(11, 11, 11, 1) 100%);
+    /* Flat solid background — NOT a gradient. A gradient on the scroll container
+       has to be re-rastered across the whole scrolled area on every scroll frame
+       (the compositor can't just translate a cached tile), which caused the
+       dominant scroll jank (~25% dropped frames -> <1% once flattened, measured).
+       A solid color is drawn as a single compositor quad, no per-frame raster.
+       The gradient was rgb 10->15->11, visually indistinguishable from this. */
+    background: rgb(12, 12, 12);
     overflow: auto;
     position: relative;
 }


### PR DESCRIPTION
  Two independent web-UI performance fixes.

  ## 1. Scroll-container raster jank
  
  `.main-content` (the main page scroller) had a `linear-gradient` background. A
  gradient painted on a scrolling container can't be cached as a single compositor
  tile, so the browser re-rasters it across the whole scrolled area **on every
  scroll frame**.
  
  Measured with headless Chromium + a CDP trace while wheel-scrolling Settings:
  - `RasterTask` ≈ **675 ms** per scroll burst, vs Layout ~3.6 ms / Paint ~7.6 ms.
  - ~**25 % of frames dropped** (>32 ms), p90 frame time **33.3 ms** (every-other-vsync stutter).

  Flattening the gradient to the equivalent solid colour (`rgb(12,12,12)` — the
  gradient was `rgb 10→15→11`, visually identical) makes the background a single
  compositor quad:
  - Dropped frames **25 % → <1 %**, p90 **33.3 ms → 16.7 ms** (solid 60 fps), on every page.

  (Layer-promoting the scroller instead — `will-change`/`translateZ` — isn't viable:
  `.main-content` contains 9 `position:fixed` overlays that must stay viewport-anchored.)

  Also scoped the playlist-explorer wheel-zoom listener to its viewport element
  instead of `document`: a non-passive `wheel` listener on `document` disables the
  compositor's async scrolling app-wide, routing every wheel/trackpad scroll
  through the main thread.
  
  ## 2. Password-manager extensions make the UI nearly unusable
  
  The bigger find. With **Bitwarden** enabled, the Settings page (and the whole app)
  was borderline unusable — hover highlights, clicks and scrolling all lagged by
  hundreds of ms. A DevTools Performance recording (~13 s, just hovering/idle)
  showed where the main thread actually went:

  **Before (Bitwarden enabled, no mitigation):**

  | Source | Main-thread time |
  |---|---|
  | **Bitwarden Password Manager (extension)** | **12,670.4 ms** |
  | [unattributed] | 1,193.2 ms |
  | **127.0.0.1 (the app itself)** | **10.2 ms** |
  | Plasma Integration (extension) | 2.4 ms |
  
  Within this ~13 s recording the app's own code used **10 ms** while Bitwarden
  used **12,670 ms** (~975 ms/s — effectively saturating the main thread for the
  entire recording). A `longtask` logger confirmed this: continuous **300–960 ms
  tasks, back-to-back**, the whole time. Every hover, click and scroll event had to
  wait behind them.

  ### Why   
  Password managers inject a content script that scans the DOM for credential fields
  and attaches a `MutationObserver` to re-scan on every DOM change. This app is a
  worst case for that:
  - Settings is full of credential inputs (API keys / tokens / secrets — 260+ inputs).
  - **All 16 pages stay mounted in the DOM** at once (huge tree).
  - The DOM **mutates constantly** (Socket.IO status pushes, pollers, the rate-monitor equalizer).

  So every mutation → a full re-scan of a giant DOM full of "login fields" → main
  thread pegged → input/hover/scroll events queue behind it.

  ### Note
  In hindsight, #783 (faster navigation, smoother scroll) was already chipping away
  at the same underlying problem — scroll/nav perf on this heavy, constantly-mutating,
  all-pages-mounted DOM — without realising the dominant *amplifier* was the browser
  extension, not the app code. The scroll-gradient fix above is the same story: a real
  app-side win that was previously invisible because an extension was saturating the
  main thread.

  ### Mitigations
  - Tag all inputs with `data-bwignore` / `data-1p-ignore` / `data-lpignore`
    (+ `autocomplete=off`) so the managers skip them — drastically less per-scan work.
  - Rate-monitor equalizer: skip DOM writes while it's off-screen (`offsetParent === null`).
    It updates on every backend `rate-monitor:update`; with all pages mounted it was
    mutating the hidden grid (and re-triggering the managers' observer) even on other
    pages, for zero visible benefit.

  **After (same scenario, mitigation applied — shorter spot-check recording):**

  | Source | Main-thread time |
  |---|---|
  | **Bitwarden Password Manager (extension)** | **442.9 ms** |
  | [unattributed] | 786.0 ms |
  | **127.0.0.1 (the app itself)** | **8.4 ms** |
  | Plasma Integration (extension) | — |

  > Note: the two recordings are of **different lengths** (before: ~13 s to capture
  > the full effect; after: a shorter spot-check), so direct ms-to-ms comparison is
  > not meaningful. The duration-robust signal is the **within-recording ratio**: in
  > both runs the app itself costs ~8–10 ms total. In the before recording Bitwarden
  > consumed ~12,670 ms and saturated the main thread for virtually the entire
  > session (~975 ms/s). In the after recording Bitwarden is no longer the dominant
  > cost. That qualitative shift — from "extension owns the main thread" to "extension
  > is a minor contributor" — is the actual result.

  ### Caveats
  - The extension numbers are environment-specific (only with a password-manager
    extension + a configured instance with live data). On a clean profile the app is
    already smooth.
  - This doesn't fully eliminate the extension's cost (its `MutationObserver` still
    fires); it removes the credential-matching work and the biggest needless mutation
    source. A fuller fix would be to stop mounting all 16 pages at once (smaller DOM)
    and/or batch the live DOM updates.