### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.8.0)'
+        description: 'Version tag (e.g. 2.8.1)'
         required: true
-        default: '2.8.0'
+        default: '2.8.1'
 
 jobs:
   build-and-push:

--- a/Modelfile
+++ b/Modelfile
@@ -1,0 +1,2 @@
+FROM qwen2.5-coder:7b
+PARAMETER num_ctx 16384

--- a/Modelfile
+++ b/Modelfile
@@ -1,2 +1,0 @@
-FROM qwen2.5-coder:7b
-PARAMETER num_ctx 16384

--- a/RELEASE_2.8.0_discord.md
+++ b/RELEASE_2.8.0_discord.md
@@ -1,0 +1,13 @@
+**SoulSync 2.8.0** is out 🎉 a quality + reliability release.
+
+🧹 **The Unverified queue, finally under control** — if you saw thousands of "unverified" rows piling up, this is for you. the AcoustID scan stops duplicating history rows, a one-time reconcile on startup clears the existing backlog from your library (no re-scan), and a new 🧹 *Clean orphaned* button sweeps dead rows whose file is gone. (#934 — thanks @nick2000713 for #938)
+
+✂️ **Preview Clip Cleanup** — a new Tools job that finds the ~30s preview clips the HiFi source sometimes hands back instead of the full song, then deletes them and re-wishlists the real version. each finding has a ▶ Play button so you can confirm before approving.
+
+💿 **Album Completeness handles split albums** — an album split across multiple library rows no longer shows every fragment as falsely "incomplete"; it groups the validated fragments into one correct finding. (#936 — thanks @ragnarlotus)
+
+🐛 **Fixes** — pasted YouTube cookies no longer throw `unsupported browser: "custom"` on Docker (thanks HellRa1SeR); longer remasters aren't quarantined as "truncated" anymore (#937, thanks @diegocade1); "Add to Wishlist" from a discography went from ~15–30s *per track* to instant; wishlist art renders for re-downloads; and **Clear Completed** is back on the Downloads page.
+
+⚡ **Performance** — trimmed the dashboard GPU usage that was hammering Firefox/Zen (and Background Particles are OFF by default now), plus bounded the runaway memory growth that could lock the app up on big libraries. (#935 / #802)
+
+enjoy! 🎶

--- a/RELEASE_2.8.1_discord.md
+++ b/RELEASE_2.8.1_discord.md
@@ -1,0 +1,15 @@
+**SoulSync 2.8.1** is out 🎉 a feature + reliability release.
+
+🎧 **Export playlists to Spotify & Deezer** — the mirrored-playlist export now has **Sync to Spotify** and **Sync to Deezer** right next to the ListenBrainz / JSPF options. it builds a playlist in your account from the track IDs soulsync already has — the discovery cache first, then your library — so an already-discovered playlist exports **instantly with zero API calls**. re-exporting updates the same playlist instead of duplicating it, and an optional *"match missing tracks"* toggle confidently searches for the stragglers (a wrong-artist or karaoke version is left out, never guessed in). spotify needs a one-time reconnect for write access. (#945)
+
+🏷️ **Library Reorganize — Rename only** — a lighter reorganize action that just **renames your files** to your current naming scheme: no re-tagging, no quality/AcoustID re-check, no copy-to-staging. much faster on a NAS, and only touches files whose path actually changes (which also fixes the "2 of 14 previewed but everything got modified" album-splitting). pick it from the new Action dropdown. (#875 — thanks @tsoulard / @Tacobell444)
+
+💿 **Broader lossless handling** — lossy-copy now works for **all lossless formats**, not just FLAC (#941); and **DSD** (`.dsf`/`.dff`) is recognized as lossless instead of being false-flagged as "truncated" (#939).
+
+🐛 **Download + search fixes** — an unbalanced bracket in a filename no longer false-fails as "file not found"; a file we couldn't quarantine is left for retry instead of deleted; "file not found" errors are actionable now; pasted Qobuz/Tidal links inject the exact track into manual search (#932); and the Wing It pool "Fix Match" search works again.
+
+⚡ **Reduce visual effects, refined** — it no longer freezes functional motion (spinners, progress) and only kills the expensive GPU stuff (blur, shadows, glow). worker orbs default OFF on Firefox for new users and run at ~30fps under reduce-effects. plus jellyfin scans page the bulk fetch so the watchdog can't false-stall a big library.
+
+🔧 **Under the hood** — settings page cleanup (#943, thanks @nick2000713), spotify oauth hardening (#942, thanks HellRa1SeR), and npm audit security fixes for vite / undici / @babel (#944, thanks HellRa1SeR).
+
+enjoy! 🎶

--- a/core/deezer_download_client.py
+++ b/core/deezer_download_client.py
@@ -233,6 +233,55 @@ class DeezerDownloadClient(DownloadSourcePlugin):
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, self.is_available)
 
+    # ─── Playlist export (#945) ──────────────────────────────────
+    #
+    # UNOFFICIAL: rides the private gw-light gateway with the ARL session already used
+    # for downloads. Deezer shut their public developer API, so this is the only write
+    # path — and it's fragile by nature (breaks when Deezer changes internals).
+
+    def create_or_update_playlist(self, name, track_ids, *, existing_id=None,
+                                  public=False, description=""):
+        """Create a Deezer playlist (or append to an existing one) from a mirrored
+        playlist's tracks. ``track_ids`` are stored ``deezer_id`` values per library track.
+        ``existing_id`` set → add to that playlist (idempotent re-export reuses the stored
+        target); unset → create a new one. Returns
+        ``{success, playlist_id, url, added, error}``."""
+        if not self._authenticated:
+            return {"success": False, "error": "Deezer is not connected (ARL)"}
+        song_ids = [str(t) for t in (track_ids or []) if t]
+        if not song_ids:
+            return {"success": False, "error": "No matching Deezer tracks to export"}
+        try:
+            songs = [[sid, i] for i, sid in enumerate(song_ids)]
+            if existing_id:
+                res = self._gw_call("playlist.addSongs",
+                                    {"playlist_id": int(existing_id), "songs": songs})
+                if res is None:
+                    return {"success": False, "error": "Deezer rejected the playlist update"}
+                playlist_id = existing_id
+            else:
+                res = self._gw_call("playlist.create", {
+                    "title": name, "description": description,
+                    "is_public": bool(public), "songs": songs,
+                })
+                if res is None:
+                    return {"success": False, "error": "Deezer rejected the playlist create"}
+                # gw 'playlist.create' returns the new playlist id (int) as `results`.
+                if isinstance(res, dict):
+                    playlist_id = res.get("PLAYLIST_ID") or res.get("id")
+                else:
+                    playlist_id = res
+                if not playlist_id:
+                    return {"success": False, "error": "Deezer did not return a playlist id"}
+            return {
+                "success": True,
+                "playlist_id": str(playlist_id),
+                "url": f"https://www.deezer.com/playlist/{playlist_id}",
+                "added": len(song_ids),
+            }
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
     def reconnect(self, arl: str = None) -> bool:
         """Re-authenticate with a new or existing ARL."""
         if arl is None:

--- a/core/downloads/file_finder.py
+++ b/core/downloads/file_finder.py
@@ -77,7 +77,16 @@ def _normalize_for_finding(text: str) -> str:
         return ""
     text = unidecode(text).lower()
     text = re.sub(r'[._/]', ' ', text)
-    text = re.sub(r'[\[\(].*?[\]\)]', '', text)
+    # Strip ONLY balanced bracket pairs (tags like "[FLAC]", "(Remastered 2016)").
+    # The old combined pattern r'[\[\(].*?[\]\)]' allowed MISMATCHED delimiters, so a
+    # lone unbalanced '[' — slskd reports "[34 - You & Me (Flume Remix)" but saves the
+    # file as "34 - You & Me (Flume Remix)" — matched from that '[' all the way to the
+    # next ')', eating the entire title and collapsing the search target to "flac". The
+    # file then scored 0.40 against the real on-disk name and was reported "not found"
+    # despite sitting right there. Per-delimiter pairs can't over-consume; a stray
+    # unbalanced bracket simply survives to the alphanumeric strip below.
+    text = re.sub(r'\[[^\]]*\]', '', text)
+    text = re.sub(r'\([^)]*\)', '', text)
     text = re.sub(r'[^a-z0-9\s-]', '', text)
     return ' '.join(text.split()).strip()
 

--- a/core/downloads/post_processing.py
+++ b/core/downloads/post_processing.py
@@ -453,7 +453,19 @@ def run_post_processing_worker(task_id: str, batch_id: str, deps: PostProcessDep
                         logger.error(f"[Post-Processing] Task {task_id} was completed by stream processor - not marking as failed")
                         return
                     download_tasks[task_id]['status'] = 'failed'
-                    download_tasks[task_id]['error_message'] = f'File not found on disk after {_file_search_max_retries} search attempts. Expected: {os.path.basename(task_filename)}'
+                    # slskd reported the transfer complete, but the finder never located
+                    # the file under the configured download folder. Name the folder we
+                    # searched and the two real causes — "still being written" (timing)
+                    # or "SoulSync's download path doesn't match slskd's" (the classic
+                    # standalone config mismatch) — so the user can self-diagnose instead
+                    # of getting an opaque "not found". (Discord: Shdjfgatdif.)
+                    _searched_name = os.path.basename((task_filename or '').replace('\\', '/')) or task_filename
+                    download_tasks[task_id]['error_message'] = (
+                        f"slskd reported '{_searched_name}' downloaded, but it never appeared "
+                        f"under the download folder ({download_dir}) after {_file_search_max_retries} "
+                        f"checks. Either it's still being written, or SoulSync's download path "
+                        f"doesn't match slskd's download directory — they must point at the same folder."
+                    )
             deps.on_download_completed(batch_id, task_id, False)
             return
 

--- a/core/downloads/track_link.py
+++ b/core/downloads/track_link.py
@@ -38,6 +38,23 @@ def bubble_linked_track_first(tracks: List[Any], link_track_id: str) -> List[Any
     target = str(link_track_id)
     return sorted(tracks, key=lambda t: linked_track_id(t) != target)
 
+
+def inject_linked_track_first(
+    tracks: List[Any], linked_result: Any, link_track_id: str
+) -> List[Any]:
+    """Put the EXACT linked track first.
+
+    When ``linked_result`` is the track fetched directly by id, prepend it and
+    drop any search duplicate of it — so an obscure track a text search never
+    surfaced is still present and downloadable (#932). When it's None (the source
+    can't fetch one), fall back to bubbling a matching search result. Pure."""
+    if not link_track_id:
+        return tracks
+    target = str(link_track_id)
+    if linked_result is not None:
+        return [linked_result] + [t for t in tracks if linked_track_id(t) != target]
+    return bubble_linked_track_first(tracks, target)
+
 # host substring → download source id. Only ID-downloadable streaming sources.
 _HOSTS = (
     ('tidal.com', 'tidal'),

--- a/core/exports/export_sources.py
+++ b/core/exports/export_sources.py
@@ -162,21 +162,25 @@ def resolve_service_track_ids(
     service: str,
     *,
     db_fn: Optional[Callable[[str, str, str], Optional[str]]] = None,
+    search_id_fn: Optional[Callable[[str, str], Optional[str]]] = None,
     on_progress: Optional[Callable[[int, int, Dict[str, Any]], None]] = None,
 ) -> Dict[str, Any]:
     """Resolve a mirrored playlist's tracks to target-service track IDs for export.
 
     Waterfall per track: the discovery cache (``extra_data`` — free + already confidently
-    matched) → the library track's stored service id. A track with neither is reported
-    unmatched (caller skips it — never a guessed/wrong id). Returns
-    ``{"resolved": [{artist, title, album, service_track_id}], "stats": {...}}`` with
-    ``from_cache`` / ``from_library`` / ``unmatched`` tallies for the status display.
+    matched) → the library track's stored service id → (only when ``search_id_fn`` is
+    given, i.e. the opt-in backfill toggle) a confident live-search match. A track that
+    clears none of these is reported unmatched (caller skips it — never a guessed/wrong
+    id). Returns ``{"resolved": [{artist, title, album, service_track_id}], "stats":
+    {...}}`` with ``from_cache`` / ``from_library`` / ``from_search`` / ``unmatched``
+    tallies for the status display.
     """
     db_fn = db_fn or db_service_track_id
     total = len(tracks or [])
     resolved: List[Dict[str, Any]] = []
     stats: Dict[str, Any] = {
-        "total": total, "resolved": 0, "unmatched": 0, "from_cache": 0, "from_library": 0,
+        "total": total, "resolved": 0, "unmatched": 0,
+        "from_cache": 0, "from_library": 0, "from_search": 0,
     }
     for i, t in enumerate(tracks or []):
         if not isinstance(t, dict):
@@ -192,6 +196,10 @@ def resolve_service_track_ids(
             tid = db_fn(artist, title, service)
             if tid:
                 stats["from_library"] += 1
+            elif search_id_fn is not None:
+                tid = search_id_fn(artist, title)
+                if tid:
+                    stats["from_search"] += 1
 
         resolved.append({"artist": artist, "title": title, "album": album,
                          "service_track_id": tid or None})
@@ -203,6 +211,45 @@ def resolve_service_track_ids(
                 pass
 
     return {"resolved": resolved, "stats": stats}
+
+
+# Confidence floor for backfill, on the score_track scale (~1.5 = exact title + exact
+# artist, thanks to the 1.5x artist boost). A cover/karaoke (x0.05) or a wrong-artist hit
+# (no boost, caps ~1.0) can't clear this — so backfill never adds a guessed/wrong version.
+BACKFILL_MIN_SCORE = 1.2
+
+
+def search_service_track_id(
+    artist: str,
+    title: str,
+    *,
+    search_fn: Callable[[str], List[Any]],
+    min_score: float = BACKFILL_MIN_SCORE,
+) -> Optional[str]:
+    """Confident live-search match for export backfill (#945): search the target service
+    for (artist, title), rerank by relevance, and return the top match's id ONLY if it
+    clears the confidence floor. Below the floor → None: the track is left out of the
+    export rather than risk a wrong/cover/karaoke version (the whole point of backfill is
+    coverage WITHOUT the wrong-track risk). ``search_fn(query) -> List[Track]`` is injected
+    so this is unit-testable without a live service."""
+    if not title:
+        return None
+    from core.metadata.relevance import build_combined_search_query, filter_and_rerank
+    query = build_combined_search_query(title, artist)
+    try:
+        candidates = list(search_fn(query) or [])
+    except Exception as exc:
+        logger.debug(f"export backfill search failed for '{artist} - {title}': {exc}")
+        return None
+    if not candidates:
+        return None
+    ranked = filter_and_rerank(
+        candidates, expected_title=title, expected_artist=artist, min_score=min_score,
+    )
+    if not ranked:
+        return None
+    tid = getattr(ranked[0], "id", None)
+    return str(tid) if tid else None
 
 
 def file_recording_mbid(artist: str, title: str) -> Optional[str]:

--- a/core/exports/export_sources.py
+++ b/core/exports/export_sources.py
@@ -16,8 +16,9 @@ writes a fresh non-cache hit back to the cache so the next export of the same so
 
 from __future__ import annotations
 
+import json
 import threading
-from typing import Callable, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from utils.logging_config import get_logger
 
@@ -119,6 +120,89 @@ def build_service_resolve_fn(service: str) -> Callable[[str, str], Tuple[Optiona
         tid = db_service_track_id(artist, title, service)
         return (tid, "library" if tid else None)
     return resolve_fn
+
+
+def service_id_from_extra_data(track: Any, service: str) -> Optional[str]:
+    """The target-service track ID the DISCOVERY step already resolved for this mirrored
+    track, read from its ``extra_data`` blob (#945 — Boulder: "all 50 are discovered to
+    Deezer already, it's not using any of that"). This is free (no API call) and reliable
+    (it's the same id used to mirror the track).
+
+    Only trusted when the track was discovered ON the export's target service — a
+    Deezer-discovered track carries a Deezer id under ``matched_data['id']``, and its
+    ``provider`` is the service name. A ``wing_it_fallback`` provider (the low-confidence
+    guess path) deliberately does NOT match here, so those fall through to the library/
+    none path rather than risk a wrong track in the exported playlist."""
+    raw = track.get("extra_data") if isinstance(track, dict) else None
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except Exception:
+        return None
+    if not isinstance(data, dict) or not data.get("discovered"):
+        return None
+    if str(data.get("provider") or "").lower() != str(service or "").lower():
+        return None
+    matched = data.get("matched_data")
+    tid = matched.get("id") if isinstance(matched, dict) else None
+    return str(tid) if tid else None
+
+
+def _track_field(track: Dict[str, Any], *names: str) -> str:
+    for n in names:
+        v = track.get(n)
+        if v:
+            return str(v)
+    return ""
+
+
+def resolve_service_track_ids(
+    tracks: List[Dict[str, Any]],
+    service: str,
+    *,
+    db_fn: Optional[Callable[[str, str, str], Optional[str]]] = None,
+    on_progress: Optional[Callable[[int, int, Dict[str, Any]], None]] = None,
+) -> Dict[str, Any]:
+    """Resolve a mirrored playlist's tracks to target-service track IDs for export.
+
+    Waterfall per track: the discovery cache (``extra_data`` — free + already confidently
+    matched) → the library track's stored service id. A track with neither is reported
+    unmatched (caller skips it — never a guessed/wrong id). Returns
+    ``{"resolved": [{artist, title, album, service_track_id}], "stats": {...}}`` with
+    ``from_cache`` / ``from_library`` / ``unmatched`` tallies for the status display.
+    """
+    db_fn = db_fn or db_service_track_id
+    total = len(tracks or [])
+    resolved: List[Dict[str, Any]] = []
+    stats: Dict[str, Any] = {
+        "total": total, "resolved": 0, "unmatched": 0, "from_cache": 0, "from_library": 0,
+    }
+    for i, t in enumerate(tracks or []):
+        if not isinstance(t, dict):
+            t = {}
+        artist = _track_field(t, "artist", "artist_name", "creator")
+        title = _track_field(t, "title", "track_name", "name")
+        album = _track_field(t, "album", "album_name", "release_name")
+
+        tid = service_id_from_extra_data(t, service)
+        if tid:
+            stats["from_cache"] += 1
+        else:
+            tid = db_fn(artist, title, service)
+            if tid:
+                stats["from_library"] += 1
+
+        resolved.append({"artist": artist, "title": title, "album": album,
+                         "service_track_id": tid or None})
+        stats["resolved" if tid else "unmatched"] += 1
+        if on_progress is not None:
+            try:
+                on_progress(i + 1, total, stats)
+            except Exception:  # noqa: S110 — a progress error must never fail the export
+                pass
+
+    return {"resolved": resolved, "stats": stats}
 
 
 def file_recording_mbid(artist: str, title: str) -> Optional[str]:

--- a/core/exports/export_sources.py
+++ b/core/exports/export_sources.py
@@ -72,6 +72,55 @@ def db_recording_mbid(artist: str, title: str) -> Optional[str]:
     return _db_match(artist, title)[0]
 
 
+# Service → the tracks-table column carrying that service's track ID (set by enrichment).
+# Trusted constants — never user input — so safe to interpolate into the SELECT below.
+_SERVICE_ID_COLUMNS = {"spotify": "spotify_track_id", "deezer": "deezer_id"}
+
+
+def db_service_track_id(artist: str, title: str, service: str) -> Optional[str]:
+    """The service track ID (``spotify_track_id`` / ``deezer_id``) stored on a matched
+    library track — what lets a mirrored playlist be exported BACK to Spotify/Deezer
+    without re-searching, since enrichment already pinned it (#945). Text-matches by
+    (artist, title), same as the MBID resolver. Fail-safe: any miss/error returns None."""
+    column = _SERVICE_ID_COLUMNS.get((service or "").lower())
+    if not column or not title:
+        return None
+    try:
+        from database.music_database import get_database
+        db = get_database()
+        conn = db._get_connection()
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                f"SELECT t.{column} FROM tracks t JOIN artists a ON t.artist_id = a.id "
+                "WHERE LOWER(t.title) = LOWER(?) AND LOWER(a.name) = LOWER(?) LIMIT 1",
+                (title, artist),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            val = row[0] if not hasattr(row, "keys") else row[column]
+            return val or None
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: S110
+                pass
+    except Exception as exc:
+        logger.debug(f"export service-id lookup failed for '{artist} - {title}' ({service}): {exc}")
+        return None
+
+
+def build_service_resolve_fn(service: str) -> Callable[[str, str], Tuple[Optional[str], Optional[str]]]:
+    """resolve_fn for service-playlist export: ``(artist, title) -> (service_track_id, 'library')``.
+    Plugs into ``resolve_playlist_tracks(..., id_key='service_track_id')`` exactly like the
+    MBID resolver plugs in for ListenBrainz."""
+    def resolve_fn(artist: str, title: str) -> Tuple[Optional[str], Optional[str]]:
+        tid = db_service_track_id(artist, title, service)
+        return (tid, "library" if tid else None)
+    return resolve_fn
+
+
 def file_recording_mbid(artist: str, title: str) -> Optional[str]:
     """Recording MBID read from the matched track's file tag (set on import post-processing)."""
     _mbid, fpath = _db_match(artist, title)

--- a/core/exports/playlist_export.py
+++ b/core/exports/playlist_export.py
@@ -36,16 +36,22 @@ def resolve_playlist_tracks(
     resolve_fn: ResolveFn,
     *,
     on_progress: Optional[ProgressFn] = None,
+    id_key: str = "recording_mbid",
 ) -> Dict[str, Any]:
-    """Resolve every track to a recording MBID and build the export pseudo-playlist.
+    """Resolve every track to an ID and build the export pseudo-playlist.
+
+    ``resolve_fn(artist, title) -> (id, source)`` returns whatever ID the target needs —
+    a MusicBrainz recording MBID for ListenBrainz/JSPF (the default), or a Spotify/Deezer
+    track ID for service export. ``id_key`` names the field that ID lands under in each
+    resolved entry (defaults to ``recording_mbid`` so existing LB/JSPF callers are
+    untouched). The dedup + stats + ordering logic is identical regardless of ID type.
 
     ``tracks`` items may use ``artist``/``artist_name`` and ``title``/``track_name`` and
     ``album``/``album_name`` (both the mirrored-playlist and LB-cache shapes are accepted).
 
     Returns ``{"resolved": [...], "stats": {...}}`` where each resolved entry is
-    ``{artist, title, album, recording_mbid}`` (recording_mbid is None when unmatched),
-    in original order, and stats carries ``total, resolved, unmatched, deduped,
-    by_source`` for the live display.
+    ``{artist, title, album, <id_key>}`` (the ID is None when unmatched), in original
+    order, and stats carries ``total, resolved, unmatched, deduped, by_source``.
     """
     total = len(tracks or [])
     memo: Dict[str, Tuple[Optional[str], Optional[str]]] = {}
@@ -71,7 +77,7 @@ def resolve_playlist_tracks(
             memo[key] = (mbid, source)
             fresh = True
 
-        resolved.append({"artist": artist, "title": title, "album": album, "recording_mbid": mbid})
+        resolved.append({"artist": artist, "title": title, "album": album, id_key: mbid})
 
         if mbid:
             stats["resolved"] += 1

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -360,6 +360,22 @@ def probe_audio_quality(file_path: str):
                 sample_rate=getattr(audio.info, 'sample_rate', None),
             )
 
+        if ext in ('dsf', 'dff'):
+            # DSD (DSD Stream File / DSDIFF) — 1-bit hi-res lossless (#939). mutagen
+            # reads .dsf (rate/bitrate/bit_depth); .dff has no mutagen reader, so it
+            # still classifies as the lossless 'dsf' tier just without measured detail.
+            sr = bd = br = None
+            if ext == 'dsf':
+                try:
+                    from mutagen.dsf import DSF
+                    info = DSF(file_path).info
+                    sr = getattr(info, 'sample_rate', None)
+                    bd = getattr(info, 'bits_per_sample', None)
+                    br = info.bitrate // 1000 if getattr(info, 'bitrate', None) else None
+                except Exception:  # noqa: S110 — unreadable DSF still classifies lossless, just without measured detail
+                    pass
+            return AudioQuality(format='dsf', bitrate=br, sample_rate=sr, bit_depth=bd)
+
         return None
     except Exception as e:
         logger.debug("probe_audio_quality failed for %s: %s", file_path, e)

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -524,14 +524,29 @@ def downsample_hires_flac(final_path, context):
     return None
 
 
+def m4a_codec(path):
+    """Codec of an .m4a/.mp4 container ('alac', 'aac', …) or None — lets the
+    lossless check tell ALAC (lossless) from AAC (lossy), since both are .m4a."""
+    try:
+        from mutagen.mp4 import MP4
+        return (getattr(MP4(path).info, 'codec', '') or '').lower() or None
+    except Exception:
+        return None
+
+
 def create_lossy_copy(final_path):
-    """Convert a FLAC file to a lossy copy using the configured codec."""
-    from mutagen.flac import FLAC
+    """Convert a lossless file (FLAC / ALAC / WAV / AIFF / DSD) to a lossy copy
+    using the configured codec. Non-lossless inputs are skipped (#941)."""
+    from core.quality.lossless import (
+        is_lossless_audio_path,
+        lossy_output_would_overwrite_source,
+    )
 
     if not config_manager.get("lossy_copy.enabled", False):
         return None
 
-    if os.path.splitext(final_path)[1].lower() != ".flac":
+    # Was FLAC-only; now any lossless source. .m4a is probed (ALAC vs AAC).
+    if not is_lossless_audio_path(final_path, probe_codec=m4a_codec):
         return None
 
     codec = config_manager.get("lossy_copy.codec", "mp3").lower()
@@ -559,6 +574,16 @@ def create_lossy_copy(final_path):
         if original_quality in out_basename:
             out_basename = out_basename.replace(original_quality, quality_label)
             out_path = os.path.join(os.path.dirname(out_path), out_basename)
+
+    # Safety invariant: never write the lossy copy over its own source (an .m4a
+    # ALAC source + AAC target lands on the same .m4a path). ffmpeg runs with -y,
+    # so this guard MUST precede it — the later delete-original guard is too late.
+    if lossy_output_would_overwrite_source(final_path, out_path):
+        logger.info(
+            f"[Lossy Copy] Skipping — {codec.upper()} output would overwrite the "
+            f"source: {os.path.basename(final_path)}"
+        )
+        return None
 
     ffmpeg_bin = shutil.which("ffmpeg")
     if not ffmpeg_bin:

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -325,11 +325,14 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                 _mark_task_quarantined(context, quarantine_path)
                 logger.error(f"File quarantined due to integrity failure: {quarantine_path}")
             except Exception as quarantine_error:
-                logger.error(f"Quarantine failed ({quarantine_error}), deleting broken file: {file_path}")
-                try:
-                    os.remove(file_path)
-                except Exception as del_error:
-                    logger.error(f"Could not delete broken file either: {del_error}")
+                # Quarantine MOVE failed (e.g. cross-device / permission on a NAS).
+                # Do NOT delete — destroying a download we couldn't even quarantine is
+                # data loss and forces a re-download. Leave it in place so it can be
+                # retried; the task is still marked failed below either way (#kettui).
+                logger.error(
+                    f"Quarantine failed ({quarantine_error}) — leaving file in place "
+                    f"for retry (not deleting): {file_path}"
+                )
 
             with matched_context_lock:
                 if context_key in matched_downloads_context:
@@ -383,11 +386,12 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                 _mark_task_quarantined(context, quarantine_path)
                 logger.warning("File quarantined — incomplete/silent audio: %s", quarantine_path)
             except Exception as quarantine_error:
-                logger.error(f"Quarantine failed ({quarantine_error}), deleting file: {file_path}")
-                try:
-                    os.remove(file_path)
-                except Exception as del_error:
-                    logger.debug("delete broken file fallback: %s", del_error)
+                # Don't delete a file we couldn't quarantine — leave it for retry
+                # instead of forcing a re-download (data loss). See integrity block.
+                logger.error(
+                    f"Quarantine failed ({quarantine_error}) — leaving file in place "
+                    f"for retry (not deleting): {file_path}"
+                )
 
             with matched_context_lock:
                 matched_downloads_context.pop(context_key, None)
@@ -437,11 +441,12 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                     _mark_task_quarantined(context, quarantine_path)
                     logger.info(f"File quarantined due to quality mismatch: {quarantine_path}")
                 except Exception as quarantine_error:
-                    logger.error(f"Quarantine failed ({quarantine_error}), deleting file: {file_path}")
-                    try:
-                        os.remove(file_path)
-                    except Exception as e:
-                        logger.debug("delete quarantine fallback: %s", e)
+                    # Don't delete a file we couldn't quarantine — leave it for retry
+                    # instead of forcing a re-download (data loss). See integrity block.
+                    logger.error(
+                        f"Quarantine failed ({quarantine_error}) — leaving file in place "
+                        f"for retry (not deleting): {file_path}"
+                    )
 
                 context['_bitdepth_rejected'] = True
                 task_id = context.get('task_id')
@@ -535,12 +540,13 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                             _mark_task_quarantined(context, quarantine_path)
                             logger.error(f"File quarantined due to verification failure: {quarantine_path}")
                         except Exception as quarantine_error:
-                            logger.error(f"Quarantine failed ({quarantine_error}), deleting wrong file: {file_path}")
-                            logger.error(f"Quarantine failed, deleting wrong file: {file_path}")
-                            try:
-                                os.remove(file_path)
-                            except Exception as del_error:
-                                logger.error(f"Could not delete wrong file either: {del_error}")
+                            # Don't delete a file we couldn't quarantine — leave it for
+                            # retry instead of forcing a re-download (data loss). The
+                            # task is still marked failed / requeued below. See integrity.
+                            logger.error(
+                                f"Quarantine failed ({quarantine_error}) — leaving file "
+                                f"in place for retry (not deleting): {file_path}"
+                            )
 
                         context['_acoustid_quarantined'] = True
                         context['_acoustid_failure_msg'] = verification_msg

--- a/core/imports/routes.py
+++ b/core/imports/routes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import threading
+import time
 import uuid
 from concurrent.futures import as_completed
 from dataclasses import dataclass
@@ -71,36 +73,86 @@ class ImportRouteRuntime:
     logger: Any = module_logger
 
 
+# ── Shared staging scan ──────────────────────────────────────────────────────
+# Opening the Import page fires staging files/groups/hints together; each used to
+# os.walk the whole staging folder AND mutagen-read every file independently — 3×
+# the directory walk + 3× the tag I/O on every page open (the import-page scan
+# storm + memory spike, issue #935). They all need the same per-file tag data, so
+# scan ONCE and let all three derive their views in-memory. A short TTL + a lock
+# means the three near-simultaneous page-open requests (and any concurrent caller)
+# share a single scan instead of each kicking off a full re-read.
+_STAGING_SCAN_LOCK = threading.Lock()
+_STAGING_SCAN_TTL = 6.0  # seconds — covers the page-open burst; re-scans after
+_staging_scan_cache: Dict[str, Any] = {"path": None, "ts": 0.0, "records": None}
+
+
+def _scan_staging_records(runtime: ImportRouteRuntime, staging_path: str) -> list[Dict[str, Any]]:
+    """Walk staging + read each audio file's tags ONCE, returning per-file records
+    that staging files/groups/hints all derive from. Briefly cached + locked so the
+    page-open trio shares a single scan rather than each re-walking and re-reading."""
+    now = time.time()
+    cached = _staging_scan_cache
+    if (cached["records"] is not None and cached["path"] == staging_path
+            and (now - cached["ts"]) < _STAGING_SCAN_TTL):
+        return cached["records"]
+
+    with _STAGING_SCAN_LOCK:
+        # Double-check: another request may have filled the cache while we waited.
+        now = time.time()
+        if (cached["records"] is not None and cached["path"] == staging_path
+                and (now - cached["ts"]) < _STAGING_SCAN_TTL):
+            return cached["records"]
+
+        records: list[Dict[str, Any]] = []
+        if os.path.isdir(staging_path):
+            for root, _dirs, filenames in os.walk(staging_path):
+                rel_dir = os.path.relpath(root, staging_path)
+                top_folder = rel_dir.split(os.sep)[0] if rel_dir != "." else None
+                for fname in filenames:
+                    ext = os.path.splitext(fname)[1].lower()
+                    if ext not in AUDIO_EXTENSIONS:
+                        continue
+                    full_path = os.path.join(root, fname)
+                    rel_path = os.path.relpath(full_path, staging_path)
+                    meta = runtime.read_staging_file_metadata(full_path, rel_path)
+                    records.append({
+                        "filename": fname, "rel_path": rel_path, "full_path": full_path,
+                        "extension": ext, "title": meta["title"], "album": meta["album"],
+                        "artist": meta["artist"], "albumartist": meta["albumartist"],
+                        "track_number": meta["track_number"], "disc_number": meta["disc_number"],
+                        "top_folder": top_folder,
+                    })
+
+        _staging_scan_cache.update({"path": staging_path, "ts": time.time(), "records": records})
+        return records
+
+
+def invalidate_staging_scan_cache() -> None:
+    """Drop the cached staging scan (call after an import moves/removes files so the
+    next files/groups/hints request reflects the new state immediately)."""
+    _staging_scan_cache.update({"path": None, "ts": 0.0, "records": None})
+
+
 def staging_files(runtime: ImportRouteRuntime) -> tuple[Dict[str, Any], int]:
     """Scan the staging folder and return audio files with tag metadata."""
     try:
         staging_path = runtime.get_staging_path()
         os.makedirs(staging_path, exist_ok=True)
 
-        files = []
-        for root, _dirs, filenames in os.walk(staging_path):
-            for fname in filenames:
-                ext = os.path.splitext(fname)[1].lower()
-                if ext not in AUDIO_EXTENSIONS:
-                    continue
-                full_path = os.path.join(root, fname)
-                rel_path = os.path.relpath(full_path, staging_path)
-
-                meta = runtime.read_staging_file_metadata(full_path, rel_path)
-
-                files.append(
-                    {
-                        "filename": fname,
-                        "rel_path": rel_path,
-                        "full_path": full_path,
-                        "title": meta["title"],
-                        "artist": meta["albumartist"] or meta["artist"] or "Unknown Artist",
-                        "album": meta["album"],
-                        "track_number": meta["track_number"],
-                        "disc_number": meta["disc_number"],
-                        "extension": ext,
-                    }
-                )
+        files = [
+            {
+                "filename": r["filename"],
+                "rel_path": r["rel_path"],
+                "full_path": r["full_path"],
+                "title": r["title"],
+                "artist": r["albumartist"] or r["artist"] or "Unknown Artist",
+                "album": r["album"],
+                "track_number": r["track_number"],
+                "disc_number": r["disc_number"],
+                "extension": r["extension"],
+            }
+            for r in _scan_staging_records(runtime, staging_path)
+        ]
 
         files.sort(key=lambda f: f["filename"].lower())
         return {"success": True, "files": files, "staging_path": staging_path}, 200
@@ -117,31 +169,23 @@ def staging_groups(runtime: ImportRouteRuntime) -> tuple[Dict[str, Any], int]:
             return {"success": True, "groups": []}, 200
 
         album_groups = {}
-        for root, _dirs, filenames in os.walk(staging_path):
-            for fname in filenames:
-                ext = os.path.splitext(fname)[1].lower()
-                if ext not in AUDIO_EXTENSIONS:
-                    continue
-                full_path = os.path.join(root, fname)
-                rel_path = os.path.relpath(full_path, staging_path)
+        for r in _scan_staging_records(runtime, staging_path):
+            album = r["album"]
+            artist = r["albumartist"] or r["artist"]
+            if not album or not artist:
+                continue
 
-                meta = runtime.read_staging_file_metadata(full_path, rel_path)
-                album = meta["album"]
-                artist = meta["albumartist"] or meta["artist"]
-                if not album or not artist:
-                    continue
-
-                key = (album.lower().strip(), artist.lower().strip())
-                if key not in album_groups:
-                    album_groups[key] = {"album": album.strip(), "artist": artist.strip(), "files": []}
-                album_groups[key]["files"].append(
-                    {
-                        "filename": fname,
-                        "full_path": full_path,
-                        "title": meta["title"],
-                        "track_number": meta["track_number"],
-                    }
-                )
+            key = (album.lower().strip(), artist.lower().strip())
+            if key not in album_groups:
+                album_groups[key] = {"album": album.strip(), "artist": artist.strip(), "files": []}
+            album_groups[key]["files"].append(
+                {
+                    "filename": r["filename"],
+                    "full_path": r["full_path"],
+                    "title": r["title"],
+                    "track_number": r["track_number"],
+                }
+            )
 
         groups = []
         for group in album_groups.values():
@@ -173,28 +217,15 @@ def staging_hints(runtime: ImportRouteRuntime) -> tuple[Dict[str, Any], int]:
 
         tag_albums = {}
         folder_hints = {}
-        for root, _dirs, filenames in os.walk(staging_path):
-            audio_files = [f for f in filenames if os.path.splitext(f)[1].lower() in AUDIO_EXTENSIONS]
-            if not audio_files:
-                continue
+        for r in _scan_staging_records(runtime, staging_path):
+            if r["top_folder"]:
+                folder_hints[r["top_folder"]] = folder_hints.get(r["top_folder"], 0) + 1
 
-            rel_dir = os.path.relpath(root, staging_path)
-            if rel_dir != ".":
-                top_folder = rel_dir.split(os.sep)[0]
-                folder_hints[top_folder] = folder_hints.get(top_folder, 0) + len(audio_files)
-
-            for fname in audio_files:
-                full_path = os.path.join(root, fname)
-                try:
-                    tags = runtime.read_tags(full_path)
-                    if tags:
-                        album = (tags.get("album") or [None])[0]
-                        artist = (tags.get("artist") or (tags.get("albumartist") or [None]))[0]
-                        if album:
-                            key = (album.strip(), (artist or "").strip())
-                            tag_albums[key] = tag_albums.get(key, 0) + 1
-                except Exception as exc:
-                    runtime.logger.debug("tag read failed: %s", exc)
+            album = r["album"]
+            artist = r["artist"] or r["albumartist"]
+            if album:
+                key = (album.strip(), (artist or "").strip())
+                tag_albums[key] = tag_albums.get(key, 0) + 1
 
         queries = []
         seen_queries_lower = set()
@@ -371,6 +402,11 @@ def album_process(runtime: ImportRouteRuntime, data: Dict[str, Any]) -> tuple[Di
             )
             runtime.refresh_import_suggestions_cache()
 
+        # Files just left staging — drop the shared scan so the next files/groups/hints
+        # reflects reality immediately instead of waiting out the cache TTL.
+        if processed > 0:
+            invalidate_staging_scan_cache()
+
         return {"success": True, "processed": processed, "total": len(matches), "errors": errors}, 200
     except Exception as exc:
         runtime.logger.error("Error processing album import: %s", exc)
@@ -505,6 +541,10 @@ def singles_process(runtime: ImportRouteRuntime, files: list[Dict[str, Any]]) ->
                 log_label="singles",
             )
             runtime.refresh_import_suggestions_cache()
+
+        # Files just left staging — drop the shared scan so the list updates immediately.
+        if processed > 0:
+            invalidate_staging_scan_cache()
 
         return {"success": True, "processed": processed, "total": len(files), "errors": errors}, 200
     except Exception as exc:

--- a/core/imports/silence.py
+++ b/core/imports/silence.py
@@ -18,6 +18,7 @@ run, so a tooling problem never blocks a legitimate import.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from typing import Optional
@@ -157,6 +158,14 @@ def measured_duration_from_astats(astats_stderr: str, sample_rate: int) -> Optio
     return int(m.group(1)) / float(sample_rate)
 
 
+def is_dsd_path(file_path: str) -> bool:
+    """True for DSD audio (.dsf / .dff). The decoded-samples truncation check is
+    invalid for DSD: ffmpeg decodes DSD to PCM at a different rate than the DSD
+    container's 2.8 MHz, so samples ÷ container-sample-rate massively under-counts
+    and would falsely report the file as truncated (#939)."""
+    return os.path.splitext(str(file_path or ''))[1].lower() in ('.dsf', '.dff')
+
+
 def incomplete_audio_reason(
     measured_s: Optional[float],
     container_s: Optional[float],
@@ -267,11 +276,14 @@ def detect_broken_audio(
 
     stderr = proc.stderr.decode("utf-8", errors="replace") if proc.stderr else ""
 
-    # Truncation check first (real audio far shorter than the container).
-    measured_s = measured_duration_from_astats(stderr, sample_rate)
-    reason = incomplete_audio_reason(measured_s, container_s, min_ratio=min_ratio)
-    if reason:
-        return reason
+    # Truncation check first (real audio far shorter than the container) — but
+    # NOT for DSD: the astats sample-count ÷ DSD-rate math is invalid there and
+    # would always false-positive (#939). Silence detection below still applies.
+    if not is_dsd_path(file_path):
+        measured_s = measured_duration_from_astats(stderr, sample_rate)
+        reason = incomplete_audio_reason(measured_s, container_s, min_ratio=min_ratio)
+        if reason:
+            return reason
 
     # Then silence-padding (mostly-silent file).
     return is_mostly_silent_reason(stderr, container_s, threshold=threshold)

--- a/core/jellyfin_client.py
+++ b/core/jellyfin_client.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 from utils.logging_config import get_logger
 from config.settings import config_manager
+from core.library.bulk_paginate import paginate_all_items
 
 # Shared dataclasses live in the neutral media_server package — every
 # server client used to define a near-identical XTrackInfo /
@@ -512,12 +513,8 @@ class JellyfinClient(MediaServerClient):
         try:
             # SIMPLIFIED APPROACH: Fetch all tracks, then all albums separately (robust and fast)
             logger.info("Fetching all tracks in bulk...")
-            all_tracks = []
-            start_index = 0
-            limit = 10000
-            consecutive_failures = 0
-            
-            while True:
+
+            def _fetch_tracks_page(start_index, limit):
                 params = {
                     'ParentId': self.music_library_id,
                     'IncludeItemTypes': 'Audio',
@@ -528,41 +525,19 @@ class JellyfinClient(MediaServerClient):
                     'StartIndex': start_index,
                     'Limit': limit
                 }
-                
                 response = self._make_request(f'/Users/{self.user_id}/Items', params)
-                
-                if not response:
-                    consecutive_failures += 1
-                    # Wait before retrying — the server may still be processing the timed-out request
-                    time.sleep(5)
-                    if limit > 1000:
-                        limit = limit // 2
-                        consecutive_failures = 0  # Reset — give the smaller batch a fair chance
-                        logger.warning(f"Track fetch failed - reducing batch size to {limit}")
-                        continue
-                    elif consecutive_failures >= 2:
-                        logger.warning("Multiple track fetch failures at minimum batch size - stopping")
-                        break
-                    else:
-                        logger.warning("Track fetch failed at minimum batch size - retrying once")
-                        continue
+                return response.get('Items', []) if response else None  # None = failed page
 
-                consecutive_failures = 0
-                batch_tracks = response.get('Items', [])
-                if not batch_tracks:
-                    break
-                    
-                all_tracks.extend(batch_tracks)
-                
-                if len(batch_tracks) < limit:
-                    break
-                    
-                start_index += limit
-                progress_msg = f"Fetched {len(all_tracks)} tracks so far..."
-                logger.info(f"   {progress_msg} (batch size: {limit})")
-                if self._progress_callback:
-                    self._progress_callback(progress_msg)
-            
+            # Page in modest chunks so progress is reported every page — a single
+            # huge silent request used to trip the 300s no-progress watchdog on
+            # slow servers even though it was alive (see bulk_paginate docstring).
+            all_tracks = paginate_all_items(
+                _fetch_tracks_page,
+                report_progress=self._progress_callback,
+                label="tracks",
+                on_retry_wait=lambda: time.sleep(5),
+            )
+
             # Group tracks by album ID for instant lookup
             self._track_cache = {}
             for track_data in all_tracks:
@@ -578,12 +553,8 @@ class JellyfinClient(MediaServerClient):
             
             # STEP 2: Fetch all albums in bulk (same proven pattern)
             logger.info("Fetching all albums in bulk...")
-            all_albums = []
-            start_index = 0
-            limit = 10000
-            consecutive_failures = 0
-            
-            while True:
+
+            def _fetch_albums_page(start_index, limit):
                 params = {
                     'ParentId': self.music_library_id,
                     'IncludeItemTypes': 'MusicAlbum',
@@ -594,41 +565,16 @@ class JellyfinClient(MediaServerClient):
                     'StartIndex': start_index,
                     'Limit': limit
                 }
-                
                 response = self._make_request(f'/Users/{self.user_id}/Items', params)
-                
-                if not response:
-                    consecutive_failures += 1
-                    # Wait before retrying — the server may still be processing the timed-out request
-                    time.sleep(5)
-                    if limit > 1000:
-                        limit = limit // 2
-                        consecutive_failures = 0  # Reset — give the smaller batch a fair chance
-                        logger.warning(f"Album fetch failed - reducing batch size to {limit}")
-                        continue
-                    elif consecutive_failures >= 2:
-                        logger.warning("Multiple album fetch failures at minimum batch size - stopping")
-                        break
-                    else:
-                        logger.warning("Album fetch failed at minimum batch size - retrying once")
-                        continue
+                return response.get('Items', []) if response else None  # None = failed page
 
-                consecutive_failures = 0
-                batch_albums = response.get('Items', [])
-                if not batch_albums:
-                    break
-                    
-                all_albums.extend(batch_albums)
-                
-                if len(batch_albums) < limit:
-                    break
-                    
-                start_index += limit
-                progress_msg = f"Fetched {len(all_albums)} albums so far..."
-                logger.info(f"   {progress_msg} (batch size: {limit})")
-                if self._progress_callback:
-                    self._progress_callback(progress_msg)
-            
+            all_albums = paginate_all_items(
+                _fetch_albums_page,
+                report_progress=self._progress_callback,
+                label="albums",
+                on_retry_wait=lambda: time.sleep(5),
+            )
+
             # Group albums by artist ID for instant lookup
             self._album_cache = {}
             for album_data in all_albums:

--- a/core/library/bulk_paginate.py
+++ b/core/library/bulk_paginate.py
@@ -1,0 +1,93 @@
+"""Paginate a bulk media-server fetch while feeding the no-progress watchdog.
+
+The library scan fetches every track/album by paging a server API. The DB-update
+watchdog (``core/database_update_health.py``) kills a job that reports no progress
+for 300s. The old Jellyfin fetch used a single 10 000-item page, so a whole
+library came back in ONE request that emitted NO progress while it was in flight —
+on a slow server that single request exceeded 300s and the watchdog declared the
+job "stuck" even though it was alive, not hung (Discord: DXP4800 NAS, 7148 tracks,
+"Fetching all tracks in bulk…").
+
+``paginate_all_items`` pages at a size chosen so progress is emitted on a cadence
+set by the PAGE SIZE, not the library size — the watchdog is fed every page, so it
+can never starve mid-fetch regardless of how big the library is. It is pure: all
+I/O lives in the injected ``fetch_page``, so the pagination + progress + failure-
+shrink logic is unit-testable without a server.
+
+This does NOT change WHAT is fetched (same query, same fields, same items) — only
+how it's paged and that every page reports progress (the old loop skipped progress
+on the final/only page, which is the entire bug for a sub-page-size library).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List, Optional
+
+# Page size for bulk library fetches. Small enough that a single request stays
+# well under the 300s no-progress watchdog even on a slow NAS, and that progress
+# is reported every page. NOT a performance knob — a resilience/observability one.
+DEFAULT_PAGE_SIZE = 1000
+
+# Floor the failure-shrink can reach before giving up — a server that can't return
+# even this many items in one request is genuinely struggling.
+DEFAULT_MIN_PAGE_SIZE = 250
+
+
+def paginate_all_items(
+    fetch_page: Callable[[int, int], Optional[List[Any]]],
+    *,
+    report_progress: Optional[Callable[[str], None]] = None,
+    label: str = "items",
+    page_size: int = DEFAULT_PAGE_SIZE,
+    min_page_size: int = DEFAULT_MIN_PAGE_SIZE,
+    on_retry_wait: Optional[Callable[[], None]] = None,
+) -> List[Any]:
+    """Page through ``fetch_page(start_index, limit)`` until the server is drained.
+
+    ``fetch_page`` returns the page's items (a list, possibly empty = end), or
+    ``None`` to signal a FAILED request (timeout/error) — on failure the page size
+    is halved down to ``min_page_size`` and retried, then abandoned after two
+    consecutive failures at the floor.
+
+    Progress is reported after EVERY non-empty page (including the final/only one),
+    so a no-progress watchdog is fed on a cadence set by ``page_size`` — never by
+    the total library size. Returns every item gathered.
+    """
+    items: List[Any] = []
+    start_index = 0
+    limit = page_size
+    consecutive_failures = 0
+
+    while True:
+        batch = fetch_page(start_index, limit)
+
+        if batch is None:  # failed request
+            consecutive_failures += 1
+            if on_retry_wait is not None:
+                on_retry_wait()
+            if limit > min_page_size:
+                limit = max(min_page_size, limit // 2)
+                consecutive_failures = 0  # give the smaller batch a fair chance
+                continue
+            if consecutive_failures >= 2:
+                break  # struggling at the floor — stop with what we have
+            continue
+
+        consecutive_failures = 0
+        if not batch:
+            break  # drained
+
+        items.extend(batch)
+        # Feed the watchdog on EVERY page — this is the line the old loop only ran
+        # when there was a *next* page, so a sub-page-size library reported nothing.
+        if report_progress is not None:
+            report_progress(f"Fetched {len(items)} {label} so far...")
+
+        if len(batch) < limit:
+            break  # last (partial) page
+        start_index += limit
+
+    return items
+
+
+__all__ = ["paginate_all_items", "DEFAULT_PAGE_SIZE", "DEFAULT_MIN_PAGE_SIZE"]

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -26,6 +26,7 @@ without a source ID are reported back to the caller and skipped
 entirely.
 """
 
+import errno
 import os
 import re
 import shutil
@@ -34,7 +35,7 @@ import time
 import uuid
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 # Per-album track concurrency. Matches the download workers' per-batch
 # concurrency (3) so reorganize feels comparable to a fresh download.
@@ -1101,6 +1102,12 @@ def preview_album_reorganize(
             'track_number': track.get('track_number', 0),
             'current_path': _trim_to_transfer(db_path, resolved, transfer_dir),
             'new_path': '',
+            # Absolute on-disk paths (additive). `current_path`/`new_path` above are
+            # display-trimmed; these carry the real paths so the rename-only executor
+            # acts on EXACTLY what the preview computed — no separate path logic that
+            # could drift from what the user saw (#875).
+            'current_path_abs': resolved or '',
+            'new_path_abs': '',
             'file_exists': resolved is not None,
             'unchanged': False,
             'collision': False,
@@ -1148,6 +1155,7 @@ def preview_album_reorganize(
             new_full, _ok = build_final_path_fn(
                 context, spotify_artist, album_info, file_ext, create_dirs=False
             )
+            item['new_path_abs'] = new_full or ''
             item['new_path'] = (
                 os.path.relpath(new_full, transfer_dir)
                 if transfer_dir and new_full and new_full.startswith(transfer_dir)
@@ -1803,6 +1811,150 @@ def reorganize_album(
                     artist_dirs.add(artist)
             for artist_dir in artist_dirs:
                 _prune_empty_album_dirs(artist_dir)
+
+    return summary
+
+
+def _rename_track_in_place(current_abs: str, new_abs: str) -> Tuple[bool, Optional[str]]:
+    """Move ONE file from ``current_abs`` to ``new_abs`` in place — no copy, no re-tag,
+    no post-processing. Creates the destination folder, carries sibling-format files
+    (e.g. a lossy ``.opus`` alongside the ``.flac``) along with the renamed stem, and
+    falls back to a cross-device move when the rename crosses a filesystem boundary.
+
+    Refuses to overwrite a DIFFERENT existing file at the destination (returns an error
+    instead) — never silent data loss. Returns ``(ok, error_message)``.
+    """
+    try:
+        if current_abs and not os.path.exists(current_abs):
+            return False, 'source file no longer on disk'
+        same = os.path.normpath(current_abs) == os.path.normpath(new_abs)
+        if os.path.exists(new_abs) and not same:
+            return False, 'destination already exists'
+        os.makedirs(os.path.dirname(new_abs), exist_ok=True)
+        # Carry sibling-format audio to the same destination with the renamed stem —
+        # mirrors _finalize_track so lossy-copy pairs don't get orphaned.
+        for sibling_src in _find_sibling_audio_files(current_abs):
+            _move_sibling_to_destination(sibling_src, new_abs)
+        try:
+            os.rename(current_abs, new_abs)
+        except OSError as e:
+            if getattr(e, 'errno', None) == errno.EXDEV:
+                shutil.move(current_abs, new_abs)  # crosses a filesystem boundary
+            else:
+                raise
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def reorganize_album_rename_only(
+    *,
+    album_id: str,
+    db,
+    transfer_dir: str,
+    resolve_file_path_fn: Callable[[Optional[str]], Optional[str]],
+    build_final_path_fn: Callable,
+    update_track_path_fn: Optional[Callable[[object, str], None]] = None,
+    cleanup_empty_dir_fn: Optional[Callable[[str], None]] = None,
+    on_progress: Optional[Callable[[dict], None]] = None,
+    primary_source: Optional[str] = None,
+    strict_source: bool = False,
+    metadata_source: str = 'api',
+    stop_check: Optional[Callable[[], bool]] = None,
+    preview_fn: Optional[Callable] = None,
+) -> dict:
+    """RENAME-ONLY reorganize (#875): move each track's file to the path the current
+    naming scheme dictates, and nothing else — no copy-to-staging, no re-tag, no
+    quality/AcoustID checks.
+
+    It acts on EXACTLY what :func:`preview_album_reorganize` computed (injected via
+    ``preview_fn`` for testability), so the apply can never disagree with what the user
+    saw, and ONLY files whose path actually changes are touched — files marked
+    ``unchanged`` are skipped, which is what keeps a rename from rewriting the whole
+    album (the #875 complaint). Tags and audio are left byte-for-byte alone.
+
+    Returns the same summary shape as :func:`reorganize_album`.
+    """
+    preview_fn = preview_fn or preview_album_reorganize
+    summary = {
+        'status': 'completed', 'source': None, 'total': 0,
+        'moved': 0, 'skipped': 0, 'failed': 0, 'errors': [],
+    }
+
+    def _emit(**updates):
+        if on_progress is None:
+            return
+        try:
+            on_progress(updates)
+        except Exception as e:
+            logger.debug("[Reorganize/rename] progress emit failed: %s", e)
+
+    preview = preview_fn(
+        album_id=album_id, db=db, transfer_dir=transfer_dir,
+        resolve_file_path_fn=resolve_file_path_fn,
+        build_final_path_fn=build_final_path_fn,
+        primary_source=primary_source, strict_source=strict_source,
+        metadata_source=metadata_source,
+    )
+    summary['source'] = preview.get('source')
+    if not preview.get('success'):
+        summary['status'] = preview.get('status', 'error')
+        return summary
+
+    tracks = preview.get('tracks', [])
+    summary['total'] = len(tracks)
+    src_dirs_touched: Set[str] = set()
+
+    for t in tracks:
+        if stop_check and stop_check():
+            break
+        title = t.get('title', 'Unknown')
+        _emit(current_track=title)
+
+        # Skip anything that isn't a real, changing move. `unchanged` is the key one —
+        # it's why a rename no longer rewrites files whose name didn't change.
+        if (not t.get('matched') or t.get('unchanged')
+                or t.get('collision') or not t.get('new_path_abs')):
+            summary['skipped'] += 1
+            _emit(skipped=summary['skipped'])
+            continue
+
+        current_abs = t.get('current_path_abs')
+        new_abs = t.get('new_path_abs')
+        ok, err = _rename_track_in_place(current_abs, new_abs)
+        if not ok:
+            summary['failed'] += 1
+            summary['errors'].append({
+                'track_id': t.get('track_id'), 'title': title,
+                'error': err or 'rename failed',
+            })
+            _emit(failed=summary['failed'], errors=list(summary['errors']))
+            continue
+
+        # File is at its new home — update the DB directly (authoritative; no need to
+        # round-trip through a server scan to learn what we just did). On DB failure the
+        # file still moved; a library scan reconciles it, so we don't fail the track.
+        if update_track_path_fn:
+            try:
+                update_track_path_fn(t.get('track_id'), new_abs)
+            except Exception as db_err:
+                logger.warning(
+                    "[Reorganize/rename] DB path update failed for %s: %s "
+                    "(file moved to %s; a scan will reconcile)",
+                    t.get('track_id'), db_err, new_abs,
+                )
+        if current_abs:
+            src_dirs_touched.add(os.path.dirname(current_abs))
+        summary['moved'] += 1
+        _emit(moved=summary['moved'],
+              processed=summary['moved'] + summary['skipped'] + summary['failed'])
+
+    if cleanup_empty_dir_fn:
+        for src_dir in src_dirs_touched:
+            try:
+                cleanup_empty_dir_fn(src_dir)
+            except Exception as e:
+                logger.debug("[Reorganize/rename] cleanup of %s failed: %s", src_dir, e)
 
     return summary
 

--- a/core/listening_stats_worker.py
+++ b/core/listening_stats_worker.py
@@ -291,6 +291,13 @@ class ListeningStatsWorker:
         if not (top_artists or top_albums or top_tracks):
             return
 
+        # Normalize image URLs HERE, at cache-build time, not on every /api/stats/cached
+        # read. normalize_image_url registers each URL in the image cache (a SQLite write
+        # under a lock) — doing that per-request made the "instant" stats endpoint take ~20s
+        # on HDD-backed installs (#935). Done once per background rebuild it's off the hot path,
+        # and the read just returns the already-browser-safe URLs.
+        from core.metadata import normalize_image_url as _fix_image
+
         conn = None
         try:
             conn = self.db._get_connection()
@@ -324,7 +331,7 @@ class ListeningStatsWorker:
                     key = (artist.get('name') or '').lower()
                     r = artist_rows.get(key)
                     if r:
-                        artist['image_url'] = r[1] or None
+                        artist['image_url'] = _fix_image(r[1]) or None
                         artist['id'] = r[2]
                         artist['global_listeners'] = r[3]
                         artist['global_playcount'] = r[4]
@@ -356,7 +363,7 @@ class ListeningStatsWorker:
                     key = (album.get('name') or '').lower()
                     r = album_rows.get(key)
                     if r:
-                        album['image_url'] = r[1] or None
+                        album['image_url'] = _fix_image(r[1]) or None
                         album['id'] = r[2]
                         album['artist_id'] = r[3]
 
@@ -395,7 +402,7 @@ class ListeningStatsWorker:
                            (track.get('artist') or '').lower())
                     r = track_rows.get(key)
                     if r:
-                        track['image_url'] = r[2] or None
+                        track['image_url'] = _fix_image(r[2]) or None
                         track['id'] = r[3]
                         track['artist_id'] = r[4]
         except Exception as e:

--- a/core/metadata/registry.py
+++ b/core/metadata/registry.py
@@ -230,7 +230,7 @@ def get_spotify_client_for_profile(profile_id: Optional[int] = None):
             return client
 
     try:
-        from core.spotify_client import SpotifyClient, normalize_spotify_oauth_config
+        from core.spotify_client import SpotifyClient, normalize_spotify_oauth_config, SPOTIFY_OAUTH_SCOPE
         from spotipy.oauth2 import SpotifyOAuth
         import spotipy
 
@@ -243,7 +243,7 @@ def get_spotify_client_for_profile(profile_id: Optional[int] = None):
             client_id=normalized_creds.get("client_id", client_id),
             client_secret=normalized_creds.get("client_secret", client_secret),
             redirect_uri=normalized_creds.get("redirect_uri", redirect_uri),
-            scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
+            scope=SPOTIFY_OAUTH_SCOPE,
             cache_path=cache_path,
             state=f"profile_{profile_id}",
         )

--- a/core/metadata/registry.py
+++ b/core/metadata/registry.py
@@ -230,14 +230,19 @@ def get_spotify_client_for_profile(profile_id: Optional[int] = None):
             return client
 
     try:
-        from core.spotify_client import SpotifyClient
+        from core.spotify_client import SpotifyClient, normalize_spotify_oauth_config
         from spotipy.oauth2 import SpotifyOAuth
         import spotipy
 
+        normalized_creds = normalize_spotify_oauth_config({
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+        })
         auth_manager = SpotifyOAuth(
-            client_id=client_id,
-            client_secret=client_secret,
-            redirect_uri=redirect_uri,
+            client_id=normalized_creds.get("client_id", client_id),
+            client_secret=normalized_creds.get("client_secret", client_secret),
+            redirect_uri=normalized_creds.get("redirect_uri", redirect_uri),
             scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
             cache_path=cache_path,
             state=f"profile_{profile_id}",

--- a/core/metadata/relevance.py
+++ b/core/metadata/relevance.py
@@ -52,6 +52,27 @@ from typing import List, Optional, Sequence
 from core.metadata.types import Track
 
 
+def build_combined_search_query(track: str = '', artist: str = '',
+                                legacy: str = '') -> str:
+    """Combine a track + artist into a PLAIN, source-agnostic search query.
+
+    Deliberately NOT field-scoped (``track:"X" artist:"Y"``). That Spotify/Lucene
+    filter syntax leaks to non-Spotify sources when a search falls back: Deezer
+    closed the connection on it outright (``RemoteDisconnected``), and even sources
+    that parse it over-constrain and miss the canonical cut (the iTunes/Deezer search
+    endpoints already dropped it for that reason). The matching ``/search_tracks``
+    endpoints rerank by expected title/artist afterward, so precision is recovered
+    without the brittle field syntax.
+
+    Falls back to ``legacy`` when neither track nor artist is given. Returns ``''``
+    when there's nothing to search (caller decides how to handle empty).
+    """
+    parts = [p.strip() for p in (track, artist) if p and p.strip()]
+    if parts:
+        return ' '.join(parts)
+    return (legacy or '').strip()
+
+
 # ---------------------------------------------------------------------------
 # Pattern tables — public so tests can introspect, callers can extend
 # ---------------------------------------------------------------------------

--- a/core/qobuz_client.py
+++ b/core/qobuz_client.py
@@ -715,6 +715,26 @@ class QobuzClient(DownloadSourcePlugin):
             logger.error(f"Error getting Qobuz track {track_id}: {e}")
             return None
 
+    def get_track_result(self, track_id):
+        """Fetch ONE track by ID and convert it to a downloadable TrackResult.
+
+        Used when a pasted Qobuz link must inject the EXACT track: a text search
+        for an obscure track's name often doesn't surface it at all, so bubbling
+        the matching id is a no-op (#932). Returns None on any failure so the
+        caller falls back to the text-search path."""
+        try:
+            track = self.get_track(track_id)
+            if not track:
+                return None
+            quality_key = quality_tier_for_source('qobuz', default='lossless')
+            quality_info = QOBUZ_QUALITY_MAP.get(quality_key, QOBUZ_QUALITY_MAP['lossless'])
+            # require_streamable=False: this is the exact track the user linked — don't
+            # let a missing/absent 'streamable' flag in track/get drop it (#932).
+            return self._qobuz_to_track_result(track, quality_info, require_streamable=False)
+        except Exception as e:
+            logger.debug(f"get_track_result failed for Qobuz {track_id}: {e}")
+            return None
+
     # ===================== Playlists & Favorites =====================
     #
     # Qobuz playlist sync surface — mirrors the Tidal client contract
@@ -1012,14 +1032,20 @@ class QobuzClient(DownloadSourcePlugin):
             traceback.print_exc()
             return ([], [])
 
-    def _qobuz_to_track_result(self, track: Dict, quality_info: dict) -> Optional[TrackResult]:
-        """Convert Qobuz track dict to TrackResult (Soulseek-compatible format)."""
+    def _qobuz_to_track_result(self, track: Dict, quality_info: dict,
+                               require_streamable: bool = True) -> Optional[TrackResult]:
+        """Convert Qobuz track dict to TrackResult (Soulseek-compatible format).
+
+        ``require_streamable`` gates bulk SEARCH results on the ``streamable`` flag
+        (filters noise). For a track the user explicitly pasted a link to, pass
+        False: ``track/get`` may omit the flag (which would default-False and wrongly
+        drop the exact track they asked for), and they should get to try it (#932)."""
         track_id = track.get('id')
         if not track_id:
             return None
 
-        # Check if track is streamable
-        if not track.get('streamable', False):
+        # Check if track is streamable (skipped for explicit by-id link fetches).
+        if require_streamable and not track.get('streamable', False):
             return None
 
         performer = track.get('performer', {})

--- a/core/quality/lossless.py
+++ b/core/quality/lossless.py
@@ -1,0 +1,103 @@
+"""Single source of truth for "is this audio lossless?" + the lossy-copy
+overwrite invariant.
+
+The "create a lossy copy of lossless tracks" feature lives in two places (the
+import post-processing path and the Lossy Converter repair job). Both used to
+hardcode ``.flac``, which is exactly how ALAC/WAV/DSD ended up being quality-
+profile options but NOT lossy-copy sources (#941). The knowledge of which
+formats are lossless now lives HERE, derived from the same format names the
+quality model ranks, so adding a format lights it up in both sites at once and
+they can never drift.
+
+Two seams, both pure (no I/O) so they're unit-testable without real files:
+
+* :func:`is_lossless_format` / :func:`is_lossless_audio_path` — eligibility.
+  ``.m4a``/``.mp4`` are ambiguous (ALAC=lossless, AAC=lossy) and can only be told
+  apart by codec, so the path check delegates them to an *injected* ``probe_codec``
+  callable — the file I/O stays at the edge, the decision stays pure.
+* :func:`lossy_output_would_overwrite_source` — the safety invariant: a lossy copy
+  must NEVER be written over its own source (which becomes possible once ``.m4a``
+  is eligible and the target codec is AAC → same ``.m4a`` path).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable, Optional
+
+from core.quality.source_map import AUDIO_EXTENSIONS, format_from_extension
+
+# Canonical lossless format set. MUST stay in sync with the lossless tiers in
+# core.quality.model.tier_score and the frontend RT_LOSSLESS_FORMATS — the
+# consistency test in tests/quality/test_lossless.py pins the tier agreement.
+LOSSLESS_FORMATS = frozenset({'flac', 'alac', 'wav', 'dsf'})
+
+# Container extensions that may hold EITHER lossless (ALAC) or lossy (AAC) audio —
+# only a codec probe can decide, so they're never lossless on extension alone.
+_AMBIGUOUS_EXTS = frozenset({'m4a', 'mp4'})
+
+
+def is_lossless_format(fmt: Any) -> bool:
+    """True when a unified format name (as returned by ``format_from_extension``)
+    is lossless. ``'aac'`` is False here — an ALAC-in-m4a file reports format
+    ``'aac'`` by extension and must be resolved by codec, not by name."""
+    return str(fmt or '').lower() in LOSSLESS_FORMATS
+
+
+# Extensions worth checking as possibly-lossless (a caller can pre-filter SQL by
+# these, then confirm each via is_lossless_audio_path). Derived from the format
+# map so it can't drift: every extension whose format is lossless, plus the
+# ambiguous ALAC containers. Leading dot included (e.g. '.flac', '.m4a').
+LOSSLESS_CANDIDATE_EXTENSIONS = frozenset(
+    e for e in AUDIO_EXTENSIONS
+    if is_lossless_format(format_from_extension(e)) or e.lstrip('.') in _AMBIGUOUS_EXTS
+)
+
+
+def _ext(path: Any) -> str:
+    return os.path.splitext(str(path or ''))[1].lower().lstrip('.')
+
+
+def is_lossless_audio_path(
+    path: Any,
+    *,
+    probe_codec: Optional[Callable[[str], Optional[str]]] = None,
+) -> bool:
+    """True when the file at ``path`` is lossless.
+
+    Unambiguous extensions (flac/wav/aiff/dsf/dff/alac) are decided by extension.
+    ``.m4a``/``.mp4`` are decided by ``probe_codec(path)`` (returns the codec, e.g.
+    ``'alac'`` or ``'aac'``) — without a probe they're treated as NOT lossless, so
+    a missing probe can never misclassify an AAC file as lossless.
+    """
+    ext = _ext(path)
+    if is_lossless_format(format_from_extension(ext)):
+        return True
+    if ext in _AMBIGUOUS_EXTS and probe_codec is not None:
+        try:
+            codec = (probe_codec(str(path)) or '').lower()
+        except Exception:
+            return False
+        return 'alac' in codec
+    return False
+
+
+def lossy_output_would_overwrite_source(source_path: Any, output_path: Any) -> bool:
+    """True when the computed lossy-copy output path is the source file itself.
+
+    Safety invariant: the converter must skip (never run ffmpeg with ``-y``) when
+    this is True, or it would destroy the original. Happens when an ``.m4a`` ALAC
+    source is converted with the AAC codec (output is also ``.m4a``)."""
+    if not source_path or not output_path:
+        return False
+    a = os.path.normcase(os.path.normpath(str(source_path)))
+    b = os.path.normcase(os.path.normpath(str(output_path)))
+    return a == b
+
+
+__all__ = [
+    'LOSSLESS_FORMATS',
+    'is_lossless_format',
+    'is_lossless_audio_path',
+    'lossy_output_would_overwrite_source',
+]

--- a/core/quality/model.py
+++ b/core/quality/model.py
@@ -39,6 +39,7 @@ class AudioQuality:
         # matched target. Cross-format PRIORITY is decided solely by the user's
         # ranked-target list (target index), never by these numbers.
         format_base: dict[str, float] = {
+            'dsf':   102.0,   # DSD — 1-bit hi-res lossless, ranks at/above FLAC (#939)
             'flac':  100.0,
             'alac':   98.0,   # lossless (Apple)
             'wav':    95.0,

--- a/core/quality/source_map.py
+++ b/core/quality/source_map.py
@@ -44,6 +44,9 @@ _EXTENSION_FORMAT_MAP = {
     'ogg': 'ogg', 'oga': 'ogg',
     'opus': 'opus',
     'wma': 'wma',
+    # DSD (DSD Stream File / DSDIFF) — 1-bit hi-res lossless (e.g. DSD64 ≈ 11 Mbps).
+    # Both container types map to the single 'dsf' tier (#939).
+    'dsf': 'dsf', 'dff': 'dsf',
 }
 
 # Audio extensions worth probing/classifying at all — derived from the map so

--- a/core/reorganize_queue.py
+++ b/core/reorganize_queue.py
@@ -70,6 +70,9 @@ class QueueItem:
     # 'tags'          = read each file's embedded tags as the source
     #                   of truth (issue #592). Zero API calls.
     metadata_source: str = 'api'
+    # Rename-only mode (#875): move files to the current naming scheme WITHOUT the
+    # copy + post-processing (re-tag / quality / AcoustID) the full flow runs.
+    rename_only: bool = False
     status: str = 'queued'              # queued | running | done | failed | cancelled
     started_at: Optional[float] = None
     finished_at: Optional[float] = None
@@ -96,6 +99,7 @@ class QueueItem:
             'artist_name': self.artist_name,
             'source': self.source,
             'metadata_source': self.metadata_source,
+            'rename_only': self.rename_only,
             'enqueued_at': self.enqueued_at,
             'started_at': self.started_at,
             'finished_at': self.finished_at,
@@ -161,6 +165,7 @@ class ReorganizeQueue:
         artist_name: str,
         source: Optional[str] = None,
         metadata_source: str = 'api',
+        rename_only: bool = False,
     ) -> dict:
         """Add an album to the queue. Returns a result dict:
 
@@ -190,6 +195,7 @@ class ReorganizeQueue:
                 source=source,
                 enqueued_at=time.time(),
                 metadata_source=metadata_source or 'api',
+                rename_only=bool(rename_only),
             )
             self._items.append(item)
             position = sum(1 for i in self._items if i.status == 'queued')

--- a/core/reorganize_runner.py
+++ b/core/reorganize_runner.py
@@ -37,6 +37,7 @@ def build_runner(
     is_shutting_down_fn: Callable[[], bool],
     get_download_path: Callable[[], str],
     get_transfer_path: Callable[[], str],
+    build_final_path_fn: Optional[Callable] = None,
 ) -> Callable[[object], dict]:
     """Return the closure the queue worker invokes per item.
 
@@ -59,7 +60,7 @@ def build_runner(
         A callable ``runner(item)`` suitable for
         :meth:`core.reorganize_queue.ReorganizeQueue.set_runner`.
     """
-    from core.library_reorganize import reorganize_album
+    from core.library_reorganize import reorganize_album, reorganize_album_rename_only
     from core.reorganize_queue import get_queue
 
     def _update_track_path(track_id, new_path):
@@ -80,17 +81,6 @@ def build_runner(
         # server restart.
         download_dir = get_download_path()
         transfer_dir = get_transfer_path()
-        staging_root = os.path.join(download_dir, 'ssync_staging')
-        try:
-            os.makedirs(staging_root, exist_ok=True)
-        except OSError as mk_err:
-            logger.error(f"[Reorganize] Cannot create staging dir {staging_root}: {mk_err}")
-            return {
-                'status': 'setup_failed',
-                'source': None,
-                'total': 0, 'moved': 0, 'skipped': 0, 'failed': 0,
-                'errors': [{'error': f'Could not create staging dir: {mk_err}'}],
-            }
 
         def _cleanup_empty(src_dir):
             try:
@@ -104,6 +94,42 @@ def build_runner(
             except Exception as e:
                 # Progress fan-out failures must never break a run.
                 logger.debug("reorganize progress fan-out: %s", e)
+
+        # Rename-only mode (#875): just move files to the current scheme — no staging,
+        # no copy, no post-processing. Falls through to the full pipeline otherwise.
+        if getattr(item, 'rename_only', False):
+            if build_final_path_fn is None:
+                return {
+                    'status': 'setup_failed', 'source': None,
+                    'total': 0, 'moved': 0, 'skipped': 0, 'failed': 0,
+                    'errors': [{'error': 'Rename-only mode unavailable (no path builder)'}],
+                }
+            return reorganize_album_rename_only(
+                album_id=item.album_id,
+                db=get_database(),
+                transfer_dir=transfer_dir,
+                resolve_file_path_fn=resolve_file_path_fn,
+                build_final_path_fn=build_final_path_fn,
+                update_track_path_fn=_update_track_path,
+                cleanup_empty_dir_fn=_cleanup_empty,
+                on_progress=_on_progress,
+                primary_source=item.source,
+                strict_source=bool(item.source),
+                metadata_source=getattr(item, 'metadata_source', 'api') or 'api',
+                stop_check=is_shutting_down_fn,
+            )
+
+        staging_root = os.path.join(download_dir, 'ssync_staging')
+        try:
+            os.makedirs(staging_root, exist_ok=True)
+        except OSError as mk_err:
+            logger.error(f"[Reorganize] Cannot create staging dir {staging_root}: {mk_err}")
+            return {
+                'status': 'setup_failed',
+                'source': None,
+                'total': 0, 'moved': 0, 'skipped': 0, 'failed': 0,
+                'errors': [{'error': f'Could not create staging dir: {mk_err}'}],
+            }
 
         return reorganize_album(
             album_id=item.album_id,

--- a/core/repair_jobs/lossy_converter.py
+++ b/core/repair_jobs/lossy_converter.py
@@ -1,13 +1,19 @@
-"""Lossy Converter Job — finds FLAC files that don't have a lossy copy.
+"""Lossy Converter Job — finds lossless files that don't have a lossy copy.
 
-Scans the library for FLAC files without a corresponding lossy copy alongside
+Scans the library for lossless files without a corresponding lossy copy alongside
 them, and creates a finding for each. The fix action converts the file using
 ffmpeg with the user's configured codec/bitrate settings.
 """
 
 import os
 
+from core.imports.file_ops import m4a_codec
 from core.library.path_resolver import resolve_library_file_path
+from core.quality.lossless import (
+    LOSSLESS_CANDIDATE_EXTENSIONS,
+    is_lossless_audio_path,
+    lossy_output_would_overwrite_source,
+)
 from core.repair_jobs import register_job
 from core.repair_jobs.base import JobContext, JobResult, RepairJob
 from utils.logging_config import get_logger
@@ -19,6 +25,16 @@ CODEC_MAP = {
     'opus': '.opus',
     'aac':  '.m4a',
 }
+
+
+def _lossless_ext_where(col: str) -> str:
+    """SQL pre-filter matching files whose extension *might* be lossless. The
+    final decision (including ALAC-in-.m4a, which needs a codec probe) is made
+    per-file by is_lossless_audio_path. Extensions are trusted constants from the
+    quality model, never user input — safe to interpolate."""
+    return '(' + ' OR '.join(
+        f"LOWER({col}) LIKE '%{ext}'" for ext in sorted(LOSSLESS_CANDIDATE_EXTENSIONS)
+    ) + ')'
 
 
 def _resolve_file_path(file_path, transfer_folder, download_folder=None, config_manager=None):
@@ -35,15 +51,15 @@ def _resolve_file_path(file_path, transfer_folder, download_folder=None, config_
 class LossyConverterJob(RepairJob):
     job_id = 'lossy_converter'
     display_name = 'Lossy Converter'
-    description = 'Finds FLAC files without a lossy copy'
+    description = 'Finds lossless files without a lossy copy'
     help_text = (
-        'Scans your library for FLAC files that don\'t already have a lossy copy '
+        'Scans your library for lossless files (FLAC/ALAC/WAV/AIFF/DSD) that don\'t already have a lossy copy '
         '(MP3, Opus, or AAC) alongside them.\n\n'
         'Uses the codec setting from your Lossy Copy configuration on the Settings '
         'page. Enable Lossy Copy in Settings first, then run this job to find FLAC '
         'files missing a lossy copy.\n\n'
         'Each finding can be fixed individually or in bulk — the fix action converts '
-        'the FLAC file using ffmpeg at your configured bitrate.\n\n'
+        'the lossless file using ffmpeg at your configured bitrate.\n\n'
         'Requires ffmpeg to be installed.'
     )
     icon = 'repair-icon-lossy'
@@ -81,14 +97,14 @@ class LossyConverterJob(RepairJob):
         try:
             conn = context.db._get_connection()
             cursor = conn.cursor()
-            cursor.execute("""
+            cursor.execute(f"""
                 SELECT t.id, t.title, ar.name, al.title, t.file_path,
                        al.thumb_url, ar.thumb_url
                 FROM tracks t
                 LEFT JOIN artists ar ON ar.id = t.artist_id
                 LEFT JOIN albums al ON al.id = t.album_id
                 WHERE t.file_path IS NOT NULL AND t.file_path != ''
-                  AND LOWER(t.file_path) LIKE '%.flac'
+                  AND {_lossless_ext_where('t.file_path')}
             """)
             tracks = cursor.fetchall()
         except Exception as e:
@@ -104,7 +120,7 @@ class LossyConverterJob(RepairJob):
             context.update_progress(0, total)
         if context.report_progress:
             context.report_progress(
-                phase=f'Scanning {total} FLAC files for missing {quality_label} copies...',
+                phase=f'Scanning {total} lossless files for missing {quality_label} copies...',
                 total=total
             )
 
@@ -135,8 +151,17 @@ class LossyConverterJob(RepairJob):
             if not resolved or not os.path.exists(resolved):
                 continue
 
+            # Confirm it's actually lossless — the SQL pre-filter lets .m4a through,
+            # which is ALAC (lossless) OR AAC (lossy); only a codec probe decides.
+            if not is_lossless_audio_path(resolved, probe_codec=m4a_codec):
+                continue
+
             # Check if lossy copy already exists
             out_path = os.path.splitext(resolved)[0] + out_ext
+            # Never offer to convert a file onto itself (e.g. .m4a ALAC + AAC target
+            # lands on the same path) — that conversion would destroy the original.
+            if lossy_output_would_overwrite_source(resolved, out_path):
+                continue
             if os.path.exists(out_path):
                 continue
 
@@ -159,7 +184,7 @@ class LossyConverterJob(RepairJob):
                         file_path=file_path,
                         title=f'No {quality_label} copy: {title or "Unknown"}',
                         description=(
-                            f'FLAC file "{title}" by {artist_name or "Unknown"} does not have '
+                            f'Lossless file "{title}" by {artist_name or "Unknown"} does not have '
                             f'a {quality_label} copy alongside it'
                         ),
                         details={
@@ -195,7 +220,7 @@ class LossyConverterJob(RepairJob):
             context.report_progress(
                 scanned=total, total=total,
                 phase='Complete',
-                log_line=f'Found {result.findings_created} FLAC files without {quality_label} copies',
+                log_line=f'Found {result.findings_created} lossless files without {quality_label} copies',
                 log_type='success' if result.findings_created == 0 else 'info'
             )
 
@@ -208,10 +233,10 @@ class LossyConverterJob(RepairJob):
         try:
             conn = context.db._get_connection()
             cursor = conn.cursor()
-            cursor.execute("""
+            cursor.execute(f"""
                 SELECT COUNT(*) FROM tracks
                 WHERE file_path IS NOT NULL AND file_path != ''
-                  AND LOWER(file_path) LIKE '%.flac'
+                  AND {_lossless_ext_where('file_path')}
             """)
             row = cursor.fetchone()
             return row[0] if row else 0

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -3373,6 +3373,14 @@ class RepairWorker:
             return {'success': False, 'error': f'Source file not found: {file_path}'}
 
         out_path = os.path.splitext(resolved)[0] + out_ext
+        # Safety invariant: ffmpeg runs with -y, so refuse to convert a file onto
+        # itself (an .m4a ALAC source + AAC target shares the .m4a path) — that
+        # would destroy the original lossless file (#941).
+        from core.quality.lossless import lossy_output_would_overwrite_source
+        if lossy_output_would_overwrite_source(resolved, out_path):
+            return {'success': False,
+                    'error': f'{codec.upper()} output would overwrite the source file; '
+                             f'choose a different lossy codec'}
         if os.path.exists(out_path):
             return {'success': True, 'action': 'already_exists',
                     'message': f'{quality_label} copy already exists'}

--- a/core/spotify_client.py
+++ b/core/spotify_client.py
@@ -13,6 +13,30 @@ from core.metadata.cache import get_metadata_cache
 
 logger = get_logger("spotify_client")
 
+
+def normalize_spotify_oauth_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Normalize Spotify OAuth config before building an auth manager.
+
+    Spotify rejects values that include surrounding whitespace, quotes, or
+    newline characters. The settings UI can paste values that carry such
+    formatting, so we trim them before sending them to Spotify.
+    """
+    if not isinstance(config, dict):
+        return {}
+
+    normalized = {}
+    for key in ("client_id", "client_secret", "redirect_uri"):
+        value = config.get(key, "")
+        if isinstance(value, str):
+            value = value.strip().strip('"').strip("'")
+            if key == "redirect_uri":
+                value = value.rstrip("/")
+            normalized[key] = value
+        else:
+            normalized[key] = value
+    return normalized
+
+
 def _upgrade_spotify_image_url(url: str) -> str:
     """Upgrade a Spotify CDN image URL to the highest available resolution.
 
@@ -697,7 +721,7 @@ class SpotifyClient:
         self._setup_client()
     
     def _setup_client(self):
-        config = config_manager.get_spotify_config()
+        config = normalize_spotify_oauth_config(config_manager.get_spotify_config())
         
         if not config.get('client_id') or not config.get('client_secret'):
             logger.warning("Spotify credentials not configured")

--- a/core/spotify_client.py
+++ b/core/spotify_client.py
@@ -17,9 +17,16 @@ logger = get_logger("spotify_client")
 def normalize_spotify_oauth_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Normalize Spotify OAuth config before building an auth manager.
 
-    Spotify rejects values that include surrounding whitespace, quotes, or
-    newline characters. The settings UI can paste values that carry such
-    formatting, so we trim them before sending them to Spotify.
+    Spotify rejects values that include surrounding whitespace or quotes, and the
+    settings UI can paste values carrying such formatting, so we trim those — they
+    can never be part of a real credential.
+
+    We deliberately do NOT strip a trailing slash from ``redirect_uri``: Spotify
+    matches the redirect URI EXACTLY against the app's dashboard registration, and
+    a trailing slash is a legitimate part of a URI. Stripping it would silently
+    break anyone who registered ``…/callback/`` (we'd send ``…/callback`` →
+    "INVALID_CLIENT: Invalid redirect URI"). So the value is preserved verbatim
+    apart from the unambiguous whitespace/quote garbage (#942 follow-up).
     """
     if not isinstance(config, dict):
         return {}
@@ -28,10 +35,7 @@ def normalize_spotify_oauth_config(config: Optional[Dict[str, Any]]) -> Dict[str
     for key in ("client_id", "client_secret", "redirect_uri"):
         value = config.get(key, "")
         if isinstance(value, str):
-            value = value.strip().strip('"').strip("'")
-            if key == "redirect_uri":
-                value = value.rstrip("/")
-            normalized[key] = value
+            normalized[key] = value.strip().strip('"').strip("'")
         else:
             normalized[key] = value
     return normalized

--- a/core/spotify_client.py
+++ b/core/spotify_client.py
@@ -14,6 +14,18 @@ from core.metadata.cache import get_metadata_cache
 logger = get_logger("spotify_client")
 
 
+# Single source of truth for the Spotify OAuth scope. Used by EVERY SpotifyOAuth
+# construction (the client, the per-profile registry, and all web_server callbacks) so
+# the authorize URL and token exchange can never request different scopes — a mismatch
+# silently re-prompts or denies. The `playlist-modify-*` pair powers exporting a mirrored
+# playlist back to Spotify (#945); existing users re-auth once to grant it.
+SPOTIFY_OAUTH_SCOPE = (
+    "user-library-read user-read-private playlist-read-private "
+    "playlist-read-collaborative user-read-email user-follow-read "
+    "playlist-modify-public playlist-modify-private"
+)
+
+
 def normalize_spotify_oauth_config(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     """Normalize Spotify OAuth config before building an auth manager.
 
@@ -744,7 +756,7 @@ class SpotifyClient:
                 client_id=config['client_id'],
                 client_secret=config['client_secret'],
                 redirect_uri=config.get('redirect_uri', "http://127.0.0.1:8888/callback"),
-                scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
+                scope=SPOTIFY_OAUTH_SCOPE,
                 cache_handler=DatabaseTokenCache(config_manager)
             )
             
@@ -1135,6 +1147,56 @@ class SpotifyClient:
                  logger.info(f"Returning {len(playlists)} playlists fetched before error.")
                  return playlists
             return []
+
+    def create_or_update_playlist(self, name, track_ids, *, existing_id=None,
+                                  public=False, description=""):
+        """Create a Spotify playlist owned by the authed user (or replace an existing
+        one's tracks in place), for exporting a mirrored playlist back to Spotify (#945).
+
+        ``track_ids`` are Spotify track IDs (the stored ``spotify_track_id`` per library
+        track). ``existing_id`` set → replace that playlist's contents (idempotent
+        re-export); unset → create a new playlist. Requires the ``playlist-modify-*``
+        scope — a token issued before that scope was added gets a clear "reconnect"
+        error rather than a raw 403. Returns
+        ``{success, playlist_id, url, added, error}``.
+        """
+        if not self.is_spotify_authenticated():
+            return {"success": False, "error": "Spotify is not connected"}
+        uris = [f"spotify:track:{t}" for t in (track_ids or []) if t]
+        if not uris:
+            return {"success": False, "error": "No matching Spotify tracks to export"}
+        try:
+            playlist_id = existing_id
+            if playlist_id:
+                # Replace contents (re-export). replace_items caps at 100 — seed with the
+                # first 100, then append the rest in 100-track chunks.
+                self.sp.playlist_replace_items(playlist_id, uris[:100])
+                for i in range(100, len(uris), 100):
+                    self.sp.playlist_add_items(playlist_id, uris[i:i + 100])
+            else:
+                user_id = (self.sp.current_user() or {}).get("id")
+                created = self.sp.user_playlist_create(
+                    user_id, name, public=public, description=description,
+                )
+                playlist_id = (created or {}).get("id")
+                if not playlist_id:
+                    return {"success": False, "error": "Spotify did not return a playlist id"}
+                for i in range(0, len(uris), 100):
+                    self.sp.playlist_add_items(playlist_id, uris[i:i + 100])
+            return {
+                "success": True,
+                "playlist_id": playlist_id,
+                "url": f"https://open.spotify.com/playlist/{playlist_id}",
+                "added": len(uris),
+            }
+        except Exception as e:
+            msg = str(e)
+            if "403" in msg or "scope" in msg.lower() or "insufficient" in msg.lower():
+                return {"success": False,
+                        "error": "Reconnect Spotify to grant playlist write access "
+                                 "(Settings → reconnect Spotify)."}
+            _detect_and_set_rate_limit(e, "create_or_update_playlist")
+            return {"success": False, "error": msg}
 
     @rate_limited
     def get_saved_tracks_count(self) -> int:

--- a/core/ui_appearance.py
+++ b/core/ui_appearance.py
@@ -1,0 +1,40 @@
+"""Pure decisions for UI-appearance defaults.
+
+Kept here (importable, no Flask/config coupling) so the rules are unit-testable in
+isolation; web_server does only the request/config plumbing around them.
+
+Worker orbs are a blurred 60fps canvas — the main remaining Firefox lag source after
+the #935 sweep. So for a FIRST-TIME user (no saved preference) we default them OFF on
+Firefox and ON everywhere else: a smooth first impression where it's needed, full
+polish where the browser handles it. An explicit saved choice ALWAYS wins — this only
+picks the default when the user hasn't chosen.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def is_firefox_user_agent(user_agent: Optional[str]) -> bool:
+    """True when a User-Agent string is Firefox.
+
+    Used ONLY to pick a performance-friendly default — never to gate functionality —
+    so a spoofed or unusual UA simply gets the default and the user can toggle. Chrome,
+    Edge, Safari, Opera, Brave do not carry 'firefox' in their UA; Firefox does
+    ('… Gecko/… Firefox/<ver>')."""
+    return 'firefox' in str(user_agent or '').lower()
+
+
+def resolve_worker_orbs_default(explicit: object, is_firefox: bool) -> bool:
+    """Whether worker orbs should be on.
+
+    ``explicit`` is the saved config value: ``True``/``False`` when the user has chosen,
+    ``None`` when unset. An explicit choice always wins; when unset, default OFF on
+    Firefox (perf) and ON elsewhere.
+    """
+    if explicit is None:
+        return not is_firefox
+    return explicit is not False
+
+
+__all__ = ['is_firefox_user_agent', 'resolve_worker_orbs_default']

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,44 +1,43 @@
-# soulsync 2.8.0 — `dev` → `main`
+# soulsync 2.8.1 — `dev` → `main`
 
-mostly a quality + reliability release. the headline is a big cleanup of the **Unverified review queue** (it stops inflating and self-heals), a new **Preview Clip Cleanup** tool, smarter **Album Completeness** for split/fragmented albums, and a real pass on **dashboard performance** (especially Firefox/Zen). plus a pile of reported fixes.
+a feature + reliability release. the headline is **export a mirrored playlist back to Spotify or Deezer** — same one-click flow as the listenbrainz export, now pointed at the streaming services. plus a **rename-only mode** for Library Reorganize, broader lossless handling, a pile of download fixes, and the reduce-visual-effects pass refined so it stops freezing functional motion.
 
 ---
 
 ## what's new
 
-### Preview Clip Cleanup (new Tools job)
-the HiFi source sometimes hands back a ~30-second **preview clip** instead of the full song, and it lands looking like a normal track. the new job scans your short tracks, checks how long each one *should* be from its metadata source, and flags the previews. approve a finding and it deletes the clip, drops it from the library, and re-wishlists the full version. each finding has a **▶ Play** button + a file-length-vs-real-length readout so you can confirm it's busted before approving. conservative by design — genuine short tracks and anything it can't verify are left alone.
+### 🎧 Export playlists to Spotify & Deezer (#945)
+the mirrored-playlist export modal now has **Sync to Spotify** and **Sync to Deezer** next to the listenbrainz / jspf options. it builds a playlist in your account from the tracks soulsync already has the service IDs for:
 
-### the Unverified queue stops inflating + self-heals (#934)
-big one for anyone who saw thousands of "unverified" rows. the AcoustID scan was creating a fresh history row every run and leaving already-verified files stuck as "unverified" (a frozen import-time path that stopped matching once the file moved). now:
-- scans no longer duplicate rows and heal on the spot, and
-- a one-time **reconcile** on startup clears the existing backlog from your library's truth — no re-scan needed, including human-verified files a scan skips, and
-- a **🧹 Clean orphaned** button removes dead rows whose file is genuinely gone (with a safety gate that refuses to run if your library looks offline).
-the Unverified review rows also got the nicer Quarantine-style cards (artwork, inline details). *(thanks @nick2000713 for #938.)*
+- resolves each track from what's already on hand first — the **discovery cache**, then your library's stored IDs — so for an already-discovered playlist it's instant and uses **zero API calls**
+- re-exporting **updates the same playlist in place** instead of spawning duplicates
+- an optional **"match missing tracks"** toggle does a confident live search for the stragglers — and only adds a match it's sure about (a wrong-artist or karaoke version is left out, never guessed)
+- service buttons grey out + point you to Settings when that service isn't connected
+- spotify needs a one-time reconnect to grant playlist-write access
 
-### Album Completeness handles split albums (#936, #929, #931)
-a physical album split across multiple library rows used to show every fragment as falsely "incomplete." it now groups the validated fragments into one logical album and emits a single correct finding — grouping by a shared id **and** validating at the track level, so unrelated rows never get fused. also recognizes MusicBrainz as a readable album source. *(thanks @ragnarlotus.)*
+### 🏷️ Library Reorganize — Rename only (#875)
+a lighter reorganize action: it just **renames your files** to your current naming scheme — no re-tagging, no quality/AcoustID re-check, no copy-to-staging. much faster on a NAS, won't fail on post-processing reasons, and only touches files whose path actually changes (which also fixes the "2 of 14 previewed but everything got modified" album-splitting). pick it from the new **Action** dropdown in the reorganize modal.
 
-### Clear Completed is back on the Downloads page
-since completed downloads now persist across restart, the **Clear Completed** button had gone missing for them. it's back — it clears the live list *and* the persisted history so the page actually empties and stays empty (your files are untouched).
+### 💿 Lossless handling
+- lossy-copy now works for **all lossless formats**, not just FLAC (#941)
+- **DSD** (`.dsf` / `.dff`) is recognized as lossless and no longer false-flagged as "truncated" (#939)
 
----
+### 🐛 Download + search fixes
+- a download with an unbalanced bracket in its name no longer false-fails as "file not found"
+- a file we couldn't quarantine is left in place for retry instead of deleted
+- the Identify search for single imports defaults to "artist - title" (with the dash)
+- "file not found" failures now say what actually happened instead of an opaque error
+- pasted Qobuz/Tidal links **inject the exact track** into manual search instead of hoping text-search surfaces it (#932)
+- the Wing It pool "Fix Match" search works again (it was returning "no results" for everything)
 
-## fixes
+### ⚡ Visual effects + scan reliability
+- **Reduce visual effects** no longer freezes functional motion (spinners, progress) — it only kills the expensive GPU stuff (blur, shadows, glow)
+- worker orbs default **OFF on Firefox** for new users, and run at ~30fps under reduce-effects
+- jellyfin library scans page the bulk fetch so the no-progress watchdog can't false-stall a big library
 
-- **pasted YouTube cookies threw `unsupported browser: "custom"` (Docker)** — the client passed the "Paste cookies.txt" mode through as a browser name instead of using the cookies file. now it loads the pasted `cookies.txt` correctly — the only auth path that works on a headless/Docker box. *(thanks HellRa1SeR.)*
-- **longer remasters quarantined as "truncated" (#937)** — the duration check was symmetric, so a remaster running a few seconds *longer* than the metadata got rejected like a truncated download. it's asymmetric now: short files stay strict, longer versions get room. *(thanks @diegocade1.)*
-- **"Add to Wishlist" from an artist discography was painfully slow** — ~15–30s *per track* on a large library, because the per-track library-ownership check fell through to a full-table fuzzy scan. it now matches in-memory against the artist's tracks once — effectively instant.
-- **wishlist art was blank for re-downloads / preview re-fetches** — library-sourced items stored a relative media-server path that doesn't render in a browser. they're normalized on read now, so album + artist art show up (fixes already-saved items too).
-- **watchlist didn't record automatic scans (#933)** + **watchlist fused different editions of an album as one.**
-- **manual search:** a pasted Qobuz/Tidal track now floats to the top of results (#932).
-- **Popular Picks came up empty on Deezer** — a popularity-threshold scale mismatch.
+### 🔧 Under the hood
+- settings page cleanup (#943 — thanks @nick2000713)
+- spotify oauth credential normalization + redirect-uri handling (#942 — thanks HellRa1SeR)
+- security: npm audit fixes for vite / undici / @babel (#944 — thanks HellRa1SeR)
 
----
-
-## performance + UI
-
-- **dashboard GPU usage, especially on Firefox/Zen (#935)** — frosted-glass blur, cursor-glow blobs, and the worker-orb animation were repainting every frame. trimmed the worst offenders, made the orb loop hold a steady framerate on Firefox instead of dropping to ~1fps, and set **Background Particles OFF by default**. the dashboard system-memory tile now also shows SoulSync's own RAM.
-- **bounded memory growth (#802)** — browsing every page used to climb RSS into the GBs (plexapi's XML trees deferring GC) and could lock the app up. a lightweight sweeper now collects + hands memory back to the OS as it grows, so it sawtooths and settles instead of climbing.
-
----
+enjoy 🎶

--- a/tests/downloads/test_downloads_post_processing.py
+++ b/tests/downloads/test_downloads_post_processing.py
@@ -170,7 +170,12 @@ def test_file_not_found_after_retries_marks_failed(monkeypatch):
     deps, rec = _build_deps()
     pp.run_post_processing_worker('t1', 'b1', deps)
     assert download_tasks['t1']['status'] == 'failed'
-    assert 'File not found on disk' in download_tasks['t1']['error_message']
+    # Actionable failure: names the folder searched + the two real causes, so a
+    # standalone user with a path mismatch can self-diagnose (Discord: Shdjfgatdif).
+    msg = download_tasks['t1']['error_message']
+    assert './downloads' in msg                    # the folder we actually searched
+    assert "download path doesn't match slskd" in msg   # the config-mismatch hint
+    assert 'song.flac' in msg                       # the file slskd reported
     assert ('on_complete', ('b1', 't1', False), {}) in rec.calls
 
 

--- a/tests/downloads/test_file_finder.py
+++ b/tests/downloads/test_file_finder.py
@@ -396,3 +396,56 @@ def test_real_soulseek_path_still_basenamed(tmp_path):
         str(downloads), r'shared\Billy Ocean\Very Best Of\01 - Suddenly.flac',
     )
     assert found == str(target)
+
+
+# ---------------------------------------------------------------------------
+# Unbalanced bracket — slskd REPORTS "[34 - Title.flac" but SAVES the file as
+# "34 - Title.flac" (it sanitises the leading '['). The normaliser's old combined
+# bracket-strip r'[\[\(].*?[\]\)]' matched from that lone '[' all the way to the
+# next ')', eating the whole title and collapsing the search target to just "flac"
+# → 0.40 fuzzy score → "File not found on disk" despite the file sitting right
+# there. (Discord: Shdjfgatdif — "You & Me (Flume Remix)".)
+# ---------------------------------------------------------------------------
+
+
+def test_finds_file_when_slskd_strips_a_leading_bracket(tmp_path):
+    downloads = tmp_path / 'downloads'
+    # On disk: no leading '['. API filename (slskd-reported): has the '['.
+    target = downloads / 'Disclosure' / '34 - You & Me (Flume Remix).flac'
+    _touch(target)
+
+    found, location = find_completed_audio_file(
+        str(downloads), r'Music\Disclosure\[34 - You & Me (Flume Remix).flac',
+    )
+
+    assert found == str(target), \
+        'the lone "[" used to collapse the target to "flac" and miss the file'
+    assert location == 'downloads'
+
+
+def test_balanced_bracket_tags_still_stripped(tmp_path):
+    """No regression: balanced "[FLAC]" / "(Remastered 2016)" tags in a Soulseek
+    filename must still be stripped so it matches the clean saved file."""
+    downloads = tmp_path / 'downloads'
+    target = downloads / 'Song.mp3'
+    _touch(target)
+
+    found, _ = find_completed_audio_file(
+        str(downloads), r'shared\Artist\Album\Song [FLAC] (Remastered 2016).mp3',
+    )
+
+    assert found == str(target)
+
+
+def test_stray_closing_bracket_does_not_break_match(tmp_path):
+    """The other shape in the wild (Discord: "Abort, Retry, Fail_]1-01 …") — a
+    stray ']' must not wreck the match either."""
+    downloads = tmp_path / 'downloads'
+    target = downloads / 'White Town' / "Fail_]1-01 Your Woman.flac"
+    _touch(target)
+
+    found, _ = find_completed_audio_file(
+        str(downloads), r"@@digadom\Music\White Town\Fail_]1-01 Your Woman.flac",
+    )
+
+    assert found == str(target)

--- a/tests/downloads/test_track_link.py
+++ b/tests/downloads/test_track_link.py
@@ -122,3 +122,112 @@ def test_bubble_noop_when_nothing_matches_or_empty():
     assert bubble_linked_track_first([a, b], '296427754') == [a, b]   # unchanged
     assert bubble_linked_track_first([], '296427754') == []
     assert bubble_linked_track_first([a, b], '') == [a, b]
+
+
+# ── inject the EXACT fetched track first (#932 reopen: text search misses obscure tracks) ──
+
+from core.downloads.track_link import inject_linked_track_first
+
+
+def test_inject_puts_fetched_track_first_when_search_missed_it():
+    # The reported case: the linked track isn't among the fuzzy text-search
+    # results at all, so the directly-fetched result is injected at the top.
+    fetched = _result('296427754')
+    search = [_result('111'), _result('222')]   # unrelated lookalikes
+    out = inject_linked_track_first(search, fetched, '296427754')
+    assert out[0] is fetched
+    assert len(out) == 3
+
+
+def test_inject_dedups_a_search_copy_of_the_linked_track():
+    fetched = _result('296427754')
+    dup = _result('296427754')                  # search also returned it
+    search = [_result('111'), dup, _result('222')]
+    out = inject_linked_track_first(search, fetched, '296427754')
+    assert out[0] is fetched
+    # exactly one element carries the linked id, and it's the injected one
+    assert [linked_track_id(t) for t in out].count('296427754') == 1
+    assert all(t is not dup for t in out)        # the search copy (by identity) was dropped
+    assert len(out) == 3
+
+
+def test_inject_falls_back_to_bubble_without_a_fetched_result():
+    exact = _result('296427754')
+    out = inject_linked_track_first([_result('111'), exact, _result('222')], None, '296427754')
+    assert linked_track_id(out[0]) == '296427754'   # bubbled, not injected
+    assert len(out) == 3
+
+
+def test_inject_is_noop_without_a_link_id():
+    search = [_result('111')]
+    assert inject_linked_track_first(search, _result('x'), '') == search
+
+
+def test_inject_int_track_id_is_str_safe():
+    fetched = _result('296427754')
+    out = inject_linked_track_first([_result('111')], fetched, 296427754)
+    assert out[0] is fetched
+
+
+# ── QobuzClient.get_track_result: fetch by id → downloadable TrackResult ──
+
+from core.qobuz_client import QobuzClient
+
+
+def _bare_qobuz():
+    return QobuzClient.__new__(QobuzClient)   # no network / __init__
+
+
+def test_get_track_result_converts_fetched_track(monkeypatch):
+    client = _bare_qobuz()
+    sentinel = object()
+    monkeypatch.setattr(client, 'get_track', lambda tid: {'id': tid, 'streamable': True})
+    monkeypatch.setattr(client, '_qobuz_to_track_result',
+                        lambda track, qi, require_streamable=True: sentinel)
+    assert client.get_track_result('296427754') is sentinel
+
+
+def test_get_track_result_none_when_track_unavailable(monkeypatch):
+    client = _bare_qobuz()
+    monkeypatch.setattr(client, 'get_track', lambda tid: None)
+    assert client.get_track_result('nope') is None
+
+
+def test_get_track_result_none_on_exception(monkeypatch):
+    client = _bare_qobuz()
+    def _boom(_tid):
+        raise RuntimeError('api down')
+    monkeypatch.setattr(client, 'get_track', _boom)
+    assert client.get_track_result('x') is None
+
+
+# ── #932 hardening: a pasted-link fetch must not be dropped by a missing
+#    'streamable' flag (track/get may omit it). Exercises the REAL converter. ──
+
+_QOBUZ_TRACK = {'id': 296427754, 'title': 'foreign lavennew',
+                'performer': {'name': 'colacola'}, 'duration': 180}
+
+
+def test_converter_rejects_non_streamable_on_search_path():
+    # Default (bulk search) still filters on streamable — unchanged behaviour.
+    client = _bare_qobuz()
+    qi = {'codec': 'flac', 'bitrate': 1411}
+    assert client._qobuz_to_track_result(dict(_QOBUZ_TRACK), qi) is None  # no streamable flag
+
+
+def test_converter_builds_for_link_fetch_without_streamable():
+    client = _bare_qobuz()
+    qi = {'codec': 'flac', 'bitrate': 1411}
+    r = client._qobuz_to_track_result(dict(_QOBUZ_TRACK), qi, require_streamable=False)
+    assert r is not None
+    assert linked_track_id(r) == '296427754'   # carries the id → injectable + downloadable
+
+
+def test_get_track_result_survives_missing_streamable_flag(monkeypatch):
+    # The feared track/get shape (no 'streamable') must STILL yield the track —
+    # this is the end-to-end gap that couldn't be confirmed against a live API.
+    client = _bare_qobuz()
+    monkeypatch.setattr(client, 'get_track', lambda _tid: dict(_QOBUZ_TRACK))
+    r = client.get_track_result('296427754')
+    assert r is not None
+    assert linked_track_id(r) == '296427754'

--- a/tests/exports/test_export_sources.py
+++ b/tests/exports/test_export_sources.py
@@ -168,4 +168,71 @@ def test_resolve_waterfall_cache_then_library_then_unmatched():
     ids = [r['service_track_id'] for r in out['resolved']]
     assert ids == ['111', 'lib-222', None]
     s = out['stats']
-    assert s == {'total': 3, 'resolved': 2, 'unmatched': 1, 'from_cache': 1, 'from_library': 1}
+    assert s == {'total': 3, 'resolved': 2, 'unmatched': 1, 'from_cache': 1,
+                 'from_library': 1, 'from_search': 0}
+
+
+# ── backfill: confident live-search match for the un-cached/un-enriched tail (#945) ──
+
+from core.metadata.types import Track as _Track
+from core.exports.export_sources import search_service_track_id, BACKFILL_MIN_SCORE
+
+
+def _cand(name, artist, tid, album_type='album'):
+    return _Track(id=tid, name=name, artists=[artist], album='A',
+                  duration_ms=200000, album_type=album_type)
+
+
+def test_backfill_exact_match_returned():
+    search = lambda q: [_cand('Not Like Us', 'Kendrick Lamar', 'dz-NLU')]
+    assert search_service_track_id('Kendrick Lamar', 'Not Like Us', search_fn=search) == 'dz-NLU'
+
+
+def test_backfill_wrong_artist_rejected():
+    """SAFETY: an exact-title hit by the WRONG artist scores below the floor (no 1.5x exact-
+    artist boost) → None, so backfill never adds someone else's same-named track."""
+    search = lambda q: [_cand('Not Like Us', 'Some Other Guy', 'wrong-id')]
+    assert search_service_track_id('Kendrick Lamar', 'Not Like Us', search_fn=search) is None
+
+
+def test_backfill_karaoke_cover_rejected():
+    """SAFETY: a karaoke/cover version is buried (x0.05) below the floor → None."""
+    search = lambda q: [_cand('Not Like Us (Karaoke Version)', 'Karaoke All Stars', 'kar-id')]
+    assert search_service_track_id('Kendrick Lamar', 'Not Like Us', search_fn=search) is None
+
+
+def test_backfill_picks_real_over_cover():
+    search = lambda q: [
+        _cand('Not Like Us (Karaoke Version)', 'Karaoke All Stars', 'kar-id'),
+        _cand('Not Like Us', 'Kendrick Lamar', 'real-id'),
+    ]
+    assert search_service_track_id('Kendrick Lamar', 'Not Like Us', search_fn=search) == 'real-id'
+
+
+def test_backfill_empty_and_error_and_no_title():
+    assert search_service_track_id('A', 'X', search_fn=lambda q: []) is None
+    def boom(q):
+        raise RuntimeError('deezer flaked')
+    assert search_service_track_id('A', 'X', search_fn=boom) is None      # fail-safe
+    assert search_service_track_id('A', '', search_fn=lambda q: [_cand('X', 'A', 'i')]) is None
+
+
+def test_resolve_waterfall_uses_search_only_when_cache_and_library_miss():
+    tracks = [
+        _extra('deezer', 111) | {'artist_name': 'A', 'track_name': 'Cached'},
+        {'artist_name': 'A', 'track_name': 'InLib'},
+        {'artist_name': 'A', 'track_name': 'OnlyOnSvc'},
+    ]
+    db_fn = lambda a, t, s: 'lib-2' if t == 'InLib' else None
+    search_id_fn = lambda a, t: 'srch-3' if t == 'OnlyOnSvc' else None
+    out = resolve_service_track_ids(tracks, 'deezer', db_fn=db_fn, search_id_fn=search_id_fn)
+    assert [r['service_track_id'] for r in out['resolved']] == ['111', 'lib-2', 'srch-3']
+    s = out['stats']
+    assert (s['from_cache'], s['from_library'], s['from_search'], s['unmatched']) == (1, 1, 1, 0)
+
+
+def test_resolve_no_search_fn_leaves_tail_unmatched():
+    out = resolve_service_track_ids([{'artist_name': 'A', 'track_name': 'X'}], 'deezer',
+                                    db_fn=lambda a, t, s: None)   # search_id_fn omitted
+    assert out['resolved'][0]['service_track_id'] is None
+    assert out['stats']['unmatched'] == 1 and out['stats']['from_search'] == 0

--- a/tests/exports/test_export_sources.py
+++ b/tests/exports/test_export_sources.py
@@ -117,3 +117,55 @@ def test_db_service_track_id_real_sql_executes(tmp_path, monkeypatch):
     assert es.db_service_track_id("Kendrick Lamar", "Not Like Us", "spotify") == "spid-NLU"
     assert es.db_service_track_id("kendrick lamar", "not like us", "deezer") == "dz-NLU"  # case-insensitive
     assert es.db_service_track_id("Kendrick Lamar", "Unknown Song", "spotify") is None
+
+
+# ── discovery-cache resolution (#945: use the already-discovered IDs, no API call) ──
+
+import json as _json
+from core.exports.export_sources import (
+    service_id_from_extra_data,
+    resolve_service_track_ids,
+)
+
+
+def _extra(service, tid, discovered=True, provider=None):
+    return {'extra_data': _json.dumps({'discovered': discovered,
+                                       'provider': provider or service,
+                                       'matched_data': {'id': tid}})}
+
+
+def test_extra_data_id_when_discovered_to_that_service():
+    assert service_id_from_extra_data(_extra('deezer', 111), 'deezer') == '111'
+    # dict (not str) extra_data also works
+    raw = {'extra_data': {'discovered': True, 'provider': 'spotify', 'matched_data': {'id': 'spX'}}}
+    assert service_id_from_extra_data(raw, 'spotify') == 'spX'
+
+
+def test_extra_data_provider_must_match_service():
+    # discovered to Spotify, exporting to Deezer → don't reuse the (wrong-service) id
+    assert service_id_from_extra_data(_extra('spotify', 111), 'deezer') is None
+
+
+def test_extra_data_wing_it_fallback_is_not_trusted():
+    track = _extra('deezer', 111, provider='wing_it_fallback')
+    assert service_id_from_extra_data(track, 'deezer') is None
+
+
+def test_extra_data_misc_none_cases():
+    assert service_id_from_extra_data({}, 'deezer') is None                       # no extra_data
+    assert service_id_from_extra_data({'extra_data': 'not json{'}, 'deezer') is None  # bad json
+    assert service_id_from_extra_data(_extra('deezer', 111, discovered=False), 'deezer') is None
+
+
+def test_resolve_waterfall_cache_then_library_then_unmatched():
+    tracks = [
+        _extra('deezer', 111) | {'artist_name': 'A', 'track_name': 'Cached'},   # cache hit
+        {'artist_name': 'A', 'track_name': 'InLib'},                            # library hit (db_fn)
+        {'artist_name': 'A', 'track_name': 'Nowhere'},                          # unmatched
+    ]
+    db_fn = lambda a, t, s: 'lib-222' if t == 'InLib' else None
+    out = resolve_service_track_ids(tracks, 'deezer', db_fn=db_fn)
+    ids = [r['service_track_id'] for r in out['resolved']]
+    assert ids == ['111', 'lib-222', None]
+    s = out['stats']
+    assert s == {'total': 3, 'resolved': 2, 'unmatched': 1, 'from_cache': 1, 'from_library': 1}

--- a/tests/exports/test_export_sources.py
+++ b/tests/exports/test_export_sources.py
@@ -57,3 +57,34 @@ def test_all_miss_returns_none_and_no_write():
     fn, recorded = _wire()
     assert fn("A", "T") == (None, None)
     assert recorded == {}
+
+
+# ── service track-id resolver (#945 export to Spotify/Deezer) ──
+
+from core.exports.export_sources import (
+    db_service_track_id,
+    build_service_resolve_fn,
+    _SERVICE_ID_COLUMNS,
+)
+
+
+def test_service_id_column_mapping():
+    assert _SERVICE_ID_COLUMNS == {'spotify': 'spotify_track_id', 'deezer': 'deezer_id'}
+
+
+def test_db_service_track_id_unknown_service_is_none():
+    assert db_service_track_id('A', 'X', 'tidal') is None
+    assert db_service_track_id('A', 'X', '') is None
+
+
+def test_db_service_track_id_no_title_is_none():
+    assert db_service_track_id('A', '', 'spotify') is None
+
+
+def test_build_service_resolve_fn_returns_id_and_source(monkeypatch):
+    import core.exports.export_sources as es
+    monkeypatch.setattr(es, 'db_service_track_id',
+                        lambda a, t, s: 'spid-99' if t == 'Hit' else None)
+    fn = build_service_resolve_fn('spotify')
+    assert fn('Artist', 'Hit') == ('spid-99', 'library')
+    assert fn('Artist', 'Miss') == (None, None)

--- a/tests/exports/test_export_sources.py
+++ b/tests/exports/test_export_sources.py
@@ -88,3 +88,32 @@ def test_build_service_resolve_fn_returns_id_and_source(monkeypatch):
     fn = build_service_resolve_fn('spotify')
     assert fn('Artist', 'Hit') == ('spid-99', 'library')
     assert fn('Artist', 'Miss') == (None, None)
+
+
+def test_db_service_track_id_real_sql_executes(tmp_path, monkeypatch):
+    """Run the ACTUAL query against a real (temp) tracks/artists schema — the broad
+    except→None in db_service_track_id would otherwise mask a column/join typo as
+    'no match' for every track (#945 verification)."""
+    import sqlite3
+    import types
+    import core.exports.export_sources as es
+
+    dbfile = tmp_path / "lib.db"
+    con = sqlite3.connect(str(dbfile))
+    con.executescript(
+        "CREATE TABLE artists (id TEXT PRIMARY KEY, name TEXT);"
+        "CREATE TABLE tracks (id TEXT, artist_id TEXT, title TEXT, "
+        "spotify_track_id TEXT, deezer_id TEXT);"
+        "INSERT INTO artists VALUES ('a1','Kendrick Lamar');"
+        "INSERT INTO tracks VALUES ('t1','a1','Not Like Us','spid-NLU','dz-NLU');"
+    )
+    con.commit()
+    con.close()
+
+    # fresh connection per call (db_service_track_id closes it in finally)
+    fake_db = types.SimpleNamespace(_get_connection=lambda: sqlite3.connect(str(dbfile)))
+    monkeypatch.setattr("database.music_database.get_database", lambda: fake_db)
+
+    assert es.db_service_track_id("Kendrick Lamar", "Not Like Us", "spotify") == "spid-NLU"
+    assert es.db_service_track_id("kendrick lamar", "not like us", "deezer") == "dz-NLU"  # case-insensitive
+    assert es.db_service_track_id("Kendrick Lamar", "Unknown Song", "spotify") is None

--- a/tests/exports/test_playlist_export.py
+++ b/tests/exports/test_playlist_export.py
@@ -72,3 +72,31 @@ def test_empty_playlist():
     out = resolve_playlist_tracks([], lambda a, t: (None, None))
     assert out["resolved"] == []
     assert out["stats"]["total"] == 0
+
+
+# ── id_key generalization (#945 service export reuses the LB resolver) ──
+
+from core.exports.playlist_export import resolve_playlist_tracks as _rpt
+
+
+def _const_resolver(mapping):
+    return lambda artist, title: mapping.get((artist, title), (None, None))
+
+
+def test_default_id_key_is_recording_mbid_unchanged():
+    # ListenBrainz/JSPF callers must be byte-for-byte unaffected by the generalization.
+    out = _rpt([{'artist': 'A', 'title': 'X'}], _const_resolver({('A', 'X'): ('mbid-1', 'db')}))
+    assert out['resolved'][0]['recording_mbid'] == 'mbid-1'
+    assert 'service_track_id' not in out['resolved'][0]
+
+
+def test_custom_id_key_carries_service_id():
+    out = _rpt(
+        [{'artist': 'A', 'title': 'X'}, {'artist': 'B', 'title': 'Y'}],
+        _const_resolver({('A', 'X'): ('spid-1', 'library')}),   # B/Y unmatched
+        id_key='service_track_id',
+    )
+    assert out['resolved'][0]['service_track_id'] == 'spid-1'
+    assert out['resolved'][1]['service_track_id'] is None
+    assert 'recording_mbid' not in out['resolved'][0]
+    assert out['stats']['resolved'] == 1 and out['stats']['unmatched'] == 1

--- a/tests/imports/test_import_file_ops.py
+++ b/tests/imports/test_import_file_ops.py
@@ -244,3 +244,61 @@ def test_atomic_helper_cleans_temp_and_keeps_source_on_failure(tmp_path, monkeyp
     assert src.exists()                           # source preserved on failure
     assert not dst.exists()                       # no partial final file
     assert not list(dstdir.glob(".*ssync-tmp"))   # temp cleaned up
+
+
+# ── #941: create_lossy_copy now accepts all lossless sources + never overwrites them ──
+
+import core.imports.file_ops as _fo
+
+
+def _enable_lossy(monkeypatch, codec="mp3", bitrate="320"):
+    cfg = {"lossy_copy.enabled": True, "lossy_copy.codec": codec,
+           "lossy_copy.bitrate": bitrate, "lossy_copy.delete_original": False}
+    monkeypatch.setattr(_fo.config_manager, "get", lambda k, d=None: cfg.get(k, d))
+    monkeypatch.setattr(_fo, "get_audio_quality_string", lambda _p: None)
+
+
+def test_create_lossy_copy_rejects_non_lossless(monkeypatch, tmp_path):
+    _enable_lossy(monkeypatch)
+    src = tmp_path / "song.mp3"
+    src.write_bytes(b"id3")
+    assert _fo.create_lossy_copy(str(src)) is None   # lossy input → nothing to do
+
+
+def test_create_lossy_copy_now_accepts_wav(monkeypatch, tmp_path):
+    """Was FLAC-only; a WAV must now pass the gate and convert (#941)."""
+    _enable_lossy(monkeypatch, codec="mp3")
+    monkeypatch.setattr(_fo.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr("mutagen.File", lambda *_a, **_k: None)  # skip tag write
+
+    seen = {}
+
+    def _fake_run(cmd, **_kw):
+        seen["cmd"] = cmd
+        open(cmd[-1], "wb").write(b"fake-mp3")   # ffmpeg "writes" the output
+        return types.SimpleNamespace(returncode=0, stderr="")
+
+    monkeypatch.setattr(_fo.subprocess, "run", _fake_run)
+
+    src = tmp_path / "song.wav"
+    src.write_bytes(b"RIFF....WAVE")
+    out = _fo.create_lossy_copy(str(src))
+    assert out and out.endswith(".mp3")          # WAV passed the gate + converted
+    assert str(src) in seen["cmd"]               # ffmpeg got the .wav input
+
+
+def test_create_lossy_copy_skips_when_output_would_overwrite_source(monkeypatch, tmp_path):
+    """REGRESSION: .m4a ALAC source + AAC codec → output is the same .m4a path.
+    ffmpeg (-y) must NEVER run, or it would destroy the original lossless file."""
+    _enable_lossy(monkeypatch, codec="aac", bitrate="256")
+    monkeypatch.setattr(_fo, "m4a_codec", lambda _p: "alac")   # source IS ALAC (lossless)
+
+    ran = {"called": False}
+    monkeypatch.setattr(_fo.subprocess, "run",
+                        lambda *_a, **_k: ran.__setitem__("called", True))
+
+    src = tmp_path / "track.m4a"
+    src.write_bytes(b"....ALAC....")
+    out = _fo.create_lossy_copy(str(src))
+    assert out is None                 # skipped — output would overwrite source
+    assert ran["called"] is False      # the original was never touched

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -711,3 +711,73 @@ def test_exhaustive_single_source_exhausted_fails(monkeypatch):
     assert task["status"] == "failed"
     assert submitted == []
     assert completion == [("rbatch", "rtask", False)]
+
+
+def test_quarantine_failure_preserves_file_instead_of_deleting(tmp_path, monkeypatch):
+    """REGRESSION: when move_to_quarantine itself FAILS (e.g. a cross-device move on
+    a NAS), the rejected file must be LEFT IN PLACE for retry — never deleted.
+
+    Deleting a download we couldn't even quarantine is data loss that forces a
+    re-download (Discord: Shdjfgatdif). The task is still marked failed + the batch
+    still notified — only the destructive os.remove is gone. Drives the real pipeline
+    through the integrity-rejection path with quarantine forced to raise."""
+    source_path = tmp_path / "source.flac"
+    source_path.write_bytes(b"audio")
+
+    context_key, task_id, batch_id = "ctx-q", "task-q", "batch-q"
+    context = {
+        "search_result": {"is_simple_download": True, "filename": "Album/source.flac", "album": "Album"},
+        "track_info": {}, "original_search_result": {}, "is_album_download": False,
+        "task_id": task_id, "batch_id": batch_id,
+    }
+    completion_calls = []
+
+    snap = (dict(runtime_state.matched_downloads_context), dict(runtime_state.download_tasks),
+            dict(runtime_state.download_batches), set(runtime_state.processed_download_ids),
+            dict(runtime_state.post_process_locks))
+    for d in (runtime_state.matched_downloads_context, runtime_state.download_tasks,
+              runtime_state.download_batches, runtime_state.processed_download_ids,
+              runtime_state.post_process_locks):
+        d.clear()
+
+    runtime = types.SimpleNamespace(
+        automation_engine=None,
+        on_download_completed=lambda b, t, success: completion_calls.append((b, t, success)),
+        web_scan_manager=types.SimpleNamespace(request_scan=lambda r: None),
+        repair_worker=None,
+    )
+    fake_acoustid = types.ModuleType("core.acoustid_verification")
+    fake_acoustid.AcoustIDVerification = _FakeAcoustidVerifier
+    fake_acoustid.VerificationResult = types.SimpleNamespace(FAIL="FAIL")
+    monkeypatch.setitem(sys.modules, "core.acoustid_verification", fake_acoustid)
+
+    from core.imports.file_integrity import IntegrityResult
+    # Integrity FAILS → enters the quarantine block.
+    monkeypatch.setattr(import_pipeline, "check_audio_integrity",
+                        lambda *_a, **_k: IntegrityResult(ok=False, reason="broken (test)", checks={}))
+    # The quarantine MOVE itself raises → exercises the except branch (the fix).
+    def _boom(*_a, **_k):
+        raise OSError("cross-device link not permitted (simulated NAS)")
+    monkeypatch.setattr(import_pipeline, "move_to_quarantine", _boom)
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _Config(str(tmp_path / "Transfer")))
+    monkeypatch.setattr(import_pipeline, "add_activity_item", lambda *a, **k: None)
+
+    runtime_state.matched_downloads_context[context_key] = context
+    runtime_state.download_tasks[task_id] = {"track_info": {}, "status": "running"}
+
+    try:
+        import_pipeline.post_process_matched_download_with_verification(
+            context_key, context, str(source_path), task_id, batch_id, runtime)
+
+        # THE regression: a file we couldn't quarantine is preserved, not deleted.
+        assert source_path.exists(), "file must be LEFT IN PLACE when quarantine fails"
+        # Downstream still correct — task failed, batch notified of failure.
+        assert runtime_state.download_tasks[task_id]["status"] == "failed"
+        assert completion_calls == [(batch_id, task_id, False)]
+    finally:
+        for d, original in zip(
+            (runtime_state.matched_downloads_context, runtime_state.download_tasks,
+             runtime_state.download_batches, runtime_state.processed_download_ids,
+             runtime_state.post_process_locks), snap):
+            d.clear()
+            d.update(original)

--- a/tests/imports/test_import_routes.py
+++ b/tests/imports/test_import_routes.py
@@ -1,6 +1,8 @@
 import os
 from concurrent.futures import Future
 
+import pytest
+
 import core.imports.routes as import_routes
 from core.imports.routes import (
     ImportRouteRuntime,
@@ -15,6 +17,15 @@ from core.imports.routes import (
     staging_hints,
     staging_suggestions,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_staging_scan_cache():
+    # The shared staging scan is cached at module level; clear it between tests so
+    # one test's scan can't satisfy another within the TTL.
+    import_routes.invalidate_staging_scan_cache()
+    yield
+    import_routes.invalidate_staging_scan_cache()
 
 
 class _FakeLogger:
@@ -181,14 +192,21 @@ def test_staging_hints_prefers_tag_queries_then_folder_queries(tmp_path):
     _touch(tmp_path / "Folder_Album" / "02.mp3")
     _touch(tmp_path / "Loose" / "track.flac")
 
-    def _read_tags(file_path):
-        if file_path.endswith("01.mp3") or file_path.endswith("02.mp3"):
-            return {"album": ["Tagged Album"], "artist": ["Tagged Artist"]}
-        return {}
+    def _empty(artist="", album="", track_number=0):
+        return {"title": "", "artist": artist, "albumartist": "",
+                "album": album, "track_number": track_number, "disc_number": 1}
+
+    # hints now derives from the shared staging scan (read_staging_file_metadata),
+    # the same reader files/groups use — not a separate read_tags pass.
+    metadata = {
+        os.path.join("Folder_Album", "01.mp3"): _empty(artist="Tagged Artist", album="Tagged Album", track_number=1),
+        os.path.join("Folder_Album", "02.mp3"): _empty(artist="Tagged Artist", album="Tagged Album", track_number=2),
+        os.path.join("Loose", "track.flac"): _empty(),
+    }
 
     runtime = ImportRouteRuntime(
         get_staging_path=lambda: str(tmp_path),
-        read_tags=_read_tags,
+        read_staging_file_metadata=_metadata_for(metadata),
         logger=_FakeLogger(),
     )
 
@@ -606,3 +624,31 @@ def test_singles_process_requires_files():
 
     assert status == 400
     assert payload == {"success": False, "error": "No files provided"}
+
+
+def test_staging_scan_is_shared_across_files_groups_hints(tmp_path):
+    """#935: opening Import fires files+groups+hints together; they must share ONE
+    staging scan (one walk + one tag read per file), not re-read every file 3×."""
+    _touch(tmp_path / "Album" / "01.mp3")
+    _touch(tmp_path / "Album" / "02.mp3")
+
+    reads = []
+
+    def _meta(full_path, rel_path):
+        reads.append(rel_path)
+        return {"title": "T", "artist": "Artist", "albumartist": "Artist",
+                "album": "Album", "track_number": 1, "disc_number": 1}
+
+    runtime = ImportRouteRuntime(
+        get_staging_path=lambda: str(tmp_path),
+        read_staging_file_metadata=_meta,
+        logger=_FakeLogger(),
+    )
+
+    # All three page-open endpoints, back to back (within the cache TTL).
+    staging_files(runtime)
+    staging_groups(runtime)
+    staging_hints(runtime)
+
+    # 2 files × ONE shared scan = 2 reads — not 6 (which is 2 files × 3 endpoints).
+    assert sorted(reads) == [os.path.join("Album", "01.mp3"), os.path.join("Album", "02.mp3")]

--- a/tests/imports/test_silence_guard.py
+++ b/tests/imports/test_silence_guard.py
@@ -6,7 +6,10 @@ parsers are tested here; the ffmpeg call is integration.
 
 import pytest
 
+import core.imports.silence as silence_mod
 from core.imports.silence import (
+    detect_broken_audio,
+    is_dsd_path,
     silence_ratio_from_output,
     is_mostly_silent_reason,
     measured_duration_from_astats,
@@ -102,3 +105,47 @@ def test_no_incomplete_reason_for_full_file():
 def test_no_incomplete_reason_when_unmeasurable():
     assert incomplete_audio_reason(None, 188.4, min_ratio=0.85) is None
     assert incomplete_audio_reason(30.0, 0, min_ratio=0.85) is None
+
+
+# ── DSD (#939): the samples÷rate truncation math is invalid for DSD, so it must
+#    be skipped for .dsf/.dff (silence detection still applies). ──
+
+def test_is_dsd_path():
+    assert is_dsd_path("/m/Album/01. Song.dsf") is True
+    assert is_dsd_path("/m/Album/01. Song.DFF") is True   # case-insensitive
+    assert is_dsd_path("/m/Album/01. Song.flac") is False
+    assert is_dsd_path("") is False
+    assert is_dsd_path(None) is False
+
+
+class _FakeProc:
+    def __init__(self, stderr):
+        self.stderr = stderr.encode("utf-8")
+
+
+class _FakeInfo:
+    length = 330.0          # container says 330s
+    sample_rate = 44100
+
+
+def _patch_broken_pipeline(monkeypatch, astats_stderr):
+    """Make detect_broken_audio run against a canned 'truncated' ffmpeg result."""
+    monkeypatch.setattr(silence_mod, "_ffmpeg_available", lambda: True)
+    monkeypatch.setattr("mutagen.File", lambda *_a, **_k: type("A", (), {"info": _FakeInfo()})())
+    monkeypatch.setattr(silence_mod.subprocess, "run", lambda *_a, **_k: _FakeProc(astats_stderr))
+
+
+def test_truncation_flagged_for_normal_file(monkeypatch):
+    # ~40s decoded of a 330s container (12%) → a normal file IS flagged truncated.
+    astats = "[Parsed_astats_0 @ 0x55] Number of samples: 1764000\n"   # 1764000/44100 ≈ 40s
+    _patch_broken_pipeline(monkeypatch, astats)
+    reason = detect_broken_audio("/m/Album/01. Song.flac", min_ratio=0.85)
+    assert reason and "Incomplete audio" in reason
+
+
+def test_truncation_skipped_for_dsd(monkeypatch):
+    # Same 12%-decoding numbers, but a .dsf file must NOT be flagged — the math is
+    # invalid for DSD (ffmpeg decodes DSD to PCM at a different rate). #939
+    astats = "[Parsed_astats_0 @ 0x55] Number of samples: 1764000\n"
+    _patch_broken_pipeline(monkeypatch, astats)
+    assert detect_broken_audio("/m/Album/01. Song.dsf", min_ratio=0.85) is None

--- a/tests/library/test_bulk_paginate.py
+++ b/tests/library/test_bulk_paginate.py
@@ -1,0 +1,95 @@
+"""Bulk-fetch pagination seam — pages a server fetch while feeding the no-progress
+watchdog every page (the DXP4800 "Fetching all tracks in bulk… stuck 300s" bug).
+Pure: a fake fetch_page stands in for the server, a list records progress calls."""
+
+import math
+
+from core.library.bulk_paginate import (
+    paginate_all_items,
+    DEFAULT_PAGE_SIZE,
+)
+
+
+def _server(total, *, fail_at=None, fail_times=0):
+    """A fake server holding `total` items. Returns the right page slice for
+    (start_index, limit). Optionally returns None (a failed request) the first
+    `fail_times` times it's called at offset `fail_at`."""
+    items = list(range(total))
+    state = {"fails": 0}
+
+    def fetch_page(start_index, limit):
+        if fail_at is not None and start_index == fail_at and state["fails"] < fail_times:
+            state["fails"] += 1
+            return None
+        return items[start_index:start_index + limit]
+
+    return fetch_page
+
+
+def test_returns_every_item_across_pages():
+    out = paginate_all_items(_server(7148), page_size=1000)
+    assert out == list(range(7148))
+
+
+def test_progress_fed_every_page_not_once_for_whole_library():
+    # The watchdog-feed invariant: progress count scales with N/page_size, so the
+    # gap between progress beats is one page — never the whole library. A single
+    # 7148-track library used to emit ZERO progress (one 10k page) and stall.
+    calls = []
+    paginate_all_items(_server(7148), page_size=1000, report_progress=calls.append)
+    assert len(calls) == math.ceil(7148 / 1000) == 8
+
+
+def test_sub_page_library_still_reports_progress():
+    # Regression: the old loop skipped progress on the final/only page, so a
+    # library smaller than one page reported nothing → watchdog starved.
+    calls = []
+    out = paginate_all_items(_server(500), page_size=1000, report_progress=calls.append)
+    assert out == list(range(500))
+    assert len(calls) == 1            # was 0 before the fix
+
+
+def test_exact_multiple_of_page_size():
+    calls = []
+    out = paginate_all_items(_server(2000), page_size=1000, report_progress=calls.append)
+    assert out == list(range(2000))
+    assert len(calls) == 2            # two full pages, both reported
+
+
+def test_empty_library():
+    calls = []
+    out = paginate_all_items(_server(0), page_size=1000, report_progress=calls.append)
+    assert out == []
+    assert calls == []
+
+
+def test_no_progress_callback_is_safe():
+    assert paginate_all_items(_server(2500), page_size=1000) == list(range(2500))
+
+
+def test_failed_page_shrinks_then_succeeds():
+    # First request at offset 0 fails once; the helper halves the page size, retries,
+    # and still returns everything — the slow-server resilience path.
+    waits = []
+    out = paginate_all_items(
+        _server(1500, fail_at=0, fail_times=1),
+        page_size=1000, min_page_size=250,
+        on_retry_wait=lambda: waits.append(1),
+    )
+    assert out == list(range(1500))
+    assert waits == [1]               # waited once before the retry
+
+
+def test_gives_up_after_repeated_failures_at_floor():
+    # A page that always fails at the floor must terminate (not loop forever) and
+    # return what was gathered — here nothing, since it fails on the first page.
+    def always_fail(_start, _limit):
+        return None
+    out = paginate_all_items(always_fail, page_size=250, min_page_size=250)
+    assert out == []
+
+
+def test_default_page_size_is_watchdog_safe():
+    # A guard on the constant itself: the default must be far below a library size
+    # that would fit in one request, so progress is always paged.
+    assert DEFAULT_PAGE_SIZE <= 1000

--- a/tests/metadata/test_relevance.py
+++ b/tests/metadata/test_relevance.py
@@ -447,3 +447,36 @@ class TestFilterAndRerank:
         # Karaoke pattern reduces score by 0.05x — well below 0.5
         assert all(t.id != 'karaoke-id' for t in result)
         assert any(t.id == 'real-id' for t in result)
+
+
+# ── build_combined_search_query: plain, source-agnostic queries (pool-fix bug) ──
+
+from core.metadata.relevance import build_combined_search_query as _bcsq
+
+
+def test_combined_query_is_plain_not_field_scoped():
+    # THE fix: must NOT emit Spotify `track:`/`artist:` syntax — that leaked to Deezer
+    # (which aborted the connection) and other fallbacks that can't parse it.
+    q = _bcsq('Not Like Us', 'Kendrick Lamar')
+    assert q == 'Not Like Us Kendrick Lamar'
+    assert 'track:' not in q and 'artist:' not in q
+
+
+def test_combined_query_track_or_artist_alone():
+    assert _bcsq('Not Like Us', '') == 'Not Like Us'
+    assert _bcsq('', 'Kendrick Lamar') == 'Kendrick Lamar'
+
+
+def test_combined_query_trims_whitespace():
+    assert _bcsq('  Not Like Us  ', '  Kendrick Lamar ') == 'Not Like Us Kendrick Lamar'
+
+
+def test_combined_query_falls_back_to_legacy():
+    assert _bcsq('', '', 'free text search') == 'free text search'
+    # track/artist win over legacy when present
+    assert _bcsq('A', 'B', 'ignored') == 'A B'
+
+
+def test_combined_query_empty_when_nothing():
+    assert _bcsq('', '', '') == ''
+    assert _bcsq('   ', '', '  ') == ''

--- a/tests/metadata/test_spotify_oauth_integration.py
+++ b/tests/metadata/test_spotify_oauth_integration.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from core.metadata.registry import get_spotify_client_for_profile
+
+# Mock config_manager as it's a global dependency
+class MockConfigManager:
+    def __init__(self):
+        self.store = {}
+
+    def get(self, key, default=None):
+        return self.store.get(key, default)
+
+    def get_spotify_config(self):
+        return self.store.get('spotify', {})
+
+    def set(self, key, value):
+        self.store[key] = value
+
+class TestSpotifyOAuthIntegration(unittest.TestCase):
+    @patch('core.metadata.registry.get_spotify_client')
+    @patch('core.metadata.registry._profile_spotify_credentials_provider')
+    @patch('core.metadata.registry._get_config_value')
+    @patch('spotipy.oauth2.SpotifyOAuth')
+    @patch('core.spotify_client.normalize_spotify_oauth_config')
+    def test_get_spotify_client_for_profile_uses_normalized_config(self, mock_normalize, mock_spotify_oauth, mock_get_config, mock_creds_provider, mock_get_global):
+        # Set up mock config values
+        mock_creds_provider.return_value = {
+            "client_id": "  original_client_id  ",
+            "client_secret": "  original_client_secret  ",
+            "redirect_uri": "http://example.com/callback/"
+        }
+        
+        # Make sure the file exists check passes
+        with patch('os.path.exists', return_value=True):
+            # Set up mock for normalize_spotify_oauth_config to return cleaned values
+            mock_normalize.return_value = {
+                "client_id": "cleaned_client_id",
+                "client_secret": "cleaned_client_secret",
+                "redirect_uri": "http://example.com/callback"
+            }
+
+            # Call the function under test with profile_id=2 (to bypass global client)
+            get_spotify_client_for_profile(profile_id=2)
+
+            # Assert that normalize_spotify_oauth_config was called with the original config
+            mock_normalize.assert_any_call({
+                "client_id": "  original_client_id  ",
+                "client_secret": "  original_client_secret  ",
+                "redirect_uri": "http://example.com/callback/"
+            })
+
+            # Assert that SpotifyOAuth was initialized with the normalized config
+            mock_spotify_oauth.assert_called_once()
+            args, kwargs = mock_spotify_oauth.call_args
+            self.assertEqual(kwargs['client_id'], "cleaned_client_id")
+            self.assertEqual(kwargs['client_secret'], "cleaned_client_secret")
+            self.assertEqual(kwargs['redirect_uri'], "http://example.com/callback")
+            self.assertEqual(kwargs['state'], 'profile_2')
+
+    @patch('core.metadata.registry.get_spotify_client')
+    @patch('core.metadata.registry._profile_spotify_credentials_provider')
+    @patch('core.metadata.registry._get_config_value')
+    @patch('spotipy.oauth2.SpotifyOAuth')
+    @patch('core.spotify_client.normalize_spotify_oauth_config')
+    def test_get_spotify_client_for_profile_handles_no_config(self, mock_normalize, mock_spotify_oauth, mock_get_config, mock_creds_provider, mock_get_global):
+        # Simulate no spotify config
+        mock_creds_provider.return_value = {}
+        mock_get_config.side_effect = lambda key, default: "" if "client" in key else "http://127.0.0.1:8888/callback"
+        
+        # Ensure os.path.exists returns False so it doesn't try to use cache
+        with patch('os.path.exists', return_value=False):
+            # Call the function under test
+            get_spotify_client_for_profile(profile_id=2)
+
+            # It still reaches get_spotify_client() which is mocked.
+            # In registry.py, the fallbacks for client_id/client_secret result in calls to get_spotify_client().
+            mock_get_global.assert_called()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/quality/test_lossless.py
+++ b/tests/quality/test_lossless.py
@@ -119,3 +119,45 @@ def test_regression_m4a_alac_to_aac_would_overwrite_and_is_blocked():
     out = src                                                     # AAC target → .m4a
     assert is_lossless_audio_path(src, probe_codec=lambda _p: 'alac') is True
     assert lossy_output_would_overwrite_source(src, out) is True   # → callers skip
+
+
+# ── cross-language drift guard: the frontend lossless lists must match the backend ──
+# (#941's root cause: a format added to the quality profile but not the lossy-copy
+#  side. The lists are physically separate by choice — runtime-fetching a yearly-
+#  changing set isn't worth the coupling — so a test makes the drift impossible to
+#  ship silently instead.)
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+_SETTINGS_JS = _ROOT / "webui" / "static" / "settings.js"
+_INDEX_HTML = _ROOT / "webui" / "index.html"
+
+
+def _js_array(text, name):
+    m = re.search(rf"{name}\s*=\s*\[([^\]]*)\]", text)
+    assert m, f"{name} not found"
+    return set(re.findall(r"'([^']+)'", m.group(1)))
+
+
+def test_frontend_rt_lossless_formats_matches_backend():
+    js = _SETTINGS_JS.read_text(encoding="utf-8")
+    frontend = _js_array(js, "RT_LOSSLESS_FORMATS")
+    assert frontend == set(LOSSLESS_FORMATS), (
+        f"settings.js RT_LOSSLESS_FORMATS {frontend} != backend LOSSLESS_FORMATS "
+        f"{set(LOSSLESS_FORMATS)} — add the new format to BOTH"
+    )
+
+
+def test_quality_profile_dropdown_offers_every_lossless_format():
+    html = _INDEX_HTML.read_text(encoding="utf-8")
+    m = re.search(r'<optgroup label="Lossless">(.*?)</optgroup>', html, re.DOTALL)
+    assert m, "Lossless optgroup not found in index.html"
+    # concrete per-format option values (skip the 'group:lossless' convenience entry)
+    option_values = {v for v in re.findall(r'value="([^"]+)"', m.group(1))
+                     if not v.startswith("group:")}
+    assert set(LOSSLESS_FORMATS) <= option_values, (
+        f"index.html lossless dropdown {option_values} is missing "
+        f"{set(LOSSLESS_FORMATS) - option_values}"
+    )

--- a/tests/quality/test_lossless.py
+++ b/tests/quality/test_lossless.py
@@ -1,0 +1,121 @@
+"""The canonical "is this lossless?" seam + the lossy-copy overwrite invariant
+(#941). All pure — no files, no ffmpeg — so the decision and the safety guard are
+unit-testable in isolation. Both the import path (create_lossy_copy) and the Lossy
+Converter repair job route through these, so the same rules drive both."""
+
+from core.quality.lossless import (
+    LOSSLESS_FORMATS,
+    LOSSLESS_CANDIDATE_EXTENSIONS,
+    is_lossless_format,
+    is_lossless_audio_path,
+    lossy_output_would_overwrite_source,
+)
+from core.quality.model import AudioQuality
+from core.repair_jobs.lossy_converter import _lossless_ext_where
+
+
+# ── is_lossless_format ──
+
+def test_lossless_formats_recognized():
+    for fmt in ('flac', 'alac', 'wav', 'dsf', 'FLAC', 'Dsf'):
+        assert is_lossless_format(fmt) is True
+
+
+def test_lossy_formats_not_lossless():
+    for fmt in ('mp3', 'aac', 'ogg', 'opus', 'wma', 'unknown', '', None):
+        assert is_lossless_format(fmt) is False
+
+
+# ── is_lossless_audio_path (the ambiguity is the whole point) ──
+
+def test_unambiguous_extensions_decided_by_extension():
+    for path in ('/m/a.flac', '/m/a.wav', '/m/a.wave', '/m/a.aiff', '/m/a.aif',
+                 '/m/a.dsf', '/m/a.dff', '/m/a.alac', '/m/A.FLAC'):
+        assert is_lossless_audio_path(path) is True
+
+
+def test_lossy_extensions_are_not_lossless():
+    for path in ('/m/a.mp3', '/m/a.ogg', '/m/a.opus', '/m/a.wma', '/m/a.aac'):
+        assert is_lossless_audio_path(path) is False
+
+
+def test_m4a_without_probe_is_not_lossless():
+    # The safe default: with no codec probe, an .m4a can't be proven lossless, so
+    # an AAC file is never misclassified as lossless and converted/deleted.
+    assert is_lossless_audio_path('/m/a.m4a') is False
+    assert is_lossless_audio_path('/m/a.mp4') is False
+
+
+def test_m4a_alac_is_lossless_via_probe():
+    assert is_lossless_audio_path('/m/a.m4a', probe_codec=lambda _p: 'alac') is True
+    assert is_lossless_audio_path('/m/a.mp4', probe_codec=lambda _p: 'ALAC') is True
+
+
+def test_m4a_aac_is_not_lossless_via_probe():
+    assert is_lossless_audio_path('/m/a.m4a', probe_codec=lambda _p: 'mp4a.40.2') is False
+
+
+def test_probe_exception_is_not_lossless():
+    def _boom(_p):
+        raise RuntimeError("probe failed")
+    assert is_lossless_audio_path('/m/a.m4a', probe_codec=_boom) is False
+
+
+# ── LOSSLESS_CANDIDATE_EXTENSIONS (the SQL pre-filter set) ──
+
+def test_candidate_extensions_cover_lossless_plus_ambiguous():
+    for e in ('.flac', '.wav', '.aiff', '.dsf', '.dff', '.alac', '.m4a', '.mp4'):
+        assert e in LOSSLESS_CANDIDATE_EXTENSIONS
+    # raw lossy extensions must NOT be candidates
+    for e in ('.mp3', '.aac', '.ogg', '.opus', '.wma'):
+        assert e not in LOSSLESS_CANDIDATE_EXTENSIONS
+
+
+def test_sql_where_clause_matches_candidates_only():
+    where = _lossless_ext_where('t.file_path')
+    assert "LIKE '%.flac'" in where and "LIKE '%.dsf'" in where and "LIKE '%.m4a'" in where
+    assert "LIKE '%.mp3'" not in where and "LIKE '%.aac'" not in where
+
+
+# ── lossy_output_would_overwrite_source (the safety invariant) ──
+
+def test_overwrite_detected_when_paths_equal():
+    assert lossy_output_would_overwrite_source('/m/Album/01.m4a', '/m/Album/01.m4a') is True
+
+
+def test_overwrite_detected_after_normalization():
+    assert lossy_output_would_overwrite_source('/m/Album/../Album/01.m4a', '/m/Album/01.m4a') is True
+
+
+def test_no_overwrite_for_different_extension():
+    assert lossy_output_would_overwrite_source('/m/Album/01.flac', '/m/Album/01.mp3') is False
+    assert lossy_output_would_overwrite_source('/m/Album/01.m4a', '/m/Album/01.mp3') is False
+
+
+def test_overwrite_guard_handles_empty():
+    assert lossy_output_would_overwrite_source('', '/x.mp3') is False
+    assert lossy_output_would_overwrite_source('/x.flac', '') is False
+
+
+# ── anti-drift: the seam must agree with the quality tier model ──
+
+def test_lossless_set_consistent_with_tier_model():
+    """If a format is in LOSSLESS_FORMATS it must out-rank every lossy format in
+    tier_score — guards against the two lists drifting apart (the whole reason
+    this seam exists)."""
+    lossy = ('mp3', 'aac', 'ogg', 'opus', 'wma')
+    worst_lossless = min(AudioQuality(f, bitrate=11290, sample_rate=44100, bit_depth=16).tier_score()
+                         for f in LOSSLESS_FORMATS)
+    best_lossy = max(AudioQuality(f, bitrate=320).tier_score() for f in lossy)
+    assert worst_lossless > best_lossy
+
+
+# ── regression: the exact bug class this guards (overwrite the original) ──
+
+def test_regression_m4a_alac_to_aac_would_overwrite_and_is_blocked():
+    """An .m4a ALAC source converted with the AAC codec lands on the SAME .m4a
+    path. The guard must catch it so ffmpeg -y never destroys the original."""
+    src = '/library/Sade/Diamond Life/01. Smooth Operator.m4a'   # ALAC
+    out = src                                                     # AAC target → .m4a
+    assert is_lossless_audio_path(src, probe_codec=lambda _p: 'alac') is True
+    assert lossy_output_would_overwrite_source(src, out) is True   # → callers skip

--- a/tests/quality/test_model.py
+++ b/tests/quality/test_model.py
@@ -128,3 +128,22 @@ def test_v2_to_v3_preserves_order_and_maps_fields():
     assert formats == ['flac', 'mp3']          # disabled mp3_192 omitted
     assert targets[0]['bit_depth'] == 24
     assert targets[1]['min_bitrate'] == 320
+
+
+# ── DSD (#939): DSF must rank as lossless, never "Low Quality" below MP3 ──
+
+def test_dsf_ranks_in_lossless_range():
+    dsf = AudioQuality('dsf', bitrate=11290).tier_score()
+    flac_cd = AudioQuality('flac', sample_rate=44100, bit_depth=16).tier_score()
+    mp3_320 = AudioQuality('mp3', bitrate=320).tier_score()
+    # DSD64 is hi-res lossless — at/above CD FLAC and well above any lossy format.
+    assert dsf >= flac_cd
+    assert dsf > mp3_320
+
+
+def test_dsf_without_measured_bitrate_still_lossless():
+    # .dff has no mutagen reader, so it classifies as 'dsf' with no measured detail —
+    # it must still land in the lossless tier, not the 'unknown' floor.
+    dsf = AudioQuality('dsf').tier_score()
+    assert dsf > AudioQuality('mp3', bitrate=320).tier_score()
+    assert dsf > AudioQuality('unknown').tier_score()

--- a/tests/quality/test_source_map.py
+++ b/tests/quality/test_source_map.py
@@ -30,6 +30,7 @@ from core.quality.source_map import (
     ("aiff", "wav"), ("aif", "wav"),   # PCM → wav tier
     ("wma", "wma"),
     ("alac", "alac"),
+    ("dsf", "dsf"), (".dsf", "dsf"), ("dff", "dsf"),   # DSD → dsf tier (#939)
     ("xyz", "unknown"), ("", "unknown"), (None, "unknown"),
 ])
 def test_format_from_extension(ext, fmt):

--- a/tests/test_deezer_playlist_export.py
+++ b/tests/test_deezer_playlist_export.py
@@ -1,0 +1,56 @@
+"""Deezer playlist export via the gw-light gateway (#945) — the write half of
+'sync a mirrored playlist back to Deezer'. Mocks the gateway call (the live API is the
+unofficial ARL gw-light path; we test the wiring, not Deezer)."""
+
+from core.deezer_download_client import DeezerDownloadClient
+
+
+def _client(gw, authed=True):
+    c = DeezerDownloadClient.__new__(DeezerDownloadClient)
+    c._authenticated = authed
+    c._gw_call = gw
+    return c
+
+
+def test_create_new_playlist():
+    calls = []
+    def gw(method, params):
+        calls.append((method, params))
+        return 12345  # gw returns the new playlist id
+    res = _client(gw).create_or_update_playlist('My Mix', ['100', '200'])
+    assert res['success'] and res['playlist_id'] == '12345'
+    assert res['url'] == 'https://www.deezer.com/playlist/12345'
+    assert res['added'] == 2
+    method, params = calls[0]
+    assert method == 'playlist.create'
+    assert params['title'] == 'My Mix'
+    assert params['songs'] == [['100', 0], ['200', 1]]
+
+
+def test_update_existing_appends_no_create():
+    calls = []
+    def gw(method, params):
+        calls.append((method, params))
+        return {}
+    res = _client(gw).create_or_update_playlist('My Mix', ['100'], existing_id='999')
+    assert res['success'] and res['playlist_id'] == '999'
+    assert calls[0][0] == 'playlist.addSongs'
+    assert calls[0][1]['playlist_id'] == 999
+    assert not any(m == 'playlist.create' for m, _ in calls)
+
+
+def test_empty_tracks_errors_no_gw_call():
+    calls = []
+    res = _client(lambda *a: calls.append(a)).create_or_update_playlist('X', [])
+    assert not res['success'] and 'No matching' in res['error']
+    assert calls == []
+
+
+def test_not_authed_errors():
+    res = _client(lambda *a: None, authed=False).create_or_update_playlist('X', ['1'])
+    assert not res['success'] and 'not connected' in res['error']
+
+
+def test_gw_rejection_is_an_error():
+    res = _client(lambda *a: None).create_or_update_playlist('X', ['1'])
+    assert not res['success'] and 'rejected' in res['error']

--- a/tests/test_listening_stats_batch_queries.py
+++ b/tests/test_listening_stats_batch_queries.py
@@ -218,12 +218,43 @@ class TestEnrichStatsItems:
 
         album_by_name = {a["name"]: a for a in cache["top_albums"]}
         assert album_by_name["First Album"]["id"] == "al1"
-        assert album_by_name["First Album"]["image_url"] == "http://img/al1.jpg"
+        # image_url is normalized at build time now (#935) — it's enriched (truthy);
+        # exact form depends on the image-cache config, so don't pin the raw value.
+        assert album_by_name["First Album"]["image_url"]
 
         track_by_name = {t["name"]: t for t in cache["top_tracks"]}
         assert track_by_name["Alpha"]["id"] == "t1"
         assert track_by_name["Bravo"]["id"] == "t2"
         assert track_by_name["Alpha"]["artist_id"] == "a1"
+
+    def test_image_urls_normalized_at_build_time(self, db, worker, monkeypatch):
+        """#935: image URLs are run through the fixer HERE, at cache-build time, so the
+        /api/stats/cached read does zero per-image image-cache writes on the hot path
+        (those writes were the ~20s stats hang on HDD-backed installs). Deterministic
+        via a stub fixer so it doesn't depend on the real image-cache config."""
+        _insert_track(db, "t1", "Alpha", "a1", "Band One", "al1", "First Album")
+
+        seen = []
+
+        def _fake_fix(url):
+            seen.append(url)
+            return f"/api/image-cache/fixed::{url}"
+
+        monkeypatch.setattr("core.metadata.normalize_image_url", _fake_fix)
+
+        cache = {
+            "top_artists": [{"name": "Band One"}],
+            "top_albums": [{"name": "First Album"}],
+            "top_tracks": [{"name": "Alpha", "artist": "Band One"}],
+        }
+        worker._enrich_stats_items(cache)
+
+        # every section's raw thumb_url was passed through the fixer, and the cached
+        # value is the fixed (browser-safe) url — so the read path has nothing to do.
+        assert cache["top_albums"][0]["image_url"] == "/api/image-cache/fixed::http://img/al1.jpg"
+        assert cache["top_artists"][0]["image_url"].startswith("/api/image-cache/fixed::")
+        assert cache["top_tracks"][0]["image_url"].startswith("/api/image-cache/fixed::")
+        assert any("al1" in str(s) for s in seen)
 
     def test_unknown_entries_left_untouched(self, db, worker):
         _insert_track(db, "t1", "Real", "a1", "Real Band", "al1", "Real Album")

--- a/tests/test_reduce_effects_css.py
+++ b/tests/test_reduce_effects_css.py
@@ -1,0 +1,39 @@
+"""Guard the reduce-visual-effects CSS contract.
+
+Performance mode must kill the GPU-EXPENSIVE properties (backdrop-filter / box-shadow
+/ filter — the real lag, esp. on Firefox) but must NOT blanket-freeze animations:
+`animation: none` on every element stuck the dash-header worker-service spinners
+mid-rotation, which read as "broken" (Discord/Boulder). Pins the surgical rule so a
+future edit can't silently re-freeze the functional spinners or kill cheap hover
+feedback."""
+
+import re
+from pathlib import Path
+
+_STYLE = Path(__file__).resolve().parent.parent / "webui" / "static" / "style.css"
+
+
+def _reduce_effects_global_body() -> str:
+    css = _STYLE.read_text(encoding="utf-8")
+    m = re.search(r"body\.reduce-effects \*,.*?\{([^}]*)\}", css, re.DOTALL)
+    assert m, "global 'body.reduce-effects *' rule not found"
+    return m.group(1)
+
+
+def test_reduce_effects_still_kills_expensive_gpu_properties():
+    body = _reduce_effects_global_body()
+    for prop in ("backdrop-filter: none", "box-shadow: none", "filter: none"):
+        assert prop in body, f"reduce-effects must still force {prop} (the real lag source)"
+
+
+def test_reduce_effects_does_not_blanket_freeze_animations():
+    body = _reduce_effects_global_body()
+    # `animation: none` on * froze the dash-header worker-service spinners mid-spin;
+    # cheap transform/opacity motion must survive so a spinner still reads as "working".
+    assert "animation: none" not in body, (
+        "blanket 'animation: none' re-freezes the worker spinners — keep motion alive, "
+        "the expensive properties are already neutralized above"
+    )
+    assert "transition-duration: 0s" not in body, (
+        "blanket 'transition-duration: 0s' kills the cheap Quick Actions hover feedback"
+    )

--- a/tests/test_reorganize_rename_only.py
+++ b/tests/test_reorganize_rename_only.py
@@ -1,0 +1,168 @@
+"""Rename-only reorganize (#875): move files to the current naming scheme with NO
+copy / re-tag / post-processing. The headline guarantee is that it acts on exactly
+what the preview computed and ONLY touches files whose path actually changes — files
+the preview marked `unchanged` are left alone (the "every file got modified" bug).
+"""
+
+import os
+
+from core.library_reorganize import (
+    _rename_track_in_place,
+    reorganize_album_rename_only,
+)
+
+
+# ── _rename_track_in_place ──
+
+def test_rename_moves_file_and_creates_dest_dir(tmp_path):
+    src = tmp_path / "old" / "01 - Song.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"audio")
+    dst = tmp_path / "new" / "Song - Artist.flac"
+
+    ok, err = _rename_track_in_place(str(src), str(dst))
+    assert ok and err is None
+    assert dst.exists() and dst.read_bytes() == b"audio"
+    assert not src.exists()
+
+
+def test_rename_refuses_to_overwrite_a_different_file(tmp_path):
+    src = tmp_path / "a.flac"
+    src.write_bytes(b"source")
+    dst = tmp_path / "b.flac"
+    dst.write_bytes(b"someone else")   # a DIFFERENT existing file
+
+    ok, err = _rename_track_in_place(str(src), str(dst))
+    assert not ok and "exists" in err
+    assert src.exists() and dst.read_bytes() == b"someone else"   # nothing destroyed
+
+
+def test_rename_missing_source_errors(tmp_path):
+    ok, err = _rename_track_in_place(str(tmp_path / "gone.flac"), str(tmp_path / "x.flac"))
+    assert not ok and "no longer on disk" in err
+
+
+def test_rename_same_path_is_noop_ok(tmp_path):
+    f = tmp_path / "x.flac"
+    f.write_bytes(b"a")
+    ok, err = _rename_track_in_place(str(f), str(f))
+    assert ok and f.exists()
+
+
+def test_rename_carries_sibling_format_file(tmp_path):
+    # lossy-copy pair: canonical .flac + sibling .opus in the same folder
+    src = tmp_path / "old" / "01 - Song.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"flac")
+    sib = tmp_path / "old" / "01 - Song.opus"
+    sib.write_bytes(b"opus")
+    dst = tmp_path / "new" / "Song.flac"
+
+    ok, _ = _rename_track_in_place(str(src), str(dst))
+    assert ok
+    assert dst.exists()
+    assert (tmp_path / "new" / "Song.opus").exists()    # sibling came along, renamed stem
+
+
+# ── reorganize_album_rename_only (fake preview injected) ──
+
+def _fake_preview(tracks, *, success=True, status="planned", source="deezer"):
+    def _preview(**_kw):
+        return {"success": success, "status": status, "source": source, "tracks": tracks}
+    return _preview
+
+
+def _run(tracks, *, update=None, cleanup=None, stop=None, **preview_kw):
+    return reorganize_album_rename_only(
+        album_id="A1", db=None, transfer_dir="/x",
+        resolve_file_path_fn=lambda p: p,
+        build_final_path_fn=lambda *a, **k: (None, True),
+        update_track_path_fn=update,
+        cleanup_empty_dir_fn=cleanup,
+        stop_check=stop,
+        preview_fn=_fake_preview(tracks, **preview_kw),
+    )
+
+
+def test_moves_changed_and_skips_unchanged(tmp_path):
+    """THE regression: a changed track moves + DB updates; an `unchanged` track is
+    left completely alone (not re-touched). This is the #875 fix in one test."""
+    src = tmp_path / "old" / "01 - A.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"a")
+    new = tmp_path / "new" / "A - Artist.flac"
+    keep = tmp_path / "keep" / "B.flac"
+    keep.parent.mkdir(parents=True)
+    keep.write_bytes(b"b")
+
+    updates = []
+    summary = _run(
+        [
+            {"track_id": "t1", "title": "A", "matched": True, "unchanged": False,
+             "collision": False, "current_path_abs": str(src), "new_path_abs": str(new)},
+            {"track_id": "t2", "title": "B", "matched": True, "unchanged": True,
+             "collision": False, "current_path_abs": str(keep), "new_path_abs": str(keep)},
+        ],
+        update=lambda tid, path: updates.append((tid, path)),
+    )
+
+    assert summary["moved"] == 1 and summary["skipped"] == 1 and summary["failed"] == 0
+    assert new.exists() and not src.exists()       # changed track moved
+    assert keep.exists() and keep.read_bytes() == b"b"   # unchanged: untouched
+    assert updates == [("t1", str(new))]           # DB updated ONLY for the moved one
+
+
+def test_collision_and_unmatched_are_skipped(tmp_path):
+    summary = _run([
+        {"track_id": "c", "title": "C", "matched": True, "unchanged": False,
+         "collision": True, "current_path_abs": "/a", "new_path_abs": "/b"},
+        {"track_id": "u", "title": "U", "matched": False, "unchanged": False,
+         "collision": False, "current_path_abs": "/a", "new_path_abs": "/b"},
+    ])
+    assert summary["skipped"] == 2 and summary["moved"] == 0 and summary["failed"] == 0
+
+
+def test_failed_rename_is_counted_not_fatal(tmp_path):
+    src = tmp_path / "a.flac"
+    src.write_bytes(b"src")
+    dst = tmp_path / "taken.flac"
+    dst.write_bytes(b"occupied")   # forces "destination already exists"
+    summary = _run([
+        {"track_id": "t", "title": "T", "matched": True, "unchanged": False,
+         "collision": False, "current_path_abs": str(src), "new_path_abs": str(dst)},
+    ])
+    assert summary["failed"] == 1 and summary["moved"] == 0
+    assert summary["errors"] and summary["errors"][0]["track_id"] == "t"
+    assert src.exists() and dst.read_bytes() == b"occupied"   # nothing lost
+
+
+def test_preview_failure_returns_its_status():
+    summary = _run([], success=False, status="no_source_id")
+    assert summary["status"] == "no_source_id"
+    assert summary["moved"] == 0
+
+
+def test_stop_check_aborts_early(tmp_path):
+    src = tmp_path / "a.flac"
+    src.write_bytes(b"a")
+    summary = _run(
+        [{"track_id": "t", "title": "T", "matched": True, "unchanged": False,
+          "collision": False, "current_path_abs": str(src), "new_path_abs": str(tmp_path / "b.flac")}],
+        stop=lambda: True,
+    )
+    assert summary["moved"] == 0          # aborted before processing
+    assert src.exists()
+
+
+def test_cleanup_called_for_emptied_source_dirs(tmp_path):
+    src = tmp_path / "old" / "01 - A.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"a")
+    cleaned = []
+    _run(
+        [{"track_id": "t1", "title": "A", "matched": True, "unchanged": False,
+          "collision": False, "current_path_abs": str(src),
+          "new_path_abs": str(tmp_path / "new" / "A.flac")}],
+        cleanup=lambda d: cleaned.append(d),
+    )
+    assert str(tmp_path / "old") in cleaned

--- a/tests/test_reorganize_runner.py
+++ b/tests/test_reorganize_runner.py
@@ -73,6 +73,9 @@ def _make_item(*, queue_id='qid-1', album_id='alb-1', source=None):
     item.queue_id = queue_id
     item.album_id = album_id
     item.source = source
+    # Match the real QueueItem default: a bare MagicMock would return a truthy
+    # mock for .rename_only and wrongly take the rename-only branch (#875).
+    item.rename_only = False
     return item
 
 
@@ -233,3 +236,57 @@ def test_runner_progress_callback_forwards_to_queue(monkeypatch, tmp_path):
     # The progress fan-out happened *while* the item was running. The
     # final snapshot shows the worker-set values — what we're really
     # asserting is that progress callbacks didn't raise.
+
+
+def test_rename_only_item_routes_to_rename_executor(monkeypatch, tmp_path):
+    """#875: an item with rename_only=True invokes the rename-only executor (NOT the
+    full reorganize_album), and never creates a staging dir."""
+    captured = {}
+
+    def fake_rename_only(**kwargs):
+        captured.update(kwargs)
+        return {'status': 'completed', 'source': 'deezer',
+                'total': 1, 'moved': 1, 'skipped': 0, 'failed': 0, 'errors': []}
+
+    def fail_full(**kwargs):
+        raise AssertionError("full reorganize_album must NOT run for rename_only")
+
+    monkeypatch.setattr('core.library_reorganize.reorganize_album', fail_full, raising=True)
+    monkeypatch.setattr('core.library_reorganize.reorganize_album_rename_only',
+                        fake_rename_only, raising=True)
+
+    runner = build_runner(
+        get_database=lambda: object(),
+        resolve_file_path_fn=lambda p: p,
+        post_process_fn=lambda *a, **k: None,
+        cleanup_empty_directories_fn=lambda *a, **k: None,
+        is_shutting_down_fn=lambda: False,
+        get_download_path=lambda: str(tmp_path),
+        get_transfer_path=lambda: str(tmp_path / 'transfer'),
+        build_final_path_fn=lambda *a, **k: (None, True),
+    )
+    item = _make_item(album_id='alb-R', source='deezer')
+    item.rename_only = True
+    summary = runner(item)
+
+    assert summary['status'] == 'completed' and summary['moved'] == 1
+    assert captured['album_id'] == 'alb-R'
+    assert callable(captured['build_final_path_fn'])
+    assert not (tmp_path / 'ssync_staging').exists()   # no staging for rename-only
+
+
+def test_rename_only_without_path_builder_fails_cleanly(monkeypatch, tmp_path):
+    # Defensive: build_final_path_fn omitted → rename-only can't run, returns setup_failed
+    # instead of crashing.
+    runner = build_runner(
+        get_database=lambda: object(),
+        resolve_file_path_fn=lambda p: p,
+        post_process_fn=lambda *a, **k: None,
+        cleanup_empty_directories_fn=lambda *a, **k: None,
+        is_shutting_down_fn=lambda: False,
+        get_download_path=lambda: str(tmp_path),
+        get_transfer_path=lambda: str(tmp_path / 'transfer'),
+    )
+    item = _make_item()
+    item.rename_only = True
+    assert runner(item)['status'] == 'setup_failed'

--- a/tests/test_service_playlist_export.py
+++ b/tests/test_service_playlist_export.py
@@ -110,3 +110,21 @@ def test_backfill_on_wires_search_fn(monkeypatch):
                            _FakeClient({'success': True, 'playlist_id': 'p', 'added': 1}),
                            _fake_resolver(['sx'], seen))
     assert seen['search_id_fn'] == 'SEARCH_FN'
+
+
+def test_spotify_backfill_search_disables_cross_service_fallback(monkeypatch):
+    """REGRESSION: Spotify's search_tracks falls back to iTunes/Deezer (non-Spotify ids) under
+    rate-limit/free. The backfill MUST disable that or it pushes wrong ids into the Spotify
+    playlist. Assert the search is invoked with allow_fallback=False."""
+    seen = {}
+
+    class _FakeSpotify:
+        def search_tracks(self, q, limit=10, allow_fallback=True):
+            seen['allow_fallback'] = allow_fallback
+            return []
+
+    monkeypatch.setattr(ws, 'get_spotify_client', lambda: _FakeSpotify())
+    fn = ws._build_service_search_id_fn('spotify')
+    assert fn is not None
+    fn('Kendrick Lamar', 'Not Like Us')   # drives the search
+    assert seen['allow_fallback'] is False

--- a/tests/test_service_playlist_export.py
+++ b/tests/test_service_playlist_export.py
@@ -1,0 +1,75 @@
+"""_run_service_export orchestration (#945): resolve mirrored tracks → service IDs → push →
+store the target for idempotent re-export. Deps injected (fake db/client/resolve_fn) so this
+needs no DB or live Spotify/Deezer."""
+
+import web_server as ws
+
+
+class _FakeDB:
+    def __init__(self, tracks, existing=None):
+        self._tracks, self._existing, self.set_calls = tracks, existing, []
+
+    def get_mirrored_playlist_tracks(self, pid):
+        return self._tracks
+
+    def get_playlist_export_target(self, pid, service):
+        return self._existing
+
+    def set_playlist_export_target(self, pid, service, target):
+        self.set_calls.append((pid, service, target))
+
+
+class _FakeClient:
+    def __init__(self, result):
+        self.result, self.calls = result, []
+
+    def create_or_update_playlist(self, title, ids, existing_id=None):
+        self.calls.append((title, list(ids), existing_id))
+        return self.result
+
+
+def _resolve(mapping):
+    return lambda artist, title: (mapping.get(title), 'library' if mapping.get(title) else None)
+
+
+def test_success_stores_target():
+    job = {}
+    db = _FakeDB([{'artist': 'A', 'title': 'X'}, {'artist': 'A', 'title': 'Y'}])
+    client = _FakeClient({'success': True, 'playlist_id': 'pl-1', 'added': 2})
+    ws._run_service_export(job, db, 5, 'My PL', 'spotify', client, _resolve({'X': 'sx', 'Y': 'sy'}))
+    assert job['phase'] == 'done'
+    assert client.calls[0] == ('My PL', ['sx', 'sy'], None)
+    assert db.set_calls == [(5, 'spotify', 'pl-1')]
+
+
+def test_no_matched_ids_errors_no_push():
+    job = {}
+    client = _FakeClient({'success': True})
+    ws._run_service_export(job, _FakeDB([{'artist': 'A', 'title': 'X'}]), 5, 'PL', 'deezer',
+                           client, _resolve({}))
+    assert job['phase'] == 'error' and 'nothing to export' in job['error']
+    assert client.calls == []
+
+
+def test_client_none_errors():
+    job = {}
+    ws._run_service_export(job, _FakeDB([{'artist': 'A', 'title': 'X'}]), 5, 'PL', 'spotify',
+                           None, _resolve({'X': 'sx'}))
+    assert job['phase'] == 'error' and 'not connected' in job['error']
+
+
+def test_push_failure_surfaces_error_no_target_store():
+    job = {}
+    db = _FakeDB([{'artist': 'A', 'title': 'X'}])
+    client = _FakeClient({'success': False, 'error': 'Reconnect Spotify'})
+    ws._run_service_export(job, db, 5, 'PL', 'spotify', client, _resolve({'X': 'sx'}))
+    assert job['phase'] == 'error' and job['error'] == 'Reconnect Spotify'
+    assert db.set_calls == []
+
+
+def test_reexport_passes_existing_target():
+    job = {}
+    db = _FakeDB([{'artist': 'A', 'title': 'X'}], existing='pl-old')
+    client = _FakeClient({'success': True, 'playlist_id': 'pl-old', 'added': 1})
+    ws._run_service_export(job, db, 5, 'PL', 'deezer', client, _resolve({'X': 'dz'}))
+    assert client.calls[0][2] == 'pl-old'

--- a/tests/test_service_playlist_export.py
+++ b/tests/test_service_playlist_export.py
@@ -29,9 +29,12 @@ class _FakeClient:
         return self.result
 
 
-def _fake_resolver(ids):
-    """resolve_ids_fn stub returning the given service ids as the resolved set."""
-    def fn(tracks, service, on_progress=None):
+def _fake_resolver(ids, seen=None):
+    """resolve_ids_fn stub returning the given service ids. When ``seen`` is given, records
+    the search_id_fn it was called with (to assert the backfill toggle wiring)."""
+    def fn(tracks, service, search_id_fn=None, on_progress=None):
+        if seen is not None:
+            seen['search_id_fn'] = search_id_fn
         resolved = [{'artist': 'A', 'title': f't{i}', 'service_track_id': s}
                     for i, s in enumerate(ids)]
         matched = sum(1 for s in ids if s)
@@ -88,3 +91,22 @@ def test_reexport_passes_existing_target():
     client = _FakeClient({'success': True, 'playlist_id': 'pl-old', 'added': 1})
     ws._run_service_export(job, db, 5, 'PL', 'deezer', client, _fake_resolver(['dz']))
     assert client.calls[0][2] == 'pl-old'
+
+
+def test_backfill_off_passes_no_search_fn():
+    job = {}   # no 'backfill' key → off
+    seen = {}
+    ws._run_service_export(job, _FakeDB([{}]), 5, 'PL', 'deezer',
+                           _FakeClient({'success': True, 'playlist_id': 'p', 'added': 1}),
+                           _fake_resolver(['dz'], seen))
+    assert seen['search_id_fn'] is None
+
+
+def test_backfill_on_wires_search_fn(monkeypatch):
+    job = {'backfill': True}
+    seen = {}
+    monkeypatch.setattr(ws, '_build_service_search_id_fn', lambda service: 'SEARCH_FN')
+    ws._run_service_export(job, _FakeDB([{}]), 5, 'PL', 'spotify',
+                           _FakeClient({'success': True, 'playlist_id': 'p', 'added': 1}),
+                           _fake_resolver(['sx'], seen))
+    assert seen['search_id_fn'] == 'SEARCH_FN'

--- a/tests/test_service_playlist_export.py
+++ b/tests/test_service_playlist_export.py
@@ -1,7 +1,8 @@
-"""_run_service_export orchestration (#945): resolve mirrored tracks → service IDs → push →
-store the target for idempotent re-export. Deps injected (fake db/client/resolve_fn) so this
-needs no DB or live Spotify/Deezer."""
+"""_run_service_export orchestration (#945): resolve mirrored tracks → service IDs
+(discovery cache → library) → push → store the target for idempotent re-export. Deps
+injected so this needs no real DB or live Spotify/Deezer."""
 
+import json
 import web_server as ws
 
 
@@ -28,48 +29,62 @@ class _FakeClient:
         return self.result
 
 
-def _resolve(mapping):
-    return lambda artist, title: (mapping.get(title), 'library' if mapping.get(title) else None)
+def _fake_resolver(ids):
+    """resolve_ids_fn stub returning the given service ids as the resolved set."""
+    def fn(tracks, service, on_progress=None):
+        resolved = [{'artist': 'A', 'title': f't{i}', 'service_track_id': s}
+                    for i, s in enumerate(ids)]
+        matched = sum(1 for s in ids if s)
+        return {'resolved': resolved,
+                'stats': {'total': len(ids), 'resolved': matched, 'unmatched': len(ids) - matched}}
+    return fn
 
 
-def test_success_stores_target():
+def _discovered(artist, title, service, tid):
+    return {'artist_name': artist, 'track_name': title,
+            'extra_data': json.dumps({'discovered': True, 'provider': service,
+                                      'matched_data': {'id': tid}})}
+
+
+def test_success_resolves_from_discovery_cache_and_stores_target():
+    """Real resolver: both tracks were discovered to Deezer, so their IDs come straight
+    from extra_data (the cache) with no DB/API — the gap Boulder spotted."""
     job = {}
-    db = _FakeDB([{'artist': 'A', 'title': 'X'}, {'artist': 'A', 'title': 'Y'}])
+    db = _FakeDB([_discovered('A', 'X', 'deezer', 111), _discovered('A', 'Y', 'deezer', 222)])
     client = _FakeClient({'success': True, 'playlist_id': 'pl-1', 'added': 2})
-    ws._run_service_export(job, db, 5, 'My PL', 'spotify', client, _resolve({'X': 'sx', 'Y': 'sy'}))
+    ws._run_service_export(job, db, 5, 'My PL', 'deezer', client)   # real resolve_service_track_ids
     assert job['phase'] == 'done'
-    assert client.calls[0] == ('My PL', ['sx', 'sy'], None)
-    assert db.set_calls == [(5, 'spotify', 'pl-1')]
+    assert client.calls[0] == ('My PL', ['111', '222'], None)
+    assert db.set_calls == [(5, 'deezer', 'pl-1')]
+    assert job['stats']['from_cache'] == 2 and job['stats']['unmatched'] == 0
 
 
-def test_no_matched_ids_errors_no_push():
+def test_no_match_errors_no_push():
     job = {}
     client = _FakeClient({'success': True})
-    ws._run_service_export(job, _FakeDB([{'artist': 'A', 'title': 'X'}]), 5, 'PL', 'deezer',
-                           client, _resolve({}))
+    ws._run_service_export(job, _FakeDB([{}]), 5, 'PL', 'deezer', client, _fake_resolver([None]))
     assert job['phase'] == 'error' and 'nothing to export' in job['error']
     assert client.calls == []
 
 
 def test_client_none_errors():
     job = {}
-    ws._run_service_export(job, _FakeDB([{'artist': 'A', 'title': 'X'}]), 5, 'PL', 'spotify',
-                           None, _resolve({'X': 'sx'}))
+    ws._run_service_export(job, _FakeDB([{}]), 5, 'PL', 'spotify', None, _fake_resolver(['sx']))
     assert job['phase'] == 'error' and 'not connected' in job['error']
 
 
 def test_push_failure_surfaces_error_no_target_store():
     job = {}
-    db = _FakeDB([{'artist': 'A', 'title': 'X'}])
+    db = _FakeDB([{}])
     client = _FakeClient({'success': False, 'error': 'Reconnect Spotify'})
-    ws._run_service_export(job, db, 5, 'PL', 'spotify', client, _resolve({'X': 'sx'}))
+    ws._run_service_export(job, db, 5, 'PL', 'spotify', client, _fake_resolver(['sx']))
     assert job['phase'] == 'error' and job['error'] == 'Reconnect Spotify'
     assert db.set_calls == []
 
 
 def test_reexport_passes_existing_target():
     job = {}
-    db = _FakeDB([{'artist': 'A', 'title': 'X'}], existing='pl-old')
+    db = _FakeDB([{}], existing='pl-old')
     client = _FakeClient({'success': True, 'playlist_id': 'pl-old', 'added': 1})
-    ws._run_service_export(job, db, 5, 'PL', 'deezer', client, _resolve({'X': 'dz'}))
+    ws._run_service_export(job, db, 5, 'PL', 'deezer', client, _fake_resolver(['dz']))
     assert client.calls[0][2] == 'pl-old'

--- a/tests/test_spotify_client.py
+++ b/tests/test_spotify_client.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.spotify_client import normalize_spotify_oauth_config
+
+def test_normalization():
+    # Normal case with leading/trailing whitespace and quotes
+    config = {
+        "client_id": "  client_id   ",
+        "client_secret": "  client_secret  ",
+        "redirect_uri": "http://127.0.0.1:8888/callback/"
+    }
+    expected = {
+        "client_id": "client_id",
+        "client_secret": "client_secret",
+        "redirect_uri": "http://127.0.0.1:8888/callback"
+    }
+    assert normalize_spotify_oauth_config(config) == expected
+
+def test_empty_values():
+    # Empty input values
+    config = {
+        "client_id": "",
+        "client_secret": None,
+        "redirect_uri": ""
+    }
+    # When value is None, it falls into the else branch: normalized[key] = value
+    # value is None, so expected is None for client_secret
+    expected = {
+        "client_id": "",
+        "client_secret": None,
+        "redirect_uri": ""
+    }
+    assert normalize_spotify_oauth_config(config) == expected
+
+def test_missing_keys():
+    # Input dictionary with missing keys
+    config = {
+        "client_id": "client_id"
+    }
+    # .get(key, "") means missing keys become ""
+    expected = {
+        "client_id": "client_id",
+        "client_secret": "",
+        "redirect_uri": ""
+    }
+    assert normalize_spotify_oauth_config(config) == expected
+
+def test_non_string_values():
+    # Input dictionary with non-string values for the keys
+    config = {
+        "client_id": 123,
+        "client_secret": True,
+        "redirect_uri": None
+    }
+    # When value is not a string, it falls into the else branch: normalized[key] = value
+    expected = {
+        "client_id": 123,
+        "client_secret": True,
+        "redirect_uri": None
+    }
+    assert normalize_spotify_oauth_config(config) == expected
+
+def test_no_input():
+    # Empty input dictionary
+    config = {}
+    # .get(key, "") means missing keys become ""
+    expected = {
+        "client_id": "",
+        "client_secret": "",
+        "redirect_uri": ""
+    }
+    assert normalize_spotify_oauth_config(None) == {}
+    assert normalize_spotify_oauth_config(config) == expected

--- a/tests/test_spotify_client.py
+++ b/tests/test_spotify_client.py
@@ -6,18 +6,32 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from core.spotify_client import normalize_spotify_oauth_config
 
 def test_normalization():
-    # Normal case with leading/trailing whitespace and quotes
+    # Whitespace + quotes are stripped (paste garbage); the redirect_uri's
+    # trailing slash is PRESERVED — Spotify matches it exactly against the app
+    # dashboard, so stripping it could break a valid registration (#942 follow-up).
     config = {
-        "client_id": "  client_id   ",
+        "client_id": '  "client_id"   ',
         "client_secret": "  client_secret  ",
-        "redirect_uri": "http://127.0.0.1:8888/callback/"
+        "redirect_uri": "  http://127.0.0.1:8888/callback/  "
     }
     expected = {
         "client_id": "client_id",
         "client_secret": "client_secret",
-        "redirect_uri": "http://127.0.0.1:8888/callback"
+        "redirect_uri": "http://127.0.0.1:8888/callback/"   # slash kept
     }
     assert normalize_spotify_oauth_config(config) == expected
+
+
+def test_trailing_slash_on_redirect_uri_is_preserved():
+    """Regression guard: Spotify requires an EXACT redirect-URI match against the
+    app dashboard, so a trailing slash a user registered must NOT be stripped —
+    stripping it would send '…/callback' and trigger INVALID_CLIENT (#942)."""
+    with_slash = {"client_id": "x", "client_secret": "y",
+                  "redirect_uri": "http://127.0.0.1:8888/callback/"}
+    without_slash = {"client_id": "x", "client_secret": "y",
+                     "redirect_uri": "http://127.0.0.1:8888/callback"}
+    assert normalize_spotify_oauth_config(with_slash)["redirect_uri"] == "http://127.0.0.1:8888/callback/"
+    assert normalize_spotify_oauth_config(without_slash)["redirect_uri"] == "http://127.0.0.1:8888/callback"
 
 def test_empty_values():
     # Empty input values

--- a/tests/test_spotify_client.py
+++ b/tests/test_spotify_client.py
@@ -88,3 +88,79 @@ def test_no_input():
     }
     assert normalize_spotify_oauth_config(None) == {}
     assert normalize_spotify_oauth_config(config) == expected
+
+# ── create_or_update_playlist: export a mirrored playlist back to Spotify (#945) ──
+
+from core.spotify_client import SpotifyClient as _SpotifyClient
+
+
+class _FakeSp:
+    def __init__(self):
+        self.calls = []
+
+    def current_user(self):
+        self.calls.append(('current_user',))
+        return {'id': 'user-1'}
+
+    def user_playlist_create(self, user_id, name, public=False, description=''):
+        self.calls.append(('create', user_id, name, public))
+        return {'id': 'pl-new'}
+
+    def playlist_add_items(self, pid, uris):
+        self.calls.append(('add', pid, list(uris)))
+
+    def playlist_replace_items(self, pid, uris):
+        self.calls.append(('replace', pid, list(uris)))
+
+
+def _spotify_with(sp, authed=True):
+    c = _SpotifyClient.__new__(_SpotifyClient)
+    c.sp = sp
+    c.is_spotify_authenticated = lambda: authed
+    return c
+
+
+def test_create_new_playlist_adds_tracks():
+    sp = _FakeSp()
+    res = _spotify_with(sp).create_or_update_playlist('My Mix', ['a', 'b', 'c'])
+    assert res['success'] and res['playlist_id'] == 'pl-new'
+    assert res['url'] == 'https://open.spotify.com/playlist/pl-new'
+    assert res['added'] == 3
+    assert ('create', 'user-1', 'My Mix', False) in sp.calls
+    assert ('add', 'pl-new', ['spotify:track:a', 'spotify:track:b', 'spotify:track:c']) in sp.calls
+
+
+def test_update_existing_replaces_no_create():
+    sp = _FakeSp()
+    res = _spotify_with(sp).create_or_update_playlist('My Mix', ['a', 'b'], existing_id='pl-x')
+    assert res['success'] and res['playlist_id'] == 'pl-x'
+    assert ('replace', 'pl-x', ['spotify:track:a', 'spotify:track:b']) in sp.calls
+    assert not any(c[0] == 'create' for c in sp.calls)
+
+
+def test_chunks_over_100_tracks():
+    sp = _FakeSp()
+    res = _spotify_with(sp).create_or_update_playlist('Big', [str(i) for i in range(250)])
+    assert res['added'] == 250
+    adds = [c for c in sp.calls if c[0] == 'add']
+    assert len(adds) == 3 and len(adds[0][2]) == 100 and len(adds[2][2]) == 50
+
+
+def test_empty_tracks_errors_no_api_calls():
+    sp = _FakeSp()
+    res = _spotify_with(sp).create_or_update_playlist('X', [])
+    assert not res['success'] and 'No matching' in res['error']
+    assert sp.calls == []
+
+
+def test_not_authed_errors():
+    res = _spotify_with(_FakeSp(), authed=False).create_or_update_playlist('X', ['a'])
+    assert not res['success'] and 'not connected' in res['error']
+
+
+def test_insufficient_scope_says_reconnect():
+    class _ScopeErr(_FakeSp):
+        def user_playlist_create(self, *a, **k):
+            raise Exception('403 Forbidden: insufficient client scope')
+    res = _spotify_with(_ScopeErr()).create_or_update_playlist('X', ['a'])
+    assert not res['success'] and 'Reconnect Spotify' in res['error']

--- a/tests/test_ui_appearance.py
+++ b/tests/test_ui_appearance.py
@@ -1,0 +1,56 @@
+"""Pure UI-appearance default rules (core/ui_appearance.py).
+
+Pins the worker-orbs default contract: explicit saved choice ALWAYS wins; when unset,
+default OFF on Firefox (the blurred orb canvas is the main remaining Firefox lag
+source) and ON elsewhere."""
+
+from core.ui_appearance import is_firefox_user_agent, resolve_worker_orbs_default
+
+_FIREFOX_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:128.0) "
+               "Gecko/20100101 Firefox/128.0")
+_CHROME_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+              "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+_SAFARI_UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+              "(KHTML, like Gecko) Version/17.0 Safari/605.1.15")
+_EDGE_UA = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0")
+
+
+# ── is_firefox_user_agent ──
+
+def test_detects_firefox():
+    assert is_firefox_user_agent(_FIREFOX_UA) is True
+
+
+def test_non_firefox_browsers_are_false():
+    for ua in (_CHROME_UA, _SAFARI_UA, _EDGE_UA):
+        assert is_firefox_user_agent(ua) is False
+
+
+def test_empty_or_none_ua_is_not_firefox():
+    assert is_firefox_user_agent('') is False
+    assert is_firefox_user_agent(None) is False
+
+
+# ── resolve_worker_orbs_default: explicit ALWAYS wins ──
+
+def test_unset_defaults_off_on_firefox():
+    assert resolve_worker_orbs_default(None, is_firefox=True) is False
+
+
+def test_unset_defaults_on_elsewhere():
+    assert resolve_worker_orbs_default(None, is_firefox=False) is True
+
+
+def test_explicit_true_wins_even_on_firefox():
+    # A Firefox user who explicitly enabled orbs keeps them — default never overrides.
+    assert resolve_worker_orbs_default(True, is_firefox=True) is True
+
+
+def test_explicit_false_wins_even_off_firefox():
+    assert resolve_worker_orbs_default(False, is_firefox=False) is False
+
+
+def test_explicit_values_ignore_browser():
+    assert resolve_worker_orbs_default(True, is_firefox=False) is True
+    assert resolve_worker_orbs_default(False, is_firefox=True) is False

--- a/web_server.py
+++ b/web_server.py
@@ -11767,6 +11767,9 @@ def reorganize_album_files(album_id):
             artist_name=meta['artist_name'],
             source=chosen_source,
             metadata_source=metadata_source,
+            # Rename-only (#875): just move files to the current naming scheme — skip
+            # the copy + post-processing (re-tag / quality / AcoustID) of the full flow.
+            rename_only=bool(data.get('rename_only')),
         )
         return jsonify({"success": True, **result})
     except Exception as e:
@@ -11883,6 +11886,9 @@ try:
         get_transfer_path=lambda: docker_resolve_path(
             config_manager.get('soulseek.transfer_path', './Transfer')
         ),
+        # Rename-only mode (#875) computes destinations via the same path builder the
+        # preview uses, so apply matches exactly what the user saw.
+        build_final_path_fn=lambda *a, **kw: _build_final_path_for_track(*a, **kw),
     ))
 except Exception as _runner_init_err:
     logger.error(f"Failed to register reorganize queue runner: {_runner_init_err}")

--- a/web_server.py
+++ b/web_server.py
@@ -27741,15 +27741,17 @@ _playlist_export_jobs = {}
 _playlist_export_jobs_lock = threading.Lock()
 
 
-def _run_service_export(job, db, playlist_id, title, service, client, resolve_fn):
+def _run_service_export(job, db, playlist_id, title, service, client, resolve_ids_fn=None):
     """Export a mirrored playlist back to a streaming service (Spotify/Deezer, #945).
 
-    Reuses the same resolve→push→store-target machinery the ListenBrainz export uses,
-    just with a service track-ID resolver and a service write client. Deps are injected
-    so the orchestration (resolve, unmatched-guard, push, idempotent target store, error
-    paths) is unit-testable without a DB or live service.
+    Resolves each track to a target-service ID via the discovery cache (the track's
+    extra_data — free + already matched) then the library's stored id, pushes the matched
+    set via the service write client, and stores the returned playlist id so a re-export
+    updates in place (idempotent, like the LB #903 fix). Deps injected so the orchestration
+    is unit-testable without a DB or live service.
     """
-    from core.exports.playlist_export import resolve_playlist_tracks
+    from core.exports.export_sources import resolve_service_track_ids
+    resolve_ids_fn = resolve_ids_fn or resolve_service_track_ids
 
     tracks = db.get_mirrored_playlist_tracks(int(playlist_id))
     job['total'] = len(tracks)
@@ -27759,8 +27761,7 @@ def _run_service_export(job, db, playlist_id, title, service, client, resolve_fn
         job['done'] = done
         job['stats'] = dict(stats)
 
-    out = resolve_playlist_tracks(tracks, resolve_fn, on_progress=on_progress,
-                                  id_key='service_track_id')
+    out = resolve_ids_fn(tracks, service, on_progress=on_progress)
     job['stats'] = out['stats']
     ids = [r['service_track_id'] for r in out['resolved'] if r.get('service_track_id')]
     if not ids:
@@ -27792,15 +27793,13 @@ def _run_playlist_export(job_id, playlist_id, title, mode):
     try:
         # Service export (#945) — resolve to Spotify/Deezer track IDs and push.
         if mode in ('spotify', 'deezer'):
-            from core.exports.export_sources import build_service_resolve_fn
             db = get_database()
             if mode == 'spotify':
                 client = get_spotify_client()
             else:
                 from core.deezer_download_client import DeezerDownloadClient
                 client = DeezerDownloadClient()
-            _run_service_export(job, db, playlist_id, title, mode, client,
-                                build_service_resolve_fn(mode))
+            _run_service_export(job, db, playlist_id, title, mode, client)
             return
 
         from core.exports.export_sources import build_resolve_fn

--- a/web_server.py
+++ b/web_server.py
@@ -363,6 +363,9 @@ def _initial_appearance_context():
     preset = config_manager.get('ui_appearance.accent_preset', '#1db954')
     custom = config_manager.get('ui_appearance.accent_color', '#1db954')
     accent = _valid_hex_color(custom if preset == 'custom' else preset)
+    particles_enabled = config_manager.get('ui_appearance.particles_enabled', False) is True
+    worker_orbs_enabled = config_manager.get('ui_appearance.worker_orbs_enabled', True) is not False
+    reduce_effects = config_manager.get('ui_appearance.reduce_effects', False) is True
     r, g, b = _hex_to_rgb(accent)
     hue, saturation, lightness = _rgb_to_hsl(r, g, b)
     light = _hsl_to_rgb(hue, saturation, min(lightness + 0.16, 0.95))
@@ -372,6 +375,9 @@ def _initial_appearance_context():
         'initial_accent_rgb': f'{r}, {g}, {b}',
         'initial_accent_light_rgb': f'{light[0]}, {light[1]}, {light[2]}',
         'initial_accent_neon_rgb': f'{neon[0]}, {neon[1]}, {neon[2]}',
+        'initial_particles_enabled': particles_enabled,
+        'initial_worker_orbs_enabled': worker_orbs_enabled,
+        'initial_reduce_effects': reduce_effects,
     }
 
 

--- a/web_server.py
+++ b/web_server.py
@@ -303,6 +303,77 @@ app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0 if DEV_STATIC_NO_CACHE else 31536000
 import time as _cache_bust_time
 _STATIC_CACHE_BUST = str(int(_cache_bust_time.time()))
 
+def _valid_hex_color(value, fallback='#1db954'):
+    value = str(value or '').strip()
+    return value if re.fullmatch(r'#[0-9a-fA-F]{6}', value) else fallback
+
+
+def _hex_to_rgb(hex_color):
+    color = _valid_hex_color(hex_color)
+    return tuple(int(color[i:i + 2], 16) for i in (1, 3, 5))
+
+
+def _rgb_to_hsl(r, g, b):
+    rn, gn, bn = r / 255, g / 255, b / 255
+    max_c = max(rn, gn, bn)
+    min_c = min(rn, gn, bn)
+    lightness = (max_c + min_c) / 2
+    if max_c == min_c:
+        return 0, 0, lightness
+
+    delta = max_c - min_c
+    saturation = delta / (2 - max_c - min_c) if lightness > 0.5 else delta / (max_c + min_c)
+    if max_c == rn:
+        hue = ((gn - bn) / delta + (6 if gn < bn else 0)) / 6
+    elif max_c == gn:
+        hue = ((bn - rn) / delta + 2) / 6
+    else:
+        hue = ((rn - gn) / delta + 4) / 6
+    return hue, saturation, lightness
+
+
+def _hsl_to_rgb(hue, saturation, lightness):
+    if saturation == 0:
+        value = round(lightness * 255)
+        return value, value, value
+
+    def hue_to_rgb(p, q, t):
+        if t < 0:
+            t += 1
+        if t > 1:
+            t -= 1
+        if t < 1 / 6:
+            return p + (q - p) * 6 * t
+        if t < 1 / 2:
+            return q
+        if t < 2 / 3:
+            return p + (q - p) * (2 / 3 - t) * 6
+        return p
+
+    q = lightness * (1 + saturation) if lightness < 0.5 else lightness + saturation - lightness * saturation
+    p = 2 * lightness - q
+    return (
+        round(hue_to_rgb(p, q, hue + 1 / 3) * 255),
+        round(hue_to_rgb(p, q, hue) * 255),
+        round(hue_to_rgb(p, q, hue - 1 / 3) * 255),
+    )
+
+
+def _initial_appearance_context():
+    preset = config_manager.get('ui_appearance.accent_preset', '#1db954')
+    custom = config_manager.get('ui_appearance.accent_color', '#1db954')
+    accent = _valid_hex_color(custom if preset == 'custom' else preset)
+    r, g, b = _hex_to_rgb(accent)
+    hue, saturation, lightness = _rgb_to_hsl(r, g, b)
+    light = _hsl_to_rgb(hue, saturation, min(lightness + 0.16, 0.95))
+    neon = _hsl_to_rgb(hue, min(saturation + 0.1, 1.0), min(lightness + 0.30, 0.95))
+    return {
+        'initial_accent_color': accent,
+        'initial_accent_rgb': f'{r}, {g}, {b}',
+        'initial_accent_light_rgb': f'{light[0]}, {light[1]}, {light[2]}',
+        'initial_accent_neon_rgb': f'{neon[0]}, {neon[1]}, {neon[2]}',
+    }
+
 
 @app.context_processor
 def _inject_static_cache_bust():
@@ -319,7 +390,7 @@ def _inject_static_cache_bust():
                 static_v = str(max(mtimes))
         except Exception:
             static_v = _STATIC_CACHE_BUST
-    return {'static_v': static_v}
+    return {'static_v': static_v, **_initial_appearance_context()}
 
 
 @app.context_processor

--- a/web_server.py
+++ b/web_server.py
@@ -7506,6 +7506,7 @@ def manual_search_for_task(task_id):
         link = parse_download_track_link(query)
         link_source = None
         link_track_id = None
+        linked_result = None  # the EXACT track fetched by id, injected into results
         # A pasted SoundCloud link can't be turned into an "artist title" query
         # and searched — unlisted/private tracks aren't searchable. Instead force
         # the SoundCloud source and keep the URL as the query; the SoundCloud
@@ -7535,6 +7536,18 @@ def manual_search_for_task(task_id):
             query = clean_q
             source = _src
             link_source, link_track_id = _src, _tid
+            # Fetch the EXACT linked track as a downloadable result to inject —
+            # a text search for an obscure track's name often doesn't surface it
+            # at all, so we can't rely on it being in the search results (#932).
+            # Defensive: only sources that expose get_track_result (Qobuz today);
+            # others fall back to the bubble path below — never worse than before.
+            _link_client = download_orchestrator.client(_src) if download_orchestrator else None
+            if _link_client is not None and hasattr(_link_client, 'get_track_result'):
+                try:
+                    linked_result = _link_client.get_track_result(_tid)
+                except Exception as _lr_err:
+                    logger.debug("[Manual Search] get_track_result failed for %s %s: %s",
+                                 _src, _tid, _lr_err)
 
         if source != 'all':
             if source not in valid_source_ids:
@@ -7595,13 +7608,15 @@ def manual_search_for_task(task_id):
                             "error": error,
                         }) + "\n"
                         continue
-                    # Pasted-link exact match: bubble the track whose source id
-                    # matches the link to the top so the user sees the exact version
-                    # first. Reads _source_metadata['track_id'] (TrackResult has no
-                    # top-level id) — the old getattr(t,'id') always missed (#932).
-                    if src_name == link_source and link_track_id and tracks:
-                        from core.downloads.track_link import bubble_linked_track_first
-                        tracks = bubble_linked_track_first(tracks, link_track_id)
+                    # Pasted-link exact match (#932): the linked source's search may
+                    # not surface an obscure linked track at all, so INJECT the exact
+                    # track (fetched by id) at the top and drop any search duplicate of
+                    # it. If we couldn't fetch it (source has no get_track_result, or it
+                    # failed), fall back to bubbling a matching search result — never
+                    # worse than before.
+                    if src_name == link_source and link_track_id:
+                        from core.downloads.track_link import inject_linked_track_first
+                        tracks = inject_linked_track_first(tracks, linked_result, link_track_id)
                     serialized = []
                     for t in tracks:
                         s = _serialize_candidate(t, source_override=src_name)

--- a/web_server.py
+++ b/web_server.py
@@ -82,7 +82,7 @@ if not pp_logger.handlers:
     _pp_handler.setFormatter(_logging.Formatter("%(asctime)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
     pp_logger.addHandler(_pp_handler)
     pp_logger.propagate = False
-from core.spotify_client import SpotifyClient, Playlist as SpotifyPlaylist, Track as SpotifyTrack, _is_globally_rate_limited as _spotify_rate_limited
+from core.spotify_client import SpotifyClient, Playlist as SpotifyPlaylist, Track as SpotifyTrack, _is_globally_rate_limited as _spotify_rate_limited, SPOTIFY_OAUTH_SCOPE
 from core.plex_client import PlexClient
 from core.ui_appearance import is_firefox_user_agent, resolve_worker_orbs_default
 from plexapi.myplex import MyPlexAccount, MyPlexPinLogin
@@ -4803,7 +4803,7 @@ def _profile_spotify_oauth(profile_id_int):
         client_id=client_id,
         client_secret=client_secret,
         redirect_uri=redirect_uri,
-        scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
+        scope=SPOTIFY_OAUTH_SCOPE,
         cache_path=f'config/.spotify_cache_profile_{profile_id_int}',
         state=f'profile_{profile_id_int}',
         show_dialog=True,
@@ -5233,7 +5233,7 @@ def spotify_callback():
             client_id=config['client_id'],
             client_secret=config['client_secret'],
             redirect_uri=configured_uri,
-            scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
+            scope=SPOTIFY_OAUTH_SCOPE,
             cache_path='config/.spotify_cache'
         )
 
@@ -35993,7 +35993,7 @@ def start_oauth_callback_servers():
                             client_id=config['client_id'],
                             client_secret=config['client_secret'],
                             redirect_uri=configured_uri,
-                            scope="user-library-read user-read-private playlist-read-private playlist-read-collaborative user-read-email user-follow-read",
+                            scope=SPOTIFY_OAUTH_SCOPE,
                             cache_path='config/.spotify_cache'
                         )
 

--- a/web_server.py
+++ b/web_server.py
@@ -40,7 +40,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.8.0"
+_SOULSYNC_BASE_VERSION = "2.8.1"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/web_server.py
+++ b/web_server.py
@@ -84,6 +84,7 @@ if not pp_logger.handlers:
     pp_logger.propagate = False
 from core.spotify_client import SpotifyClient, Playlist as SpotifyPlaylist, Track as SpotifyTrack, _is_globally_rate_limited as _spotify_rate_limited
 from core.plex_client import PlexClient
+from core.ui_appearance import is_firefox_user_agent, resolve_worker_orbs_default
 from plexapi.myplex import MyPlexAccount, MyPlexPinLogin
 from core.jellyfin_client import JellyfinClient
 from core.navidrome_client import NavidromeClient
@@ -359,12 +360,32 @@ def _hsl_to_rgb(hue, saturation, lightness):
     )
 
 
+def _request_is_firefox() -> bool:
+    """Whether the current request's browser is Firefox (UA-based). Used ONLY to pick a
+    performance-friendly default; an explicit saved setting always wins. Safe outside a
+    request context (returns False)."""
+    try:
+        from flask import has_request_context, request
+        if not has_request_context():
+            return False
+        return is_firefox_user_agent(request.headers.get('User-Agent'))
+    except Exception:
+        return False
+
+
 def _initial_appearance_context():
     preset = config_manager.get('ui_appearance.accent_preset', '#1db954')
     custom = config_manager.get('ui_appearance.accent_color', '#1db954')
     accent = _valid_hex_color(custom if preset == 'custom' else preset)
     particles_enabled = config_manager.get('ui_appearance.particles_enabled', False) is True
-    worker_orbs_enabled = config_manager.get('ui_appearance.worker_orbs_enabled', True) is not False
+    # Worker orbs: explicit choice wins; unset → OFF on Firefox (the blurred orb canvas
+    # is the main remaining Firefox lag source), ON elsewhere. config default None so we
+    # can tell "unset" from an explicit False. (#kettui — single source: the server
+    # decides, the client consumes the injected value below.)
+    worker_orbs_enabled = resolve_worker_orbs_default(
+        config_manager.get('ui_appearance.worker_orbs_enabled', None),
+        _request_is_firefox(),
+    )
     reduce_effects = config_manager.get('ui_appearance.reduce_effects', False) is True
     r, g, b = _hex_to_rgb(accent)
     hue, saturation, lightness = _rgb_to_hsl(r, g, b)

--- a/web_server.py
+++ b/web_server.py
@@ -21612,17 +21612,13 @@ def search_spotify_tracks():
         legacy_query = request.args.get('query', '').strip()
         limit = int(request.args.get('limit', 20))
 
-        # Build Spotify field-filtered query
-        if track_q or artist_q:
-            parts = []
-            if track_q:
-                parts.append(f'track:{track_q}')
-            if artist_q:
-                parts.append(f'artist:{artist_q}')
-            query = ' '.join(parts)
-        elif legacy_query:
-            query = legacy_query
-        else:
+        # Plain combined query — NOT field-scoped (`track:X artist:Y`). That Spotify
+        # syntax leaks to non-Spotify sources when search falls back (Deezer aborted
+        # the connection on it); the iTunes/Deezer endpoints already dropped it for the
+        # same reason, and the rerank below recovers precision. (Pool-fix "no results".)
+        from core.metadata.relevance import build_combined_search_query
+        query = build_combined_search_query(track_q, artist_q, legacy_query)
+        if not query:
             return jsonify({"error": "Query parameter is required"}), 400
 
         if use_hydrabase:

--- a/web_server.py
+++ b/web_server.py
@@ -27749,12 +27749,21 @@ def _build_service_search_id_fn(service):
     try:
         if service == 'spotify':
             client = get_spotify_client()
+            if not client:
+                return None
+            # allow_fallback=False is CRITICAL: Spotify's search falls back to iTunes/Deezer
+            # when rate-limited/free, returning tracks whose .id is NOT a Spotify id — backfill
+            # would then push wrong ids into the Spotify playlist. Disable it: real Spotify hits
+            # or nothing.
+            search_fn = lambda q: client.search_tracks(q, limit=8, allow_fallback=False)  # noqa: E731
         else:
             from core.metadata.registry import get_deezer_client
             client = get_deezer_client()
-        if not client:
-            return None
-        search_fn = lambda q: client.search_tracks(q, limit=8)  # noqa: E731
+            if not client:
+                return None
+            # Deezer's search stays within Deezer (query-only fallback), so its .id is always a
+            # Deezer id — no cross-service guard needed.
+            search_fn = lambda q: client.search_tracks(q, limit=8)  # noqa: E731
         return lambda artist, title: search_service_track_id(artist, title, search_fn=search_fn)
     except Exception:
         return None

--- a/web_server.py
+++ b/web_server.py
@@ -4692,11 +4692,13 @@ def _profile_spotify_oauth(profile_id_int):
     chooser so a user can't silently inherit whatever Spotify session is active
     in their browser (e.g. the admin's). Returns None if no app creds exist."""
     from spotipy.oauth2 import SpotifyOAuth
+    from core.spotify_client import normalize_spotify_oauth_config
     creds = (get_database().get_profile_spotify(profile_id_int) or {})
-    cfg = config_manager.get_spotify_config()
-    client_id = creds.get('client_id') or cfg.get('client_id')
-    client_secret = creds.get('client_secret') or cfg.get('client_secret')
-    redirect_uri = creds.get('redirect_uri') or cfg.get('redirect_uri', 'http://127.0.0.1:8888/callback')
+    cfg = normalize_spotify_oauth_config(config_manager.get_spotify_config())
+    profile_creds = normalize_spotify_oauth_config(creds)
+    client_id = profile_creds.get('client_id') or cfg.get('client_id')
+    client_secret = profile_creds.get('client_secret') or cfg.get('client_secret')
+    redirect_uri = profile_creds.get('redirect_uri') or cfg.get('redirect_uri', 'http://127.0.0.1:8888/callback')
     if not client_id or not client_secret:
         return None
     return SpotifyOAuth(
@@ -5095,7 +5097,7 @@ def spotify_callback():
             pass
 
     try:
-        from core.spotify_client import SpotifyClient
+        from core.spotify_client import SpotifyClient, normalize_spotify_oauth_config
         from spotipy.oauth2 import SpotifyOAuth
         from config.settings import config_manager
 
@@ -5125,7 +5127,7 @@ def spotify_callback():
                     raise Exception("Failed to exchange authorization code for access token")
 
         # Global callback (admin)
-        config = config_manager.get_spotify_config()
+        config = normalize_spotify_oauth_config(config_manager.get_spotify_config())
         configured_uri = config.get('redirect_uri', "http://127.0.0.1:8888/callback")
         logger.info(f"Using redirect_uri for token exchange: {configured_uri}")
 
@@ -35864,9 +35866,10 @@ def start_oauth_callback_servers():
                     try:
                         from spotipy.oauth2 import SpotifyOAuth
                         from config.settings import config_manager
+                        from core.spotify_client import normalize_spotify_oauth_config
 
                         # Get Spotify config
-                        config = config_manager.get_spotify_config()
+                        config = normalize_spotify_oauth_config(config_manager.get_spotify_config())
                         configured_uri = config.get('redirect_uri', "http://127.0.0.1:8888/callback")
                         _oauth_logger.info(f"Using redirect_uri for token exchange: {configured_uri}")
 

--- a/web_server.py
+++ b/web_server.py
@@ -27741,14 +27741,34 @@ _playlist_export_jobs = {}
 _playlist_export_jobs_lock = threading.Lock()
 
 
+def _build_service_search_id_fn(service):
+    """Bind a confident-search ID resolver to the service's metadata search client, for the
+    opt-in export backfill (#945). Returns None when the search client isn't available — the
+    backfill then simply finds nothing for that track rather than crashing the export."""
+    from core.exports.export_sources import search_service_track_id
+    try:
+        if service == 'spotify':
+            client = get_spotify_client()
+        else:
+            from core.metadata.registry import get_deezer_client
+            client = get_deezer_client()
+        if not client:
+            return None
+        search_fn = lambda q: client.search_tracks(q, limit=8)  # noqa: E731
+        return lambda artist, title: search_service_track_id(artist, title, search_fn=search_fn)
+    except Exception:
+        return None
+
+
 def _run_service_export(job, db, playlist_id, title, service, client, resolve_ids_fn=None):
     """Export a mirrored playlist back to a streaming service (Spotify/Deezer, #945).
 
     Resolves each track to a target-service ID via the discovery cache (the track's
-    extra_data — free + already matched) then the library's stored id, pushes the matched
-    set via the service write client, and stores the returned playlist id so a re-export
-    updates in place (idempotent, like the LB #903 fix). Deps injected so the orchestration
-    is unit-testable without a DB or live service.
+    extra_data — free + already matched) → the library's stored id → (when job['backfill']
+    is set) a confident live-search match, pushes the matched set via the service write
+    client, and stores the returned playlist id so a re-export updates in place (idempotent,
+    like the LB #903 fix). Deps injected so the orchestration is unit-testable without a DB
+    or live service.
     """
     from core.exports.export_sources import resolve_service_track_ids
     resolve_ids_fn = resolve_ids_fn or resolve_service_track_ids
@@ -27761,7 +27781,9 @@ def _run_service_export(job, db, playlist_id, title, service, client, resolve_id
         job['done'] = done
         job['stats'] = dict(stats)
 
-    out = resolve_ids_fn(tracks, service, on_progress=on_progress)
+    # Opt-in backfill: confident live-search for tracks the cache + library couldn't resolve.
+    search_id_fn = _build_service_search_id_fn(service) if job.get('backfill') else None
+    out = resolve_ids_fn(tracks, service, search_id_fn=search_id_fn, on_progress=on_progress)
     job['stats'] = out['stats']
     ids = [r['service_track_id'] for r in out['resolved'] if r.get('service_track_id')]
     if not ids:
@@ -27885,6 +27907,8 @@ def start_playlist_export_service(playlist_id, service):
         service = (service or '').lower()
         if service not in ('spotify', 'deezer'):
             return jsonify({"success": False, "error": f"Unsupported export target: {service}"}), 400
+        body = request.get_json(silent=True) or {}
+        backfill = bool(body.get('backfill'))
         db = get_database()
         meta = db.get_mirrored_playlist(int(playlist_id)) or {}
         title = (meta.get('name') or meta.get('title') or 'SoulSync Export').strip() or 'SoulSync Export'
@@ -27894,8 +27918,8 @@ def start_playlist_export_service(playlist_id, service):
         with _playlist_export_jobs_lock:
             _playlist_export_jobs[job_id] = {
                 'job_id': job_id, 'playlist_id': str(playlist_id), 'title': title,
-                'mode': service, 'phase': 'starting', 'done': 0, 'total': 0,
-                'stats': {}, 'error': None,
+                'mode': service, 'backfill': backfill, 'phase': 'starting', 'done': 0,
+                'total': 0, 'stats': {}, 'error': None,
             }
         t = threading.Thread(target=_run_playlist_export,
                              args=(job_id, playlist_id, title, service), daemon=True)

--- a/web_server.py
+++ b/web_server.py
@@ -27741,9 +27741,68 @@ _playlist_export_jobs = {}
 _playlist_export_jobs_lock = threading.Lock()
 
 
+def _run_service_export(job, db, playlist_id, title, service, client, resolve_fn):
+    """Export a mirrored playlist back to a streaming service (Spotify/Deezer, #945).
+
+    Reuses the same resolve→push→store-target machinery the ListenBrainz export uses,
+    just with a service track-ID resolver and a service write client. Deps are injected
+    so the orchestration (resolve, unmatched-guard, push, idempotent target store, error
+    paths) is unit-testable without a DB or live service.
+    """
+    from core.exports.playlist_export import resolve_playlist_tracks
+
+    tracks = db.get_mirrored_playlist_tracks(int(playlist_id))
+    job['total'] = len(tracks)
+    job['phase'] = 'resolving'
+
+    def on_progress(done, total, stats):
+        job['done'] = done
+        job['stats'] = dict(stats)
+
+    out = resolve_playlist_tracks(tracks, resolve_fn, on_progress=on_progress,
+                                  id_key='service_track_id')
+    job['stats'] = out['stats']
+    ids = [r['service_track_id'] for r in out['resolved'] if r.get('service_track_id')]
+    if not ids:
+        job['phase'] = 'error'
+        job['error'] = f"No tracks matched a {service.title()} ID — nothing to export"
+        return
+    if client is None:
+        job['phase'] = 'error'
+        job['error'] = f"{service.title()} is not connected"
+        return
+
+    job['phase'] = 'pushing'
+    # Re-export updates the same service playlist in place (idempotent), mirroring the
+    # ListenBrainz #903 fix — the target ID is stored per (playlist, service).
+    existing = db.get_playlist_export_target(int(playlist_id), service)
+    res = client.create_or_update_playlist(title, ids, existing_id=existing)
+    job['push'] = res
+    if res.get('success'):
+        if res.get('playlist_id'):
+            db.set_playlist_export_target(int(playlist_id), service, str(res['playlist_id']))
+        job['phase'] = 'done'
+    else:
+        job['phase'] = 'error'
+        job['error'] = res.get('error') or f"{service.title()} push failed"
+
+
 def _run_playlist_export(job_id, playlist_id, title, mode):
     job = _playlist_export_jobs[job_id]
     try:
+        # Service export (#945) — resolve to Spotify/Deezer track IDs and push.
+        if mode in ('spotify', 'deezer'):
+            from core.exports.export_sources import build_service_resolve_fn
+            db = get_database()
+            if mode == 'spotify':
+                client = get_spotify_client()
+            else:
+                from core.deezer_download_client import DeezerDownloadClient
+                client = DeezerDownloadClient()
+            _run_service_export(job, db, playlist_id, title, mode, client,
+                                build_service_resolve_fn(mode))
+            return
+
         from core.exports.export_sources import build_resolve_fn
         from core.exports.playlist_export import resolve_playlist_tracks
         from core.exports.jspf_export import build_jspf
@@ -27813,6 +27872,38 @@ def start_playlist_export_listenbrainz(playlist_id):
         return jsonify({"success": True, "job_id": job_id})
     except Exception as e:
         logger.error(f"Playlist export start failed: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@app.route('/api/playlists/<playlist_id>/export/service/<service>', methods=['POST'])
+def start_playlist_export_service(playlist_id, service):
+    """Export a mirrored playlist back to a streaming service (#945).
+
+    ``service`` ∈ {spotify, deezer}. Creates a service-owned playlist (or updates the
+    one a prior export created) from the library tracks' stored service IDs. Returns
+    {job_id} to poll via the shared export-status endpoint."""
+    try:
+        service = (service or '').lower()
+        if service not in ('spotify', 'deezer'):
+            return jsonify({"success": False, "error": f"Unsupported export target: {service}"}), 400
+        db = get_database()
+        meta = db.get_mirrored_playlist(int(playlist_id)) or {}
+        title = (meta.get('name') or meta.get('title') or 'SoulSync Export').strip() or 'SoulSync Export'
+
+        import uuid
+        job_id = uuid.uuid4().hex
+        with _playlist_export_jobs_lock:
+            _playlist_export_jobs[job_id] = {
+                'job_id': job_id, 'playlist_id': str(playlist_id), 'title': title,
+                'mode': service, 'phase': 'starting', 'done': 0, 'total': 0,
+                'stats': {}, 'error': None,
+            }
+        t = threading.Thread(target=_run_playlist_export,
+                             args=(job_id, playlist_id, title, service), daemon=True)
+        t.start()
+        return jsonify({"success": True, "job_id": job_id})
+    except Exception as e:
+        logger.error(f"Service playlist export start failed ({service}): {e}")
         return jsonify({"success": False, "error": str(e)}), 500
 
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -7,12 +7,19 @@
     <title>SoulSync - Music Sync & Manager</title>
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png', v=static_v) }}">
     <link rel="manifest" href="{{ url_for('static', filename='manifest.json', v=static_v) }}">
-    <meta name="theme-color" content="#1db954">
+    <meta name="theme-color" content="{{ initial_accent_color }}">
     <link rel="apple-touch-icon" href="{{ url_for('static', filename='pwa-icon-192.png', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='basic-search-v2.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='mobile.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='setup-wizard.css', v=static_v) }}">
+    <style id="soulsync-initial-appearance">
+        :root {
+            --accent-rgb: {{ initial_accent_rgb }};
+            --accent-light-rgb: {{ initial_accent_light_rgb }};
+            --accent-neon-rgb: {{ initial_accent_neon_rgb }};
+        }
+    </style>
     {{ vite_assets('head')|safe }}
 </head>
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -5190,18 +5190,19 @@
                                     <div class="setting-row">
                                         <label class="checkbox-label">
                                             <input type="checkbox" id="import-quality-filter-enabled" checked>
-                                            Only import tracks that meet your quality profile
+                                            Quality profile check on import
                                         </label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
                                             onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <div class="setting-help-body" hidden>
-                                        On by default. SoulSync always probes each downloaded file's real audio quality; this
-                                        toggle decides what to do with the result. <strong>On</strong> — files that don't meet your
-                                        quality profile are quarantined instead of imported (the same gate the download pipeline
-                                        uses; fallback/downsample settings still apply). <strong>Off</strong> — everything is
-                                        imported regardless of quality. Either way, the library <em>Quality Upgrade Scanner</em>
-                                        still flags below-profile tracks so you can act on them later.
+                                        On by default. SoulSync probes each imported file's real audio quality and compares it
+                                        with your Quality Profile. <strong>On</strong> — files that don't meet your profile are
+                                        quarantined instead of imported (fallback/downsample settings still apply).
+                                        <strong>Off</strong> — files are imported regardless of format, bitrate, bit depth, or
+                                        sample rate. This does <strong>not</strong> skip AcoustID; fingerprint verification is a
+                                        separate setting below. Either way, the library <em>Quality Upgrade Scanner</em> still
+                                        flags below-profile tracks so you can act on them later.
                                     </div>
                                 </div>
                                 <div class="form-group">
@@ -5298,17 +5299,18 @@
                                     <div class="setting-row">
                                         <label class="checkbox-label">
                                             <input type="checkbox" id="acoustid-require-verified">
-                                            Only import AcoustID-verified tracks (reject "could not confirm")
+                                            Only allow AcoustID-verified tracks for imports and downloads
                                         </label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
                                             onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <div class="setting-help-body" hidden>
-                                        When <strong>on</strong>, a track that AcoustID runs but <em>cannot confirm</em>
+                                        Applies to both <strong>imports</strong> and <strong>downloads</strong>. When
+                                        <strong>on</strong>, a track that AcoustID runs but <em>cannot confirm</em>
                                         (no fingerprint match / cross-script metadata — the ⚠ "unverified" case) is
-                                        <strong>quarantined</strong> instead of imported. Downloads then try the next
-                                        candidate; imports just quarantine (no candidate to retry). Only a clean AcoustID
-                                        <strong>pass</strong> is kept.
+                                        <strong>quarantined</strong> instead of being allowed into the library. Downloads then
+                                        try the next candidate; imports just quarantine (no candidate to retry). Only a clean
+                                        AcoustID <strong>pass</strong> is kept.
                                         <br><br>
                                         ⚠️ <strong>Use with care.</strong> AcoustID "could not confirm" is <em>common</em>
                                         for perfectly good tracks — anything not in its fingerprint database: new/obscure

--- a/webui/index.html
+++ b/webui/index.html
@@ -3913,21 +3913,22 @@
                     <div class="header-text">
                         <h2 class="header-title"><img src="/static/settings.png" class="page-header-icon" alt=""><span>Settings</span></h2>
                     </div>
-                    <div class="header-spacer"></div>
-                    <div class="header-actions">
-                        <button class="save-button" id="save-settings">Save Settings</button>
-                    </div>
                 </div>
                 <div class="settings-content">
                     <!-- Category Tab Bar -->
-                    <div class="stg-tabbar">
-                        <button class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">Connections</button>
-                        <button class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">Downloads</button>
-                        <button class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">Quality</button>
-                        <button class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">Library</button>
-                        <button class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">Appearance</button>
-                        <button class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">Advanced</button>
-                        <button class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">Logs</button>
+                    <div class="settings-nav-row">
+                        <div class="stg-tabbar">
+                            <button class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">Connections</button>
+                            <button class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">Downloads</button>
+                            <button class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">Quality</button>
+                            <button class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">Library</button>
+                            <button class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">Appearance</button>
+                            <button class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">Advanced</button>
+                            <button class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">Logs</button>
+                        </div>
+                        <div class="header-actions">
+                            <button class="save-button" id="save-settings">Save Settings</button>
+                        </div>
                     </div>
                     <!-- Settings Panels -->
                     <div class="settings-columns">

--- a/webui/index.html
+++ b/webui/index.html
@@ -20,10 +20,15 @@
             --accent-neon-rgb: {{ initial_accent_neon_rgb }};
         }
     </style>
+    <script>
+        window._particlesEnabled = {{ initial_particles_enabled|tojson }};
+        window._workerOrbsEnabled = {{ initial_worker_orbs_enabled|tojson }};
+        window._reduceEffectsActive = {{ initial_reduce_effects|tojson }};
+    </script>
     {{ vite_assets('head')|safe }}
 </head>
 
-<body>
+<body{% if initial_reduce_effects %} class="reduce-effects"{% endif %}>
     <!-- Setup Wizard Overlay -->
     <div id="setup-wizard-overlay" class="setup-wizard-overlay" style="display: none;">
         <div class="setup-wizard-container">
@@ -354,7 +359,7 @@
         <!-- Main Content Area -->
         <div class="main-content">
             <!-- Global particle canvas for page background animations -->
-            <canvas id="page-particles-canvas"></canvas>
+            <canvas id="page-particles-canvas"{% if not initial_particles_enabled or initial_reduce_effects %} style="display: none;"{% endif %}></canvas>
             <div id="webui-react-root" class="page" data-react-app="router"></div>
 
             <!-- Dashboard Page -->

--- a/webui/index.html
+++ b/webui/index.html
@@ -5100,6 +5100,7 @@
                                                 <option value="flac">FLAC</option>
                                                 <option value="alac">ALAC</option>
                                                 <option value="wav">WAV / AIFF</option>
+                                                <option value="dsf">DSD (DSF / DFF)</option>
                                             </optgroup>
                                             <optgroup label="Lossy">
                                                 <option value="group:lossy">All lossy</option>

--- a/webui/index.html
+++ b/webui/index.html
@@ -2148,7 +2148,7 @@
 
             <!-- Search Page -->
             <div class="page" id="search-page">
-                <!-- 
+                <!--
                 This top-level container replicates the QSplitter from downloads.py,
                 creating the two-panel layout for the page.
                 -->
@@ -3908,14 +3908,13 @@
             <!-- Settings Page -->
             <div class="page" id="settings-page">
                 <div class="page-shell">
-                <div class="dashboard-header"><div class="dashboard-header-sweep" aria-hidden="true"><span></span></div>
+                <div class="dashboard-header settings-header-compact"><div class="dashboard-header-sweep" aria-hidden="true"><span></span></div>
                     <div class="header-text">
                         <h2 class="header-title"><img src="/static/settings.png" class="page-header-icon" alt=""><span>Settings</span></h2>
-                        <p class="header-subtitle">Configure services, downloads, and preferences</p>
                     </div>
                     <div class="header-spacer"></div>
                     <div class="header-actions">
-                        <button class="save-button" onclick="document.getElementById('save-settings').click()">Save Settings</button>
+                        <button class="save-button" id="save-settings">Save Settings</button>
                     </div>
                 </div>
                 <div class="settings-content">
@@ -3923,7 +3922,7 @@
                     <div class="stg-tabbar">
                         <button class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">Connections</button>
                         <button class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">Downloads</button>
-                        <button class="stg-tab" data-tab="indexers" onclick="switchSettingsTab('indexers')">Indexers &amp; Downloaders</button>
+                        <button class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">Quality</button>
                         <button class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">Library</button>
                         <button class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">Appearance</button>
                         <button class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">Advanced</button>
@@ -3936,6 +3935,7 @@
                             <!-- API Configuration -->
                             <div class="settings-group" data-stg="connections">
                                 <h3>API Configuration <button class="stg-accordion-toggle" onclick="toggleAllServiceAccordions(this)">Expand All</button></h3>
+
 
                                 <!-- Metadata Source Selection (first — tells user what they're configuring for) -->
                                 <div class="api-service-frame">
@@ -3950,9 +3950,9 @@
                                             <option value="discogs">Discogs</option>
                                             <option value="musicbrainz">MusicBrainz</option>
                                         </select>
-                                    </div>
-                                    <div class="callback-info">
-                                        <div class="callback-help">Where artist, album, and track metadata comes from:<br>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                        <div class="setting-help-text setting-help-body" hidden>Where artist, album, and track metadata comes from:<br>
                                             • <strong>Spotify</strong> — official Spotify; connect your account in the Spotify section below.<br>
                                             • <strong>Spotify (no auth)</strong> — the same Spotify catalog with no account needed. It's unofficial and best-effort (may break if Spotify changes its site) and can't read your personal library or playlists.<br>
                                             • <strong>Deezer</strong> / <strong>iTunes</strong> — free, no account.<br>
@@ -3999,13 +3999,15 @@
                                                 Disconnect</button>
                                         </div>
                                         <div class="form-group" style="margin-top: 14px; border-top: 1px solid rgba(255,255,255,0.08); padding-top: 14px;">
-                                            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-weight: normal;">
-                                                <input type="checkbox" id="metadata-spotify-free-enrichment" style="width: auto; margin: 0;">
-                                                <span>Use Spotify (no auth) for background enrichment</span>
-                                            </label>
-                                            <div class="callback-info">
-                                                <div class="callback-help">Runs the background metadata enrichment worker on the no-auth Spotify source instead of this connected account — keeping bulk enrichment off your official API quota (and dodging rate-limit bans), so your account is reserved for interactive search and playlist sync. <strong>On by default.</strong> Turn off to enrich through your connected account instead. Works even with no account connected. Note: the no-auth source can't supply artist genres.</div>
+                                            <div class="setting-row" style="flex:1;min-width:0;">
+                                                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; font-weight: normal; margin:0;">
+                                                    <input type="checkbox" id="metadata-spotify-free-enrichment" style="width: auto; margin: 0;">
+                                                    <span>Use Spotify (no auth) for background enrichment</span>
+                                                </label>
+                                                <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                                    onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                             </div>
+                                            <div class="setting-help-text setting-help-body" hidden>Runs the background metadata enrichment worker on the no-auth Spotify source instead of this connected account — keeping bulk enrichment off your official API quota (and dodging rate-limit bans), so your account is reserved for interactive search and playlist sync. <strong>On by default.</strong> Turn off to enrich through your connected account instead. Works even with no account connected. Note: the no-auth source can't supply artist genres.</div>
                                         </div>
                                     </div>
                                 </div>
@@ -4571,81 +4573,17 @@
                         <!-- Right Column - Download Settings, Database, Metadata, Logging -->
                         <div class="settings-right-column">
                             <!-- Download Settings -->
-                            <div class="settings-group" data-stg="downloads">
-                                <h3>Download Settings</h3>
-                                <div class="setting-help-text">
-                                    These are container-internal paths. Only modify them if you know what you're doing — incorrect values will break downloads.
-                                </div>
+                                                        <!-- Download Settings (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Source Settings</h3>
+                                <span class="settings-section-hint">Source, stream &amp; concurrency</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="downloads">
+<div class="settings-group source-settings-wrapper" data-stg="downloads">
 
-                                <div class="form-group">
-                                    <label>Input Folder (Download Dir):</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="download-path" placeholder="./downloads" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('download', this)">Unlock</button>
-                                    </div>
-                                </div>
 
-                                <div class="form-group">
-                                    <label>Output Folder (Music Library):</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="transfer-path" placeholder="./Transfer" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('transfer', this)">Unlock</button>
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>Import Folder:</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="staging-path" placeholder="./Staging" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('staging', this)">Unlock</button>
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>Music Videos Dir:</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="music-videos-path" placeholder="./MusicVideos" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('music-videos', this)">Unlock</button>
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>Playlists Folder:</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="playlists-materialize-path" placeholder="./Playlists" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('playlists-materialize', this)">Unlock</button>
-                                    </div>
-                                    <div class="setting-help-text" style="margin-top: 6px;">
-                                        Where <strong>Organize by playlist</strong> builds playlist folders — as shortcuts into your library, so songs are never stored twice. Keep this <strong>outside</strong> your music library folder so your media server doesn't scan the same tracks twice.
-                                    </div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>Playlist Folder Style:</label>
-                                    <select id="playlists-materialize-mode">
-                                        <option value="symlink">Symlinks — no extra disk, point to your library</option>
-                                        <option value="copy">Copies — real duplicates (USB sticks / players that can't follow links)</option>
-                                    </select>
-                                    <div class="setting-help-text" style="margin-top: 6px;">
-                                        Symlinks use almost no space. Copies are self-contained. Symlinks fall back to copies automatically where the filesystem can't link (Windows without privileges, some network shares, FAT/exFAT drives).
-                                    </div>
-                                    <button class="test-button" id="playlists-rebuild-btn" onclick="rebuildPlaylistFolders()" style="margin-top: 10px;">
-                                        Rebuild playlist folders now
-                                    </button>
-                                    <div class="setting-help-text" id="playlists-rebuild-status" style="margin-top: 6px;"></div>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>M3U Entry Base Path:</label>
-                                    <div class="path-input-group">
-                                        <input type="text" id="m3u-entry-base-path" placeholder="e.g. /mnt/music (leave empty for relative paths)" readonly>
-                                        <button class="browse-button locked" onclick="togglePathLock('m3u-entry-base', this)">Unlock</button>
-                                    </div>
-                                    <div class="setting-help-text">
-                                        Optional prefix added to every track path in exported M3U files. Use this when your media server needs absolute paths (e.g. <code>/mnt/music</code>).
-                                    </div>
-                                </div>
-
+                                <div class="settings-subcard">
                                 <div class="form-group">
                                     <label>Download Source:</label>
                                     <select id="download-source-mode" class="form-select"
@@ -4663,7 +4601,9 @@
                                         <option value="usenet">Usenet Only (via Prowlarr)</option>
                                         <option value="hybrid">Hybrid (Primary + Fallback)</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                        onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Choose where to download music from. Hybrid mode tries primary source first,
                                         then falls back to secondary if it fails.
                                     </div>
@@ -4675,7 +4615,9 @@
                                         <option value="youtube">YouTube (Instant)</option>
                                         <option value="active">Active Download Source</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                        onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Where to stream audio when previewing tracks. YouTube is instant and requires no setup.
                                         "Active Download Source" uses your configured source (Tidal, Qobuz, etc.) — if that's Soulseek, YouTube is used automatically.
                                     </div>
@@ -4693,17 +4635,23 @@
                                         <option value="8">8</option>
                                         <option value="10">10</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                        onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Maximum simultaneous downloads per batch. Soulseek album downloads always use 1 worker
                                         due to per-user upload limits. Higher values speed up large playlists and wishlists.
                                     </div>
                                 </div>
 
+                                <div class="form-group">
+                                    <button class="test-button" id="test-all-sources-btn" onclick="testAllSources()">Test all sources</button>
+                                    <span class="setting-help-text" style="margin-left:10px;">Checks every selected source &amp; configured connection.</span>
+                                </div>
+
                                 <!-- Hybrid Mode Settings (shown only when hybrid is selected) -->
                                 <div id="hybrid-settings-container" style="display: none;">
                                     <div class="setting-help-text">
-                                        Drag to reorder source priority. Enable sources you want to use. Downloads try each enabled source in order.
-                                        The first source can use album-level downloads when supported; later sources stay track-level fallback.
+                                        Drag to reorder source priority. Toggle the sources you want to use — downloads try each enabled source in order. Click a source (or its ⚙) to configure it below. The first source can use album-level downloads when supported; later sources stay track-level fallback.
                                     </div>
                                     <div class="hybrid-source-list" id="hybrid-source-list">
                                         <!-- Populated by JS -->
@@ -4712,6 +4660,7 @@
                                     <select id="hybrid-primary-source" style="display:none;"><option value="soulseek">Soulseek</option><option value="youtube">YouTube</option><option value="tidal">Tidal</option><option value="qobuz">Qobuz</option><option value="hifi">HiFi</option><option value="deezer_dl">Deezer</option><option value="soundcloud">SoundCloud</option></select>
                                     <select id="hybrid-secondary-source" style="display:none;"><option value="soulseek">Soulseek</option><option value="youtube">YouTube</option><option value="tidal">Tidal</option><option value="qobuz">Qobuz</option><option value="hifi">HiFi</option><option value="deezer_dl">Deezer</option><option value="soundcloud">SoundCloud</option></select>
                                 </div>
+                                </div><!-- end basic source subcard -->
 
                                 <!-- Soulseek Settings (shown when soulseek is active source) -->
                                 <div id="soulseek-settings-container" style="display: none;">
@@ -4981,7 +4930,7 @@
                                 <div id="prowlarr-source-redirect" style="display: none;">
                                     <div class="form-group">
                                         <div class="setting-help-text" style="padding: 12px 14px; background: rgba(var(--accent-rgb), 0.06); border: 1px solid rgba(var(--accent-rgb), 0.2); border-radius: 10px;">
-                                            📡 Torrent and Usenet downloads run through your Prowlarr indexers and your configured downloader. Set up Prowlarr + the torrent / usenet client on the <strong>Indexers &amp; Downloaders</strong> tab. Once Test Connection is green on both, this source is ready to use.
+                                            📡 Torrent / Usenet downloads use Prowlarr plus a torrent or usenet client — configure them in the <strong>Indexers &amp; Downloaders</strong> tiles below.
                                         </div>
                                     </div>
                                 </div>
@@ -5029,21 +4978,22 @@
                                 </div>
 
                             </div>
+                            </div><!-- end Download Settings body -->
 
                             <!-- ═══ QUALITY PROFILE ═══ -->
                             <!-- Whole tile is gated as a unit (Soulseek-only + downloads tab)
                                  by settings.js updateSourceVisibility — gating only the inner
                                  group would leave an empty expandable shell. -->
-                            <div id="quality-profile-tile" data-stg="downloads">
+                            <div id="quality-profile-tile" data-stg="quality">
                             <div class="settings-section-header collapsed" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
                                 <h3>Quality Profile</h3>
                                 <span class="settings-section-hint">Format priorities, bitrate, bit depth</span>
                             </div>
-                            <div class="settings-section-body collapsed" data-stg="downloads">
+                            <div class="settings-section-body collapsed" data-stg="quality">
 
                             <!-- Quality Profile Settings (global — applies to all download sources) -->
-                            <div class="settings-group" id="quality-profile-section" data-stg="downloads">
+                            <div class="settings-group" id="quality-profile-section" data-stg="quality">
 
                                 <!-- Presets -->
                                 <div class="quality-presets">
@@ -5079,7 +5029,7 @@
                                     <div class="setting-row">
                                         <label class="ranked-targets-label" style="margin:0;">Quality priority (drag to reorder — 1st = most preferred):</label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
-                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">ⓘ</span>
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <div class="help-text setting-help-body" hidden>
                                         <strong>How it works:</strong> Each download source is checked against this list
@@ -5154,7 +5104,7 @@
                                     <div class="setting-row" style="margin-bottom:4px;">
                                         <label for="quality-search-mode" style="font-weight:600;">Search strategy</label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
-                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">ⓘ</span>
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <select id="quality-search-mode" style="width:100%;max-width:420px;" onchange="onSearchModeChange()">
                                         <option value="priority">Source priority — fast (use the first source that has it)</option>
@@ -5180,7 +5130,7 @@
                                             Rank-based download order
                                         </label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
-                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">ⓘ</span>
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <div class="help-text setting-help-body" hidden>
                                         A single source often returns several copies of the same track.<br><br>
@@ -5203,7 +5153,7 @@
                                             Accept off-list quality when nothing in the list is available
                                         </label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
-                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">ⓘ</span>
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
                                     <div class="help-text setting-help-body" hidden>
                                         This does <strong>not</strong> mean "walk down my list" — the list already
@@ -5216,17 +5166,137 @@
                                     </div>
                                 </div>
 
-                                <!-- Require hard AcoustID verification — only shown when AcoustID is enabled -->
-                                <div class="form-group" id="acoustid-require-verified-group" style="display:none;">
+                            </div>
+
+                            </div><!-- end Quality Profile body -->
+                            </div><!-- end Quality Profile tile -->
+
+                            <!-- ═══ QUALITY ON IMPORT (moved from Library > Import — quality enforcement at import time) ═══ -->
+                            <div class="settings-section-header collapsed" data-stg="quality" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Quality on Import</h3>
+                                <span class="settings-section-hint">Apply the profile to manually imported files</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="quality">
+                            <div class="settings-group" data-stg="quality">
+                                <div class="form-group">
                                     <div class="setting-row">
-                                        <label class="checkbox-label" style="margin:0;">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="import-quality-filter-enabled" checked>
+                                            Only import tracks that meet your quality profile
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>
+                                        On by default. SoulSync always probes each downloaded file's real audio quality; this
+                                        toggle decides what to do with the result. <strong>On</strong> — files that don't meet your
+                                        quality profile are quarantined instead of imported (the same gate the download pipeline
+                                        uses; fallback/downsample settings still apply). <strong>Off</strong> — everything is
+                                        imported regardless of quality. Either way, the library <em>Quality Upgrade Scanner</em>
+                                        still flags below-profile tracks so you can act on them later.
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="import-replace-lower-quality">
+                                            Replace lower quality files on import
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>
+                                        When importing from Staging, if a track already exists in your library at a lower quality
+                                        (e.g. MP3), it will be replaced with the higher quality version (e.g. FLAC).
+                                        If disabled, existing tracks are always kept and the import file is skipped.
+                                    </div>
+                                </div>
+                            </div>
+                            </div><!-- end Quality on Import body -->
+
+                            <!-- ═══ POST-DOWNLOAD CONVERSION (quality — moved from Library) ═══ -->
+                            <div class="settings-section-header collapsed" data-stg="quality" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Post-Download Conversion</h3>
+                                <span class="settings-section-hint">Downsample hi-res, make lossy copies</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="quality">
+                            <div class="settings-group" data-stg="quality">
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="downsample-hires">
+                                            Downsample Hi-Res FLAC to CD quality (16-bit / 44.1kHz)
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>When a 24-bit or high sample-rate FLAC is downloaded, it is automatically converted to 16-bit/44.1kHz. The hi-res original is <strong>replaced</strong>, not kept alongside. Requires ffmpeg.</div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="lossy-copy-enabled"
+                                                onchange="document.getElementById('lossy-copy-options').style.display = this.checked ? 'block' : 'none'">
+                                            Create lossy copy of downloaded FLAC files
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>After downloading a FLAC, a lossy copy at the selected codec and bitrate is created in the same folder. Requires ffmpeg.</div>
+                                </div>
+                                <div id="lossy-copy-options" style="display: none;">
+                                    <div class="form-group">
+                                        <label>Codec:</label>
+                                        <select id="lossy-copy-codec" onchange="updateLossyBitrateOptions()">
+                                            <option value="mp3">MP3</option>
+                                            <option value="opus">Opus</option>
+                                            <option value="aac">AAC (M4A)</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-group">
+                                        <label>Bitrate:</label>
+                                        <select id="lossy-copy-bitrate">
+                                            <option value="320">320 kbps</option>
+                                            <option value="256">256 kbps</option>
+                                            <option value="192">192 kbps</option>
+                                            <option value="128">128 kbps</option>
+                                        </select>
+                                    </div>
+                                    <div class="form-group" style="margin-top: 12px;">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="lossy-copy-delete-original">
+                                            Blasphemy Mode — Delete original FLAC after conversion
+                                        </label>
+                                    </div>
+                                    <div class="help-text" style="color: rgba(255, 100, 100, 0.8);">
+                                        Warning: The original high-quality file will be permanently deleted.
+                                        Only the lossy copy will remain.
+                                    </div>
+                                </div>
+                            </div>
+                            </div><!-- end Post-Download Conversion body -->
+
+                            <!-- ═══ AUDIO VERIFICATION (global quality gate) ═══ -->
+                            <div class="settings-section-header collapsed" data-stg="quality" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Audio Verification</h3>
+                                <span class="settings-section-hint">AcoustID identity match + truncated/silent detection</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="quality">
+                            <div class="settings-group" data-stg="quality">
+                                <!-- AcoustID identity gate — always shown here; help notes it needs AcoustID enabled -->
+                                <div class="form-group" id="acoustid-require-verified-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
                                             <input type="checkbox" id="acoustid-require-verified">
                                             Only import AcoustID-verified tracks (reject "could not confirm")
                                         </label>
                                         <span class="info-icon" role="button" tabindex="0" title="What's this?"
-                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">ⓘ</span>
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
-                                    <div class="help-text setting-help-body" hidden>
+                                    <div class="setting-help-body" hidden>
                                         When <strong>on</strong>, a track that AcoustID runs but <em>cannot confirm</em>
                                         (no fingerprint match / cross-script metadata — the ⚠ "unverified" case) is
                                         <strong>quarantined</strong> instead of imported. Downloads then try the next
@@ -5244,96 +5314,51 @@
                                         outage) always import, so an AcoustID outage never stalls you. Requires AcoustID enabled.
                                     </div>
                                 </div>
-                            </div>
-
-                            </div><!-- end Quality Profile body -->
-                            </div><!-- end Quality Profile tile -->
-
-                            <!-- ═══ RETRY LOGIC ═══ -->
-                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
-                                <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Retry Logic</h3>
-                                <span class="settings-section-hint">Next-best candidate, exhaustive per-source retry</span>
-                            </div>
-                            <div class="settings-section-body collapsed" data-stg="downloads">
-
-                            <div class="settings-group" data-stg="downloads">
-                                <h3>🔁 Retry Logic</h3>
-                                <small class="settings-hint" style="margin-bottom: 10px; display: block;">Controls what happens when a downloaded file is rejected (AcoustID mismatch, wrong version, or duration/integrity failure). Independent of post-processing.</small>
                                 <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="retry-next-candidate" checked>
-                                        Retry next-best candidate on mismatch
-                                    </label>
-                                    <small class="settings-hint">When a download is quarantined (AcoustID mismatch or duration/integrity failure), automatically try the next-best candidate instead of failing the track. Off = quarantine and fail immediately.</small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="retry-exhaustive">
-                                        Exhaustive retry (separate budget per source)
-                                    </label>
-                                    <small class="settings-hint">Give every source (Soulseek, then HiFi/Tidal/…) its own retry budget. Each source spends <em>queries × retries-per-query</em> attempts before the track moves on. Worst case across two sources can mean many downloads — use for hard-to-match tracks (e.g. CJK artist names). Requires the option above.</small>
-                                </div>
-                                <div class="form-group">
-                                    <label for="retries-per-query">Retries per query (per source)</label>
-                                    <input type="number" id="retries-per-query" min="1" max="20" step="1" value="5" style="width: 100px;" autocomplete="off" data-bwignore="" data-1p-ignore="" data-lpignore="true">
-                                    <small class="settings-hint">In exhaustive mode, how many candidates to try per search query per source. The per-source budget is <em>number of search queries × this value</em>. Only used when Exhaustive retry is on.</small>
-                                </div>
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="accept-version-mismatch-fallback">
-                                        Accept best version mismatch as last resort
-                                    </label>
-                                    <small class="settings-hint">When retries are fully exhausted and <em>every</em> candidate for a track failed the <strong>same</strong> version mismatch (e.g. only an instrumental exists), accept the best (first-tried) one instead of leaving the track missing. Only AcoustID is bypassed — integrity/duration/bit-depth checks still run, so truncated or genuinely wrong files are never let through. Off = leave such tracks failed.</small>
-                                </div>
-                                <div class="form-group">
-                                    <label for="version-mismatch-min-count">Minimum matching mismatches before accepting</label>
-                                    <input type="number" id="version-mismatch-min-count" min="1" max="20" step="1" value="2" style="width: 100px;" autocomplete="off" data-bwignore="" data-1p-ignore="" data-lpignore="true">
-                                    <small class="settings-hint">How many quarantined candidates must have failed the <em>same</em> version mismatch before the last-resort acceptance kicks in. Higher = more confirmation that no correct version exists. Only used when the option above is on.</small>
-                                </div>
-                            </div>
-
-                            </div><!-- end Retry Logic body -->
-
-                            <!-- ═══ INDEXERS & DOWNLOADERS ═══ -->
-                            <!-- Intro hero — explains the search → fetch flow in one glance -->
-                            <div class="settings-group ind-hero" data-stg="indexers">
-                                <div class="ind-hero-title">Indexers &amp; Downloaders</div>
-                                <div class="ind-hero-flow">
-                                    <span class="ind-hero-step"><span class="ind-hero-step-num">1</span> Indexers find releases</span>
-                                    <span class="ind-hero-arrow">→</span>
-                                    <span class="ind-hero-step"><span class="ind-hero-step-num">2</span> Downloader fetches them</span>
-                                    <span class="ind-hero-arrow">→</span>
-                                    <span class="ind-hero-step"><span class="ind-hero-step-num">3</span> SoulSync imports to library</span>
-                                </div>
-                                <div class="ind-hero-sub">
-                                    Configure your Prowlarr instance to feed search results, and pick a torrent client and/or usenet client to handle the actual downloads. You only need to set up the protocols you actually use.
-                                </div>
-                                <div class="ind-hero-warning">
-                                    <div class="ind-hero-warning-title">💡 Filesystem access — easiest setup</div>
-                                    <div class="ind-hero-warning-body">
-                                        Torrent and usenet clients write files to <strong>their own download folders</strong>, not Soulseek's. SoulSync needs read access to those folders to import the files. <strong>Simplest fix:</strong> point all your downloaders (Soulseek, qBittorrent, SABnzbd / NZBGet) at the <em>same</em> download folder. One folder, one path to worry about, everything just works.
-                                        <ul>
-                                            <li><strong>Bare-metal:</strong> just set every client's download path to the same folder (e.g. your existing slskd folder). Done.</li>
-                                            <li><strong>Docker:</strong> easiest is to reuse the <code>./downloads</code> mount you already have for slskd — point qBit and SAB at <code>/downloads</code> inside their containers too. Or use the commented placeholders in <code>docker-compose.yml</code> if you want separate folders.</li>
-                                            <li><strong>Remote client (NAS / different host):</strong> mount the remote folder locally (SMB / NFS / rclone) before SoulSync can see it.</li>
-                                        </ul>
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="audio-completeness-check">
+                                            Verify real audio with ffmpeg
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                     </div>
+                                    <div class="setting-help-body" hidden>Decodes every downloaded file with ffmpeg to catch fake 30s previews padded to full length and mostly-silent files — the kind whose header lies about the length so mutagen can't catch them. <strong>Off by default:</strong> this fully decodes each file, the most CPU-heavy post-processing step. Most sources (HiFi, Qobuz) already catch previews on their own, so only turn this on if you see padded/silent files slip through. Applies to all download sources.</div>
+                                </div>
+                            </div>
+                            </div><!-- end Audio Verification body -->
+
+                            <!-- ═══ INDEXERS & DOWNLOADERS (gated: only shown when torrent/usenet is a selected source — see updateDownloadSourceUI) ═══ -->
+                            <div id="indexers-downloaders-section" data-stg="downloads">
+                            <!-- Compact collapsible filesystem note (flow/intro text removed per design) -->
+                            <div class="ind-hero-warning" style="margin-bottom:12px;">
+                                <div class="ind-hero-warning-title" style="cursor:pointer;user-select:none;" onclick="const b=this.nextElementSibling; b.style.display=(b.style.display==='none'?'':'none'); const c=this.querySelector('.ind-hero-warning-caret'); if(c)c.textContent=(b.style.display==='none'?'▾':'▴');">💡 Filesystem access — easiest setup <span class="ind-hero-warning-caret" style="opacity:.6;">▾</span></div>
+                                <div class="ind-hero-warning-body" style="display:none;">
+                                    Torrent and usenet clients write files to <strong>their own download folders</strong>, not Soulseek's. SoulSync needs read access to those folders to import the files. <strong>Simplest fix:</strong> point all your downloaders (Soulseek, qBittorrent, SABnzbd / NZBGet) at the <em>same</em> download folder. One folder, one path to worry about, everything just works.
+                                    <ul>
+                                        <li><strong>Bare-metal:</strong> just set every client's download path to the same folder (e.g. your existing slskd folder). Done.</li>
+                                        <li><strong>Docker:</strong> easiest is to reuse the <code>./downloads</code> mount you already have for slskd — point qBit and SAB at <code>/downloads</code> inside their containers too. Or use the commented placeholders in <code>docker-compose.yml</code> if you want separate folders.</li>
+                                        <li><strong>Remote client (NAS / different host):</strong> mount the remote folder locally (SMB / NFS / rclone) before SoulSync can see it.</li>
+                                    </ul>
                                 </div>
                             </div>
 
                             <!-- ─── INDEXERS section ─── -->
-                            <div class="settings-section-header" data-stg="indexers" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>🔎 Indexers</h3>
+                                <h3>Indexers</h3>
                                 <span class="settings-section-hint">Prowlarr — search aggregator</span>
                                 <span class="ind-status-dot ind-status-dot-unknown" id="prowlarr-status-dot" title="Not tested"></span>
                             </div>
-                            <div class="settings-section-body" data-stg="indexers">
-                                <div class="settings-group" data-stg="indexers">
+                            <div class="settings-section-body collapsed" data-stg="downloads">
+                                <div class="settings-group" data-stg="downloads">
                                     <div class="api-service-frame">
-                                        <h4 class="service-title prowlarr-title">⬢ Prowlarr</h4>
-                                        <div class="setting-help-text" style="margin-bottom: 14px;">
+                                        <div class="setting-row" style="padding:14px 18px;">
+                                            <h4 class="service-title prowlarr-title" style="padding:0!important;border:0!important;margin:0!important;flex:1;">⬢ Prowlarr</h4>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                                onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                        </div>
+                                        <div class="setting-help-text setting-help-body" style="margin-bottom: 14px;" hidden>
                                             Prowlarr manages your Usenet and torrent indexers and exposes them through one API. SoulSync uses Prowlarr to search across every indexer at once for the Torrent and Usenet download sources.
                                             <br><br>
                                             Don't have it? Grab Prowlarr from <code>prowlarr.com</code> (or your *arr stack). You point Prowlarr at your indexers, then point SoulSync at Prowlarr.
@@ -5381,18 +5406,23 @@
                                 </div>
                             </div>
 
-                            <!-- ─── TORRENT CLIENT section ─── -->
-                            <div class="settings-section-header collapsed" data-stg="indexers" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                            <!-- ─── TORRENT CLIENT section (gated on torrent source) ─── -->
+                            <div id="torrent-tile">
+                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>🧲 Torrent Client</h3>
+                                <h3>Torrent Client</h3>
                                 <span class="settings-section-hint">qBittorrent · Transmission · Deluge</span>
                                 <span class="ind-status-dot ind-status-dot-unknown" id="torrent-client-status-dot" title="Not tested"></span>
                             </div>
-                            <div class="settings-section-body collapsed" data-stg="indexers">
-                                <div class="settings-group" data-stg="indexers">
+                            <div class="settings-section-body collapsed" data-stg="downloads">
+                                <div class="settings-group" data-stg="downloads">
                                     <div class="api-service-frame">
-                                        <h4 class="service-title torrent-title">⬢ Torrent Downloader</h4>
-                                        <div class="setting-help-text" style="margin-bottom: 14px;">
+                                        <div class="setting-row" style="padding:14px 18px;">
+                                            <h4 class="service-title torrent-title" style="padding:0!important;border:0!important;margin:0!important;flex:1;">⬢ Torrent Downloader</h4>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                                onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                        </div>
+                                        <div class="setting-help-text setting-help-body" style="margin-bottom: 14px;" hidden>
                                             Where SoulSync sends torrents once Prowlarr finds them. Pick the client you already use — only one can be active at a time. Add the URL of the client's WebUI, log in if it asks for credentials, and hit Test Connection.
                                         </div>
                                         <div class="form-group">
@@ -5473,18 +5503,25 @@
                                 </div>
                             </div>
 
-                            <!-- ─── USENET CLIENT section ─── -->
-                            <div class="settings-section-header collapsed" data-stg="indexers" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                            </div><!-- end torrent-tile -->
+
+                            <!-- ─── USENET CLIENT section (gated on usenet source) ─── -->
+                            <div id="usenet-tile">
+                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>📰 Usenet Client</h3>
+                                <h3>Usenet Client</h3>
                                 <span class="settings-section-hint">SABnzbd · NZBGet</span>
                                 <span class="ind-status-dot ind-status-dot-unknown" id="usenet-client-status-dot" title="Not tested"></span>
                             </div>
-                            <div class="settings-section-body collapsed" data-stg="indexers">
-                                <div class="settings-group" data-stg="indexers">
+                            <div class="settings-section-body collapsed" data-stg="downloads">
+                                <div class="settings-group" data-stg="downloads">
                                     <div class="api-service-frame">
-                                        <h4 class="service-title usenet-title">⬢ Usenet Downloader</h4>
-                                        <div class="setting-help-text" style="margin-bottom: 14px;">
+                                        <div class="setting-row" style="padding:14px 18px;">
+                                            <h4 class="service-title usenet-title" style="padding:0!important;border:0!important;margin:0!important;flex:1;">⬢ Usenet Downloader</h4>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                                onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                        </div>
+                                        <div class="setting-help-text setting-help-body" style="margin-bottom: 14px;" hidden>
                                             Where SoulSync sends NZBs once Prowlarr finds them. Pick one usenet downloader. SABnzbd uses an API key for auth; NZBGet uses a username + password.
                                         </div>
                                         <div class="form-group">
@@ -5542,18 +5579,164 @@
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- end usenet-tile -->
+                            </div><!-- end indexers-downloaders-section -->
+
+                            <!-- ═══ RETRY LOGIC (download behaviour — after the source/indexer config) ═══ -->
+                            <div class="settings-section-header collapsed" data-stg="downloads" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Retry Logic</h3>
+                                <span class="settings-section-hint">What happens when a download is rejected</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="downloads">
+                            <div class="settings-group" data-stg="downloads">
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="retry-next-candidate" checked>
+                                            Retry next-best candidate on mismatch
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>Controls what happens when a downloaded file is rejected (AcoustID mismatch, wrong version, or duration/integrity failure) — independent of post-processing. When on, SoulSync automatically tries the next-best candidate instead of failing the track. <strong>Off</strong> = quarantine and fail immediately.</div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="retry-exhaustive" onchange="syncRetryConditionalRows()">
+                                            Exhaustive retry (separate budget per source)
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>Give every source (Soulseek, then HiFi/Tidal/…) its own retry budget. Each source spends <em>queries × retries-per-query</em> attempts before the track moves on. Worst case across two sources can mean many downloads — use for hard-to-match tracks (e.g. CJK artist names). Requires the option above.</div>
+                                </div>
+                                <div class="form-group" id="retries-per-query-row" style="display:none;">
+                                    <div class="setting-row">
+                                        <label for="retries-per-query">Retries per query (per source)</label>
+                                        <input type="number" id="retries-per-query" min="1" max="20" step="1" value="5" style="width: 100px;" autocomplete="off" data-bwignore="" data-1p-ignore="" data-lpignore="true">
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>In exhaustive mode, how many candidates to try per search query per source. The per-source budget is <em>number of search queries × this value</em>. Only used when Exhaustive retry is on.</div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="accept-version-mismatch-fallback" onchange="syncRetryConditionalRows()">
+                                            Accept best version mismatch as last resort
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>When retries are fully exhausted and <em>every</em> candidate for a track failed the <strong>same</strong> version mismatch (e.g. only an instrumental exists), accept the best (first-tried) one instead of leaving the track missing. Only AcoustID is bypassed — integrity/duration/bit-depth checks still run, so truncated or genuinely wrong files are never let through. <strong>Off</strong> = leave such tracks failed.</div>
+                                </div>
+                                <div class="form-group" id="version-mismatch-min-count-row" style="display:none;">
+                                    <div class="setting-row">
+                                        <label for="version-mismatch-min-count">Minimum matching mismatches before accepting</label>
+                                        <input type="number" id="version-mismatch-min-count" min="1" max="20" step="1" value="2" style="width: 100px;" autocomplete="off" data-bwignore="" data-1p-ignore="" data-lpignore="true">
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="setting-help-body" hidden>How many quarantined candidates must have failed the <em>same</em> version mismatch before the last-resort acceptance kicks in. Higher = more confirmation that no correct version exists. Only used when the option above is on.</div>
+                                </div>
+                            </div>
+                            </div><!-- end Retry Logic body -->
 
                             <!-- ═══ PATHS & ORGANIZATION ═══ -->
                             <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
                                 <h3>Paths &amp; Organization</h3>
-                                <span class="settings-section-hint">File templates, music library paths</span>
+                                <span class="settings-section-hint">Folders, file templates &amp; library paths</span>
                             </div>
                             <div class="settings-section-body collapsed" data-stg="library">
 
+                            <!-- Folder Paths (moved here from Downloads — all path settings live together) -->
+                            <div class="settings-group" data-stg="library">
+                                <h3>Folder Paths</h3>
+                                <div class="setting-help-text" style="margin-bottom: 4px;">
+                                    Container-internal paths. Only change them if you know what you're doing — wrong values break downloads.
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Input Folder (Download Dir):</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="download-path" placeholder="./downloads" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('download', this)">Unlock</button>
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Output Folder (Music Library):</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="transfer-path" placeholder="./Transfer" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('transfer', this)">Unlock</button>
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Import Folder:</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="staging-path" placeholder="./Staging" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('staging', this)">Unlock</button>
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Music Videos Dir:</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="music-videos-path" placeholder="./MusicVideos" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('music-videos', this)">Unlock</button>
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Playlists Folder:</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="playlists-materialize-path" placeholder="./Playlists" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('playlists-materialize', this)">Unlock</button>
+                                    </div>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
+                                        Where <strong>Organize by playlist</strong> builds playlist folders — as shortcuts into your library, so songs are never stored twice. Keep this <strong>outside</strong> your music library folder so your media server doesn't scan the same tracks twice.
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Playlist Folder Style:</label>
+                                    <select id="playlists-materialize-mode">
+                                        <option value="symlink">Symlinks — no extra disk, point to your library</option>
+                                        <option value="copy">Copies — real duplicates (USB sticks / players that can't follow links)</option>
+                                    </select>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
+                                        Symlinks use almost no space. Copies are self-contained. Symlinks fall back to copies automatically where the filesystem can't link (Windows without privileges, some network shares, FAT/exFAT drives).
+                                    </div>
+                                    <div style="flex-basis:100%; width:100%;">
+                                        <button class="test-button" id="playlists-rebuild-btn" onclick="rebuildPlaylistFolders()">
+                                            Rebuild playlist folders now
+                                        </button>
+                                        <div class="setting-help-text" id="playlists-rebuild-status" style="margin-top: 6px;"></div>
+                                    </div>
+                                </div>
+
+                                <div class="form-group">
+                                    <label>M3U Entry Base Path:</label>
+                                    <div class="path-input-group">
+                                        <input type="text" id="m3u-entry-base-path" placeholder="e.g. /mnt/music (leave empty for relative paths)" readonly>
+                                        <button class="browse-button locked" onclick="togglePathLock('m3u-entry-base', this)">Unlock</button>
+                                    </div>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
+                                        Optional prefix added to every track path in exported M3U files. Use this when your media server needs absolute paths (e.g. <code>/mnt/music</code>).
+                                    </div>
+                                </div>
+                            </div>
+
                             <!-- File Organization Settings -->
                             <div class="settings-group" data-stg="library">
-                                <h3>📁 File Organization</h3>
+                                <h3>File Organization</h3>
 
                                 <div class="form-group">
                                     <label class="checkbox-label">
@@ -5566,15 +5749,16 @@
                                     <label>Album Path Template:</label>
                                     <input type="text" id="template-album-path"
                                         placeholder="$albumartist/$albumartist - $album/$track - $title">
-                                    <small class="settings-hint">Variables: $albumartist, $artist, $artistletter, $album, $albumtype,
-                                        $title, $track, $disc (01), $discnum (1), $cdnum (CD01 on multi-disc, empty on single), $year, $quality (filename only). Use ${var} to append text: ${albumtype}s → Albums</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Variables: <code>$albumartist</code>, <code>$artist</code>, <code>$artistletter</code>, <code>$album</code>, <code>$albumtype</code>, <code>$title</code>, <code>$track</code>, <code>$disc</code> (01), <code>$discnum</code> (1), <code>$cdnum</code> (CD01 on multi-disc, empty on single), <code>$year</code>, <code>$quality</code> (filename only). Use <code>${var}</code> to append text: <code>${albumtype}s</code> → Albums</small>
                                 </div>
 
                                 <div class="form-group">
                                     <label>Single Path Template:</label>
                                     <input type="text" id="template-single-path"
                                         placeholder="$artist/$artist - $title/$title">
-                                    <small class="settings-hint">Variables: $albumartist, $artist, $artistletter, $title, $track (01), $album, $albumtype, $year, $quality (filename only). Use ${var} to append text: ${albumtype}s → Singles</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Variables: <code>$albumartist</code>, <code>$artist</code>, <code>$artistletter</code>, <code>$title</code>, <code>$track</code> (01), <code>$album</code>, <code>$albumtype</code>, <code>$year</code>, <code>$quality</code> (filename only). Use <code>${var}</code> to append text: <code>${albumtype}s</code> → Singles</small>
                                 </div>
 
                                 <!-- Playlist Path Template: hidden from the UI. Playlists now import
@@ -5593,14 +5777,16 @@
                                     <label>Playlist File Naming:</label>
                                     <input type="text" id="template-playlist-item"
                                         placeholder="Leave empty to keep the library filename">
-                                    <small class="settings-hint">Renames the files inside each "Organize by Playlist" folder (your real library files are never touched). <strong>Filename only — no folders.</strong> Variables: $position (playlist order), $artist, $album, $track, $title. Must include $title and cannot contain "/". Example: <code>$position - $artist - $title</code> → <code>01 - Daft Punk - One More Time.flac</code>. Empty = keep the original library filename.</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Renames the files inside each "Organize by Playlist" folder (your real library files are never touched). <strong>Filename only — no folders.</strong> Variables: <code>$position</code> (playlist order), <code>$artist</code>, <code>$album</code>, <code>$track</code>, <code>$title</code>. Must include <code>$title</code> and cannot contain "/". Example: <code>$position - $artist - $title</code> → <code>01 - Daft Punk - One More Time.flac</code>. Empty = keep the original library filename.</small>
                                 </div>
 
                                 <div class="form-group">
                                     <label>Music Video Path Template:</label>
                                     <input type="text" id="template-video-path"
                                         placeholder="$artist/$title-video">
-                                    <small class="settings-hint">Variables: $artist, $artistletter, $title, $year. Use ${var} to append text. Default: $artist/$title-video</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Variables: <code>$artist</code>, <code>$artistletter</code>, <code>$title</code>, <code>$year</code>. Use <code>${var}</code> to append text. Default: <code>$artist/$title-video</code></small>
                                 </div>
 
                                 <div class="form-group">
@@ -5609,7 +5795,8 @@
                                         <option value="Disc">Disc (e.g., Disc 1/)</option>
                                         <option value="CD">CD (e.g., CD 1/)</option>
                                     </select>
-                                    <small class="settings-hint">Label used for auto-created disc subfolders on multi-disc albums.</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Label used for auto-created disc subfolders on multi-disc albums.</small>
                                 </div>
 
                                 <div class="form-group">
@@ -5618,9 +5805,8 @@
                                         <option value="first">First Listed Artist (recommended)</option>
                                         <option value="all">All Artists Combined</option>
                                     </select>
-                                    <small class="settings-hint">How $albumartist resolves for albums with multiple artists.
-                                        "First Listed" uses only the primary artist for folder names (e.g., "Larry June" instead of "Larry June, Curren$y & The Alchemist").
-                                        Full artist list is always preserved in file metadata tags.</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>How <code>$albumartist</code> resolves for albums with multiple artists. "First Listed" uses only the primary artist for folder names (e.g., "Larry June" instead of "Larry June, Curren$y &amp; The Alchemist"). Full artist list is always preserved in file metadata tags.</small>
                                 </div>
 
                                 <div class="form-group">
@@ -5631,21 +5817,24 @@
                                         <option value=" / ">/ (slash)</option>
                                         <option value=" & ">&amp; (ampersand)</option>
                                     </select>
-                                    <small class="settings-hint">Separator between multiple artists in the ARTIST tag (e.g. <code>&amp;</code> matches MusicBrainz/Picard style)</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Separator between multiple artists in the ARTIST tag (e.g. <code>&amp;</code> matches MusicBrainz/Picard style)</small>
                                 </div>
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="write-multi-artist">
                                         <span>Write multi-value ARTISTS tag</span>
                                     </label>
-                                    <small class="settings-hint">Write each artist as a separate tag value for Navidrome/Jellyfin multi-artist support</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Write each artist as a separate tag value for Navidrome/Jellyfin multi-artist support</small>
                                 </div>
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="feat-in-title">
                                         <span>Move featured artists to title</span>
                                     </label>
-                                    <small class="settings-hint">Keep only primary artist in ARTIST tag, append others as (feat. ...) in title</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Keep only primary artist in ARTIST tag, append others as (feat. ...) in title</small>
                                 </div>
 
                                 <div class="form-group">
@@ -5653,9 +5842,8 @@
                                         <input type="checkbox" id="allow-duplicate-tracks" checked>
                                         Allow duplicate tracks across albums
                                     </label>
-                                    <small class="settings-hint">When enabled, the same song can be added to the wishlist from
-                                        different albums (e.g., completing a discography where albums share tracks).
-                                        When disabled, tracks with the same name and artist are skipped.</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>When enabled, the same song can be added to the wishlist from different albums (e.g., completing a discography where albums share tracks). When disabled, tracks with the same name and artist are skipped.</small>
                                 </div>
 
                                 <div class="form-group">
@@ -5671,7 +5859,7 @@
 
                             <!-- Music Library Paths (moved into Paths & Organization) -->
                             <div class="settings-group" data-stg="library">
-                                <h3>📂 Music Library Paths</h3>
+                                <h3>Music Library Paths</h3>
 
                                 <div class="help-text" style="margin-bottom: 12px;">
                                     Tell SoulSync where your music files live. Required for tag writing, streaming, and file detection
@@ -5699,7 +5887,6 @@
 
                             <!-- Metadata Enhancement Settings -->
                             <div class="settings-group" data-stg="library">
-                                <h3>🎵 Post-Processing</h3>
 
                                 <div class="form-group">
                                     <label class="checkbox-label">
@@ -5707,7 +5894,8 @@
                                             onchange="document.getElementById('post-processing-options').style.display = this.checked ? 'block' : 'none'">
                                         Enable post-processing on downloaded files
                                     </label>
-                                    <small class="settings-hint">Master toggle — disabling this skips all metadata, artwork, and lyrics processing</small>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <small class="settings-hint setting-help-body" hidden>Master toggle — disabling this skips all metadata, artwork, and lyrics processing.</small>
                                 </div>
 
                                 <div id="post-processing-options">
@@ -5731,11 +5919,13 @@
                                                 <input type="checkbox" id="prefer-caa-art">
                                                 Use MusicBrainz Cover Art Archive for album art
                                             </label>
-                                            <small>Higher resolution but quality may vary. When off, uses Spotify/iTunes/Deezer art (consistent 640x640). Ignored when a preferred album art source list is set below — add Cover Art Archive to that list instead.</small>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                            <small class="settings-hint setting-help-body" hidden>Higher resolution but quality may vary. When off, uses Spotify/iTunes/Deezer art (consistent 640x640). Ignored when a preferred album art source list is set below — add Cover Art Archive to that list instead.</small>
                                         </div>
                                         <div class="form-group">
                                             <label class="checkbox-label" style="cursor:default;">Preferred album art sources</label>
-                                            <small class="settings-hint">Order the sources to choose whose cover art is used. The first source that has a cover wins; misses fall through to the next, and if none match, your download's own art is kept. Only sources you're connected to are shown — leave all off to keep current behavior.</small>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                            <small class="settings-hint setting-help-body" hidden>Order the sources to choose whose cover art is used. The first source that has a cover wins; misses fall through to the next, and if none match, your download's own art is kept. Only sources you're connected to are shown — leave all off to keep current behavior.</small>
                                             <div class="hybrid-source-list" id="art-source-list"></div>
                                         </div>
                                         <div class="form-group">
@@ -5743,7 +5933,8 @@
                                                 <input type="checkbox" id="single-to-album-enabled">
                                                 Match singles to their parent album
                                             </label>
-                                            <small class="settings-hint">When a track matches a single release, look up the album that contains it and tag it as that album — so every song in an album gets the same (album) cover instead of some getting the single's art. Off by default: adds an extra metadata lookup per single-matched track.</small>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                            <small class="settings-hint setting-help-body" hidden>When a track matches a single release, look up the album that contains it and tag it as that album — so every song in an album gets the same (album) cover instead of some getting the single's art. Off by default: adds an extra metadata lookup per single-matched track.</small>
                                         </div>
                                         <div class="form-group">
                                             <label class="checkbox-label">
@@ -5756,19 +5947,14 @@
                                                 <input type="checkbox" id="replaygain-enabled">
                                                 Apply ReplayGain tags after download
                                             </label>
-                                            <small class="settings-hint">Analyzes loudness and writes ReplayGain track gain/peak tags. Requires ffmpeg. Adds a few seconds per track.</small>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                            <small class="settings-hint setting-help-body" hidden>Analyzes loudness and writes ReplayGain track gain/peak tags. Requires ffmpeg. Adds a few seconds per track.</small>
                                         </div>
                                         <div class="form-group">
                                             <label for="duration-tolerance-seconds">Duration tolerance (seconds)</label>
                                             <input type="number" id="duration-tolerance-seconds" min="0" max="60" step="0.5" value="0" style="width: 100px;">
-                                            <small class="settings-hint">Maximum drift between the file's actual length and the metadata source's expected length before the file is quarantined. <strong>0 = auto</strong> (3s normal, 5s for tracks &gt;10min). Raise this if tracks routinely quarantine for being a few seconds off (live recordings, alternate masterings, etc). Capped at 60s.</small>
-                                        </div>
-                                        <div class="form-group">
-                                            <label class="checkbox-label">
-                                                <input type="checkbox" id="audio-completeness-check">
-                                                Verify real audio with ffmpeg (detect truncated / silent files)
-                                            </label>
-                                            <small class="settings-hint">Decodes every downloaded file with ffmpeg to catch fake 30s previews padded to full length and mostly-silent files — the kind whose header lies about the length so mutagen can't catch them. <strong>Off by default:</strong> this fully decodes each file, the most CPU-heavy post-processing step. Most sources (HiFi, Qobuz) already catch previews on their own, so only turn this on if you see padded/silent files slip through. Applies to all download sources.</small>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                            <small class="settings-hint setting-help-body" hidden>Maximum drift between the file's actual length and the metadata source's expected length before the file is quarantined. <strong>0 = auto</strong> (3s normal, 5s for tracks &gt;10min). Raise this if tracks routinely quarantine for being a few seconds off (live recordings, alternate masterings, etc). Capped at 60s.</small>
                                         </div>
                                     </div>
 
@@ -5983,99 +6169,42 @@
                                 </div>
                             </div>
 
-                            <!-- Post-Download Conversion Settings -->
-                            <div class="settings-group" data-stg="library">
-                                <h3>📀 Post-Download Conversion</h3>
-
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="downsample-hires">
-                                        Downsample Hi-Res FLAC to CD quality (16-bit / 44.1kHz)
-                                    </label>
-                                </div>
-                                <div class="help-text">
-                                    When a 24-bit or high sample rate FLAC is downloaded, it will be
-                                    automatically converted to 16-bit/44.1kHz. The hi-res original is
-                                    replaced — not kept alongside. Requires ffmpeg.
-                                </div>
-
-                                <div class="form-group" style="margin-top: 16px;">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="lossy-copy-enabled"
-                                            onchange="document.getElementById('lossy-copy-options').style.display = this.checked ? 'block' : 'none'">
-                                        Create lossy copy of downloaded FLAC files
-                                    </label>
-                                </div>
-
-                                <div id="lossy-copy-options" style="display: none;">
-                                    <div class="form-group">
-                                        <label>Codec:</label>
-                                        <select id="lossy-copy-codec" onchange="updateLossyBitrateOptions()">
-                                            <option value="mp3">MP3</option>
-                                            <option value="opus">Opus</option>
-                                            <option value="aac">AAC (M4A)</option>
-                                        </select>
-                                    </div>
-                                    <div class="form-group">
-                                        <label>Bitrate:</label>
-                                        <select id="lossy-copy-bitrate">
-                                            <option value="320">320 kbps</option>
-                                            <option value="256">256 kbps</option>
-                                            <option value="192">192 kbps</option>
-                                            <option value="128">128 kbps</option>
-                                        </select>
-                                    </div>
-                                    <div class="help-text">
-                                        After downloading a FLAC, a lossy copy at the selected codec and bitrate
-                                        will be created in the same folder. Requires ffmpeg.
-                                    </div>
-                                    <div class="form-group" style="margin-top: 12px;">
-                                        <label class="checkbox-label">
-                                            <input type="checkbox" id="lossy-copy-delete-original">
-                                            Blasphemy Mode — Delete original FLAC after conversion
-                                        </label>
-                                    </div>
-                                    <div class="help-text" style="color: rgba(255, 100, 100, 0.8);">
-                                        Warning: The original high-quality file will be permanently deleted.
-                                        Only the lossy copy will remain.
-                                    </div>
-                                </div>
-                            </div>
-
                             </div><!-- end Post-Processing body -->
 
-                            <!-- ═══ LIBRARY PREFERENCES ═══ -->
+                            <!-- ═══ LISTENING STATS ═══ -->
                             <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Library Preferences</h3>
-                                <span class="settings-section-hint">Import, content filter, playlists, stats</span>
+                                <h3>Listening Stats</h3>
+                                <span class="settings-section-hint">Play history from your media server</span>
                             </div>
                             <div class="settings-section-body collapsed" data-stg="library">
-
-                            <!-- Listening Stats Settings -->
                             <div class="settings-group" data-stg="library">
-                                <h3>📊 Listening Stats</h3>
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="listening-stats-enabled">
                                         Enable listening stats collection from media server
                                     </label>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                </div>
+                                <div class="help-text setting-help-body" hidden>
+                                    Polls your active media server (Plex, Jellyfin, or Navidrome) for play history
+                                    and displays stats on the Stats page.
                                 </div>
                                 <div class="form-group">
                                     <label>Poll Interval (minutes):</label>
                                     <input type="number" id="listening-stats-interval" min="5" max="1440" value="30">
                                 </div>
-                                <div class="help-text">
-                                    Polls your active media server (Plex, Jellyfin, or Navidrome) for play history
-                                    and displays stats on the Stats page.
-                                </div>
                             </div>
+                            </div><!-- end Listening Stats body -->
 
-                            </div><!-- end Library Preferences body -->
-
-                            <!-- Security & Access Settings -->
-                            <div class="settings-group" data-stg="advanced">
-                                <h3>🔒 Security &amp; Access</h3>
+                            <!-- Security & Access (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Security &amp; Access</h3>
+                                <span class="settings-section-hint">PIN · user accounts · reverse proxy</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+                            <div class="settings-group security-wrapper" data-stg="advanced">
                                 <div class="setting-help-text" style="margin-bottom: 18px;">
                                     By default, anyone who can reach SoulSync on your network can use it. Protect access below with a simple shared <strong>PIN</strong>, or full <strong>user accounts</strong> with passwords — you only need one. The last group is just for exposing SoulSync over the internet.
                                 </div>
@@ -6192,10 +6321,18 @@
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- end Security & Access body -->
 
                             <!-- Discovery Settings -->
-                            <div class="settings-group" data-stg="advanced">
-                                <h3>🔍 Discovery Pool Settings</h3>
+                                                        <!-- Discovery Pool Settings (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Discovery Pool Settings</h3>
+                                <span class="settings-section-hint">Lookback &amp; hemisphere</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
 
                                 <div class="form-group">
                                     <label>Lookback Period:</label>
@@ -6206,7 +6343,9 @@
                                         <option value="180">Last 6 months</option>
                                         <option value="all">Entire discography</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                        onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Controls how far back to scan when adding new artists or refreshing discovery
                                         pool.
                                         Once scanned, artists are kept updated with new releases only.
@@ -6219,13 +6358,16 @@
                                         <option value="northern">Northern Hemisphere</option>
                                         <option value="southern">Southern Hemisphere</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                        onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Adjusts seasonal playlists on the Discover page to match your region.
                                         Southern hemisphere flips seasons (e.g. December = Summer, June = Winter).
                                         Holidays like Christmas and Halloween stay calendar-fixed.
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- end Discovery Pool Settings body -->
 
                         </div>
 
@@ -6291,8 +6433,15 @@
                             </div>
 
                             <!-- Database Settings -->
-                            <div class="settings-group" data-stg="advanced">
+                                                        <!-- Database Settings (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
                                 <h3>Database Settings</h3>
+                                <span class="settings-section-hint">Concurrency</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
 
                                 <div class="form-group">
                                     <label>Concurrent Workers:</label>
@@ -6306,15 +6455,23 @@
                                         <option value="9">9</option>
                                         <option value="10">10</option>
                                     </select>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                 </div>
 
-                                <div class="help-text">Number of parallel threads for database updates. Higher values =
-                                    faster updates but more server load.</div>
+                                <div class="help-text setting-help-body" hidden>Number of parallel threads for database updates. Higher values = faster updates but more server load.</div>
                             </div>
+                            </div><!-- end Database Settings body -->
 
                             <!-- Database Maintenance -->
-                            <div class="settings-group" data-stg="advanced">
+                                                        <!-- Database Maintenance (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
                                 <h3>Database Maintenance</h3>
+                                <span class="settings-section-hint">Size, vacuum &amp; cleanup</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
 
                                 <div class="form-group" id="db-maintenance-info">
                                     <label>Database Size:</label>
@@ -6339,39 +6496,87 @@
                                 </div>
                                 <div id="db-vacuum-status" style="display: none; margin-top: 8px; padding: 8px 12px; border-radius: 8px; font-size: 0.85em;"></div>
                             </div>
+                            </div><!-- end Database Maintenance body -->
 
 
-                            <!-- Content Filter Settings -->
+                            <!-- Import Settings (collapsible tile) — first here so it isn't buried among filters -->
+                            <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Import</h3>
+                                <span class="settings-section-hint">Folder-artist override, permanent library</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="library">
                             <div class="settings-group" data-stg="library">
-                                <h3>🔞 Content Filter</h3>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="import-folder-artist-override">
+                                            Use the top Staging folder as the artist
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="help-text setting-help-body" hidden>
+                                        On by default (legacy behaviour). When enabled, files staged as
+                                        <code>Artist/Album/…</code> (or <code>Artist/Albums/Album/…</code>) take the top
+                                        folder as the album artist — handy for mixtapes/compilations whose embedded tags
+                                        carry DJ names. <strong>Turn this off</strong> if you drop a mixed pile of songs
+                                        under one container folder: otherwise every file's artist gets overwritten with
+                                        that folder's name (the cause of the "soulsync" mass-mislabel). With it off, the
+                                        metadata-identified artist is always kept.
+                                    </div>
+                                </div>
+                                <div class="form-group">
+                                    <div class="setting-row">
+                                        <label class="checkbox-label">
+                                            <input type="checkbox" id="import-transfer-permanent">
+                                            Transfer is my permanent library — never move files out
+                                        </label>
+                                        <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                            onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    </div>
+                                    <div class="help-text setting-help-body" hidden>
+                                        Off by default. Turn this <strong>on</strong> if your Transfer folder is your
+                                        real, permanent library (served by Navidrome/Plex/etc.) rather than a scratch
+                                        drop area. A Deep Scan then never relocates files it doesn't recognize out to
+                                        Staging — it leaves them in place and just reports them. Even with this off, a
+                                        Deep Scan now refuses to move files when the database looks badly out of sync
+                                        with disk, as a safety guard against wiping a library (issue #904).
+                                    </div>
+                                </div>
+                            </div>
+                            </div><!-- end Import body -->
 
+                            <!-- Filtering (Content Filter + Genre Whitelist consolidated into one tile) -->
+                            <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Filtering</h3>
+                                <span class="settings-section-hint">Explicit content &amp; genre whitelist</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="library">
+                            <div class="settings-group" data-stg="library">
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="allow-explicit" checked>
                                         Allow explicit content in downloads
                                     </label>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                 </div>
-                                <div class="help-text">
+                                <div class="help-text setting-help-body" hidden>
                                     When disabled, tracks marked as explicit on Spotify will be skipped
                                     during matched downloads. Does not affect manual Soulseek searches.
                                 </div>
-                            </div>
-
-
-                            <!-- Genre Whitelist -->
-                            <div class="settings-group" data-stg="library">
-                                <h3>🎵 Genre Whitelist</h3>
 
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="genre-whitelist-enabled" onchange="if(typeof debouncedAutoSaveSettings==='function')debouncedAutoSaveSettings()">
                                         Enable strict genre filtering
                                     </label>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                 </div>
-                                <div class="help-text" style="margin-bottom:12px;">
+                                <div class="help-text setting-help-body" hidden style="margin-bottom:12px;">
                                     When enabled, only genres on the whitelist below are kept during enrichment. Junk tags (artist names, radio shows, playlist names) are silently dropped. When disabled, all genres pass through unchanged.
                                 </div>
-
                                 <div id="genre-whitelist-container" style="display:none">
                                     <div class="form-group" style="margin-bottom:8px;">
                                         <input type="text" id="genre-whitelist-search" placeholder="Search or add genre..." class="form-input" style="margin-bottom:8px;">
@@ -6383,98 +6588,26 @@
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- end Filtering body -->
 
-                            <!-- Import Settings (collapsible tile) -->
+                            <!-- Playlists (M3U Export + Playlist Sync consolidated into one tile) -->
                             <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Import</h3>
-                                <span class="settings-section-hint">Quality filter, replace rules, folder-artist</span>
+                                <h3>Playlists</h3>
+                                <span class="settings-section-hint">M3U export &amp; server playlist sync</span>
                             </div>
                             <div class="settings-section-body collapsed" data-stg="library">
-
                             <div class="settings-group" data-stg="library">
-                                <h3>📥 Import Settings</h3>
-
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="import-quality-filter-enabled" checked>
-                                        Only import tracks that meet your quality profile
-                                    </label>
-                                </div>
-                                <div class="help-text">
-                                    On by default. SoulSync always probes each downloaded file's real audio quality; this
-                                    toggle decides what to do with the result. <strong>On</strong> — files that don't meet your
-                                    quality profile are quarantined instead of imported (the same gate the download pipeline
-                                    uses; fallback/downsample settings still apply). <strong>Off</strong> — everything is
-                                    imported regardless of quality. Either way, the library <em>Quality Upgrade Scanner</em>
-                                    still flags below-profile tracks so you can act on them later.
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="import-replace-lower-quality">
-                                        Replace lower quality files on import
-                                    </label>
-                                </div>
-                                <div class="help-text">
-                                    When importing from Staging, if a track already exists in your library at a lower quality
-                                    (e.g. MP3), it will be replaced with the higher quality version (e.g. FLAC).
-                                    If disabled, existing tracks are always kept and the import file is skipped.
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="import-folder-artist-override">
-                                        Use the top Staging folder as the artist
-                                    </label>
-                                </div>
-                                <div class="help-text">
-                                    On by default (legacy behaviour). When enabled, files staged as
-                                    <code>Artist/Album/…</code> (or <code>Artist/Albums/Album/…</code>) take the top
-                                    folder as the album artist — handy for mixtapes/compilations whose embedded tags
-                                    carry DJ names. <strong>Turn this off</strong> if you drop a mixed pile of songs
-                                    under one container folder: otherwise every file's artist gets overwritten with
-                                    that folder's name (the cause of the "soulsync" mass-mislabel). With it off, the
-                                    metadata-identified artist is always kept.
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="checkbox-label">
-                                        <input type="checkbox" id="import-transfer-permanent">
-                                        Transfer is my permanent library — never move files out
-                                    </label>
-                                </div>
-                                <div class="help-text">
-                                    Off by default. Turn this <strong>on</strong> if your Transfer folder is your
-                                    real, permanent library (served by Navidrome/Plex/etc.) rather than a scratch
-                                    drop area. A Deep Scan then never relocates files it doesn't recognize out to
-                                    Staging — it leaves them in place and just reports them. Even with this off, a
-                                    Deep Scan now refuses to move files when the database looks badly out of sync
-                                    with disk, as a safety guard against wiping a library (issue #904).
-                                </div>
-                            </div>
-
-                            </div><!-- end Import body -->
-
-
-                            <!-- M3U Export Settings -->
-                            <div class="settings-group" data-stg="library">
-                                <h3>📋 M3U Playlist Export</h3>
-
                                 <div class="form-group">
                                     <label class="checkbox-label">
                                         <input type="checkbox" id="m3u-export-enabled">
                                         Auto-save M3U file when downloading playlists
                                     </label>
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
                                 </div>
-                                <div class="help-text">
+                                <div class="help-text setting-help-body" hidden>
                                     Saves an M3U playlist file alongside your music. Albums are skipped — they're already grouped by your media server.
                                 </div>
-                            </div>
-
-                            <!-- Playlist Sync Settings -->
-                            <div class="settings-group" data-stg="library">
-                                <h3>Playlist Sync Settings</h3>
 
                                 <div class="form-group">
                                     <label>Sync mode:</label>
@@ -6483,7 +6616,8 @@
                                         <option value="reconcile">Reconcile — edit in place, keep image &amp; description</option>
                                         <option value="append">Append — only add new tracks, never remove</option>
                                     </select>
-                                    <div class="help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="help-text setting-help-body" hidden>
                                         "Replace" deletes and recreates the server playlist every sync, which wipes its custom image/description. "Reconcile" updates the same playlist in place (adds new tracks, removes ones no longer in the source) so your custom image and description survive. "Append" only ever adds.
                                     </div>
                                 </div>
@@ -6495,10 +6629,18 @@
                                     </label>
                                 </div>
                             </div>
+                            </div><!-- end Playlists body -->
 
                             <!-- Logging Settings -->
-                            <div class="settings-group" data-stg="advanced">
+                                                        <!-- Logging (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
                                 <h3>Logging</h3>
+                                <span class="settings-section-hint">Log level &amp; path</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
 
                                 <div class="form-group">
                                     <label>Log Level:</label>
@@ -6508,7 +6650,8 @@
                                         <option value="WARNING">WARNING (Minimal)</option>
                                         <option value="ERROR">ERROR (Critical Only)</option>
                                     </select>
-                                    <div class="setting-help-text">
+                                    <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                    <div class="setting-help-text setting-help-body" hidden>
                                         Controls the level of detail in application logs. DEBUG shows all details, INFO
                                         shows general operations, WARNING and ERROR show only issues.
                                     </div>
@@ -6519,10 +6662,18 @@
                                     <div class="readonly-field" id="log-path-display">logs/app.log</div>
                                 </div>
                             </div>
+                            </div><!-- end Logging body -->
 
                             <!-- SoulSync API Keys -->
-                            <div class="settings-group" data-stg="advanced">
+                                                        <!-- SoulSync API (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
                                 <h3>SoulSync API</h3>
+                                <span class="settings-section-hint">REST keys &amp; inbound endpoint</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
                                 <div class="api-service-frame">
                                     <h4 class="service-title" style="color: #64ffda;">REST API Keys</h4>
                                     <div class="setting-help-text" style="margin-bottom: 12px; color: #888; font-size: 12px;">
@@ -6575,10 +6726,18 @@
                                     </div>
                                 </div>
                             </div>
+                            </div><!-- end SoulSync API body -->
 
                             <!-- Developer Mode -->
-                            <div class="settings-group" data-stg="advanced">
-                                <h3>🔧 Developer Mode</h3>
+                                                        <!-- Developer Mode (collapsible tile) -->
+                            <div class="settings-section-header collapsed" data-stg="advanced" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''">
+                                <span class="settings-section-arrow">&#9660;</span>
+                                <h3>Developer Mode</h3>
+                                <span class="settings-section-hint">Advanced log viewer</span>
+                            </div>
+                            <div class="settings-section-body collapsed" data-stg="advanced">
+<div class="settings-group" data-stg="advanced">
+
                                 <div class="form-group">
                                     <label>Password:</label>
                                     <div style="display: flex; gap: 8px;">
@@ -6588,6 +6747,7 @@
                                     <div id="dev-mode-status" style="margin-top: 8px; color: #888;">Inactive</div>
                                 </div>
                             </div>
+                            </div><!-- end Developer Mode body -->
                         </div>
                     </div>
 
@@ -6630,10 +6790,6 @@
                         </div>
                     </div>
 
-                    <!-- Save Button -->
-                    <div class="settings-actions">
-                        <button class="save-button" id="save-settings">Save Settings</button>
-                    </div>
                 </div>
                 </div>
             </div>

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -96,13 +96,13 @@
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -121,21 +121,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -169,14 +169,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,29 +206,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -258,9 +258,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -268,9 +268,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -278,27 +278,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -349,33 +349,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -383,14 +383,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -610,21 +610,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -633,9 +633,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -862,14 +862,14 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -904,6 +904,16 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@oxfmt/binding-android-arm-eabi": {
       "version": "0.47.0",
@@ -1736,9 +1746,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -1753,9 +1763,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -1770,9 +1780,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -1787,9 +1797,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -1804,9 +1814,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -1821,9 +1831,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -1841,9 +1851,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -1861,9 +1871,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -1881,9 +1891,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -1901,9 +1911,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -1921,9 +1931,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -1941,9 +1951,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1958,9 +1968,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
@@ -1968,18 +1978,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -1994,9 +2004,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -2426,9 +2436,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2819,9 +2829,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
-      "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2868,9 +2878,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
       "dev": true,
       "funding": [
         {
@@ -2888,10 +2898,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2902,9 +2912,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001785",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
-      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -3271,9 +3281,9 @@
       "peer": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.380",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.380.tgz",
+      "integrity": "sha512-W6d5AbuEoRayO447cqrg6lKJIlscgRnnxOZl/08kfV71BQDoEBC7Wwis68z87LjyK6f4kWyTaubuDbhHKrZkbA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4059,9 +4069,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -4078,11 +4088,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4295,9 +4308,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -4315,7 +4328,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4535,14 +4548,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.137.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4551,37 +4564,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
-      }
-    },
-    "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4788,9 +4791,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4922,9 +4925,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5026,17 +5029,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "~1.1.2",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5052,7 +5055,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/webui/src/routes/import/-ui/import-page.tsx
+++ b/webui/src/routes/import/-ui/import-page.tsx
@@ -102,9 +102,9 @@ function ImportOptions() {
         />
         <span
           id="import-quality-filter-label"
-          title="Only import tracks that meet your quality profile; otherwise import everything regardless of quality."
+          title="Checks imported files against your Quality Profile only. Turning this off imports files regardless of format/bitrate/bit depth/sample rate; AcoustID verification is separate and is not skipped."
         >
-          Quality check on import
+          Quality profile check on import
         </span>
       </div>
       <div className={styles.importOption}>

--- a/webui/src/routes/import/-ui/singles-import-tab.tsx
+++ b/webui/src/routes/import/-ui/singles-import-tab.tsx
@@ -50,7 +50,10 @@ export function SinglesImportTab() {
 
     setOpenSingleSearch(fileKey);
     const defaultQuery =
-      [file?.artist, file?.title].filter(Boolean).join(' ') ||
+      // "artist - title" (the placeholder hints this, and source search needs the
+      // dash to disambiguate — "Sub Focus Last Jungle" finds junk, "Sub Focus - Last
+      // Jungle" finds the track). filter(Boolean) keeps a lone title dash-free.
+      [file?.artist, file?.title].filter(Boolean).join(' - ') ||
       (file?.filename || '').replace(/\.[^.]+$/, '');
     ensureSingleSearch(fileKey, defaultQuery);
     if (defaultQuery && !singleSearches[fileKey]?.results.length) {

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,20 +3404,15 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '2.8.0': [
-        { date: 'June 2026 — 2.8.0 release' },
-        { title: 'Preview Clip Cleanup (new Tools job)', desc: 'the HiFi source sometimes returns a ~30s preview clip instead of the full song, landing as a normal track. the new job scans your short tracks, checks how long each should be from its metadata source, and flags the previews. approve a finding and it deletes the clip, drops it from the library, and re-wishlists the full version. each finding has a ▶ Play button + a file-length-vs-real-length readout so you can confirm before approving.', page: 'downloads' },
-        { title: 'Unverified queue stops inflating + self-heals (#934)', desc: 'the AcoustID scan was creating a fresh history row every run and leaving already-verified files stuck "unverified". now scans don\'t duplicate rows, a one-time reconcile on startup clears the existing backlog from your library truth (no re-scan), and a 🧹 Clean orphaned button removes dead rows whose file is gone. unverified review rows also got the Quarantine-style cards. (thanks @nick2000713 for #938.)', page: 'downloads' },
-        { title: 'Album Completeness handles split albums (#936)', desc: 'an album split across multiple library rows used to show every fragment as falsely "incomplete". it now groups the validated fragments into one logical album and emits one correct finding — grouping by shared id AND validating at the track level, so unrelated rows never fuse. also recognizes MusicBrainz as a readable source. (thanks @ragnarlotus.)', page: 'library' },
-        { title: 'Clear Completed is back on Downloads', desc: 'completed downloads now persist across restart, which had hidden the Clear Completed button for them. it\'s back, and clears the live list AND the persisted history so the page actually empties and stays empty (your files are untouched).', page: 'downloads' },
-        { title: 'Pasted YouTube cookies fixed (#Docker)', desc: 'pasting cookies threw `unsupported browser: "custom"` — the client passed the "Paste cookies.txt" mode through as a browser name instead of loading the file. now it uses the pasted cookies.txt, the only auth path that works on a headless/Docker box. (thanks HellRa1SeR.)', page: 'settings' },
-        { title: 'Longer remasters no longer quarantined (#937)', desc: 'the duration check was symmetric, so a remaster running a few seconds LONGER than the metadata got rejected like a truncated download. it\'s asymmetric now — short files stay strict, longer versions get room. (thanks @diegocade1.)', page: 'downloads' },
-        { title: '"Add to Wishlist" from a discography is instant now', desc: 'it was ~15–30s PER TRACK on a large library — the per-track ownership check fell through to a full-table fuzzy scan. it now matches in-memory against the artist\'s tracks once.', page: 'library' },
-        { title: 'Wishlist art renders for re-downloads', desc: 'library-sourced wishlist items (re-downloads, preview re-fetches) stored a relative media-server path that doesn\'t render in a browser. they\'re normalized on read now, so album + artist art show up — fixes already-saved items too.', page: 'downloads' },
-        { title: 'More fixes', desc: 'watchlist now records automatic scans (#933) and no longer fuses different editions of an album; a pasted Qobuz/Tidal track floats to the top of manual search (#932); Popular Picks no longer comes up empty on Deezer.', page: 'search' },
-        { title: 'Dashboard performance, esp. Firefox/Zen (#935)', desc: 'frosted-glass blur, cursor-glow blobs and the worker-orb animation were repainting every frame. trimmed the worst offenders, kept the orb framerate steady on Firefox (was dropping to ~1fps), and set Background Particles OFF by default. the system-memory tile now also shows SoulSync\'s own RAM.', page: 'dashboard' },
-        { title: 'Bounded memory growth (#802)', desc: 'browsing every page used to climb RSS into the GBs (plexapi XML trees deferring garbage collection) and could lock the app up. a lightweight sweeper now collects + hands memory back to the OS as it grows, so it sawtooths and settles instead of climbing.', page: 'dashboard' },
-        { title: 'Earlier versions', desc: '2.7.9 brought best-quality downloads + a ranked quality profile, the quarantine-into-Downloads consolidation, Discover "Based On Your Listening" + Listening Mix, the Wing It Pool, the Auto-Sync redesign, and the multi-disc fix (#927). 2.7.8 added Align Playlists; 2.7.3 the Quality Upgrade Finder; 2.7.0 made multi-user real.' },
+    '2.8.1': [
+        { date: 'June 2026 — 2.8.1 release' },
+        { title: 'Export playlists to Spotify & Deezer (#945)', desc: 'the mirrored-playlist export modal now has Sync to Spotify and Sync to Deezer next to the ListenBrainz/JSPF options. it builds a playlist in your account from the IDs soulsync already has — the discovery cache first, then your library — so an already-discovered playlist exports instantly with zero API calls. re-exporting updates the same playlist instead of duplicating it, and an optional "match missing tracks" toggle confidently searches for the stragglers (a wrong-artist or karaoke version is left out, never guessed). spotify needs a one-time reconnect for write access.', page: 'playlists' },
+        { title: 'Library Reorganize — Rename only (#875)', desc: 'a lighter reorganize action that just renames your files to your current naming scheme — no re-tagging, no quality/AcoustID re-check, no copy-to-staging. much faster on a NAS, won\'t fail on post-processing, and only touches files whose path actually changes (which also fixes the "2 of 14 previewed but everything got modified" album-splitting). pick it from the new Action dropdown. (thanks @tsoulard / @Tacobell444.)', page: 'library' },
+        { title: 'Broader lossless handling (#941, #939)', desc: 'lossy-copy now works for all lossless formats, not just FLAC; and DSD (.dsf/.dff) is recognized as lossless instead of being false-flagged as "truncated".', page: 'downloads' },
+        { title: 'Download + search fixes', desc: 'an unbalanced bracket in a filename no longer false-fails as "file not found"; a file we couldn\'t quarantine is left for retry instead of deleted; the Identify search defaults to "artist - title"; "file not found" errors are actionable now; pasted Qobuz/Tidal links inject the exact track into manual search (#932); and the Wing It pool "Fix Match" search works again.', page: 'downloads' },
+        { title: 'Reduce visual effects, refined', desc: 'it no longer freezes functional motion (spinners, progress) — only the expensive GPU stuff (blur, shadows, glow) is killed. worker orbs default OFF on Firefox for new users and run at ~30fps under reduce-effects.', page: 'settings' },
+        { title: 'More fixes', desc: 'jellyfin scans page the bulk fetch so the no-progress watchdog can\'t false-stall a big library; settings page cleanup (#943, thanks @nick2000713); spotify oauth credential normalization (#942, thanks HellRa1SeR); npm audit security fixes for vite/undici/babel (#944, thanks HellRa1SeR).', page: 'settings' },
+        { title: 'Earlier versions', desc: '2.8.0 brought the Unverified-queue cleanup (#934), Preview Clip Cleanup, split-album Completeness (#936), and a dashboard performance + memory pass (#935/#802). 2.7.9 added best-quality downloads + ranked quality profiles, Discover "Based On Your Listening", and the Wing It Pool; 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3448,50 +3443,49 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "The Unverified queue, finally under control",
-        description: "the headline cleanup — review-queue rows stop piling up and the existing backlog clears itself.",
+        title: "Export playlists to Spotify & Deezer",
+        description: "send a mirrored playlist back to your streaming account — the same one-click export, now pointed at Spotify and Deezer.",
         features: [
-            "#934 — the AcoustID scan was creating a fresh history row every run and leaving already-verified files stuck \"unverified\" (a frozen import-time path that stopped matching once the file moved)",
-            "scans no longer duplicate rows + heal on the spot; a one-time reconcile on startup clears the existing backlog from your library's truth — no re-scan, including human-verified files a scan skips",
-            "a 🧹 Clean orphaned button removes dead rows whose file is genuinely gone, with a safety gate that refuses to run if your library looks offline",
-            "Unverified review rows got the nicer Quarantine-style cards (artwork + inline details). thanks @nick2000713 for #938",
+            "#945 — Sync to Spotify / Sync to Deezer sit next to the ListenBrainz/JSPF options in the export modal; each builds a playlist in your account",
+            "resolves IDs from what's already on hand first — the discovery cache, then your library — so an already-discovered playlist exports instantly with zero API calls",
+            "re-exporting updates the same playlist in place instead of spawning duplicates",
+            "an optional \"match missing tracks\" toggle confidently searches for the stragglers — a wrong-artist or karaoke version is left out, never guessed in",
+            "service buttons grey out + point to Settings when disconnected; Spotify needs a one-time reconnect for write access",
         ],
     },
     {
-        title: "Preview Clip Cleanup (new Tools job)",
-        description: "find the ~30s preview clips the HiFi source sometimes hands back instead of the full song.",
+        title: "Library Reorganize — Rename only",
+        description: "a lighter reorganize that just renames, no reprocessing.",
         features: [
-            "scans your short tracks, checks how long each should be from its metadata source, and flags the previews — conservative, so genuine short tracks and anything it can't verify are left alone",
-            "approve a finding and it deletes the clip, drops it from the library, and re-wishlists the full version",
-            "each finding has a ▶ Play button + a file-length-vs-real-length readout so you can confirm it's busted before approving",
-        ],
-    },
-    {
-        title: "Album Completeness handles split albums",
-        description: "a physical album split across multiple library rows no longer reports false \"incomplete\".",
-        features: [
-            "#936 — fragments are grouped into one logical album and emit a single correct finding, instead of each row looking incomplete on its own",
-            "safe by design: it groups by a shared id AND validates at the track level, so a stale id can never fuse two unrelated albums; also recognizes MusicBrainz as a readable album source. thanks @ragnarlotus",
+            "#875 — renames your files to your current naming scheme with no re-tag, no quality/AcoustID re-check, no copy-to-staging — much faster on a NAS and won't fail on post-processing reasons",
+            "only touches files whose path actually changes, which also fixes the \"2 of 14 previewed but everything got modified\" album-splitting; pick it from the new Action dropdown. thanks @tsoulard / @Tacobell444",
         ],
     },
     {
         title: "Recent fixes",
-        description: "reported bugs squashed this cycle.",
+        description: "reliability + reported bugs squashed this cycle.",
         features: [
-            "pasted YouTube cookies threw `unsupported browser: \"custom\"` on Docker — now it loads the pasted cookies.txt (the only auth path on a headless box). thanks HellRa1SeR",
-            "#937 — a remaster running a few seconds LONGER than the metadata got quarantined like a truncated download; the duration check is asymmetric now. thanks @diegocade1",
-            "\"Add to Wishlist\" from a discography went from ~15–30s PER TRACK to instant (the ownership check was doing a full-table fuzzy scan per track)",
-            "wishlist art now renders for re-downloads/preview re-fetches (relative media-server paths are normalized on read); Clear Completed is back on the Downloads page and clears the persisted history too",
-            "watchlist records automatic scans (#933) + stops fusing different editions; pasted Qobuz/Tidal floats to the top of manual search (#932); Popular Picks no longer empty on Deezer",
+            "lossy-copy now covers all lossless formats, not just FLAC (#941); DSD (.dsf/.dff) is recognized as lossless instead of false-flagged \"truncated\" (#939)",
+            "downloads: an unbalanced bracket no longer false-fails as \"file not found\"; a file we couldn't quarantine is left for retry instead of deleted; \"file not found\" errors are actionable now",
+            "pasted Qobuz/Tidal links inject the exact track into manual search (#932); the Wing It pool \"Fix Match\" search works again; the Identify search defaults to \"artist - title\"",
+            "jellyfin scans page the bulk fetch so the no-progress watchdog can't false-stall a big library; settings page cleanup (#943); spotify oauth normalization (#942); npm security fixes (#944)",
         ],
     },
     {
-        title: "Performance — dashboard + memory",
-        description: "lower idle cost and no more runaway RAM.",
+        title: "Reduce visual effects, refined",
+        description: "the lag toggle that no longer breaks the UI.",
         features: [
-            "#935 — frosted-glass blur, cursor-glow blobs and the worker-orb animation were repainting every frame, hammering the GPU (worst on Firefox/Zen). trimmed them, kept the orb framerate steady on Firefox, and set Background Particles OFF by default",
-            "#802 — browsing every page used to climb RSS into the GBs (plexapi XML trees deferring GC) and could lock up; a lightweight sweeper now collects + returns memory to the OS as it grows, so it settles instead of climbing",
-            "the dashboard system-memory tile now also shows SoulSync's own RAM",
+            "it no longer freezes functional motion (spinners, progress indicators) — only the expensive GPU properties (blur, shadows, glow) are killed",
+            "worker orbs default OFF on Firefox for first-time users, and run at ~30fps when reduce-effects is on",
+        ],
+    },
+    {
+        title: "Earlier in 2.8.0",
+        description: "2.8.0 was a quality + reliability release.",
+        features: [
+            "the Unverified review queue stopped inflating and self-heals — the AcoustID scan no longer duplicates rows, a startup reconcile clears the backlog, and a 🧹 Clean orphaned button sweeps dead rows (#934, thanks @nick2000713 for #938)",
+            "Preview Clip Cleanup (a Tools job that finds ~30s preview clips and re-wishlists the real version); Album Completeness handles split albums (#936, thanks @ragnarlotus)",
+            "dashboard performance + bounded memory growth that could lock up big libraries (#935 / #802)",
         ],
     },
     {

--- a/webui/static/init.js
+++ b/webui/static/init.js
@@ -274,6 +274,34 @@ function applyReduceEffects(enabled) {
     }
 })();
 
+async function bootstrapServerAppearanceSettings() {
+    try {
+        const response = await fetch('/api/settings', { credentials: 'same-origin' });
+        const settings = await response.json();
+        if (!response.ok || !settings || typeof settings !== 'object' || settings.error) return;
+
+        const appearance = settings.ui_appearance || {};
+        const preset = appearance.accent_preset || '#1db954';
+        const custom = appearance.accent_color || '#1db954';
+        const accent = preset === 'custom' ? custom : preset;
+        applyAccentColor(accent);
+
+        if (Object.prototype.hasOwnProperty.call(appearance, 'particles_enabled')) {
+            applyParticlesSetting(appearance.particles_enabled !== false);
+        }
+        if (Object.prototype.hasOwnProperty.call(appearance, 'worker_orbs_enabled')) {
+            applyWorkerOrbsSetting(appearance.worker_orbs_enabled !== false);
+        }
+        if (localStorage.getItem('soulsync-reduce-effects') === null) {
+            applyReduceEffects(appearance.reduce_effects === true);
+        }
+    } catch (error) {
+        console.warn('Could not bootstrap appearance settings:', error);
+    }
+}
+
+bootstrapServerAppearanceSettings();
+
 // ── Profile System ─────────────────────────────────────────────
 let currentProfile = null;
 const PROFILE_CONTEXT_CHANGED_EVENT = 'ss:webui-profile-context-changed';

--- a/webui/static/init.js
+++ b/webui/static/init.js
@@ -254,16 +254,28 @@ function applyReduceEffects(enabled) {
         }
     }
 
-    if (localStorage.getItem('soulsync-reduce-effects') === '1') {
+    const reduceEffectsSaved = localStorage.getItem('soulsync-reduce-effects');
+    if (reduceEffectsSaved === '1') {
         document.body.classList.add('reduce-effects');
         window._reduceEffectsActive = true;
+    } else if (reduceEffectsSaved === '0') {
+        document.body.classList.remove('reduce-effects');
+        window._reduceEffectsActive = false;
+    } else if (window._reduceEffectsActive) {
+        document.body.classList.add('reduce-effects');
     }
     const saved = localStorage.getItem('soulsync-accent');
     if (saved) applyAccentColor(saved);
     // Bootstrap particles setting from localStorage — OFF by default (continuous
     // full-page canvas = real GPU cost); only on when the user explicitly enabled it.
     const particlesSaved = localStorage.getItem('soulsync-particles');
-    window._particlesEnabled = (particlesSaved === 'true');
+    if (particlesSaved === 'true') {
+        window._particlesEnabled = true;
+    } else if (particlesSaved === 'false') {
+        window._particlesEnabled = false;
+    } else if (typeof window._particlesEnabled !== 'boolean') {
+        window._particlesEnabled = false;
+    }
     if (!window._particlesEnabled) {
         const canvas = document.getElementById('page-particles-canvas');
         if (canvas) canvas.style.display = 'none';
@@ -272,6 +284,10 @@ function applyReduceEffects(enabled) {
     const workerOrbsSaved = localStorage.getItem('soulsync-worker-orbs');
     if (workerOrbsSaved === 'false') {
         window._workerOrbsEnabled = false;
+    } else if (workerOrbsSaved === 'true') {
+        window._workerOrbsEnabled = true;
+    } else if (typeof window._workerOrbsEnabled !== 'boolean') {
+        window._workerOrbsEnabled = true;
     }
 })();
 

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -7460,6 +7460,16 @@ async function showReorganizeModal(albumId) {
     html += '</select>';
     html += '</div>';
 
+    // Action: full pipeline vs rename-only (#875).
+    html += '<div class="reorganize-source-section">';
+    html += '<label class="reorganize-label">Action</label>';
+    html += '<div class="reorganize-template-hint">"Full reorganize" re-tags and re-checks every track through the import pipeline — thorough, but slow and it re-touches every file. "Rename only" just moves files to your current naming scheme: no re-tagging, no quality/AcoustID checks, and only files whose name actually changes are touched. Tip: renaming can reset play counts / date-added on your media server.</div>';
+    html += '<select id="reorganize-action-select" class="reorganize-template-input">';
+    html += '<option value="full">Full reorganize (default)</option>';
+    html += '<option value="rename">Rename only (skip post-processing)</option>';
+    html += '</select>';
+    html += '</div>';
+
     // Preview area
     html += '<div class="reorganize-preview-section">';
     html += '<div class="reorganize-preview-header">';
@@ -7644,10 +7654,11 @@ async function executeReorganize() {
     try {
         const chosenSource = document.getElementById('reorganize-source-select')?.value || '';
         const chosenMode = document.getElementById('reorganize-mode-select')?.value || 'api';
+        const renameOnly = document.getElementById('reorganize-action-select')?.value === 'rename';
         const response = await fetch(`/api/library/album/${_reorganizeAlbumId}/reorganize`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ source: chosenSource, mode: chosenMode })
+            body: JSON.stringify({ source: chosenSource, mode: chosenMode, rename_only: renameOnly })
         });
         const result = await response.json();
         if (!result.success) throw new Error(result.error);

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -40,14 +40,30 @@ async function copyAddress(address, cryptoName) {
 
 let settingsAutoSaveTimer = null;
 
-// The "Only import AcoustID-verified tracks" toggle (under Quality Profile) is
-// meaningless when AcoustID itself is off — only show it when verification is on.
+// The "Only import AcoustID-verified tracks" toggle lives in Audio Verification
+// and is always shown (its help notes it needs AcoustID enabled), so users can
+// always find it. Kept as a no-op for any existing callers.
 function syncAcoustidRequireVerifiedVisibility() {
     const group = document.getElementById('acoustid-require-verified-group');
-    const enabled = document.getElementById('acoustid-enabled');
-    if (group) group.style.display = (enabled && enabled.checked) ? '' : 'none';
+    if (group) group.style.display = '';
 }
 window.syncAcoustidRequireVerifiedVisibility = syncAcoustidRequireVerifiedVisibility;
+
+// Retry Logic: the two numeric rows are only meaningful when their parent toggle
+// is on — hide them otherwise. "Retries per query" needs Exhaustive retry;
+// "Minimum matching mismatches" needs the version-mismatch fallback.
+function syncRetryConditionalRows() {
+    const pairs = [
+        ['retry-exhaustive', 'retries-per-query-row'],
+        ['accept-version-mismatch-fallback', 'version-mismatch-min-count-row'],
+    ];
+    for (const [toggleId, rowId] of pairs) {
+        const toggle = document.getElementById(toggleId);
+        const row = document.getElementById(rowId);
+        if (row) row.style.display = (toggle && toggle.checked) ? '' : 'none';
+    }
+}
+window.syncRetryConditionalRows = syncRetryConditionalRows;
 
 function debouncedAutoSaveSettings() {
     // Ignore changes made while the page is programmatically populating its
@@ -417,6 +433,11 @@ function switchSettingsTab(tab) {
     if (tab === 'advanced' && typeof loadDbMaintenanceInfo === 'function') {
         try { loadDbMaintenanceInfo(); } catch (e) { }
     }
+    // First time the Downloads tab is shown, auto-probe source status so the
+    // dots reflect real connection state without a manual "Test all sources".
+    if (tab === 'downloads' && typeof autoTestSourcesOnce === 'function') {
+        autoTestSourcesOnce();
+    }
     // Initialize live log viewer when switching to Logs tab
     if (tab === 'logs') {
         _logViewerInit();
@@ -659,6 +680,126 @@ const ALBUM_LEVEL_HYBRID_SOURCES = new Set(['soulseek', 'torrent', 'usenet']);
 let _hybridSourceOrder = ['soulseek', 'youtube'];
 let _hybridSourceEnabled = { soulseek: true, youtube: true, tidal: false, qobuz: false, hifi: false, deezer_dl: false, amazon: false, lidarr: false, soundcloud: false, torrent: false, usenet: false };
 let _hybridVisualOrder = null; // Full visual order including disabled sources
+// In hybrid mode, only one source's config panel is shown at a time (clicked
+// open from its row), so the long per-source config blocks don't all stack up.
+let _expandedHybridSource = null;
+
+function toggleHybridSourceConfig(srcId) {
+    _expandedHybridSource = (_expandedHybridSource === srcId) ? null : srcId;
+    buildHybridSourceList();
+    updateDownloadSourceUI();
+    // Bring the freshly opened config panel into view.
+    if (_expandedHybridSource) {
+        const map = {
+            soulseek: 'soulseek-settings-container', youtube: 'youtube-settings-container',
+            tidal: 'tidal-download-settings-container', qobuz: 'qobuz-settings-container',
+            hifi: 'hifi-download-settings-container', deezer_dl: 'deezer-download-settings-container',
+            amazon: 'amazon-download-settings-container', lidarr: 'lidarr-download-settings-container',
+            soundcloud: 'soundcloud-download-settings-container', torrent: 'prowlarr-source-redirect',
+            usenet: 'prowlarr-source-redirect',
+        };
+        const el = document.getElementById(map[_expandedHybridSource]);
+        if (el) setTimeout(() => el.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 60);
+    }
+}
+
+// ── Per-source live connection status (shown as a dot in the hybrid list and
+// driven by the "Test all sources" button). srcId -> 'unknown'|'testing'|'ok'|'fail'|'na'
+let _hybridSourceStatus = {};
+
+async function _ssJson(url, opts) {
+    const r = await fetch(url, opts);
+    return await r.json();
+}
+function _ssTestConn(service) {
+    return _ssJson(API.testConnection || '/api/test-connection', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ service })
+    }).then(j => !!j.success);
+}
+// Each probe returns a boolean (connected/ok). Endpoints mirror the per-source
+// "Test Connection" buttons so the results match what those buttons would show.
+const HYBRID_SOURCE_PROBE = {
+    soulseek:   () => _ssTestConn('soulseek'),
+    tidal:      () => _ssTestConn('tidal'),
+    qobuz:      () => _ssJson('/api/qobuz/auth/status').then(j => j.authenticated === true),
+    hifi:       () => _ssJson('/api/hifi/status').then(j => j.available === true),
+    deezer_dl:  () => _ssJson('/api/deezer-download/test').then(j => j.success === true),
+    amazon:     () => _ssJson('/api/amazon/test-connection').then(j => j.connected === true),
+    lidarr:     () => _ssTestConn('lidarr'),
+    soundcloud: () => _ssJson('/api/soundcloud/status').then(j => j.available === true && j.reachable === true),
+    torrent:    () => _ssTestConn('torrent_client'),
+    usenet:     () => _ssTestConn('usenet_client'),
+    youtube:    () => Promise.resolve(true),  // no auth required
+};
+// Configured metadata / server connections that support a generic test.
+const CONNECTION_TEST_SERVICES = ['spotify', 'server', 'tidal', 'qobuz', 'lastfm', 'genius', 'listenbrainz', 'acoustid', 'discogs'];
+
+async function testAllSources(opts = {}) {
+    const silent = opts.silent === true;          // no toast / no connection sweep (used for auto-run on load)
+    const btn = document.getElementById('test-all-sources-btn');
+    if (btn && !silent) { btn.disabled = true; btn.dataset._label = btn.textContent; btn.textContent = 'Testing…'; }
+
+    // Which download sources to test: the enabled hybrid sources, or the single
+    // selected source in non-hybrid mode.
+    const mode = document.getElementById('download-source-mode')?.value;
+    const sources = new Set();
+    if (mode === 'hybrid') {
+        (typeof getHybridOrder === 'function' ? getHybridOrder() : []).forEach(s => sources.add(s));
+    } else if (mode) {
+        sources.add(mode);
+    }
+    if (sources.size === 0) sources.add('soulseek');
+
+    // Torrent/Usenet downloads go through Prowlarr — its connection must be
+    // established first or those source tests fail. Probe Prowlarr up front.
+    if (sources.has('torrent') || sources.has('usenet')) {
+        try { await _ssTestConn('prowlarr'); } catch (e) { /* surfaced via the per-source test below */ }
+    }
+
+    for (const id of sources) _hybridSourceStatus[id] = 'testing';
+    buildHybridSourceList();
+
+    let ok = 0, fail = 0;
+    for (const id of sources) {
+        const probe = HYBRID_SOURCE_PROBE[id];
+        if (!probe) { _hybridSourceStatus[id] = 'na'; continue; }
+        try { const good = await probe(); _hybridSourceStatus[id] = good ? 'ok' : 'fail'; good ? ok++ : fail++; }
+        catch (e) { _hybridSourceStatus[id] = 'fail'; fail++; }
+        buildHybridSourceList();
+    }
+
+    // Also test the metadata / server connections the user has configured
+    // (skipped on the silent auto-run to keep page load light).
+    let connOk = 0, connFail = 0;
+    if (!silent) {
+        try {
+            const cfg = await _ssJson('/api/settings/config-status');
+            for (const svc of CONNECTION_TEST_SERVICES) {
+                const configured = svc === 'server' ? true : (cfg && cfg[svc] && cfg[svc].configured);
+                if (!configured) continue;
+                try { const good = await _ssTestConn(svc); good ? connOk++ : connFail++; } catch (e) { connFail++; }
+            }
+        } catch (e) { /* config-status unavailable — skip connection sweep */ }
+    }
+
+    if (btn && !silent) { btn.disabled = false; btn.textContent = btn.dataset._label || 'Test all sources'; }
+    if (!silent) {
+        const parts = [`sources ${ok}✓${fail ? ' / ' + fail + '✗' : ''}`];
+        if (connOk || connFail) parts.push(`connections ${connOk}✓${connFail ? ' / ' + connFail + '✗' : ''}`);
+        showToast('Tested ' + parts.join(', '), (fail || connFail) ? 'error' : 'success');
+    }
+}
+window.testAllSources = testAllSources;
+
+// Auto-populate the source status dots once after the page settles, so they
+// reflect real state after a restart without the user having to click Test.
+let _sourcesAutoTested = false;
+function autoTestSourcesOnce() {
+    if (_sourcesAutoTested) return;
+    _sourcesAutoTested = true;
+    setTimeout(() => { try { testAllSources({ silent: true }); } catch (e) { } }, 1200);
+}
 
 function buildHybridSourceList() {
     const container = document.getElementById('hybrid-source-list');
@@ -689,11 +830,16 @@ function buildHybridSourceList() {
         const sourceLevelBadge = `<span class="hybrid-source-badge hybrid-source-badge-${sourceLevelClass}" title="${sourceLevelTitle}">${sourceLevel}</span>`;
 
         const item = document.createElement('div');
-        item.className = `hybrid-source-item${enabled ? '' : ' disabled'}`;
+        const isExpanded = enabled && _expandedHybridSource === srcId;
+        item.className = `hybrid-source-item${enabled ? '' : ' disabled'}${isExpanded ? ' config-open' : ''}`;
         item.draggable = true;
         item.dataset.sourceId = srcId;
 
+        // The name + a config chevron open this source's settings panel inline
+        // (only one at a time), so the long config blocks don't all stack up.
+        const clickConfig = enabled ? `onclick="toggleHybridSourceConfig('${srcId}')"` : '';
         item.innerHTML = `
+            <span class="hybrid-source-handle" title="Drag to reorder">⠿</span>
             <span class="hybrid-source-arrows">
                 <button class="hybrid-arrow-btn" onclick="moveHybridSource('${srcId}', -1)" title="Move up">▲</button>
                 <button class="hybrid-arrow-btn" onclick="moveHybridSource('${srcId}', 1)" title="Move down">▼</button>
@@ -702,9 +848,11 @@ function buildHybridSourceList() {
                 ? `<img class="hybrid-source-icon" src="${src.icon}" alt="${src.name}" onerror="this.outerHTML='<span class=\\'hybrid-source-icon emoji-icon\\'>${src.emoji}</span>'">`
                 : `<span class="hybrid-source-icon emoji-icon">${src.emoji}</span>`
             }
-            <span class="hybrid-source-name">${src.name}</span>
+            <span class="hybrid-source-name" ${clickConfig} style="${enabled ? 'cursor:pointer;' : ''}">${src.name}</span>
             ${sourceLevelBadge}
             <span class="hybrid-source-priority">${priorityNum}</span>
+            <span class="hybrid-source-status hss-${_hybridSourceStatus[srcId] || 'unknown'}" title="${({ unknown: 'Not tested yet', testing: 'Testing…', ok: 'Connected', fail: 'Connection failed', na: 'No connection test for this source' })[_hybridSourceStatus[srcId] || 'unknown']}"></span>
+            ${enabled ? `<button class="hybrid-source-config-btn" ${clickConfig} title="Configure ${src.name}">⚙</button>` : ''}
             <label class="hybrid-source-toggle">
                 <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleHybridSource('${srcId}', this.checked)">
                 <span class="toggle-track"></span>
@@ -718,10 +866,15 @@ function buildHybridSourceList() {
             e.dataTransfer.setData('text/plain', srcId);
             item.classList.add('dragging');
         });
-        item.addEventListener('dragend', () => item.classList.remove('dragging'));
-        item.addEventListener('dragover', (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; });
+        item.addEventListener('dragend', () => {
+            item.classList.remove('dragging');
+            container.querySelectorAll('.hybrid-source-item').forEach(el => el.classList.remove('drag-over'));
+        });
+        item.addEventListener('dragover', (e) => { e.preventDefault(); e.dataTransfer.dropEffect = 'move'; item.classList.add('drag-over'); });
+        item.addEventListener('dragleave', () => item.classList.remove('drag-over'));
         item.addEventListener('drop', (e) => {
             e.preventDefault();
+            item.classList.remove('drag-over');
             const draggedId = e.dataTransfer.getData('text/plain');
             if (draggedId && draggedId !== srcId) _reorderHybridSource(draggedId, srcId);
         });
@@ -768,6 +921,8 @@ function _reorderHybridSource(draggedId, targetId) {
 
 function toggleHybridSource(srcId, enabled) {
     _hybridSourceEnabled[srcId] = enabled;
+    // If the source we just disabled had its config panel open, close it.
+    if (!enabled && _expandedHybridSource === srcId) _expandedHybridSource = null;
     // Rebuild enabled order from visual order so priority matches position
     if (_hybridVisualOrder) {
         _hybridSourceOrder = _hybridVisualOrder.filter(id => _hybridSourceEnabled[id] !== false);
@@ -1269,6 +1424,7 @@ async function loadSettingsData() {
         document.getElementById('retries-per-query').value = settings.post_processing?.retries_per_query ?? 5;
         document.getElementById('accept-version-mismatch-fallback').checked = settings.post_processing?.accept_version_mismatch_fallback === true;
         document.getElementById('version-mismatch-min-count').value = settings.post_processing?.version_mismatch_min_count ?? 2;
+        if (typeof syncRetryConditionalRows === 'function') syncRetryConditionalRows();
         // Load service master toggles
         document.getElementById('embed-spotify').checked = settings.spotify?.embed_tags !== false;
         document.getElementById('embed-itunes').checked = settings.itunes?.embed_tags !== false;
@@ -1861,20 +2017,42 @@ function updateDownloadSourceUI() {
         activeSources.add(mode);
     }
 
-    soulseekContainer.style.display = activeSources.has('soulseek') ? 'block' : 'none';
-    tidalContainer.style.display = activeSources.has('tidal') ? 'block' : 'none';
-    qobuzContainer.style.display = activeSources.has('qobuz') ? 'block' : 'none';
-    youtubeContainer.style.display = activeSources.has('youtube') ? 'block' : 'none';
-    hifiContainer.style.display = activeSources.has('hifi') ? 'block' : 'none';
-    if (deezerDlContainer) deezerDlContainer.style.display = activeSources.has('deezer_dl') ? 'block' : 'none';
-    if (amazonContainer) amazonContainer.style.display = activeSources.has('amazon') ? 'block' : 'none';
-    if (lidarrContainer) lidarrContainer.style.display = activeSources.has('lidarr') ? 'block' : 'none';
-    if (soundcloudContainer) soundcloudContainer.style.display = activeSources.has('soundcloud') ? 'block' : 'none';
+    // In single-source mode the one config block is shown directly. In hybrid
+    // mode there can be many active sources, so we only reveal the one the user
+    // clicked open in the priority list (accordion-style) — no endless stack.
+    const isHybrid = mode === 'hybrid';
+    const showCfg = (src) => activeSources.has(src) && (!isHybrid || _expandedHybridSource === src);
+
+    soulseekContainer.style.display = showCfg('soulseek') ? 'block' : 'none';
+    tidalContainer.style.display = showCfg('tidal') ? 'block' : 'none';
+    qobuzContainer.style.display = showCfg('qobuz') ? 'block' : 'none';
+    youtubeContainer.style.display = showCfg('youtube') ? 'block' : 'none';
+    hifiContainer.style.display = showCfg('hifi') ? 'block' : 'none';
+    if (deezerDlContainer) deezerDlContainer.style.display = showCfg('deezer_dl') ? 'block' : 'none';
+    if (amazonContainer) amazonContainer.style.display = showCfg('amazon') ? 'block' : 'none';
+    if (lidarrContainer) lidarrContainer.style.display = showCfg('lidarr') ? 'block' : 'none';
+    if (soundcloudContainer) soundcloudContainer.style.display = showCfg('soundcloud') ? 'block' : 'none';
     const prowlarrRedirect = document.getElementById('prowlarr-source-redirect');
     if (prowlarrRedirect) {
-        const showProwlarr = activeSources.has('torrent') || activeSources.has('usenet');
+        const showProwlarr = showCfg('torrent') || showCfg('usenet');
         prowlarrRedirect.style.display = showProwlarr ? 'block' : 'none';
     }
+
+    // Indexers & Downloaders section: only relevant when a torrent or usenet
+    // source is actually selected. Hide the whole intro + Prowlarr/Torrent/Usenet
+    // tiles otherwise (Soulseek/HiFi-only users never see them). The two client
+    // tiles are gated individually on their own source. Selection-based (not the
+    // hybrid expand state) — the tiles are full config sections, not accordion
+    // panels. Tab-gated so it never leaks onto another tab.
+    const onDownloadsTab = document.querySelector('.stg-tab.active')?.dataset.tab === 'downloads';
+    const torrentActive = activeSources.has('torrent');
+    const usenetActive = activeSources.has('usenet');
+    const indSection = document.getElementById('indexers-downloaders-section');
+    if (indSection) indSection.style.display = (onDownloadsTab && (torrentActive || usenetActive)) ? '' : 'none';
+    const torrentTile = document.getElementById('torrent-tile');
+    if (torrentTile) torrentTile.style.display = torrentActive ? '' : 'none';
+    const usenetTile = document.getElementById('usenet-tile');
+    if (usenetTile) usenetTile.style.display = usenetActive ? '' : 'none';
 
     // Quality profile is now a GLOBAL system — the same ranked-target list
     // drives every source (Soulseek, Tidal, Qobuz, HiFi, Deezer, …), so it is
@@ -1884,23 +2062,25 @@ function updateDownloadSourceUI() {
     const qualityProfileTile = document.getElementById('quality-profile-tile');
     if (qualityProfileTile) {
         const activeTab = document.querySelector('.stg-tab.active');
-        const onDownloadsTab = activeTab && activeTab.dataset.tab === 'downloads';
-        qualityProfileTile.style.display = onDownloadsTab ? '' : 'none';
+        const onQualityTab = activeTab && activeTab.dataset.tab === 'quality';
+        qualityProfileTile.style.display = onQualityTab ? '' : 'none';
     }
 
-    if (activeSources.has('tidal')) {
+    // Only auto-probe a source's live status when its config panel is visible
+    // (always in single-source mode; only the opened one in hybrid mode).
+    if (showCfg('tidal')) {
         checkTidalDownloadAuthStatus();
     }
-    if (activeSources.has('qobuz')) {
+    if (showCfg('qobuz')) {
         checkQobuzAuthStatus();
     }
-    if (activeSources.has('hifi')) {
+    if (showCfg('hifi')) {
         testHiFiConnection();
     }
-    if (activeSources.has('amazon')) {
+    if (showCfg('amazon')) {
         testAmazonConnection();
     }
-    if (activeSources.has('soundcloud')) {
+    if (showCfg('soundcloud')) {
         testSoundcloudConnection();
     }
 }
@@ -2021,12 +2201,30 @@ function onSearchModeChange() {
 // body is the immediate next element or sits after a control (e.g. a <select>),
 // and regardless of any wrapping container.
 function toggleSettingHelp(iconEl) {
+    // Locate the help body to toggle. Search order:
+    //  1) the next .setting-help-body sibling after the icon's row (icon + body
+    //     both inside the same .form-group / .setting-row),
+    //  2) the element right after the enclosing .form-group (help wall that sits
+    //     as a sibling just below the group — the common always-visible case).
     const row = iconEl.closest('.setting-row') || iconEl;
     let el = row.nextElementSibling;
     while (el && !el.classList.contains('setting-help-body')) {
         el = el.nextElementSibling;
     }
-    if (el) el.hidden = !el.hidden;
+    if (!el) {
+        const fg = iconEl.closest('.form-group');
+        let sib = fg ? fg.nextElementSibling : null;
+        // Only accept an immediately-following help body — never reach across
+        // into the next setting/group.
+        if (sib && sib.classList.contains('setting-help-body')) el = sib;
+    }
+    if (el) {
+        el.hidden = !el.hidden;
+        // Reflect open state on the icon itself (filled badge) so it's clear
+        // which help panel is currently revealed.
+        const icon = iconEl.classList.contains('info-icon') ? iconEl : row.querySelector('.info-icon');
+        if (icon) icon.classList.toggle('open', !el.hidden);
+    }
 }
 
 function renderRankedTargets() {

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -2094,7 +2094,7 @@ function deleteRankedTarget(i) {
 
 // Lossless formats take bit-depth + sample-rate constraints; lossy take a
 // minimum bitrate. Single source of truth for the add-target field toggle.
-const RT_LOSSLESS_FORMATS = ['flac', 'alac', 'wav'];
+const RT_LOSSLESS_FORMATS = ['flac', 'alac', 'wav', 'dsf'];
 const RT_LOSSY_FORMATS = ['mp3', 'aac', 'ogg', 'opus', 'wma'];
 // "group:" selections are a UI convenience: picking one + constraints expands
 // into individual per-format targets at that slot (the backend still works

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1548,8 +1548,14 @@ async function loadSettingsData() {
         if (particlesCheckbox) particlesCheckbox.checked = particlesEnabled;
         applyParticlesSetting(particlesEnabled);
 
-        // Worker orbs toggle
-        const workerOrbsEnabled = settings.ui_appearance?.worker_orbs_enabled !== false; // default true
+        // Worker orbs toggle. When the user hasn't saved a preference, reflect the
+        // server-decided browser-aware default (window._workerOrbsEnabled — OFF on
+        // Firefox for perf) so saving settings doesn't silently flip a first-time
+        // Firefox user's orbs back on. An explicit saved config value always wins.
+        const _orbsCfg = settings.ui_appearance?.worker_orbs_enabled;
+        const workerOrbsEnabled = (_orbsCfg === undefined || _orbsCfg === null)
+            ? (window._workerOrbsEnabled !== false)
+            : (_orbsCfg !== false);
         const workerOrbsCheckbox = document.getElementById('worker-orbs-enabled');
         if (workerOrbsCheckbox) workerOrbsCheckbox.checked = workerOrbsEnabled;
         applyWorkerOrbsSetting(workerOrbsEnabled);

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -40,7 +40,7 @@ async function copyAddress(address, cryptoName) {
 
 let settingsAutoSaveTimer = null;
 
-// The "Only import AcoustID-verified tracks" toggle lives in Audio Verification
+// The "Only allow AcoustID-verified tracks" toggle lives in Audio Verification
 // and is always shown (its help notes it needs AcoustID enabled), so users can
 // always find it. Kept as a no-op for any existing callers.
 function syncAcoustidRequireVerifiedVisibility() {

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -686,6 +686,13 @@ function exportMirroredPlaylist(playlistId, name) {
     overlay.querySelectorAll('.pl-export-choice').forEach(btn => {
         btn.addEventListener('click', () => {
             const mode = btn.dataset.mode;
+            // Gated service button (not connected) → nudge to Settings instead of a doomed export.
+            if (btn.dataset.disconnected) {
+                const dest = mode[0].toUpperCase() + mode.slice(1);
+                overlay.remove();
+                _setExportStatus(playlistId, `<span style="color:#f59e0b;">Connect ${dest} in Settings → Connections to export here</span>`, 9000);
+                return;
+            }
             const bfEl = overlay.querySelector('#pl-export-backfill');
             const backfill = !!(bfEl && bfEl.checked);
             overlay.remove();
@@ -693,6 +700,21 @@ function exportMirroredPlaylist(playlistId, name) {
         });
     });
     document.body.appendChild(overlay);
+
+    // Gate Spotify/Deezer on connection (cheap token/ARL check — no live verify). Disconnected
+    // services grey out + nudge to Settings rather than letting the export fail with "not connected".
+    fetch('/api/discover/your-albums/sources').then(r => r.json()).then(data => {
+        const connected = (data && data.connected) || [];
+        overlay.querySelectorAll('.pl-export-choice[data-mode]').forEach(btn => {
+            const m = btn.dataset.mode;
+            if ((m === 'spotify' || m === 'deezer') && !connected.includes(m)) {
+                btn.dataset.disconnected = '1';
+                btn.style.opacity = '0.5';
+                const hint = btn.querySelector('div:last-child');
+                if (hint) hint.innerHTML = `<span style="color:#f59e0b;">Not connected</span> — set up ${m[0].toUpperCase() + m.slice(1)} in Settings → Connections first.`;
+            }
+        });
+    }).catch(() => {});
 }
 
 async function _startPlaylistExport(playlistId, mode, name, backfill) {

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -663,11 +663,19 @@ function exportMirroredPlaylist(playlistId, name) {
                 <div style="font-weight:600;">Sync to ListenBrainz</div>
                 <div style="font-size:12px;color:rgba(255,255,255,0.55);">Create the playlist directly on your ListenBrainz account (needs your LB token).</div>
             </button>
-            <button class="pl-export-choice" data-mode="download" style="width:100%;text-align:left;margin-bottom:16px;padding:13px 15px;border-radius:12px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.04);color:#fff;cursor:pointer;">
+            <button class="pl-export-choice" data-mode="download" style="width:100%;text-align:left;margin-bottom:10px;padding:13px 15px;border-radius:12px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.04);color:#fff;cursor:pointer;">
                 <div style="font-weight:600;">Download .jspf file</div>
                 <div style="font-size:12px;color:rgba(255,255,255,0.55);">Save a JSPF playlist you can upload to ListenBrainz manually.</div>
             </button>
-            <div style="font-size:11.5px;color:rgba(255,255,255,0.4);line-height:1.5;">Each track is matched to its MusicBrainz recording ID (cached → library → file tag → MusicBrainz). Tracks without an ID can't be included — you'll see how many matched.</div>
+            <button class="pl-export-choice" data-mode="spotify" style="width:100%;text-align:left;margin-bottom:10px;padding:13px 15px;border-radius:12px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.04);color:#fff;cursor:pointer;">
+                <div style="font-weight:600;">Sync to Spotify</div>
+                <div style="font-size:12px;color:rgba(255,255,255,0.55);">Create a Spotify playlist in your account from this list (reconnect Spotify if it asks for write access).</div>
+            </button>
+            <button class="pl-export-choice" data-mode="deezer" style="width:100%;text-align:left;margin-bottom:16px;padding:13px 15px;border-radius:12px;border:1px solid rgba(255,255,255,0.1);background:rgba(255,255,255,0.04);color:#fff;cursor:pointer;">
+                <div style="font-weight:600;">Sync to Deezer</div>
+                <div style="font-size:12px;color:rgba(255,255,255,0.55);">Create a Deezer playlist from this list (uses your Deezer login).</div>
+            </button>
+            <div style="font-size:11.5px;color:rgba(255,255,255,0.4);line-height:1.5;">Tracks are matched by ID (MusicBrainz for ListenBrainz/JSPF; the stored Spotify/Deezer ID for those). Tracks without a match can't be included — you'll see how many made it. Renaming/re-syncing can reset play counts on the destination.</div>
             <div style="text-align:right;margin-top:14px;"><button onclick="document.getElementById('pl-export-modal').remove()" style="background:none;border:none;color:rgba(255,255,255,0.5);cursor:pointer;font-size:13px;">Cancel</button></div>
         </div>`;
     overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
@@ -684,9 +692,14 @@ function exportMirroredPlaylist(playlistId, name) {
 async function _startPlaylistExport(playlistId, mode, name) {
     _setExportStatus(playlistId, `<span style="color:#a78bfa;">Starting export…</span>`);
     try {
-        const resp = await fetch(`/api/playlists/${playlistId}/export/listenbrainz`, {
+        // Spotify/Deezer go to the service endpoint; ListenBrainz/JSPF keep the LB one.
+        const isService = (mode === 'spotify' || mode === 'deezer');
+        const url = isService
+            ? `/api/playlists/${playlistId}/export/service/${mode}`
+            : `/api/playlists/${playlistId}/export/listenbrainz`;
+        const resp = await fetch(url, {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ mode }),
+            body: isService ? '{}' : JSON.stringify({ mode }),
         });
         const data = await resp.json();
         if (!data.success || !data.job_id) {
@@ -709,8 +722,19 @@ async function _pollPlaylistExport(jobId, playlistId, mode, name) {
             const pct = job.total ? Math.round(100 * (job.done || 0) / job.total) : 0;
             _setExportStatus(playlistId, `<span style="color:#38bdf8;">Matching ${job.done || 0}/${job.total || 0} (${pct}%)${st.resolved != null ? ` · ${st.resolved} matched` : ''}</span>`);
         } else if (job.phase === 'pushing') {
-            _setExportStatus(playlistId, `<span style="color:#a78bfa;">Pushing to ListenBrainz…</span>`);
+            const dest = (mode === 'spotify' || mode === 'deezer') ? (mode[0].toUpperCase() + mode.slice(1)) : 'ListenBrainz';
+            _setExportStatus(playlistId, `<span style="color:#a78bfa;">Pushing to ${dest}…</span>`);
         } else if (job.phase === 'done') {
+            // Spotify/Deezer export: report added + unmatched and link the new playlist.
+            if (mode === 'spotify' || mode === 'deezer') {
+                const dest = mode[0].toUpperCase() + mode.slice(1);
+                const push = job.push || {};
+                const cov = `${st.resolved || 0} added${st.unmatched ? ` · ${st.unmatched} not on ${dest}` : ''}`;
+                const link = push.url ? ` <a href="${push.url}" target="_blank" style="color:#38bdf8;">open</a>` : '';
+                _setExportStatus(playlistId, `<span style="color:#22c55e;">Exported to ${dest} · ${cov}</span>${link}`, 12000);
+                if (typeof showToast === 'function') showToast(`Playlist exported to ${dest} (${cov})`, 'success');
+                return;
+            }
             const sum = job.summary || {};
             const cov = `${sum.included || 0}/${sum.total || 0} matched${sum.skipped ? ` · ${sum.skipped} unmatched` : ''}`;
             if (mode === 'download') {

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -676,20 +676,26 @@ function exportMirroredPlaylist(playlistId, name) {
                 <div style="font-size:12px;color:rgba(255,255,255,0.55);">Create a Deezer playlist from this list (uses your Deezer login).</div>
             </button>
             <div style="font-size:11.5px;color:rgba(255,255,255,0.4);line-height:1.5;">Tracks are matched by ID (MusicBrainz for ListenBrainz/JSPF; the stored Spotify/Deezer ID for those). Tracks without a match can't be included — you'll see how many made it. Renaming/re-syncing can reset play counts on the destination.</div>
+            <label style="display:flex;align-items:flex-start;gap:8px;margin-top:12px;font-size:12px;color:rgba(255,255,255,0.6);cursor:pointer;">
+                <input type="checkbox" id="pl-export-backfill" style="margin-top:2px;flex-shrink:0;accent-color:rgb(var(--accent-rgb));">
+                <span><b style="color:rgba(255,255,255,0.75);">Match missing tracks</b> (Spotify/Deezer only) — search the service for tracks with no known ID. Slower, and only confident matches are added.</span>
+            </label>
             <div style="text-align:right;margin-top:14px;"><button onclick="document.getElementById('pl-export-modal').remove()" style="background:none;border:none;color:rgba(255,255,255,0.5);cursor:pointer;font-size:13px;">Cancel</button></div>
         </div>`;
     overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove(); });
     overlay.querySelectorAll('.pl-export-choice').forEach(btn => {
         btn.addEventListener('click', () => {
             const mode = btn.dataset.mode;
+            const bfEl = overlay.querySelector('#pl-export-backfill');
+            const backfill = !!(bfEl && bfEl.checked);
             overlay.remove();
-            _startPlaylistExport(playlistId, mode, name);
+            _startPlaylistExport(playlistId, mode, name, backfill);
         });
     });
     document.body.appendChild(overlay);
 }
 
-async function _startPlaylistExport(playlistId, mode, name) {
+async function _startPlaylistExport(playlistId, mode, name, backfill) {
     _setExportStatus(playlistId, `<span style="color:#a78bfa;">Starting export…</span>`);
     try {
         // Spotify/Deezer go to the service endpoint; ListenBrainz/JSPF keep the LB one.
@@ -699,7 +705,7 @@ async function _startPlaylistExport(playlistId, mode, name) {
             : `/api/playlists/${playlistId}/export/listenbrainz`;
         const resp = await fetch(url, {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: isService ? '{}' : JSON.stringify({ mode }),
+            body: isService ? JSON.stringify({ backfill: !!backfill }) : JSON.stringify({ mode }),
         });
         const data = await resp.json();
         if (!data.success || !data.job_id) {
@@ -729,7 +735,7 @@ async function _pollPlaylistExport(jobId, playlistId, mode, name) {
             if (mode === 'spotify' || mode === 'deezer') {
                 const dest = mode[0].toUpperCase() + mode.slice(1);
                 const push = job.push || {};
-                const cov = `${st.resolved || 0} added${st.unmatched ? ` · ${st.unmatched} not on ${dest}` : ''}`;
+                const cov = `${st.resolved || 0} added${st.from_search ? ` (${st.from_search} matched live)` : ''}${st.unmatched ? ` · ${st.unmatched} not on ${dest}` : ''}`;
                 const link = push.url ? ` <a href="${push.url}" target="_blank" style="color:#38bdf8;">open</a>` : '';
                 _setExportStatus(playlistId, `<span style="color:#22c55e;">Exported to ${dest} · ${cov}</span>${link}`, 12000);
                 if (typeof showToast === 'function') showToast(`Playlist exported to ${dest} (${cov})`, 'success');

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -1860,9 +1860,17 @@ async function searchPoolFix() {
         if (artistVal) params.set('artist', artistVal);
         params.set('limit', '20');
         const res = await fetch(`/api/spotify/search_tracks?${params.toString()}`);
-        const data = await res.json();
-        const tracks = data.tracks || [];
+        const data = await res.json().catch(() => ({}));
 
+        // Surface the real failure instead of masking every error (auth, 500, an
+        // upstream connection abort) as a bland "No results found".
+        if (!res.ok || data.error) {
+            const msg = data.error || res.statusText || `request failed (${res.status})`;
+            resultsContainer.innerHTML = `<div class="pool-fix-empty">Search error: ${_esc(msg)}</div>`;
+            return;
+        }
+
+        const tracks = data.tracks || [];
         if (tracks.length === 0) {
             resultsContainer.innerHTML = '<div class="pool-fix-empty">No results found</div>';
             return;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -55442,6 +55442,23 @@ tr.tag-diff-same {
     max-width: 100%;
 }
 
+#settings-page .settings-group[data-stg="logs"] {
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+}
+
+#settings-page .settings-group[data-stg="logs"] .log-viewer-header,
+#settings-page .settings-group[data-stg="logs"] .log-viewer-terminal,
+#settings-page .settings-group[data-stg="logs"] .log-viewer-status {
+    width: 100%;
+}
+
+#settings-page .settings-group[data-stg="logs"] .log-viewer-controls,
+#settings-page .settings-group[data-stg="logs"] .log-viewer-actions {
+    min-width: 0;
+}
+
 /* ── Compact settings header — single row, no wasted vertical space ── */
 #settings-page .dashboard-header.settings-header-compact {
     flex-direction: row;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -55650,11 +55650,27 @@ tr.tag-diff-same {
     margin: 0;
     transition: border-color 0.25s, background 0.25s, box-shadow 0.25s;
 }
+#settings-page .form-group > textarea {
+    padding: 9px 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 10px;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.88em;
+    margin: 0;
+    resize: vertical;
+    transition: border-color 0.25s, background 0.25s, box-shadow 0.25s;
+}
 #settings-page .form-group > input:hover {
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.1);
 }
-#settings-page .form-group > input:focus {
+#settings-page .form-group > textarea:hover {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.1);
+}
+#settings-page .form-group > input:focus,
+#settings-page .form-group > textarea:focus {
     border-color: rgba(var(--accent-rgb), 0.4);
     background: rgba(255, 255, 255, 0.06);
     outline: none;
@@ -56018,6 +56034,9 @@ tr.tag-diff-same {
 #settings-page .settings-section-body:not(.collapsed) > .settings-group:last-child,
 #settings-page .settings-section-body:not(.collapsed) .security-subgroup:last-child {
     margin-bottom: 0 !important;
+}
+#settings-page .settings-section-body:not(.collapsed) .security-subgroup {
+    padding-top: 14px !important;
 }
 #settings-page .settings-section-body:not(.collapsed) > .settings-group::before { display: none; }
 /* Sub-card title: clean header inside its frame (no accent bar / huge padding). */

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -3389,66 +3389,6 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     color: #a78bfa;          /* Usenet — violet */
 }
 
-/* Lidarr-style intro hero card on Indexers & Downloaders tab */
-.ind-hero {
-    padding: 18px 22px;
-    background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.08), rgba(35, 35, 35, 0.6));
-    border: 1px solid rgba(var(--accent-rgb), 0.15);
-}
-
-.ind-hero-title {
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: 0.8px;
-    text-transform: uppercase;
-    color: rgb(var(--accent-rgb));
-    margin-bottom: 12px;
-}
-
-.ind-hero-flow {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 12px;
-    font-size: 13px;
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.ind-hero-step {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 999px;
-}
-
-.ind-hero-step-num {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: rgba(var(--accent-rgb), 0.2);
-    color: rgb(var(--accent-rgb));
-    font-weight: 700;
-    font-size: 11px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.ind-hero-arrow {
-    color: rgba(var(--accent-rgb), 0.55);
-    font-weight: 700;
-}
-
-.ind-hero-sub {
-    font-size: 12.5px;
-    color: rgba(255, 255, 255, 0.55);
-    line-height: 1.55;
-}
-
 .ind-hero-warning {
     margin-top: 14px;
     padding: 12px 14px;
@@ -3939,23 +3879,6 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     font-size: 12px;
     color: rgba(255, 255, 255, 0.85);
 }
-.info-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 16px;
-    height: 16px;
-    flex: 0 0 auto;
-    font-size: 12px;
-    line-height: 1;
-    color: rgba(var(--accent-rgb), 0.85);
-    cursor: pointer;
-    user-select: none;
-    transition: color 0.15s ease;
-}
-.info-icon:hover { color: rgba(var(--accent-rgb), 1); }
-.setting-help-body { margin-top: 4px; }
-
 /* Supported Formats */
 .supported-formats {
     color: rgba(255, 255, 255, 0.7);
@@ -4343,213 +4266,6 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     background: rgba(99, 179, 237, 0.3);
 }
 
-.quality-tier {
-    margin-bottom: 16px;
-    padding: 12px;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 12px;
-    transition: all 0.2s ease;
-}
-
-.quality-tier:hover {
-    border-color: rgba(255, 255, 255, 0.12);
-}
-
-.quality-tier-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 10px;
-}
-
-.quality-tier-name {
-    color: rgba(255, 255, 255, 0.95);
-    font-size: 12px;
-    font-weight: 600;
-}
-
-.quality-tier-priority {
-    color: rgba(255, 255, 255, 0.45);
-    font-size: 10px;
-    font-weight: 500;
-}
-
-.quality-tier-sliders {
-    padding-left: 24px;
-    opacity: 1;
-    transition: opacity 0.3s ease;
-}
-
-.quality-tier-sliders.disabled {
-    opacity: 0.35;
-    pointer-events: none;
-}
-
-.flac-bit-depth-selector {
-    padding: 8px 12px;
-    transition: opacity 0.3s ease;
-}
-
-.flac-bit-depth-selector.disabled {
-    opacity: 0.35;
-    pointer-events: none;
-}
-
-.flac-bit-depth-selector label {
-    display: block;
-    margin-bottom: 6px;
-    color: rgba(255, 255, 255, 0.7);
-    font-size: 11px;
-}
-
-.bit-depth-buttons {
-    display: flex;
-    gap: 8px;
-}
-
-.bit-depth-btn {
-    flex: 1;
-    padding: 7px 12px;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.02));
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
-    color: rgba(255, 255, 255, 0.7);
-    font-size: 11px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.bit-depth-btn.active {
-    background: linear-gradient(135deg,
-            rgba(var(--accent-rgb), 0.2) 0%,
-            rgba(var(--accent-light-rgb), 0.12) 100%);
-    border-color: rgba(var(--accent-rgb), 0.4);
-    color: rgb(var(--accent-light-rgb));
-    font-weight: 600;
-    box-shadow: 0 4px 16px rgba(var(--accent-rgb), 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.bit-depth-btn:hover {
-    background: rgba(255, 255, 255, 0.08);
-    border-color: rgba(255, 255, 255, 0.15);
-    color: #ffffff;
-    transform: translateY(-1px);
-}
-
-.bit-depth-btn.active:hover {
-    background: linear-gradient(135deg,
-            rgba(var(--accent-rgb), 0.28) 0%,
-            rgba(var(--accent-light-rgb), 0.18) 100%);
-}
-
-.slider-group {
-    margin-top: 8px;
-}
-
-.slider-group label {
-    display: block;
-    margin-bottom: 8px;
-    color: rgba(255, 255, 255, 0.7);
-    font-size: 11px;
-}
-
-.dual-slider-container {
-    position: relative;
-    height: 40px;
-    margin: 10px 0;
-}
-
-.range-slider {
-    position: absolute;
-    width: 100%;
-    height: 4px;
-    -webkit-appearance: none;
-    appearance: none;
-    background: transparent;
-    outline: none;
-    pointer-events: none;
-}
-
-.range-slider::-webkit-slider-track {
-    width: 100%;
-    height: 4px;
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 2px;
-}
-
-.range-slider::-webkit-slider-thumb {
-    -webkit-appearance: none;
-    appearance: none;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, rgb(var(--accent-rgb)), rgb(var(--accent-light-rgb)));
-    cursor: pointer;
-    pointer-events: all;
-    border: 2px solid #0a0a0a;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4), 0 0 8px rgba(var(--accent-rgb), 0.2);
-}
-
-.range-slider::-webkit-slider-thumb:hover {
-    background: linear-gradient(135deg, rgb(var(--accent-light-rgb)), #22e968);
-    transform: scale(1.15);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4), 0 0 12px rgba(var(--accent-rgb), 0.3);
-}
-
-.range-slider::-moz-range-track {
-    width: 100%;
-    height: 4px;
-    background: rgba(255, 255, 255, 0.08);
-    border-radius: 2px;
-}
-
-.range-slider::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, rgb(var(--accent-rgb)), rgb(var(--accent-light-rgb)));
-    cursor: pointer;
-    pointer-events: all;
-    border: 2px solid #0a0a0a;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4), 0 0 8px rgba(var(--accent-rgb), 0.2);
-}
-
-.range-slider::-moz-range-thumb:hover {
-    background: linear-gradient(135deg, rgb(var(--accent-light-rgb)), #22e968);
-    transform: scale(1.15);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4), 0 0 12px rgba(var(--accent-rgb), 0.3);
-}
-
-.range-slider-track {
-    position: absolute;
-    top: 18px;
-    width: 100%;
-    height: 4px;
-    background: rgba(var(--accent-rgb), 0.25);
-    border-radius: 2px;
-    pointer-events: none;
-}
-
-.slider-values {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 8px;
-    color: rgba(255, 255, 255, 0.5);
-    font-size: 11px;
-    font-weight: 500;
-}
-
-.slider-values span:first-child,
-.slider-values span:last-child {
-    color: rgb(var(--accent-light-rgb));
-    font-weight: 700;
-}
-
-/* ===== END QUALITY PROFILE STYLES ===== */
-
 .test-button {
     background: rgba(var(--accent-rgb), 0.1);
     color: rgb(var(--accent-light-rgb));
@@ -4601,12 +4317,6 @@ body.helper-mode-active #dashboard-activity-feed:hover {
 
 .save-button:active {
     transform: translateY(0) scale(0.97);
-}
-
-.settings-actions {
-    display: flex;
-    justify-content: center;
-    padding-top: 20px;
 }
 
 /* Additional Settings Components */
@@ -55841,18 +55551,6 @@ tr.tag-diff-same {
     flex-wrap: wrap;
 }
 
-/* ── Quality section ── */
-#settings-page .quality-tier {
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.05);
-    border-radius: 12px;
-    margin-bottom: 10px;
-    transition: border-color 0.2s;
-}
-#settings-page .quality-tier:hover {
-    border-color: rgba(255, 255, 255, 0.1);
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
-}
 #settings-page .preset-button {
     border-radius: 8px;
     font-size: 0.84em;
@@ -55900,30 +55598,6 @@ tr.tag-diff-same {
 }
 #settings-page .tag-service-body {
     padding: 0 18px 12px;
-}
-
-/* ── Save button — centered, sticky feel ── */
-#settings-page .settings-actions {
-    max-width: 760px;
-    width: 100%;
-    margin: 0 auto;
-    padding: 24px 0 16px;
-}
-#settings-page .settings-actions .save-button {
-    width: 100%;
-    padding: 12px;
-    border-radius: 10px;
-    font-size: 0.92em;
-    font-weight: 600;
-    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-}
-#settings-page .settings-actions .save-button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 20px rgba(var(--accent-rgb, 29, 185, 84), 0.35);
-}
-#settings-page .settings-actions .save-button:active {
-    transform: scale(0.99);
-    box-shadow: 0 2px 8px rgba(var(--accent-rgb, 29, 185, 84), 0.2);
 }
 
 /* ── Path input groups (dir paths with Unlock buttons) ── */
@@ -56026,12 +55700,6 @@ tr.tag-diff-same {
 #settings-page #hybrid-settings-container:hover {
     border-color: rgba(255, 255, 255, 0.1);
     box-shadow: 0 2px 16px rgba(0, 0, 0, 0.12);
-}
-
-/* ── Path inputs with lock buttons ── */
-#settings-page .form-group .path-input-wrapper {
-    flex: 1;
-    max-width: 340px;
 }
 
 /* ── Hybrid source priority list (drag and drop) ── */
@@ -56415,9 +56083,6 @@ tr.tag-diff-same {
     /* Accordion headers */
     #settings-page .stg-service > .stg-service-header { padding: 12px 14px; }
     #settings-page .stg-service > .stg-service-body { padding: 0 0 8px; }
-    /* Save button */
-    #settings-page .settings-actions { padding: 16px 8px; }
-    #settings-page .settings-actions .save-button { width: 100%; }
     /* Section titles */
     #settings-page .settings-group > h3 { padding: 24px 0 10px; }
 }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -55420,9 +55420,44 @@ tr.tag-diff-same {
     padding-bottom: 10vh;
 }
 
-/* Tab bar centered */
-#settings-page .stg-tabbar {
+/* Tab bar + save action sit on one control row. */
+#settings-page .settings-nav-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 14px;
+    width: 100%;
+    max-width: 920px;
     margin: 0 auto 28px;
+    padding: 0 2px;
+}
+
+#settings-page .stg-tabbar {
+    display: flex;
+    flex: 0 1 auto;
+    margin: 0;
+    width: fit-content;
+    max-width: 100%;
+    min-width: 0;
+}
+
+#settings-page .settings-nav-row .header-actions {
+    display: flex;
+    flex: 0 0 auto;
+    justify-content: flex-end;
+    align-items: center;
+    flex-wrap: nowrap;
+    width: auto;
+    margin: 0 0 0 auto;
+    margin-top: 0;
+}
+
+#settings-page .settings-nav-row .save-button {
+    padding: 8px 16px;
+    border-radius: 9px;
+    font-size: 0.84em;
+    font-weight: 600;
+    white-space: nowrap;
 }
 
 /* Columns become single centered column */
@@ -55459,38 +55494,38 @@ tr.tag-diff-same {
     min-width: 0;
 }
 
-/* ── Compact settings header — single row, no wasted vertical space ── */
+/* ── Settings local title — quiet, far-left, no dashboard banner ── */
 #settings-page .dashboard-header.settings-header-compact {
     flex-direction: row;
     align-items: center;
-    padding: 12px 24px;
-    margin-bottom: 16px;
+    width: 100%;
+    min-height: 0;
+    padding: 0;
+    margin: 0 0 12px;
     position: relative;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    overflow: visible;
 }
-/* Centre the Save button in the header regardless of the title width. */
-#settings-page .settings-header-compact .header-actions {
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
+#settings-page .dashboard-header.settings-header-compact::after,
+#settings-page .settings-header-compact .dashboard-header-sweep {
+    display: none;
+}
+#settings-page .settings-header-compact .header-text {
+    min-width: 0;
 }
 #settings-page .settings-header-compact .header-title {
-    font-size: 1.15em;
+    font-size: 1.42em;
     margin: 0;
+    line-height: 1.1;
+    color: rgba(255, 255, 255, 0.88);
 }
 #settings-page .settings-header-compact .page-header-icon {
-    width: 26px;
-    height: 26px;
-}
-#settings-page .settings-header-compact .header-actions {
-    margin-left: auto;
-}
-#settings-page .settings-header-compact .header-actions .save-button {
-    padding: 9px 22px;
-    border-radius: 10px;
-    font-size: 0.9em;
-    font-weight: 600;
+    width: 32px;
+    height: 32px;
+    opacity: 0.86;
 }
 
 /* Checkbox/label rows that carry an ⓘ icon span the full width so the help
@@ -56560,11 +56595,20 @@ tr.tag-diff-same {
 
 /* ── Responsive ── */
 @media (max-width: 768px) {
+    #settings-page .settings-nav-row {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        gap: 10px;
+        padding: 0 8px;
+    }
+    #settings-page .settings-nav-row .header-actions {
+        margin-left: auto;
+    }
     /* Tab bar scrolls horizontally */
     #settings-page .stg-tabbar {
         width: 100%;
+        flex: 1 1 100%;
         border-radius: 0;
-        margin-bottom: 16px;
         justify-content: flex-start;
     }
     .stg-tab { padding: 8px 14px; font-size: 0.8em; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -55517,14 +55517,14 @@ tr.tag-diff-same {
     min-width: 0;
 }
 #settings-page .settings-header-compact .header-title {
-    font-size: 1.42em;
+    font-size: 1.82em;
     margin: 0;
     line-height: 1.1;
     color: rgba(255, 255, 255, 0.88);
 }
 #settings-page .settings-header-compact .page-header-icon {
-    width: 32px;
-    height: 32px;
+    width: 44px;
+    height: 44px;
     opacity: 0.86;
 }
 

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -3269,10 +3269,14 @@ body.helper-mode-active #dashboard-activity-feed:hover {
 
 .settings-section-body {
     transition: all 0.2s ease;
+    /* Breathing room before the next tile header so an expanded tile's last
+       control (e.g. "+ Add Path") never sits flush against the next section. */
+    margin-bottom: 18px;
 }
 
 .settings-section-body.collapsed {
     display: none;
+    margin-bottom: 0;
 }
 
 .settings-group {
@@ -3392,16 +3396,16 @@ body.helper-mode-active #dashboard-activity-feed:hover {
 .ind-hero-warning {
     margin-top: 14px;
     padding: 12px 14px;
-    background: rgba(255, 165, 0, 0.06);
-    border: 1px solid rgba(255, 165, 0, 0.2);
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid rgba(255, 255, 255, 0.07);
     border-radius: 10px;
 }
 
 .ind-hero-warning-title {
     font-size: 12px;
-    font-weight: 700;
-    color: #ffb155;
-    letter-spacing: 0.4px;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.6);
+    letter-spacing: 0.3px;
     margin-bottom: 6px;
 }
 
@@ -21800,8 +21804,13 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 8px;
     height: 520px;
+    width: 100%;
+    box-sizing: border-box;
     overflow-y: auto;
     overflow-x: hidden;
+    /* Always reserve the scrollbar gutter so switching between a long log
+       (scrollbar present) and a short one (absent) never shifts the width. */
+    scrollbar-gutter: stable;
     padding: 12px;
     font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', 'Courier New', monospace;
     font-size: 12px;
@@ -55251,11 +55260,62 @@ tr.tag-diff-same {
 /* Columns become single centered column */
 #settings-page .settings-columns {
     flex-direction: column;
-    max-width: 760px;
+    max-width: 920px;
     width: 100%;
     gap: 0;
     margin: 0 auto;
     margin-bottom: 0;
+}
+/* The Logs tab uses the full available width — the log terminal benefits from
+   the extra horizontal space (other tabs stay at the readable 920px). Matches
+   only while the logs group is the visible one (switchSettingsTab clears its
+   inline display when active, sets display:none otherwise). */
+#settings-page .settings-columns:has(> .settings-group[data-stg="logs"]:not([style*="none"])) {
+    max-width: 100%;
+}
+
+/* ── Compact settings header — single row, no wasted vertical space ── */
+#settings-page .dashboard-header.settings-header-compact {
+    flex-direction: row;
+    align-items: center;
+    padding: 12px 24px;
+    margin-bottom: 16px;
+    position: relative;
+}
+/* Centre the Save button in the header regardless of the title width. */
+#settings-page .settings-header-compact .header-actions {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+}
+#settings-page .settings-header-compact .header-title {
+    font-size: 1.15em;
+    margin: 0;
+}
+#settings-page .settings-header-compact .page-header-icon {
+    width: 26px;
+    height: 26px;
+}
+#settings-page .settings-header-compact .header-actions {
+    margin-left: auto;
+}
+#settings-page .settings-header-compact .header-actions .save-button {
+    padding: 9px 22px;
+    border-radius: 10px;
+    font-size: 0.9em;
+    font-weight: 600;
+}
+
+/* Checkbox/label rows that carry an ⓘ icon span the full width so the help
+   body wraps cleanly beneath them. */
+#settings-page .form-group > .setting-row {
+    flex: 1 1 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 #settings-page .settings-left-column,
@@ -55321,12 +55381,14 @@ tr.tag-diff-same {
 #settings-page .form-group {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    /* Row grammar: label grows to hold the left, control + ⓘ group at the right.
+       (Was justify-content:space-between, which stranded selects in mid-row.) */
+    justify-content: flex-start;
     flex-wrap: wrap;
-    gap: 8px 20px;
-    padding: 14px 8px !important;
+    gap: 8px 16px;
+    padding: 12px 8px !important;
     margin: 0 !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.035);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
     border-radius: 8px;
     transition: background 0.2s;
 }
@@ -55339,9 +55401,17 @@ tr.tag-diff-same {
     font-size: 0.9em;
     color: rgba(255, 255, 255, 0.8);
     font-weight: 400;
-    white-space: nowrap;
     margin: 0;
-    flex-shrink: 0;
+    /* Grow to fill the left so the control aligns to a consistent right edge. */
+    flex: 1 1 auto;
+    min-width: 0;
+}
+/* The growing label pushes the control to a consistent right edge; the ⓘ rides
+   immediately after the control as a pair so it can never shove it around. The
+   help callout (flex-basis:100%) wraps to its own line below. */
+#settings-page .form-group > select,
+#settings-page .form-group > .form-select {
+    flex: 0 0 auto;
 }
 
 #settings-page .form-group > input[type="text"],
@@ -55579,6 +55649,15 @@ tr.tag-diff-same {
     color: #fff;
 }
 #settings-page .checkbox-label:last-child { border-bottom: none; }
+/* When a checkbox-label is the control of a .form-group row, the row separator
+   is the form-group's own border-bottom — drop the label's own border/box so
+   every row (checkbox or input/select) has ONE consistent full-width divider. */
+#settings-page .form-group > .checkbox-label {
+    border-bottom: 0 !important;
+    border-radius: 0 !important;
+    padding: 4px 0 !important;
+    background: transparent !important;
+}
 
 /* ── Tag service groups ── */
 #settings-page .tag-service-group {
@@ -55663,6 +55742,188 @@ tr.tag-diff-same {
     line-height: 1.5;
     margin: 0;
 }
+/* Collapsible ⓘ help bodies stay hidden until toggled — wins over the
+   .setting-help-text/.settings-hint display rules that would otherwise show them. */
+#settings-page .setting-help-body[hidden],
+.setting-help-body[hidden] {
+    display: none !important;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Expanded tile = ONE connected card. The header rounds only its top
+   and joins seamlessly to its body, which carries the side + bottom
+   frame; inner groups drop their own card frame so the expanded
+   settings clearly belong to the tile (no box-in-a-box, no detached feel).
+   ════════════════════════════════════════════════════════════════ */
+#settings-page .settings-section-header:not(.collapsed) {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-bottom: 0;
+    /* Accent-tinted frame so the OPEN card clearly stands out from the grey
+       page instead of grey-on-grey. */
+    background: rgba(var(--accent-rgb), 0.07);
+    border-color: rgba(var(--accent-rgb), 0.30);
+    border-bottom: 1px solid rgba(var(--accent-rgb), 0.18);
+}
+#settings-page .settings-section-body:not(.collapsed) {
+    border: 1px solid rgba(var(--accent-rgb), 0.30);
+    border-top: none;
+    border-bottom-left-radius: 12px;
+    border-bottom-right-radius: 12px;
+    /* Dark neutral body (accent stays on the border + header) so the lighter
+       inner sub-cards stand out clearly instead of washing out on a tint.
+       Symmetric padding so the inner sub-cards sit an equal distance from the
+       outer frame on every side. */
+    background: rgba(0, 0, 0, 0.22);
+    box-shadow: 0 6px 22px rgba(0, 0, 0, 0.28);
+    padding: 14px;
+}
+/* Inner groups inside an expanded tile: no own frame/shadow/accent bar —
+   they're sub-sections of the one tile card, separated by their h3 labels. */
+/* ── Sub-cards: each sub-section inside an OPEN tile sits in its own framed
+   card that stands out clearly on the accent-tinted tile background. Covers
+   inner settings-groups (Folder Paths, File Organization, Retry rows, …) and
+   the Security method cards. ── */
+#settings-page .settings-section-body:not(.collapsed) > .settings-group,
+#settings-page .settings-section-body:not(.collapsed) .security-subgroup,
+#settings-page .settings-section-body:not(.collapsed) .settings-subcard,
+#settings-page .settings-section-body:not(.collapsed) [id$="-settings-container"]:not(#hybrid-settings-container) {
+    background: rgba(255, 255, 255, 0.045) !important;
+    border: 1px solid rgba(255, 255, 255, 0.13) !important;
+    border-radius: 10px !important;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25) !important;
+    padding: 6px 16px 12px !important;
+    margin: 0 0 14px !important;
+}
+#settings-page .settings-section-body:not(.collapsed) > .settings-group:last-child,
+#settings-page .settings-section-body:not(.collapsed) .security-subgroup:last-child {
+    margin-bottom: 0 !important;
+}
+#settings-page .settings-section-body:not(.collapsed) > .settings-group::before { display: none; }
+/* Sub-card title: clean header inside its frame (no accent bar / huge padding). */
+#settings-page .settings-section-body:not(.collapsed) > .settings-group > h3 {
+    padding: 10px 0 10px;
+    border-left: none;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+}
+/* The Security wrapper group is a transparent passthrough — its .security-subgroup
+   children are the actual sub-cards (avoids a card-in-a-card). */
+#settings-page .settings-section-body:not(.collapsed) > .settings-group.security-wrapper {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 4px 14px 6px !important;
+    margin: 0 !important;
+}
+/* Mid-level framed containers inside a tile sub-card get flattened so there are
+   never 3 stacked frames (tile → sub-card → container). The innermost
+   interactive items (draggable hybrid rows, tag-embed accordions) keep theirs. */
+#settings-page .settings-section-body:not(.collapsed) .api-service-frame,
+#settings-page .settings-section-body:not(.collapsed) .post-processing-section,
+#settings-page .settings-section-body:not(.collapsed) #hybrid-settings-container {
+    border: none !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+}
+/* The Source Settings group is a transparent passthrough: the basic source/
+   stream/concurrency rows + the hybrid drag list sit flat in the tile, and each
+   per-source config pops open in ITS OWN frame directly inside the tile
+   (tile → config card, never a triple frame). */
+#settings-page .settings-section-body:not(.collapsed) > .settings-group.source-settings-wrapper {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 4px 14px 6px !important;
+    margin: 0 !important;
+}
+
+/* ════════════════════════════════════════════════════════════════
+   Collapsible info panel (ⓘ help) — one consistent pattern.
+   The ⓘ is a small circular badge flush at the end of its row; the
+   help body, when revealed, is an indented accent-bordered panel that
+   spans the full width below the control. Rows never reflow sideways.
+   ════════════════════════════════════════════════════════════════ */
+#settings-page .info-icon {
+    /* Single clean circle with a centred "i" (was the ⓘ glyph, which carried
+       its own inner circle → a double-circle that read as off-centre). */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 1px solid rgba(var(--accent-rgb), 0.45);
+    background: transparent;
+    color: rgba(var(--accent-rgb), 0.9);
+    font-family: Georgia, 'Times New Roman', serif;
+    font-style: italic;
+    font-weight: 700;
+    font-size: 11px;
+    line-height: 1;
+    text-align: center;
+    margin-left: 6px;
+    flex: 0 0 auto;
+    transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+#settings-page .info-icon:hover {
+    background: rgba(var(--accent-rgb), 0.16);
+    border-color: rgba(var(--accent-rgb), 0.85);
+    color: rgba(var(--accent-rgb), 1);
+}
+#settings-page .info-icon.open {
+    background: rgba(var(--accent-rgb), 0.9);
+    border-color: rgba(var(--accent-rgb), 0.9);
+    color: #0b0f14;
+}
+/* The revealed panel — indented, readable, clearly a callout (not a
+   detached muted line). Higher source-order than the .settings-hint /
+   .setting-help-text colour rules above, so it wins on equal specificity. */
+#settings-page .setting-help-body {
+    display: block;
+    width: 100%;
+    flex-basis: 100%;
+    box-sizing: border-box;
+    margin: 8px 0 4px;
+    padding: 10px 12px;
+    background: rgba(var(--accent-rgb), 0.06);
+    border-left: 2px solid rgba(var(--accent-rgb), 0.5);
+    border-radius: 0 6px 6px 0;
+    font-size: 0.8em;
+    line-height: 1.55;
+    color: rgba(255, 255, 255, 0.6);
+    letter-spacing: 0.01em;
+}
+#settings-page .setting-help-body strong { color: rgba(255, 255, 255, 0.82); font-weight: 600; }
+#settings-page .setting-help-body em { color: rgba(var(--accent-rgb), 0.9); font-style: normal; }
+#settings-page .setting-help-body code {
+    font-family: monospace;
+    background: rgba(255, 255, 255, 0.06);
+    padding: 1px 5px;
+    border-radius: 4px;
+    color: rgba(255, 255, 255, 0.75);
+}
+/* A checkbox-label inside a .setting-row must drop its row-divider border and
+   box padding — otherwise it draws a partial underline only under the label
+   text and sits in a padded box, misaligned with the ⓘ. The label fills the
+   row so the icon is pushed flush to the right edge. (Replaces the old
+   per-element inline style="border:0;padding:0;flex:1" hacks.) */
+#settings-page .setting-row > .checkbox-label {
+    flex: 1 1 auto;
+    border-bottom: 0 !important;
+    border-radius: 0 !important;
+    padding: 4px 0 !important;
+}
+#settings-page .setting-row > .checkbox-label:hover { background: transparent; }
+/* Icon always sits at the right edge of its row, vertically centred. */
+#settings-page .setting-row > .info-icon {
+    margin-left: auto;
+    align-self: center;
+}
+
 /* Standalone help text (not inside a form-group) — add separator */
 #settings-page .settings-group > .setting-help-text {
     padding: 6px 0 14px;
@@ -55682,6 +55943,9 @@ tr.tag-diff-same {
 #settings-page #qobuz-settings-container,
 #settings-page #hifi-download-settings-container,
 #settings-page #deezer-download-settings-container,
+#settings-page #amazon-download-settings-container,
+#settings-page #lidarr-download-settings-container,
+#settings-page #soundcloud-download-settings-container,
 #settings-page #youtube-settings-container,
 #settings-page #hybrid-settings-container {
     background: rgba(255, 255, 255, 0.02);
@@ -55696,6 +55960,9 @@ tr.tag-diff-same {
 #settings-page #qobuz-settings-container:hover,
 #settings-page #hifi-download-settings-container:hover,
 #settings-page #deezer-download-settings-container:hover,
+#settings-page #amazon-download-settings-container:hover,
+#settings-page #lidarr-download-settings-container:hover,
+#settings-page #soundcloud-download-settings-container:hover,
 #settings-page #youtube-settings-container:hover,
 #settings-page #hybrid-settings-container:hover {
     border-color: rgba(255, 255, 255, 0.1);
@@ -55779,6 +56046,36 @@ tr.tag-diff-same {
     color: rgba(255, 255, 255, 0.85);
     font-weight: 500;
 }
+.hybrid-source-name[onclick]:hover {
+    color: rgb(var(--accent-light-rgb, 29, 185, 84));
+}
+/* ⚙ Configure button on each enabled source row */
+.hybrid-source-config-btn {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.3);
+    font-size: 0.95em;
+    cursor: pointer;
+    padding: 2px 6px;
+    border-radius: 6px;
+    line-height: 1;
+    transition: all 0.15s;
+}
+.hybrid-source-config-btn:hover {
+    color: rgb(var(--accent-light-rgb, 29, 185, 84));
+    background: rgba(255, 255, 255, 0.06);
+    transform: rotate(45deg);
+}
+/* Row whose config panel is currently open */
+.hybrid-source-item.config-open {
+    border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.45);
+    background: rgba(var(--accent-rgb, 29, 185, 84), 0.06);
+}
+.hybrid-source-item.config-open .hybrid-source-config-btn {
+    color: rgb(var(--accent-light-rgb, 29, 185, 84));
+    transform: rotate(45deg);
+}
 .hybrid-source-badge {
     flex-shrink: 0;
     font-size: 0.68em;
@@ -55803,6 +56100,35 @@ tr.tag-diff-same {
     min-width: 18px;
     text-align: center;
 }
+/* Drag handle + drop-target highlight (mirrors the Quality ranked-target list). */
+.hybrid-source-handle {
+    cursor: grab;
+    color: rgba(255, 255, 255, 0.3);
+    font-size: 14px;
+    line-height: 1;
+    padding: 0 2px;
+    user-select: none;
+    flex-shrink: 0;
+}
+.hybrid-source-handle:active { cursor: grabbing; }
+.hybrid-source-item.drag-over {
+    border-color: rgba(var(--accent-rgb), 0.7) !important;
+    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb), 0.4);
+}
+/* Per-source live connection status dot (set by "Test all sources"). */
+.hybrid-source-status {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+.hybrid-source-status.hss-ok     { background: #34d27b; box-shadow: 0 0 6px rgba(52, 210, 123, 0.6); }
+.hybrid-source-status.hss-fail   { background: #ff5f57; box-shadow: 0 0 6px rgba(255, 95, 87, 0.5); }
+.hybrid-source-status.hss-na     { background: rgba(255, 255, 255, 0.12); }
+.hybrid-source-status.hss-testing { background: #f0b429; animation: hssPulse 0.9s ease-in-out infinite; }
+@keyframes hssPulse { 0%,100% { opacity: 0.35; } 50% { opacity: 1; } }
 .hybrid-source-toggle {
     position: relative;
     width: 36px;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -68589,3 +68589,14 @@ body.app-locked > *:not(#launch-pin-overlay):not(#login-overlay):not(script):not
 .reid-replace-text em { color: #7f879e; font-style: normal; font-size: 11.5px; }
 .reid-footer-actions { display: flex; gap: 10px; }
 #reid-confirm-btn:disabled { opacity: 0.4; cursor: not-allowed; filter: grayscale(0.4); }
+
+/* Settings cleanup: source settings uses the same inner-card spacing as Retry Logic. */
+#settings-page .settings-section-body:not(.collapsed) > .settings-group.source-settings-wrapper {
+    padding: 0 !important;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+#settings-page .settings-section-body:not(.collapsed) > .settings-group.source-settings-wrapper > .settings-subcard {
+    margin: 0 !important;
+}

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -60380,14 +60380,21 @@ tr:hover .enhanced-track-actions-group { opacity: 1; }
 }
 .blacklist-entry-remove:hover { background: rgba(239, 83, 80, 0.12); color: #ef5350; }
 
-/* ── Reduce Visual Effects ── Full performance mode: disables GPU-heavy
-   properties and halts decorative animation globally. */
+/* ── Reduce Visual Effects ── Performance mode. Kills the GPU-EXPENSIVE
+   properties only — the actual lag (esp. Firefox) is backdrop-filter / box-shadow /
+   filter re-rasterizing every frame. Because !important author declarations outrank
+   animation + transition declarations in the cascade, any keyframe/transition that
+   tries to set these is forced to none even while it runs — so the expensive part is
+   neutralized without freezing the motion itself.
+
+   We deliberately do NOT blanket `animation: none` / `transition-duration: 0s`:
+   that froze every functional loading spinner (the dash-header worker-service
+   spinners read as BROKEN, stuck mid-rotation) and killed cheap transform/colour
+   feedback (e.g. the Quick Actions hover). Transform- and opacity-only motion is
+   composited for ~free, so it stays — a spinner that spins, just without glow. */
 body.reduce-effects *,
 body.reduce-effects *::before,
 body.reduce-effects *::after {
-    animation: none !important;
-    transition-duration: 0s !important;
-    transition-delay: 0s !important;
     backdrop-filter: none !important;
     -webkit-backdrop-filter: none !important;
     box-shadow: none !important;

--- a/webui/static/worker-orbs.js
+++ b/webui/static/worker-orbs.js
@@ -1057,7 +1057,12 @@
     // ── Page awareness ──
 
     function isEnabled() {
-        return window._workerOrbsEnabled !== false && !window._reduceEffectsActive;
+        // The worker-orbs toggle controls the orbs on its own — reduce-effects no
+        // longer force-kills them. The orb glow is canvas radial gradients, NOT a CSS
+        // blur(28px) (that's the sidebar aura orbs + frosted glass, which reduce-effects
+        // still kills), so the per-frame cost is moderate, not the blur-rasterize lag.
+        // If real telemetry says otherwise, revert by re-adding `&& !window._reduceEffectsActive`.
+        return window._workerOrbsEnabled !== false;
     }
 
     // ── Real telemetry → pulses ──

--- a/webui/static/worker-orbs.js
+++ b/webui/static/worker-orbs.js
@@ -605,10 +605,18 @@
         if (performance.now() < _scrollPauseUntil) return;
 
         frameCount++;
-        // Fully asleep: render at ~20fps. The drift is at crawl speed so the
-        // difference is invisible, and the canvas GPU cost drops by two thirds
-        // for the hours the dashboard sits idle. Wakes re-run every frame.
-        if (sleepLevel > 0.95 && frameCount % 3 !== 0) return;
+        // Frame-skip throttles. The canvas ticks at 60fps; we drop renders to cut cost.
+        // frameCount still increments every tick, so `time` below stays real-time and the
+        // drift speed is unchanged — we just draw it less often.
+        if (sleepLevel > 0.95) {
+            // Fully asleep → ~20fps: drift is at crawl speed so it's invisible, and the
+            // GPU cost drops two-thirds for the hours the dashboard sits idle.
+            if (frameCount % 3 !== 0) return;
+        } else if (window._reduceEffectsActive) {
+            // Reduce-effects on (user asked for performance) → ~30fps: the slow drift and
+            // sparks look the same, the per-frame cost roughly halves.
+            if (frameCount % 2 !== 0) return;
+        }
         const time = frameCount / 60;
         const w = canvas.width;
         const h = canvas.height;


### PR DESCRIPTION
# soulsync 2.8.1 — `dev` → `main`

a feature + reliability release. the headline is **export a mirrored playlist back to Spotify or Deezer** — same one-click flow as the listenbrainz export, now pointed at the streaming services. plus a **rename-only mode** for Library Reorganize, broader lossless handling, a pile of download fixes, and the reduce-visual-effects pass refined so it stops freezing functional motion.

---

## what's new

### 🎧 Export playlists to Spotify & Deezer (#945)
the mirrored-playlist export modal now has **Sync to Spotify** and **Sync to Deezer** next to the listenbrainz / jspf options. it builds a playlist in your account from the tracks soulsync already has the service IDs for:

- resolves each track from what's already on hand first — the **discovery cache**, then your library's stored IDs — so for an already-discovered playlist it's instant and uses **zero API calls**
- re-exporting **updates the same playlist in place** instead of spawning duplicates
- an optional **"match missing tracks"** toggle does a confident live search for the stragglers — and only adds a match it's sure about (a wrong-artist or karaoke version is left out, never guessed)
- service buttons grey out + point you to Settings when that service isn't connected
- spotify needs a one-time reconnect to grant playlist-write access

### 🏷️ Library Reorganize — Rename only (#875)
a lighter reorganize action: it just **renames your files** to your current naming scheme — no re-tagging, no quality/AcoustID re-check, no copy-to-staging. much faster on a NAS, won't fail on post-processing reasons, and only touches files whose path actually changes (which also fixes the "2 of 14 previewed but everything got modified" album-splitting). pick it from the new **Action** dropdown in the reorganize modal.

### 💿 Lossless handling
- lossy-copy now works for **all lossless formats**, not just FLAC (#941)
- **DSD** (`.dsf` / `.dff`) is recognized as lossless and no longer false-flagged as "truncated" (#939)

### 🐛 Download + search fixes
- a download with an unbalanced bracket in its name no longer false-fails as "file not found"
- a file we couldn't quarantine is left in place for retry instead of deleted
- the Identify search for single imports defaults to "artist - title" (with the dash)
- "file not found" failures now say what actually happened instead of an opaque error
- pasted Qobuz/Tidal links **inject the exact track** into manual search instead of hoping text-search surfaces it (#932)
- the Wing It pool "Fix Match" search works again (it was returning "no results" for everything)

### ⚡ Visual effects + scan reliability
- **Reduce visual effects** no longer freezes functional motion (spinners, progress) — it only kills the expensive GPU stuff (blur, shadows, glow)
- worker orbs default **OFF on Firefox** for new users, and run at ~30fps under reduce-effects
- jellyfin library scans page the bulk fetch so the no-progress watchdog can't false-stall a big library

### 🔧 Under the hood
- settings page cleanup (#943 — thanks @nick2000713)
- spotify oauth credential normalization + redirect-uri handling (#942 — thanks HellRa1SeR)
- security: npm audit fixes for vite / undici / @babel (#944 — thanks HellRa1SeR)

enjoy 🎶
