### PR TITLE
fix(matching): stop penalizing long single-word titles as "short titles"

### DIFF
--- a/core/matching_engine.py
+++ b/core/matching_engine.py
@@ -743,9 +743,16 @@ class MusicMatchingEngine:
                 # No penalty for low similarity — the file might just not have album folders
 
         # 5. Special handling for short titles (high false positive risk)
-        # Titles like "Run", "Love", "Girls", "Stay" need stricter artist matching
-        title_words = spotify_cleaned_title.split()
-        is_short_title = len(spotify_cleaned_title) <= 5 or len(title_words) == 1
+        # Titles like "Run", "Love", "Girls", "Stay" need stricter artist matching.
+        # Length alone is the risk signal — a short SUBSTRING is more likely to
+        # accidentally appear inside an unrelated title. The old `or` clause
+        # additionally flagged every single-word title regardless of length,
+        # so an 11-character word like "Dumbfounded" (common for self-titled
+        # tracks — same name as the containing album/single) got the same 60%
+        # penalty as "Run" whenever artist-path matching was only fuzzy, often
+        # dropping it below the pass threshold while multi-word sibling tracks
+        # in the same album passed under identical artist-match conditions.
+        is_short_title = len(spotify_cleaned_title) <= 5
 
         # --- Junk Artist Gate ---
         # Reject results from generic/compilation folders where metadata is unreliable.

--- a/tests/test_matching_engine_short_title_gate.py
+++ b/tests/test_matching_engine_short_title_gate.py
@@ -1,0 +1,116 @@
+"""Regression test for the short-title penalty in
+``MusicMatchingEngine.calculate_slskd_match_confidence``.
+
+Reported pattern: searching Soulseek for an album whose title track
+shares the exact same name as the album (e.g. "Py - DUMBFOUNDED" the
+album containing "Py - DUMBFOUNDED - DUMBFOUNDED" the song) often
+missed that one track while every other track in the same album
+downloaded fine.
+
+Root cause: the "short title" gate (added to prevent false positives
+like "Love" matching "Loveless") was defined as::
+
+    is_short_title = len(spotify_cleaned_title) <= 5 or len(title_words) == 1
+
+The ``or len(title_words) == 1`` clause flagged *any* single-word
+title regardless of its actual length — an 11-character word like
+"Dumbfounded" got the same 60% confidence penalty as "Run" whenever
+the artist could only be fuzzy-matched (not a clean word-boundary
+hit) against the candidate's file path. Self-titled tracks are
+disproportionately single, distinctive words, so this collapsed
+their score below the 0.63 accept threshold while multi-word
+sibling tracks in the same album — scored under identical artist-
+match conditions — passed easily.
+
+Fix: base the gate on title length alone, matching the documented
+intent (the examples given — "Run", "Love", "Girls", "Stay" — are
+all short strings, not merely single words).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.matching_engine import MusicMatchingEngine
+from core.download_plugins.types import TrackResult
+from core.spotify_client import Track as SpotifyTrack
+
+
+@pytest.fixture
+def engine() -> MusicMatchingEngine:
+    return MusicMatchingEngine()
+
+
+def _track(name: str, artists: list[str], album: str) -> SpotifyTrack:
+    return SpotifyTrack(
+        id='1', name=name, artists=artists, album=album,
+        duration_ms=200000, popularity=0, preview_url=None, external_urls={},
+    )
+
+
+def _result(filename: str, duration_ms: int = 200000) -> TrackResult:
+    return TrackResult(
+        username='peer', filename=filename, size=30_000_000, bitrate=1000,
+        duration=duration_ms, quality='flac',
+        free_upload_slots=1, upload_speed=100000, queue_length=0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The reported scenario: self-titled long single-word track.
+# ---------------------------------------------------------------------------
+
+
+def test_long_single_word_self_titled_track_passes_with_weak_artist_match(engine):
+    """A long single-word title (album == track name) must not be treated
+    like a short/collision-prone title just because it's one word.
+
+    "Pi" stands in for a peer whose share only fuzzy-matches "Py" (no
+    clean word-boundary hit) — realistic for slightly different artist
+    folder naming on Soulseek."""
+    track = _track('DUMBFOUNDED', ['Py'], 'DUMBFOUNDED')
+    candidate = _result('Pi/DUMBFOUNDED/01 DUMBFOUNDED.flac')
+
+    confidence = engine.calculate_slskd_match_confidence(track, candidate)
+
+    assert confidence > 0.63
+
+
+def test_multi_word_sibling_track_passes_under_identical_conditions(engine):
+    """Sanity check: a multi-word title in the same album, scored under
+    the same weak-artist-match conditions, already passed before the fix
+    — confirms the bug was specific to the single-word gate, not the
+    weak artist match itself."""
+    track = _track('Some Other Song', ['Py'], 'DUMBFOUNDED')
+    candidate = _result('Pi/DUMBFOUNDED/02 Some Other Song.flac')
+
+    confidence = engine.calculate_slskd_match_confidence(track, candidate)
+
+    assert confidence > 0.63
+
+
+# ---------------------------------------------------------------------------
+# The gate must still protect genuinely short titles.
+# ---------------------------------------------------------------------------
+
+
+def test_genuinely_short_title_still_gated_under_weak_artist_match(engine):
+    """"Run" (<=5 chars) must still get the stricter short-title scrutiny
+    — the fix narrows the gate, it doesn't remove it."""
+    track = _track('Run', ['Muse'], 'Origin of Symmetry')
+    candidate = _result('Mu/Origin of Symmetry/Run.flac')
+
+    confidence = engine.calculate_slskd_match_confidence(track, candidate)
+
+    assert confidence < 0.63
+
+
+def test_short_title_with_strong_artist_match_still_passes(engine):
+    """A short title must still pass when the artist match IS clean —
+    the gate is a penalty for weak artist matches, not an outright ban."""
+    track = _track('Run', ['Muse'], 'Origin of Symmetry')
+    candidate = _result('Muse/Origin of Symmetry/Run.flac')
+
+    confidence = engine.calculate_slskd_match_confidence(track, candidate)
+
+    assert confidence > 0.63


