### PR TITLE
fix: prefer exact library title matches

### DIFF
--- a/core/text/title_match.py
+++ b/core/text/title_match.py
@@ -22,6 +22,10 @@ get rejected; the real track is then correctly reported missing.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable, Iterable
+from typing import TypeVar
+
+T = TypeVar("T")
 
 # Articles / prepositions / conjunctions only. Deliberately NOT pronouns
 # ("you", "me", "i") — those carry meaning in song titles and dropping them
@@ -227,10 +231,48 @@ def base_title_before_dash(title: str) -> str:
     return title[:idx].strip() if idx > 0 else title
 
 
+def choose_best_title_candidate(
+    search_norm: str,
+    search_clean: str,
+    candidates: Iterable[tuple[str, str, T]],
+    similarity_fn: Callable[[str, str], float],
+    *,
+    threshold: float = 0.7,
+) -> T | None:
+    """Pick the best title candidate instead of the first acceptable one.
+
+    Several UI/library paths strip parenthetical qualifiers for fallback matching,
+    so both ``Ratata`` and ``Ratata (Afro Bros Remix)`` clean to ``ratata``.
+    A first-match loop can therefore select the remix for a bare-title request
+    when DB order happens to put the remix first. Rank exact normalized title
+    matches before cleaned-title fallbacks, then fuzzy matches.
+    """
+    best_payload: T | None = None
+    best_rank: tuple[float, float, float] | None = None
+
+    for db_norm, db_clean, payload in candidates:
+        if search_norm == db_norm:
+            rank = (0, 0.0, abs(len(search_norm) - len(db_norm)))
+        elif search_clean == db_clean:
+            rank = (1, 0.0, abs(len(search_norm) - len(db_norm)))
+        else:
+            sim = max(similarity_fn(search_norm, db_norm), similarity_fn(search_clean, db_clean))
+            if sim < threshold:
+                continue
+            rank = (2, -sim, abs(len(search_norm) - len(db_norm)))
+
+        if best_rank is None or rank < best_rank:
+            best_rank = rank
+            best_payload = payload
+
+    return best_payload
+
+
 __all__ = [
     "titles_plausibly_same",
     "strip_redundant_context_qualifiers",
     "strip_subtitle_qualifiers",
     "numeric_tokens_differ",
     "base_title_before_dash",
+    "choose_best_title_candidate",
 ]

--- a/tests/test_title_match_guard.py
+++ b/tests/test_title_match_guard.py
@@ -17,8 +17,9 @@ Two layers tested:
 from __future__ import annotations
 
 import types
+from difflib import SequenceMatcher
 
-from core.text.title_match import titles_plausibly_same
+from core.text.title_match import choose_best_title_candidate, titles_plausibly_same
 
 
 # ── the pure guard ────────────────────────────────────────────────────────
@@ -63,6 +64,34 @@ def test_single_word_titles_defer_to_char_floor():
     assert titles_plausibly_same("tonite", "tonight", 0.77) is True
     # ...even when the char score is low — the floor, not the gate, rejects it.
     assert titles_plausibly_same("numb", "creep", 0.2) is True
+
+
+def test_best_title_candidate_prefers_exact_title_over_cleaned_remix():
+    candidates = [
+        ("ratata (afro bros remix)", "ratata", "remix-path"),
+        ("ratata", "ratata", "base-path"),
+    ]
+
+    assert choose_best_title_candidate(
+        "ratata",
+        "ratata",
+        candidates,
+        lambda left, right: SequenceMatcher(None, left, right).ratio(),
+    ) == "base-path"
+
+
+def test_best_title_candidate_keeps_requested_remix_when_exact():
+    candidates = [
+        ("ratata", "ratata", "base-path"),
+        ("ratata (afro bros remix)", "ratata", "remix-path"),
+    ]
+
+    assert choose_best_title_candidate(
+        "ratata (afro bros remix)",
+        "ratata",
+        candidates,
+        lambda left, right: SequenceMatcher(None, left, right).ratio(),
+    ) == "remix-path"
 
 
 def test_all_stopword_side_defers():

--- a/web_server.py
+++ b/web_server.py
@@ -2829,6 +2829,7 @@ def generate_playlist_m3u():
         # contention) — which is exactly why "Export M3U" hung with nothing in the
         # logs. One WAL-concurrent read can't be starved that way.
         from collections import defaultdict
+        from core.text.title_match import choose_best_title_candidate
         lib_by_artist = defaultdict(list)
         for row in db.get_tracks_for_m3u_resolution(server_source=active_server):
             lib_by_artist[_clean(row['artist'])].append(
@@ -2847,15 +2848,12 @@ def generate_playlist_m3u():
                 file_path_map[idx] = None
                 continue
             s_norm, s_clean = _norm(name), _clean(name)
-            matched_path = None
-            for db_n, db_c, fp in candidates:
-                if s_norm == db_n or s_clean == db_c:
-                    matched_path = fp
-                    break
-                if max(SequenceMatcher(None, s_norm, db_n).ratio(),
-                       SequenceMatcher(None, s_clean, db_c).ratio()) >= 0.7:
-                    matched_path = fp
-                    break
+            matched_path = choose_best_title_candidate(
+                s_norm,
+                s_clean,
+                candidates,
+                lambda left, right: SequenceMatcher(None, left, right).ratio(),
+            )
             file_path_map[idx] = matched_path
 
         # --- build M3U content ---
@@ -10357,16 +10355,13 @@ def library_check_tracks():
 
         def _match_title(search_norm, search_clean, candidates):
             """Find best matching track from a list of (norm, clean, db_track) candidates."""
-            for db_norm, db_clean, db_track in candidates:
-                if search_norm == db_norm or search_clean == db_clean:
-                    return db_track
-                sim = max(
-                    SequenceMatcher(None, search_norm, db_norm).ratio(),
-                    SequenceMatcher(None, search_clean, db_clean).ratio()
-                )
-                if sim >= 0.7:
-                    return db_track
-            return None
+            from core.text.title_match import choose_best_title_candidate
+            return choose_best_title_candidate(
+                search_norm,
+                search_clean,
+                candidates,
+                lambda left, right: SequenceMatcher(None, left, right).ratio(),
+            )
 
         # Split DB tracks by album if album-aware matching is active
         album_entries = []


### PR DESCRIPTION
## Summary
- Fix library/playlist matching so exact title matches win over cleaned-title fallback matches.
- Apply same best-candidate title selection to M3U export and `/api/library/check-tracks`.
- Add regression coverage for `Ratata` vs `Ratata (Afro Bros Remix)`.

## Root Cause
The matcher strips parenthetical qualifiers before comparison. That made:

- `Ratata`
- `Ratata (Afro Bros Remix)`

both clean to `ratata`.

Because matching returned the first acceptable candidate, DB/candidate order could select the remix even when the exact base track existed.

## Fix
Rank matching candidates instead of returning the first match:

1. exact normalized title
2. exact cleaned title
3. fuzzy similarity fallback

This keeps fuzzy matching behavior while preventing remixes/versions/live variants from beating exact title matches.

Fixes #958
