### PR TITLE
fix: treat colon as separator in normalize_string so T:T matches T_T

### DIFF
--- a/core/matching_engine.py
+++ b/core/matching_engine.py
@@ -115,7 +115,8 @@ class MusicMatchingEngine:
         # Replace common separators with spaces to preserve word boundaries.
         # Include hyphen in separator replacement for artist names like "AC/DC" vs "AC-DC"
         # Include '&' so "Pig&Dan" becomes "Pig Dan" (matches "Pig & Dan" on Soulseek)
-        text = re.sub(r'[._/&-]', ' ', text)
+        # Include ':' so "T:T" becomes "T T" (matches "T_T" stored with underscores on Soulseek)
+        text = re.sub(r'[._/&:\-]', ' ', text)
 
         # Keep alphanumeric characters, spaces, AND the '$' sign.
         # When CJK was detected upstream, also preserve CJK Unified


### PR DESCRIPTION
## Problem

Tracks with `:` in their title (e.g. `You See Big Girl / T:T`) failed to download 
even when candidates were found on Soulseek. The search returned 10 results but all 
were rejected by the candidate matcher.

**Root cause:** In `normalize_string()` (`core/matching_engine.py`), the colon `:` 
was stripped entirely rather than replaced with a space. This caused `T:T` to normalize 
to `tt` (one token), while the Soulseek filename `T_T` normalized to `t t` (two tokens) 
— low similarity score, all candidates rejected.

## Fix

Added `:` to the separator regex on line 118:

Before: `re.sub(r'[._/&-]', ' ', text)`  
After:  `re.sub(r'[._/&:\-]', ' ', text)`

## Tested

- `You See Big Girl / T:T` by Sawano Hiroyuki — successfully downloaded ✅

## Notes

`core/matching/audio_verification.py` already handles `:` correctly in its own 
`normalize()` function, but that is only used for post-download AcoustID verification. 
The candidate matching before the download uses `matching_engine.normalize_string()` — 
which is what this PR fixes.