### PR DESCRIPTION
## Summary
- The short-title confidence gate in `calculate_slskd_match_confidence` (`core/matching_engine.py`) was `len(title) <= 5 or len(words) == 1`, so **any** single-word title — regardless of actual length — got the same 60% confidence penalty designed for genuinely short/collision-prone titles like "Run" or "Love".
- Self-titled tracks (same name as their containing album/single — a common pattern, e.g. the album "Py - DUMBFOUNDED" containing the song "DUMBFOUNDED") are disproportionately long single words. Whenever the artist could only be fuzzy-matched against a candidate's Soulseek file path (not a clean word-boundary hit — common with real-world folder naming), this collapsed the score below the 0.63 accept threshold, while multi-word sibling tracks in the same album — scored under identical artist-match conditions — passed easily. Net effect: that one track silently went missing from otherwise-successful album downloads.
- Fix: gate on title length alone, matching the documented intent (the examples given — "Run", "Love", "Girls", "Stay" — are all short strings, not merely single words).

Reproduced the bug and confirmed the fix numerically:
| Scenario | Before | After |
|---|---|---|
| "DUMBFOUNDED" (self-titled, weak artist match) | ~0.36 (fails 0.63 threshold) | 0.775 (passes) |
| "Run" (genuinely short, weak artist match) | still gated | still gated (unchanged) |
| "Run" (genuinely short, strong artist match) | passes | passes (unchanged) |

## Test plan
- [x] Added `tests/test_matching_engine_short_title_gate.py` — 4 tests covering the self-titled scenario, a multi-word sibling under identical conditions, and sanity checks that genuinely short titles still get the protection
- [x] `python -m pytest tests/` — 7152 passed
- [x] `python -m ruff check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)