### PR TITLE
Sigma artist map

### DIFF
--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -119,13 +119,14 @@ def build_genre_grouped_map(
 ) -> Dict[str, List[dict]]:
     """Genre-anchored Taste Map: EVERY library artist as a node, grouped by genre + wired by similarity.
 
-    ``artists`` is ``(name, genres, thumb_url)`` for every library artist (``genres`` a JSON-array
-    string). This includes the ~3.8k artists that have no owned<->owned similarity edge — they'd be
-    dropped by :func:`build_taste_map` — by attaching each artist to a per-genre "hub" node so a
-    force layout clusters them by genre. Similarity edges (owned<->owned) are reused verbatim.
+    ``artists`` is ``(name, genres, thumb_url[, id, source])`` for every library artist (``genres`` a
+    JSON-array string; ``id``/``source`` optional, used by the frontend to link to the artist page).
+    This includes the ~3.8k artists that have no owned<->owned similarity edge — they'd be dropped by
+    :func:`build_taste_map` — by attaching each artist to a per-genre "hub" node so a force layout
+    clusters them by genre. Similarity edges (owned<->owned) are reused verbatim.
 
     Node kinds:
-      * ``artist`` — ``{key, label, kind, owned, primary_genre, popularity, thumb}``
+      * ``artist`` — ``{key, label, kind, owned, primary_genre, popularity, thumb, id, source}``
       * ``genre``  — ``{key, label, kind, genre}`` (one hub per distinct primary genre)
     Edge kinds: ``similarity`` (from :func:`build_taste_map`) and ``membership`` (artist -> its genre).
     """
@@ -137,7 +138,10 @@ def build_genre_grouped_map(
     seen_artist: set = set()
     genre_labels: Dict[str, str] = {}
 
-    for name, genres, thumb in artists:
+    for row in artists:
+        name, genres, thumb = row[0], row[1], row[2]
+        artist_id = row[3] if len(row) > 3 else None
+        source = row[4] if len(row) > 4 else None
         key = _norm(name)
         if not key or key in seen_artist:
             continue
@@ -151,6 +155,8 @@ def build_genre_grouped_map(
             "primary_genre": prim,
             "popularity": pop_by.get(key, 0),
             "thumb": thumb,
+            "id": artist_id,
+            "source": source,
         })
         if prim:
             gkey = "genre::" + prim.strip().lower()

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -12,6 +12,7 @@ ID — done once in memory here (a SQL self-join over 75k rows is too slow).
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 # Row shape from similar_artists:
@@ -91,4 +92,72 @@ def build_taste_map(
         for norm_name, label in node_label.items()
     ]
     edges = [{"source": a, "target": b, "weight": w} for (a, b), w in edge_weight.items()]
+    return {"nodes": nodes, "edges": edges}
+
+
+def _primary_genre(genres: Any) -> Optional[str]:
+    """First genre from an artist's ``genres`` value (a JSON array string, or already a list)."""
+    if not genres:
+        return None
+    arr = genres
+    if isinstance(genres, str):
+        try:
+            arr = json.loads(genres)
+        except (ValueError, TypeError):
+            return None
+    if isinstance(arr, list) and arr:
+        first = str(arr[0]).strip()
+        return first or None
+    return None
+
+
+def build_genre_grouped_map(
+    artists: Iterable[Tuple[Any, Any, Any]],
+    rows: Iterable[Row],
+    owned_names: set,
+    artist_meta: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, List[dict]]:
+    """Genre-anchored Taste Map: EVERY library artist as a node, grouped by genre + wired by similarity.
+
+    ``artists`` is ``(name, genres, thumb_url)`` for every library artist (``genres`` a JSON-array
+    string). This includes the ~3.8k artists that have no owned<->owned similarity edge — they'd be
+    dropped by :func:`build_taste_map` — by attaching each artist to a per-genre "hub" node so a
+    force layout clusters them by genre. Similarity edges (owned<->owned) are reused verbatim.
+
+    Node kinds:
+      * ``artist`` — ``{key, label, kind, owned, primary_genre, popularity, thumb}``
+      * ``genre``  — ``{key, label, kind, genre}`` (one hub per distinct primary genre)
+    Edge kinds: ``similarity`` (from :func:`build_taste_map`) and ``membership`` (artist -> its genre).
+    """
+    base = build_taste_map(rows, owned_names, artist_meta)
+    pop_by = {n["key"]: n.get("popularity", 0) for n in base["nodes"]}
+
+    nodes: List[dict] = []
+    edges: List[dict] = [{**e, "kind": "similarity"} for e in base["edges"]]
+    seen_artist: set = set()
+    genre_labels: Dict[str, str] = {}
+
+    for name, genres, thumb in artists:
+        key = _norm(name)
+        if not key or key in seen_artist:
+            continue
+        seen_artist.add(key)
+        prim = _primary_genre(genres)
+        nodes.append({
+            "key": key,
+            "label": name,
+            "kind": "artist",
+            "owned": True,
+            "primary_genre": prim,
+            "popularity": pop_by.get(key, 0),
+            "thumb": thumb,
+        })
+        if prim:
+            gkey = "genre::" + prim.strip().lower()
+            genre_labels.setdefault(gkey, prim)
+            edges.append({"source": key, "target": gkey, "weight": 1, "kind": "membership"})
+
+    for gkey, glabel in genre_labels.items():
+        nodes.append({"key": gkey, "label": glabel, "kind": "genre", "genre": glabel})
+
     return {"nodes": nodes, "edges": edges}

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -95,20 +95,28 @@ def build_taste_map(
     return {"nodes": nodes, "edges": edges}
 
 
-def _primary_genre(genres: Any) -> Optional[str]:
-    """First genre from an artist's ``genres`` value (a JSON array string, or already a list)."""
+def _genre_list(genres: Any) -> List[str]:
+    """An artist's genres as a clean list of strings (from a JSON array string, or already a list)."""
     if not genres:
-        return None
+        return []
     arr = genres
     if isinstance(genres, str):
         try:
             arr = json.loads(genres)
         except (ValueError, TypeError):
-            return None
-    if isinstance(arr, list) and arr:
-        first = str(arr[0]).strip()
-        return first or None
-    return None
+            return []
+    if not isinstance(arr, list):
+        return []
+    return [s for s in (str(g).strip() for g in arr) if s]
+
+
+def _primary_genre(genres: Any) -> Optional[str]:
+    """First genre from an artist's ``genres`` value."""
+    gl = _genre_list(genres)
+    return gl[0] if gl else None
+
+
+OTHER_GENRE = "Other"
 
 
 def build_genre_grouped_map(
@@ -116,22 +124,39 @@ def build_genre_grouped_map(
     rows: Iterable[Row],
     owned_names: set,
     artist_meta: Optional[Dict[str, Dict[str, Any]]] = None,
+    max_hubs: int = 16,
 ) -> Dict[str, List[dict]]:
     """Genre-anchored Taste Map: EVERY library artist as a node, grouped by genre + wired by similarity.
 
     ``artists`` is ``(name, genres, thumb_url[, id, source])`` for every library artist (``genres`` a
     JSON-array string; ``id``/``source`` optional, used by the frontend to link to the artist page).
     This includes the ~3.8k artists that have no owned<->owned similarity edge — they'd be dropped by
-    :func:`build_taste_map` — by attaching each artist to a per-genre "hub" node so a force layout
-    clusters them by genre. Similarity edges (owned<->owned) are reused verbatim.
+    :func:`build_taste_map` — by attaching each artist to a genre "hub" node so a force layout clusters
+    them into legible islands. Similarity edges (owned<->owned) are reused verbatim.
+
+    To keep the layout readable we DON'T make a hub per distinct genre (there are ~436, mostly tiny).
+    Instead we keep the ``max_hubs`` most common primary genres as anchors and route every artist to
+    the first of *its* genres that is an anchor (so a "Lo-fi house / Rap/Hip Hop" artist lands in the
+    Rap/Hip Hop island even though its primary is the rare one). Anything with genres but no anchor
+    match falls into a single ``Other`` hub; artists with no genre at all get no hub.
 
     Node kinds:
-      * ``artist`` — ``{key, label, kind, owned, primary_genre, popularity, thumb, id, source}``
-      * ``genre``  — ``{key, label, kind, genre}`` (one hub per distinct primary genre)
-    Edge kinds: ``similarity`` (from :func:`build_taste_map`) and ``membership`` (artist -> its genre).
+      * ``artist`` — ``{key, label, kind, owned, primary_genre, cluster, popularity, thumb, id, source}``
+        where ``cluster`` is the anchor genre it was grouped under (drives color + membership).
+      * ``genre``  — ``{key, label, kind, genre}`` (one hub per anchor genre, plus ``Other``)
+    Edge kinds: ``similarity`` (from :func:`build_taste_map`) and ``membership`` (artist -> its cluster).
     """
     base = build_taste_map(rows, owned_names, artist_meta)
     pop_by = {n["key"]: n.get("popularity", 0) for n in base["nodes"]}
+    artists = list(artists)
+
+    # Pass 1: rank primary genres by frequency; the top ``max_hubs`` become the anchor set.
+    prim_counts: Dict[str, int] = {}
+    for row in artists:
+        prim = _primary_genre(row[1])
+        if prim:
+            prim_counts[prim] = prim_counts.get(prim, 0) + 1
+    anchor_set = set(sorted(prim_counts, key=lambda g: (-prim_counts[g], g))[:max_hubs])
 
     nodes: List[dict] = []
     edges: List[dict] = [{**e, "kind": "similarity"} for e in base["edges"]]
@@ -146,21 +171,29 @@ def build_genre_grouped_map(
         if not key or key in seen_artist:
             continue
         seen_artist.add(key)
-        prim = _primary_genre(genres)
+
+        gl = _genre_list(genres)
+        prim = gl[0] if gl else None
+        # Cluster = first of the artist's genres that's an anchor; else Other (only if it has genres).
+        cluster = next((g for g in gl if g in anchor_set), None)
+        if cluster is None and gl:
+            cluster = OTHER_GENRE
+
         nodes.append({
             "key": key,
             "label": name,
             "kind": "artist",
             "owned": True,
             "primary_genre": prim,
+            "cluster": cluster,
             "popularity": pop_by.get(key, 0),
             "thumb": thumb,
             "id": artist_id,
             "source": source,
         })
-        if prim:
-            gkey = "genre::" + prim.strip().lower()
-            genre_labels.setdefault(gkey, prim)
+        if cluster:
+            gkey = "genre::" + cluster.strip().lower()
+            genre_labels.setdefault(gkey, cluster)
             edges.append({"source": key, "target": gkey, "weight": 1, "kind": "membership"})
 
     for gkey, glabel in genre_labels.items():

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -1,0 +1,94 @@
+"""Build an artist-similarity graph (nodes + edges) from the discovery ``similar_artists`` data.
+
+Pure + side-effect free: the caller loads the rows (and the set of owned library-artist names) and
+hands them here; this only shapes them into a ``{nodes, edges}`` payload for the frontend
+(graphology -> sigma.js). No DB or Flask deps, so the graph logic is unit-testable in isolation.
+
+The ``similar_artists`` grain is a DIRECTED edge ``source_artist_id -> similar_artist_name``, where the
+source is an external ID (Spotify/Deezer/...) and the target is a name (plus its own external IDs). A
+source ID is resolved to a name self-referentially — it usually also appears as some target's external
+ID — done once in memory here (a SQL self-join over 75k rows is too slow).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Row shape from similar_artists:
+# (source_artist_id, similar_artist_name, spotify_id, deezer_id, itunes_id, occurrence_count, popularity)
+Row = Tuple[Any, Any, Any, Any, Any, Any, Any]
+
+
+def _norm(name: Any) -> str:
+    return str(name or "").strip().lower()
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def build_taste_map(
+    rows: Iterable[Row],
+    owned_names: set,
+    artist_meta: Optional[Dict[str, Dict[str, Any]]] = None,
+) -> Dict[str, List[dict]]:
+    """Build the "Taste Map": your library artists wired together by direct similarity.
+
+    ``owned_names`` is the set of library artist names, lowercased. ``artist_meta`` optionally maps a
+    lowercased name to ``{thumb_url, genres}`` for richer nodes.
+
+    Returns ``{"nodes": [...], "edges": [...]}``. Only edges where BOTH endpoints are owned library
+    artists are kept (owned<->owned). Directed similarity collapses to undirected edges (weights
+    summed). A node's ``popularity`` is the max seen for that artist as a similarity target.
+    """
+    meta = artist_meta or {}
+    rows = list(rows)
+
+    # Self-referential ID -> name: a source id is resolvable when it also appears as a target ext id.
+    id2name: Dict[str, str] = {}
+    for _src, name, sp, dz, it, _occ, _pop in rows:
+        for eid in (sp, dz, it):
+            if eid and eid not in id2name:
+                id2name[eid] = name
+
+    node_label: Dict[str, str] = {}
+    node_pop: Dict[str, int] = {}
+    edge_weight: Dict[Tuple[str, str], int] = {}
+
+    def _touch(norm_name: str, label: str, pop: Any) -> None:
+        node_label.setdefault(norm_name, label)
+        p = _as_int(pop)
+        if p > node_pop.get(norm_name, 0):
+            node_pop[norm_name] = p
+
+    for src, name, _sp, _dz, _it, occ, pop in rows:
+        tgt = _norm(name)
+        if tgt not in owned_names:
+            continue
+        src_name = id2name.get(src)
+        if not src_name:
+            continue
+        src_norm = _norm(src_name)
+        if src_norm not in owned_names or src_norm == tgt:
+            continue
+        _touch(src_norm, src_name, None)      # source pop filled if it's a target elsewhere
+        _touch(tgt, name, pop)
+        key = (src_norm, tgt) if src_norm < tgt else (tgt, src_norm)
+        edge_weight[key] = edge_weight.get(key, 0) + _as_int(occ, 1)
+
+    nodes = [
+        {
+            "key": norm_name,
+            "label": label,
+            "owned": True,
+            "popularity": node_pop.get(norm_name, 0),
+            "thumb": meta.get(norm_name, {}).get("thumb_url"),
+            "genres": meta.get(norm_name, {}).get("genres"),
+        }
+        for norm_name, label in node_label.items()
+    ]
+    edges = [{"source": a, "target": b, "weight": w} for (a, b), w in edge_weight.items()]
+    return {"nodes": nodes, "edges": edges}

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -200,3 +200,86 @@ def build_genre_grouped_map(
         nodes.append({"key": gkey, "label": glabel, "kind": "genre", "genre": glabel})
 
     return {"nodes": nodes, "edges": edges}
+
+
+def build_discovery_map(
+    rows: Iterable[Row],
+    owned_names: set,
+    owned_meta: Optional[Dict[str, Dict[str, Any]]] = None,
+    cache_lookup: Optional[Dict[Any, Dict[str, Any]]] = None,
+    seed_count: int = 30,
+    per_anchor: int = 6,
+) -> Dict[str, List[dict]]:
+    """Discovery map: owned artists as anchors, their UNOWNED similar artists as discovery candidates.
+
+    The inverse of :func:`build_taste_map`'s filter — instead of owned<->owned, we keep owned->UNowned
+    edges (new artists to find). Each unowned candidate is enriched from ``cache_lookup`` — a dict
+    ``{external_id: {"image_url", "genres", "popularity", "name"}}`` (the caller builds it from the
+    metadata cache). Anchors are ranked by how many unowned neighbors they have; the top ``seed_count``
+    seed the initial view, each showing its top ``per_anchor`` candidates (by consensus then popularity).
+
+    Node kinds: ``owned`` (anchor: ``{key,label,owned,kind,id,thumb,genres}``) and ``discovery``
+    (candidate: ``{key,label,owned,kind,popularity,image_url,genres}``). Edges are owned -> discovery.
+    """
+    owned_meta = owned_meta or {}
+    cache_lookup = cache_lookup or {}
+    rows = list(rows)
+
+    # Same self-referential resolution as build_taste_map: source ext id -> name.
+    id2name: Dict[str, str] = {}
+    for _src, name, sp, dz, it, _occ, _pop in rows:
+        for eid in (sp, dz, it):
+            if eid and eid not in id2name:
+                id2name[eid] = name
+
+    # Gather each OWNED anchor's UNOWNED similar targets.
+    anchors: Dict[str, Dict[str, Any]] = {}
+    for src, name, sp, dz, it, occ, pop in rows:
+        src_name = id2name.get(src)
+        if not src_name:
+            continue
+        src_norm = _norm(src_name)
+        if src_norm not in owned_names:
+            continue                              # anchor must be owned
+        tgt_norm = _norm(name)
+        if not tgt_norm or tgt_norm in owned_names:
+            continue                              # discovery = UNowned target only
+        a = anchors.setdefault(src_norm, {"label": src_name, "targets": []})
+        a["targets"].append((name, sp, dz, it, _as_int(occ, 1), _as_int(pop)))
+
+    ranked = sorted(anchors.items(), key=lambda kv: len(kv[1]["targets"]), reverse=True)[:seed_count]
+
+    nodes: Dict[str, dict] = {}
+    edges: List[dict] = []
+    edge_seen: set = set()
+
+    for anchor_norm, info in ranked:
+        if anchor_norm not in nodes:
+            meta = owned_meta.get(anchor_norm, {})
+            nodes[anchor_norm] = {
+                "key": anchor_norm, "label": info["label"], "owned": True, "kind": "owned",
+                "id": meta.get("id"), "thumb": meta.get("thumb_url"), "genres": meta.get("genres"),
+            }
+        top = sorted(info["targets"], key=lambda t: (t[4], t[5]), reverse=True)[:per_anchor]
+        for (tname, sp, dz, it, occ, pop) in top:
+            tkey = _norm(tname)
+            if not tkey:
+                continue
+            if tkey not in nodes:
+                enrich: Dict[str, Any] = {}
+                for eid in (sp, dz, it):
+                    if eid and eid in cache_lookup:
+                        enrich = cache_lookup[eid]
+                        break
+                nodes[tkey] = {
+                    "key": tkey, "label": tname, "owned": False, "kind": "discovery",
+                    "popularity": enrich.get("popularity", pop),
+                    "image_url": enrich.get("image_url"), "genres": enrich.get("genres"),
+                    "ids": [e for e in (sp, dz, it) if e],   # external ids, for cache enrichment + add-to-watchlist
+                }
+            ekey = (anchor_norm, tkey)
+            if ekey not in edge_seen:
+                edge_seen.add(ekey)
+                edges.append({"source": anchor_norm, "target": tkey, "weight": _as_int(occ, 1)})
+
+    return {"nodes": list(nodes.values()), "edges": edges}

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -283,3 +283,75 @@ def build_discovery_map(
                 edges.append({"source": anchor_norm, "target": tkey, "weight": _as_int(occ, 1)})
 
     return {"nodes": list(nodes.values()), "edges": edges}
+
+
+def expand_discovery_node(
+    rows: Iterable[Row],
+    owned_names: set,
+    node_key: str,
+    node_ids: Optional[Iterable[Any]] = None,
+    owned_meta: Optional[Dict[str, Dict[str, Any]]] = None,
+    cache_lookup: Optional[Dict[Any, Dict[str, Any]]] = None,
+    per: int = 10,
+    exclude: Optional[set] = None,
+) -> Dict[str, List[dict]]:
+    """One expand-on-click step for the Discovery map: the clicked node's similar artists.
+
+    The clicked node is identified by ``node_key`` (normalized name) and/or ``node_ids`` (its external
+    ids) — a row matches when its source id resolves to that name or is one of those ids. Targets in
+    ``exclude`` (keys already on screen) are skipped, then the strongest ``per`` (by consensus, then
+    popularity) are returned. Unowned targets become ``discovery`` nodes (cache-enriched, like
+    :func:`build_discovery_map`); owned targets become ``owned`` nodes, so a trail can also reveal how
+    a candidate connects back into your library. Edges run ``node_key -> target``.
+    """
+    owned_meta = owned_meta or {}
+    cache_lookup = cache_lookup or {}
+    exclude = exclude or set()
+    ids_set = {i for i in (node_ids or []) if i}
+    node_key = _norm(node_key)
+    rows = list(rows)
+
+    id2name: Dict[str, str] = {}
+    for _src, name, sp, dz, it, _occ, _pop in rows:
+        for eid in (sp, dz, it):
+            if eid and eid not in id2name:
+                id2name[eid] = name
+
+    targets: List[Tuple[str, Any, Any, Any, int, int]] = []
+    seen_targets: set = set()
+    for src, name, sp, dz, it, occ, pop in rows:
+        if src not in ids_set and _norm(id2name.get(src, "")) != node_key:
+            continue                              # row isn't about the clicked node
+        tkey = _norm(name)
+        if not tkey or tkey == node_key or tkey in exclude or tkey in seen_targets:
+            continue
+        seen_targets.add(tkey)
+        targets.append((name, sp, dz, it, _as_int(occ, 1), _as_int(pop)))
+
+    targets.sort(key=lambda t: (t[4], t[5]), reverse=True)
+
+    nodes: List[dict] = []
+    edges: List[dict] = []
+    for (tname, sp, dz, it, occ, pop) in targets[:per]:
+        tkey = _norm(tname)
+        if tkey in owned_names:
+            meta = owned_meta.get(tkey, {})
+            nodes.append({
+                "key": tkey, "label": tname, "owned": True, "kind": "owned",
+                "id": meta.get("id"), "thumb": meta.get("thumb_url"), "genres": meta.get("genres"),
+            })
+        else:
+            enrich: Dict[str, Any] = {}
+            for eid in (sp, dz, it):
+                if eid and eid in cache_lookup:
+                    enrich = cache_lookup[eid]
+                    break
+            nodes.append({
+                "key": tkey, "label": tname, "owned": False, "kind": "discovery",
+                "popularity": enrich.get("popularity", pop),
+                "image_url": enrich.get("image_url"), "genres": enrich.get("genres"),
+                "ids": [e for e in (sp, dz, it) if e],
+            })
+        edges.append({"source": node_key, "target": tkey, "weight": _as_int(occ, 1)})
+
+    return {"nodes": nodes, "edges": edges}

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -202,27 +202,77 @@ def build_genre_grouped_map(
     return {"nodes": nodes, "edges": edges}
 
 
+def _merge_target(bucket: Dict[str, list], name: str, sp: Any, dz: Any, it: Any, occ: Any, pop: Any) -> None:
+    """Fold one similar-artist row into a per-target bucket, keyed by normalized name.
+
+    The same target often appears in several rows (the anchor was discovered against Spotify AND
+    Deezer), so we merge: max occurrence/popularity (a target ranks by its STRONGEST evidence, not
+    whichever row happened first) and the union of external ids (more ids -> better cache enrichment).
+    Bucket value: [label, sp, dz, it, occ, pop].
+    """
+    tkey = _norm(name)
+    cur = bucket.get(tkey)
+    if cur is None:
+        bucket[tkey] = [name, sp, dz, it, _as_int(occ, 1), _as_int(pop)]
+        return
+    cur[1] = cur[1] or sp
+    cur[2] = cur[2] or dz
+    cur[3] = cur[3] or it
+    cur[4] = max(cur[4], _as_int(occ, 1))
+    cur[5] = max(cur[5], _as_int(pop))
+
+
+def _id_pairs(sp: Any, dz: Any, it: Any) -> List[List[Any]]:
+    """External ids as ``[source, id]`` pairs — the source matters: Deezer and iTunes ids are both
+    numeric and can collide, so consumers (cache enrichment, watchlist add) must know which is which.
+    """
+    return [[s, e] for s, e in (("spotify", sp), ("deezer", dz), ("itunes", it)) if e]
+
+
+def enrich_discovery_nodes(
+    nodes: List[dict],
+    cache_lookup: Dict[Tuple[str, Any], Dict[str, Any]],
+) -> List[dict]:
+    """Fill discovery nodes' image/genres/popularity from cached metadata, in place.
+
+    ``cache_lookup`` is keyed by ``(source, external_id)`` — source-scoped, because Deezer and iTunes
+    ids share the numeric space and an unscoped lookup can return the wrong artist's metadata. The
+    first of the node's id pairs with a cache hit wins; row-level popularity is kept as fallback.
+    """
+    for n in nodes:
+        if n.get("kind") != "discovery":
+            continue
+        for src, eid in n.get("ids", []):
+            hit = cache_lookup.get((src, eid))
+            if hit:
+                n["image_url"] = hit.get("image_url")
+                n["genres"] = hit.get("genres")
+                if hit.get("popularity"):
+                    n["popularity"] = hit["popularity"]
+                break
+    return nodes
+
+
 def build_discovery_map(
     rows: Iterable[Row],
     owned_names: set,
     owned_meta: Optional[Dict[str, Dict[str, Any]]] = None,
-    cache_lookup: Optional[Dict[Any, Dict[str, Any]]] = None,
     seed_count: int = 30,
     per_anchor: int = 6,
 ) -> Dict[str, List[dict]]:
     """Discovery map: owned artists as anchors, their UNOWNED similar artists as discovery candidates.
 
     The inverse of :func:`build_taste_map`'s filter — instead of owned<->owned, we keep owned->UNowned
-    edges (new artists to find). Each unowned candidate is enriched from ``cache_lookup`` — a dict
-    ``{external_id: {"image_url", "genres", "popularity", "name"}}`` (the caller builds it from the
-    metadata cache). Anchors are ranked by how many unowned neighbors they have; the top ``seed_count``
-    seed the initial view, each showing its top ``per_anchor`` candidates (by consensus then popularity).
+    edges (new artists to find). Anchors are ranked by how many DISTINCT unowned neighbors they have;
+    the top ``seed_count`` seed the initial view, each showing its top ``per_anchor`` candidates (by
+    max consensus, then popularity — duplicate multi-source rows are merged, see :func:`_merge_target`).
 
     Node kinds: ``owned`` (anchor: ``{key,label,owned,kind,id,thumb,genres}``) and ``discovery``
-    (candidate: ``{key,label,owned,kind,popularity,image_url,genres}``). Edges are owned -> discovery.
+    (candidate: ``{key,label,owned,kind,popularity,image_url,genres,ids}`` where ``ids`` is a list of
+    ``[source, external_id]`` pairs). Edges are owned -> discovery. Enrichment is a separate step —
+    see :func:`enrich_discovery_nodes`.
     """
     owned_meta = owned_meta or {}
-    cache_lookup = cache_lookup or {}
     rows = list(rows)
 
     # Same self-referential resolution as build_taste_map: source ext id -> name.
@@ -232,7 +282,7 @@ def build_discovery_map(
             if eid and eid not in id2name:
                 id2name[eid] = name
 
-    # Gather each OWNED anchor's UNOWNED similar targets.
+    # Gather each OWNED anchor's UNOWNED similar targets, merged per target name.
     anchors: Dict[str, Dict[str, Any]] = {}
     for src, name, sp, dz, it, occ, pop in rows:
         src_name = id2name.get(src)
@@ -244,8 +294,8 @@ def build_discovery_map(
         tgt_norm = _norm(name)
         if not tgt_norm or tgt_norm in owned_names:
             continue                              # discovery = UNowned target only
-        a = anchors.setdefault(src_norm, {"label": src_name, "targets": []})
-        a["targets"].append((name, sp, dz, it, _as_int(occ, 1), _as_int(pop)))
+        a = anchors.setdefault(src_norm, {"label": src_name, "targets": {}})
+        _merge_target(a["targets"], name, sp, dz, it, occ, pop)
 
     ranked = sorted(anchors.items(), key=lambda kv: len(kv[1]["targets"]), reverse=True)[:seed_count]
 
@@ -260,27 +310,18 @@ def build_discovery_map(
                 "key": anchor_norm, "label": info["label"], "owned": True, "kind": "owned",
                 "id": meta.get("id"), "thumb": meta.get("thumb_url"), "genres": meta.get("genres"),
             }
-        top = sorted(info["targets"], key=lambda t: (t[4], t[5]), reverse=True)[:per_anchor]
-        for (tname, sp, dz, it, occ, pop) in top:
-            tkey = _norm(tname)
-            if not tkey:
-                continue
+        top = sorted(info["targets"].items(), key=lambda kv: (kv[1][4], kv[1][5]), reverse=True)[:per_anchor]
+        for tkey, (tname, sp, dz, it, occ, pop) in top:
             if tkey not in nodes:
-                enrich: Dict[str, Any] = {}
-                for eid in (sp, dz, it):
-                    if eid and eid in cache_lookup:
-                        enrich = cache_lookup[eid]
-                        break
                 nodes[tkey] = {
                     "key": tkey, "label": tname, "owned": False, "kind": "discovery",
-                    "popularity": enrich.get("popularity", pop),
-                    "image_url": enrich.get("image_url"), "genres": enrich.get("genres"),
-                    "ids": [e for e in (sp, dz, it) if e],   # external ids, for cache enrichment + add-to-watchlist
+                    "popularity": pop, "image_url": None, "genres": None,
+                    "ids": _id_pairs(sp, dz, it),
                 }
             ekey = (anchor_norm, tkey)
             if ekey not in edge_seen:
                 edge_seen.add(ekey)
-                edges.append({"source": anchor_norm, "target": tkey, "weight": _as_int(occ, 1)})
+                edges.append({"source": anchor_norm, "target": tkey, "weight": occ})
 
     return {"nodes": list(nodes.values()), "edges": edges}
 
@@ -291,21 +332,20 @@ def expand_discovery_node(
     node_key: str,
     node_ids: Optional[Iterable[Any]] = None,
     owned_meta: Optional[Dict[str, Dict[str, Any]]] = None,
-    cache_lookup: Optional[Dict[Any, Dict[str, Any]]] = None,
     per: int = 10,
     exclude: Optional[set] = None,
 ) -> Dict[str, List[dict]]:
     """One expand-on-click step for the Discovery map: the clicked node's similar artists.
 
     The clicked node is identified by ``node_key`` (normalized name) and/or ``node_ids`` (its external
-    ids) — a row matches when its source id resolves to that name or is one of those ids. Targets in
-    ``exclude`` (keys already on screen) are skipped, then the strongest ``per`` (by consensus, then
-    popularity) are returned. Unowned targets become ``discovery`` nodes (cache-enriched, like
-    :func:`build_discovery_map`); owned targets become ``owned`` nodes, so a trail can also reveal how
-    a candidate connects back into your library. Edges run ``node_key -> target``.
+    ids, flat) — a row matches when its source id resolves to that name or is one of those ids.
+    Targets in ``exclude`` (keys already on screen) are skipped; duplicate multi-source rows merge to
+    the target's strongest evidence (see :func:`_merge_target`); the strongest ``per`` are returned.
+    Unowned targets become ``discovery`` nodes (enrich via :func:`enrich_discovery_nodes`); owned
+    targets become ``owned`` nodes, so a trail can also reveal how a candidate connects back into your
+    library. Edges run ``node_key -> target``.
     """
     owned_meta = owned_meta or {}
-    cache_lookup = cache_lookup or {}
     exclude = exclude or set()
     ids_set = {i for i in (node_ids or []) if i}
     node_key = _norm(node_key)
@@ -317,23 +357,20 @@ def expand_discovery_node(
             if eid and eid not in id2name:
                 id2name[eid] = name
 
-    targets: List[Tuple[str, Any, Any, Any, int, int]] = []
-    seen_targets: set = set()
+    targets: Dict[str, list] = {}
     for src, name, sp, dz, it, occ, pop in rows:
         if src not in ids_set and _norm(id2name.get(src, "")) != node_key:
             continue                              # row isn't about the clicked node
         tkey = _norm(name)
-        if not tkey or tkey == node_key or tkey in exclude or tkey in seen_targets:
+        if not tkey or tkey == node_key or tkey in exclude:
             continue
-        seen_targets.add(tkey)
-        targets.append((name, sp, dz, it, _as_int(occ, 1), _as_int(pop)))
+        _merge_target(targets, name, sp, dz, it, occ, pop)
 
-    targets.sort(key=lambda t: (t[4], t[5]), reverse=True)
+    ranked = sorted(targets.items(), key=lambda kv: (kv[1][4], kv[1][5]), reverse=True)
 
     nodes: List[dict] = []
     edges: List[dict] = []
-    for (tname, sp, dz, it, occ, pop) in targets[:per]:
-        tkey = _norm(tname)
+    for tkey, (tname, sp, dz, it, occ, pop) in ranked[:per]:
         if tkey in owned_names:
             meta = owned_meta.get(tkey, {})
             nodes.append({
@@ -341,17 +378,11 @@ def expand_discovery_node(
                 "id": meta.get("id"), "thumb": meta.get("thumb_url"), "genres": meta.get("genres"),
             })
         else:
-            enrich: Dict[str, Any] = {}
-            for eid in (sp, dz, it):
-                if eid and eid in cache_lookup:
-                    enrich = cache_lookup[eid]
-                    break
             nodes.append({
                 "key": tkey, "label": tname, "owned": False, "kind": "discovery",
-                "popularity": enrich.get("popularity", pop),
-                "image_url": enrich.get("image_url"), "genres": enrich.get("genres"),
-                "ids": [e for e in (sp, dz, it) if e],
+                "popularity": pop, "image_url": None, "genres": None,
+                "ids": _id_pairs(sp, dz, it),
             })
-        edges.append({"source": node_key, "target": tkey, "weight": _as_int(occ, 1)})
+        edges.append({"source": node_key, "target": tkey, "weight": occ})
 
     return {"nodes": nodes, "edges": edges}

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -67,13 +67,16 @@ def build_taste_map(
 
     for src, name, _sp, _dz, _it, occ, pop in rows:
         tgt = _norm(name)
-        if tgt not in owned_names:
+        # Skip blank/whitespace names (bad scans put ""-named artists in owned_names, so the
+        # `in owned_names` test alone lets them through) — a ""-keyed node/edge produces a
+        # dangling edge that makes graphology reject the ENTIRE library graph on import.
+        if not tgt or tgt not in owned_names:
             continue
         src_name = id2name.get(src)
         if not src_name:
             continue
         src_norm = _norm(src_name)
-        if src_norm not in owned_names or src_norm == tgt:
+        if not src_norm or src_norm not in owned_names or src_norm == tgt:
             continue
         _touch(src_norm, src_name, None)      # source pop filled if it's a target elsewhere
         _touch(tgt, name, pop)
@@ -284,8 +287,8 @@ def build_discovery_map(
         if not src_name:
             continue
         src_norm = _norm(src_name)
-        if src_norm not in owned_names:
-            continue                              # anchor must be owned
+        if not src_norm or src_norm not in owned_names:
+            continue                              # anchor must be owned (and non-blank)
         tgt_norm = _norm(name)
         if not tgt_norm or tgt_norm in owned_names:
             continue                              # discovery = UNowned target only

--- a/core/graph/artist_graph.py
+++ b/core/graph/artist_graph.py
@@ -202,24 +202,28 @@ def build_genre_grouped_map(
     return {"nodes": nodes, "edges": edges}
 
 
-def _merge_target(bucket: Dict[str, list], name: str, sp: Any, dz: Any, it: Any, occ: Any, pop: Any) -> None:
+def _merge_target(bucket: Dict[str, list], name: str, sp: Any, dz: Any, it: Any, occ: Any, pop: Any,
+                  image_url: Any = None, genres: Any = None) -> None:
     """Fold one similar-artist row into a per-target bucket, keyed by normalized name.
 
     The same target often appears in several rows (the anchor was discovered against Spotify AND
     Deezer), so we merge: max occurrence/popularity (a target ranks by its STRONGEST evidence, not
-    whichever row happened first) and the union of external ids (more ids -> better cache enrichment).
-    Bucket value: [label, sp, dz, it, occ, pop].
+    whichever row happened first), the union of external ids, and the first non-empty image/genres
+    (similar_artists rows carry their own enrichment — ~99% have image_url + popularity).
+    Bucket value: [label, sp, dz, it, occ, pop, image_url, genres].
     """
     tkey = _norm(name)
     cur = bucket.get(tkey)
     if cur is None:
-        bucket[tkey] = [name, sp, dz, it, _as_int(occ, 1), _as_int(pop)]
+        bucket[tkey] = [name, sp, dz, it, _as_int(occ, 1), _as_int(pop), image_url or None, genres or None]
         return
     cur[1] = cur[1] or sp
     cur[2] = cur[2] or dz
     cur[3] = cur[3] or it
     cur[4] = max(cur[4], _as_int(occ, 1))
     cur[5] = max(cur[5], _as_int(pop))
+    cur[6] = cur[6] or image_url or None
+    cur[7] = cur[7] or genres or None
 
 
 def _id_pairs(sp: Any, dz: Any, it: Any) -> List[List[Any]]:
@@ -229,62 +233,53 @@ def _id_pairs(sp: Any, dz: Any, it: Any) -> List[List[Any]]:
     return [[s, e] for s, e in (("spotify", sp), ("deezer", dz), ("itunes", it)) if e]
 
 
-def enrich_discovery_nodes(
-    nodes: List[dict],
-    cache_lookup: Dict[Tuple[str, Any], Dict[str, Any]],
-) -> List[dict]:
-    """Fill discovery nodes' image/genres/popularity from cached metadata, in place.
+def _row7(row: Any) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
+    """The 7 core columns of a similar_artists row; rows may carry image_url/genres at [7]/[8]."""
+    return row[0], row[1], row[2], row[3], row[4], row[5], row[6]
 
-    ``cache_lookup`` is keyed by ``(source, external_id)`` — source-scoped, because Deezer and iTunes
-    ids share the numeric space and an unscoped lookup can return the wrong artist's metadata. The
-    first of the node's id pairs with a cache hit wins; row-level popularity is kept as fallback.
-    """
-    for n in nodes:
-        if n.get("kind") != "discovery":
-            continue
-        for src, eid in n.get("ids", []):
-            hit = cache_lookup.get((src, eid))
-            if hit:
-                n["image_url"] = hit.get("image_url")
-                n["genres"] = hit.get("genres")
-                if hit.get("popularity"):
-                    n["popularity"] = hit["popularity"]
-                break
-    return nodes
+
+def _row_enrich(row: Any) -> Tuple[Any, Any]:
+    """Optional row-level enrichment columns: (image_url, genres). Absent on 7-tuples."""
+    return (row[7] if len(row) > 7 else None), (row[8] if len(row) > 8 else None)
 
 
 def build_discovery_map(
     rows: Iterable[Row],
     owned_names: set,
     owned_meta: Optional[Dict[str, Dict[str, Any]]] = None,
-    seed_count: int = 30,
-    per_anchor: int = 6,
+    seed_count: Optional[int] = None,
+    per_anchor: Optional[int] = None,
 ) -> Dict[str, List[dict]]:
     """Discovery map: owned artists as anchors, their UNOWNED similar artists as discovery candidates.
 
     The inverse of :func:`build_taste_map`'s filter — instead of owned<->owned, we keep owned->UNowned
-    edges (new artists to find). Anchors are ranked by how many DISTINCT unowned neighbors they have;
-    the top ``seed_count`` seed the initial view, each showing its top ``per_anchor`` candidates (by
+    edges (new artists to find). By default the WHOLE frontier is returned (real-world size is modest:
+    only artists whose similars were fetched can anchor). ``seed_count`` optionally keeps just the top
+    anchors (ranked by distinct unowned neighbors) and ``per_anchor`` each anchor's top candidates (by
     max consensus, then popularity — duplicate multi-source rows are merged, see :func:`_merge_target`).
+
+    Rows may be 7-tuples or extended with ``image_url, genres`` at [7]/[8] — similar_artists rows
+    carry their own enrichment (~99% have image_url + real popularity), so no extra lookup is needed.
 
     Node kinds: ``owned`` (anchor: ``{key,label,owned,kind,id,thumb,genres}``) and ``discovery``
     (candidate: ``{key,label,owned,kind,popularity,image_url,genres,ids}`` where ``ids`` is a list of
-    ``[source, external_id]`` pairs). Edges are owned -> discovery. Enrichment is a separate step —
-    see :func:`enrich_discovery_nodes`.
+    ``[source, external_id]`` pairs).
     """
     owned_meta = owned_meta or {}
     rows = list(rows)
 
     # Same self-referential resolution as build_taste_map: source ext id -> name.
     id2name: Dict[str, str] = {}
-    for _src, name, sp, dz, it, _occ, _pop in rows:
+    for row in rows:
+        _src, name, sp, dz, it, _occ, _pop = _row7(row)
         for eid in (sp, dz, it):
             if eid and eid not in id2name:
                 id2name[eid] = name
 
     # Gather each OWNED anchor's UNOWNED similar targets, merged per target name.
     anchors: Dict[str, Dict[str, Any]] = {}
-    for src, name, sp, dz, it, occ, pop in rows:
+    for row in rows:
+        src, name, sp, dz, it, occ, pop = _row7(row)
         src_name = id2name.get(src)
         if not src_name:
             continue
@@ -295,9 +290,12 @@ def build_discovery_map(
         if not tgt_norm or tgt_norm in owned_names:
             continue                              # discovery = UNowned target only
         a = anchors.setdefault(src_norm, {"label": src_name, "targets": {}})
-        _merge_target(a["targets"], name, sp, dz, it, occ, pop)
+        img, gen = _row_enrich(row)
+        _merge_target(a["targets"], name, sp, dz, it, occ, pop, img, gen)
 
-    ranked = sorted(anchors.items(), key=lambda kv: len(kv[1]["targets"]), reverse=True)[:seed_count]
+    ranked = sorted(anchors.items(), key=lambda kv: len(kv[1]["targets"]), reverse=True)
+    if seed_count is not None:
+        ranked = ranked[:seed_count]
 
     nodes: Dict[str, dict] = {}
     edges: List[dict] = []
@@ -310,12 +308,14 @@ def build_discovery_map(
                 "key": anchor_norm, "label": info["label"], "owned": True, "kind": "owned",
                 "id": meta.get("id"), "thumb": meta.get("thumb_url"), "genres": meta.get("genres"),
             }
-        top = sorted(info["targets"].items(), key=lambda kv: (kv[1][4], kv[1][5]), reverse=True)[:per_anchor]
-        for tkey, (tname, sp, dz, it, occ, pop) in top:
+        top = sorted(info["targets"].items(), key=lambda kv: (kv[1][4], kv[1][5]), reverse=True)
+        if per_anchor is not None:
+            top = top[:per_anchor]
+        for tkey, (tname, sp, dz, it, occ, pop, img, gen) in top:
             if tkey not in nodes:
                 nodes[tkey] = {
                     "key": tkey, "label": tname, "owned": False, "kind": "discovery",
-                    "popularity": pop, "image_url": None, "genres": None,
+                    "popularity": pop, "image_url": img, "genres": gen,
                     "ids": _id_pairs(sp, dz, it),
                 }
             ekey = (anchor_norm, tkey)
@@ -341,8 +341,8 @@ def expand_discovery_node(
     ids, flat) — a row matches when its source id resolves to that name or is one of those ids.
     Targets in ``exclude`` (keys already on screen) are skipped; duplicate multi-source rows merge to
     the target's strongest evidence (see :func:`_merge_target`); the strongest ``per`` are returned.
-    Unowned targets become ``discovery`` nodes (enrich via :func:`enrich_discovery_nodes`); owned
-    targets become ``owned`` nodes, so a trail can also reveal how a candidate connects back into your
+    Unowned targets become ``discovery`` nodes (image/genres from the rows themselves); owned targets
+    become ``owned`` nodes, so a trail can also reveal how a candidate connects back into your
     library. Edges run ``node_key -> target``.
     """
     owned_meta = owned_meta or {}
@@ -352,25 +352,28 @@ def expand_discovery_node(
     rows = list(rows)
 
     id2name: Dict[str, str] = {}
-    for _src, name, sp, dz, it, _occ, _pop in rows:
+    for row in rows:
+        _src, name, sp, dz, it, _occ, _pop = _row7(row)
         for eid in (sp, dz, it):
             if eid and eid not in id2name:
                 id2name[eid] = name
 
     targets: Dict[str, list] = {}
-    for src, name, sp, dz, it, occ, pop in rows:
+    for row in rows:
+        src, name, sp, dz, it, occ, pop = _row7(row)
         if src not in ids_set and _norm(id2name.get(src, "")) != node_key:
             continue                              # row isn't about the clicked node
         tkey = _norm(name)
         if not tkey or tkey == node_key or tkey in exclude:
             continue
-        _merge_target(targets, name, sp, dz, it, occ, pop)
+        img, gen = _row_enrich(row)
+        _merge_target(targets, name, sp, dz, it, occ, pop, img, gen)
 
     ranked = sorted(targets.items(), key=lambda kv: (kv[1][4], kv[1][5]), reverse=True)
 
     nodes: List[dict] = []
     edges: List[dict] = []
-    for tkey, (tname, sp, dz, it, occ, pop) in ranked[:per]:
+    for tkey, (tname, sp, dz, it, occ, pop, img, gen) in ranked[:per]:
         if tkey in owned_names:
             meta = owned_meta.get(tkey, {})
             nodes.append({
@@ -380,7 +383,7 @@ def expand_discovery_node(
         else:
             nodes.append({
                 "key": tkey, "label": tname, "owned": False, "kind": "discovery",
-                "popularity": pop, "image_url": None, "genres": None,
+                "popularity": pop, "image_url": img, "genres": gen,
                 "ids": _id_pairs(sp, dz, it),
             })
         edges.append({"source": node_key, "target": tkey, "weight": occ})

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -1,0 +1,38 @@
+"""Unit tests for the pure artist-similarity graph builder (Taste Map)."""
+from core.graph.artist_graph import build_taste_map
+# Row: (source_id, similar_name, spotify_id, deezer_id, itunes_id, occurrence_count, popularity)
+
+
+def test_basic_owned_edge_collapses_and_sums():
+    rows = [
+        ("aid", "B", "bid", None, None, 3, 80),   # A -> B (B's ext id = bid, pop 80)
+        ("bid", "A", "aid", None, None, 2, 60),   # B -> A (A's ext id = aid, pop 60)
+    ]
+    g = build_taste_map(rows, {"a", "b"})
+    assert {n["key"] for n in g["nodes"]} == {"a", "b"}
+    assert len(g["edges"]) == 1 and g["edges"][0]["weight"] == 5   # undirected, 3+2
+    pops = {n["key"]: n["popularity"] for n in g["nodes"]}
+    assert pops["b"] == 80 and pops["a"] == 60
+
+
+def test_unowned_target_skipped():
+    rows = [("aid", "Zztop", "zid", None, None, 1, 50), ("zid", "A", "aid", None, None, 1, 40)]
+    g = build_taste_map(rows, {"a"})
+    assert g["nodes"] == [] and g["edges"] == []
+
+
+def test_unresolvable_source_skipped():
+    g = build_taste_map([("unknownid", "A", "aid", None, None, 1, 40)], {"a"})
+    assert g["edges"] == []
+
+
+def test_self_loop_skipped():
+    g = build_taste_map([("aid", "A", "aid", None, None, 1, 40)], {"a"})
+    assert g["edges"] == []
+
+
+def test_meta_enrichment():
+    rows = [("aid", "B", "bid", None, None, 1, 80), ("bid", "A", "aid", None, None, 1, 60)]
+    g = build_taste_map(rows, {"a", "b"}, artist_meta={"a": {"thumb_url": "u", "genres": ["rock"]}})
+    a = next(n for n in g["nodes"] if n["key"] == "a")
+    assert a["thumb"] == "u" and a["genres"] == ["rock"]

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -74,6 +74,15 @@ def test_grouped_artist_without_genre_has_no_hub_edge():
     assert [e for e in g["edges"] if e["kind"] == "membership"] == []
 
 
+def test_grouped_carries_id_and_source_when_provided():
+    artists = [("A", '["Rock"]', "http://t", 42, "spotify"), ("B", '["Rock"]', None)]  # 5-tuple + 3-tuple
+    g = build_genre_grouped_map(artists, [], {"a", "b"})
+    a = next(n for n in g["nodes"] if n["key"] == "a")
+    b = next(n for n in g["nodes"] if n["key"] == "b")
+    assert a["id"] == 42 and a["source"] == "spotify" and a["thumb"] == "http://t"
+    assert b["id"] is None and b["source"] is None       # 3-tuple still works (back-compat)
+
+
 def test_grouped_shares_genre_hub_and_dedups_artists():
     artists = [("A", '["Rock"]', None), ("B", '["Rock"]', None), ("A", '["Rock"]', None)]  # dup A
     g = build_genre_grouped_map(artists, [], {"a", "b"})

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -1,5 +1,5 @@
 """Unit tests for the pure artist-similarity graph builder (Taste Map)."""
-from core.graph.artist_graph import build_taste_map
+from core.graph.artist_graph import build_taste_map, build_genre_grouped_map
 # Row: (source_id, similar_name, spotify_id, deezer_id, itunes_id, occurrence_count, popularity)
 
 
@@ -36,3 +36,48 @@ def test_meta_enrichment():
     g = build_taste_map(rows, {"a", "b"}, artist_meta={"a": {"thumb_url": "u", "genres": ["rock"]}})
     a = next(n for n in g["nodes"] if n["key"] == "a")
     assert a["thumb"] == "u" and a["genres"] == ["rock"]
+
+
+# ---- genre-grouped map: EVERY artist included, wired to a per-genre hub -----------------------
+
+def _nodes_by_kind(g):
+    return ([n for n in g["nodes"] if n["kind"] == "artist"],
+            [n for n in g["nodes"] if n["kind"] == "genre"])
+
+
+def test_grouped_includes_isolated_artists():
+    """The bug this fixes: an artist with no owned<->owned edge must STILL appear (via its genre)."""
+    artists = [("A", '["Rock"]', None), ("B", '["Rock"]', None), ("Lonely", '["Jazz"]', None)]
+    rows = [("aid", "B", "bid", None, None, 1, 80), ("bid", "A", "aid", None, None, 1, 60)]
+    g = build_genre_grouped_map(artists, rows, {"a", "b", "lonely"})
+    art, gen = _nodes_by_kind(g)
+    assert {n["key"] for n in art} == {"a", "b", "lonely"}          # Lonely is NOT dropped
+    assert {n["genre"] for n in gen} == {"Rock", "Jazz"}
+    # Lonely has no similarity edge but IS attached to its genre hub.
+    membership = [e for e in g["edges"] if e["kind"] == "membership"]
+    assert {"source": "lonely", "target": "genre::jazz", "weight": 1, "kind": "membership"} in membership
+
+
+def test_grouped_reuses_similarity_edges():
+    artists = [("A", '["Rock"]', None), ("B", '["Rock"]', None)]
+    rows = [("aid", "B", "bid", None, None, 3, 80), ("bid", "A", "aid", None, None, 2, 60)]
+    g = build_genre_grouped_map(artists, rows, {"a", "b"})
+    sim = [e for e in g["edges"] if e["kind"] == "similarity"]
+    assert len(sim) == 1 and sim[0]["weight"] == 5                  # same collapse+sum as build_taste_map
+
+
+def test_grouped_artist_without_genre_has_no_hub_edge():
+    artists = [("A", None, None), ("B", "[]", None), ("C", "not-json", None)]
+    g = build_genre_grouped_map(artists, [], {"a", "b", "c"})
+    art, gen = _nodes_by_kind(g)
+    assert {n["key"] for n in art} == {"a", "b", "c"} and gen == []
+    assert [e for e in g["edges"] if e["kind"] == "membership"] == []
+
+
+def test_grouped_shares_genre_hub_and_dedups_artists():
+    artists = [("A", '["Rock"]', None), ("B", '["Rock"]', None), ("A", '["Rock"]', None)]  # dup A
+    g = build_genre_grouped_map(artists, [], {"a", "b"})
+    art, gen = _nodes_by_kind(g)
+    assert len(art) == 2                                            # dup A collapsed
+    assert len(gen) == 1 and gen[0]["genre"] == "Rock"             # one shared hub
+    assert len([e for e in g["edges"] if e["kind"] == "membership"]) == 2

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -83,6 +83,26 @@ def test_grouped_carries_id_and_source_when_provided():
     assert b["id"] is None and b["source"] is None       # 3-tuple still works (back-compat)
 
 
+def test_grouped_consolidates_to_top_hubs_and_reroutes_via_secondary():
+    # Rock x3, Pop x2 are the top-2; Jazz/Blues are long-tail. max_hubs=2.
+    artists = [
+        ("A", '["Rock"]', None), ("B", '["Rock"]', None), ("C", '["Rock"]', None),
+        ("D", '["Pop"]', None), ("E", '["Pop"]', None),
+        ("F", '["Lofi", "Rock"]', None),   # primary Lofi (tail) -> reroute to Rock (anchor)
+        ("G", '["Jazz"]', None),           # no anchor in list -> Other
+    ]
+    g = build_genre_grouped_map(artists, [], {"a", "b", "c", "d", "e", "f", "gg", "g"}, max_hubs=2)
+    hubs = {n["genre"] for n in g["nodes"] if n["kind"] == "genre"}
+    assert hubs == {"Rock", "Pop", "Other"}                 # only top-2 anchors + Other
+    clusters = {n["key"]: n["cluster"] for n in g["nodes"] if n["kind"] == "artist"}
+    assert clusters["f"] == "Rock"                          # rerouted via its secondary genre
+    assert clusters["g"] == "Other"                         # long-tail-only -> Other
+    assert clusters["a"] == "Rock" and clusters["d"] == "Pop"
+    # F's true primary is preserved even though it clustered under Rock.
+    f = next(n for n in g["nodes"] if n["key"] == "f")
+    assert f["primary_genre"] == "Lofi"
+
+
 def test_grouped_shares_genre_hub_and_dedups_artists():
     artists = [("A", '["Rock"]', None), ("B", '["Rock"]', None), ("A", '["Rock"]', None)]  # dup A
     g = build_genre_grouped_map(artists, [], {"a", "b"})

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -233,3 +233,22 @@ def test_expand_ranks_duplicate_target_by_strongest_row():
     g = expand_discovery_node(rows, {"a"}, "A", per=1)
     assert [n["label"] for n in g["nodes"]] == ["Foo"]   # occ 5 beats Bar's 2 (old code: occ 1 lost)
     assert g["edges"][0]["weight"] == 5
+
+
+def test_blank_named_artist_never_becomes_a_node_or_dangling_edge():
+    # A blank/whitespace-named owned artist (bad scan) must NOT produce a ""-keyed node or an
+    # edge with a "" endpoint — graphology rejects the whole graph on import if an edge references
+    # a missing node, so one dangling edge blanks the entire Artist Web (Pass 5 review).
+    rows = [
+        ("spB", "A", "spA", None, None, 5, 40),        # B -> A (both owned): a real edge
+        ("spA", "B", "spB", None, None, 5, 30),        # A -> B: collapses/sums with the above
+        ("spA", "   ", "spBlank", None, None, 9, 40),  # A -> blank-named owned target: MUST drop
+    ]
+    g = build_taste_map(rows, {"a", "b", ""})
+    keys = {n["key"] for n in g["nodes"]}
+    assert keys == {"a", "b"}                          # blank never becomes a node
+    endpoints = set()
+    for e in g["edges"]:
+        endpoints.add(e["source"]); endpoints.add(e["target"])
+    assert "" not in endpoints                         # no dangling edge endpoint
+    assert endpoints <= keys                           # every edge endpoint resolves to a node

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -1,5 +1,5 @@
 """Unit tests for the pure artist-similarity graph builder (Taste Map)."""
-from core.graph.artist_graph import build_taste_map, build_genre_grouped_map
+from core.graph.artist_graph import build_taste_map, build_genre_grouped_map, build_discovery_map
 # Row: (source_id, similar_name, spotify_id, deezer_id, itunes_id, occurrence_count, popularity)
 
 
@@ -110,3 +110,49 @@ def test_grouped_shares_genre_hub_and_dedups_artists():
     assert len(art) == 2                                            # dup A collapsed
     assert len(gen) == 1 and gen[0]["genre"] == "Rock"             # one shared hub
     assert len([e for e in g["edges"] if e["kind"] == "membership"]) == 2
+
+
+# ---- discovery map: owned anchors -> UNOWNED similar candidates -------------------------------
+
+def test_discovery_keeps_owned_to_unowned_only():
+    rows = [
+        ("aid", "X", "xid", None, None, 5, 70),   # A -> X (unowned)
+        ("aid", "Y", "yid", None, None, 3, 60),   # A -> Y (unowned)
+        ("aid", "B", "bid", None, None, 2, 50),   # A -> B (OWNED → excluded from discovery)
+        ("bid", "A", "aid", None, None, 1, 40),   # gives 'aid' the name A
+    ]
+    g = build_discovery_map(rows, {"a", "b"})
+    kinds = {n["key"]: n["kind"] for n in g["nodes"]}
+    assert kinds["a"] == "owned"
+    assert kinds["x"] == "discovery" and kinds["y"] == "discovery"
+    assert "b" not in kinds                       # owned target is not a discovery node
+    e = {(x["source"], x["target"]) for x in g["edges"]}
+    assert ("a", "x") in e and ("a", "y") in e and ("a", "b") not in e
+
+
+def test_discovery_enriches_from_cache():
+    rows = [("aid", "X", "xid", None, None, 5, 70), ("bid", "A", "aid", None, None, 1, 40)]
+    cache = {"xid": {"image_url": "http://img", "genres": ["Pop"], "popularity": 88}}
+    g = build_discovery_map(rows, {"a"}, cache_lookup=cache)
+    x = next(n for n in g["nodes"] if n["key"] == "x")
+    assert x["image_url"] == "http://img" and x["genres"] == ["Pop"] and x["popularity"] == 88
+
+
+def test_discovery_per_anchor_limit_keeps_strongest():
+    rows = [("aid", f"T{i}", f"t{i}", None, None, i + 1, 0) for i in range(10)]  # occ 1..10
+    rows.append(("t0", "A", "aid", None, None, 1, 0))                            # 'aid' → A
+    g = build_discovery_map(rows, {"a"}, per_anchor=3)
+    disc = sorted(n["label"] for n in g["nodes"] if n["kind"] == "discovery")
+    assert disc == ["T7", "T8", "T9"]             # top 3 by occurrence_count
+
+
+def test_discovery_seed_count_ranks_by_neighbor_count():
+    rows = [
+        ("aid", "X", "xid", None, None, 1, 0), ("aid", "Y", "yid", None, None, 1, 0),
+        ("aid", "Z", "zid", None, None, 1, 0), ("bid", "W", "wid", None, None, 1, 0),
+        ("xid", "A", "aid", None, None, 1, 0),    # 'aid' → A
+        ("wid", "B", "bid", None, None, 1, 0),    # 'bid' → B
+    ]
+    g = build_discovery_map(rows, {"a", "b"}, seed_count=1)
+    anchors = [n["key"] for n in g["nodes"] if n["kind"] == "owned"]
+    assert anchors == ["a"]                       # A (3 neighbors) outranks B (1); only 1 seeded

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -156,3 +156,42 @@ def test_discovery_seed_count_ranks_by_neighbor_count():
     g = build_discovery_map(rows, {"a", "b"}, seed_count=1)
     anchors = [n["key"] for n in g["nodes"] if n["kind"] == "owned"]
     assert anchors == ["a"]                       # A (3 neighbors) outranks B (1); only 1 seeded
+
+
+# ---- expand-on-click: one node's similar artists, minus what's already on screen ---------------
+
+def test_expand_matches_by_name_and_by_id():
+    from core.graph.artist_graph import expand_discovery_node
+    rows = [
+        ("aid", "X", "xid", None, None, 5, 0),    # source resolves to A (by name)
+        ("cid", "Y", "yid", None, None, 3, 0),    # source is cid — matches via node_ids
+        ("bid", "A", "aid", None, None, 1, 0),    # teaches id2name: aid -> A
+        ("bid", "Z", "zid", None, None, 9, 0),    # unrelated source -> excluded
+    ]
+    g = expand_discovery_node(rows, {"a"}, "A", node_ids=["cid"])
+    keys = {n["key"] for n in g["nodes"]}
+    assert keys == {"x", "y"}                     # Z's source matches neither name nor ids
+    assert all(e["source"] == "a" for e in g["edges"])
+
+
+def test_expand_skips_excluded_and_limits_by_strength():
+    from core.graph.artist_graph import expand_discovery_node
+    rows = [("aid", f"T{i}", f"t{i}", None, None, i, 0) for i in range(1, 6)]  # occ 1..5
+    rows.append(("bid", "A", "aid", None, None, 1, 0))
+    g = expand_discovery_node(rows, {"a"}, "A", per=2, exclude={"t5"})
+    labels = sorted(n["label"] for n in g["nodes"])
+    assert labels == ["T3", "T4"]                 # T5 excluded (on screen), then top-2 by occ
+
+
+def test_expand_owned_target_comes_back_as_owned_node():
+    from core.graph.artist_graph import expand_discovery_node
+    rows = [
+        ("aid", "B", "bid", None, None, 4, 0),    # B is OWNED -> comes back kind=owned
+        ("aid", "X", "xid", None, None, 2, 0),    # X unowned -> discovery
+        ("bid", "A", "aid", None, None, 1, 0),
+    ]
+    g = expand_discovery_node(rows, {"a", "b"}, "A", owned_meta={"b": {"id": 7, "thumb_url": "t"}})
+    kinds = {n["key"]: n["kind"] for n in g["nodes"]}
+    assert kinds == {"b": "owned", "x": "discovery"}
+    b = next(n for n in g["nodes"] if n["key"] == "b")
+    assert b["id"] == 7 and b["thumb"] == "t"

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -130,12 +130,39 @@ def test_discovery_keeps_owned_to_unowned_only():
     assert ("a", "x") in e and ("a", "y") in e and ("a", "b") not in e
 
 
-def test_discovery_enriches_from_cache():
-    rows = [("aid", "X", "xid", None, None, 5, 70), ("bid", "A", "aid", None, None, 1, 40)]
-    cache = {"xid": {"image_url": "http://img", "genres": ["Pop"], "popularity": 88}}
-    g = build_discovery_map(rows, {"a"}, cache_lookup=cache)
+def test_discovery_enriches_from_cache_source_scoped():
+    from core.graph.artist_graph import enrich_discovery_nodes
+    rows = [
+        ("aid", "X", None, "12345", None, 5, 70),   # X has Deezer id 12345
+        ("bid", "A", "aid", None, None, 1, 40),
+    ]
+    g = build_discovery_map(rows, {"a"})
     x = next(n for n in g["nodes"] if n["key"] == "x")
+    assert x["ids"] == [["deezer", "12345"]]        # ids carry their source
+    # The cache has an iTunes artist with the SAME numeric id — it must NOT win (source-scoped keys).
+    cache = {
+        ("itunes", "12345"): {"image_url": "http://WRONG", "genres": ["Wrong"], "popularity": 1},
+        ("deezer", "12345"): {"image_url": "http://img", "genres": ["Pop"], "popularity": 88},
+    }
+    enrich_discovery_nodes(g["nodes"], cache)
     assert x["image_url"] == "http://img" and x["genres"] == ["Pop"] and x["popularity"] == 88
+
+
+def test_discovery_merges_duplicate_multisource_rows():
+    """Reviewer finding: an anchor discovered against Spotify AND Deezer repeats each target; dupes
+    must merge (max occ/pop, ids unioned) instead of eating per_anchor slots and inflating rank."""
+    rows = [
+        ("aid_sp", "X", "x_sp", None, None, 1, 10),   # X via the Spotify run (weak row)
+        ("aid_dz", "X", None, "x_dz", None, 5, 70),   # X again via the Deezer run (strong row)
+        ("aid_sp", "Y", "y_sp", None, None, 2, 20),
+        ("bid", "A", "aid_sp", "aid_dz", None, 1, 40),  # both source ids resolve to A
+    ]
+    g = build_discovery_map(rows, {"a"}, per_anchor=2)
+    disc = {n["key"]: n for n in g["nodes"] if n["kind"] == "discovery"}
+    assert set(disc) == {"x", "y"}                  # X once, not twice — Y still gets its slot
+    assert disc["x"]["ids"] == [["spotify", "x_sp"], ["deezer", "x_dz"]]   # ids unioned
+    xedge = next(e for e in g["edges"] if e["target"] == "x")
+    assert xedge["weight"] == 5                     # strongest evidence wins, not first-seen
 
 
 def test_discovery_per_anchor_limit_keeps_strongest():
@@ -195,3 +222,17 @@ def test_expand_owned_target_comes_back_as_owned_node():
     assert kinds == {"b": "owned", "x": "discovery"}
     b = next(n for n in g["nodes"] if n["key"] == "b")
     assert b["id"] == 7 and b["thumb"] == "t"
+
+
+def test_expand_ranks_duplicate_target_by_strongest_row():
+    """Reviewer finding: first-seen dedupe let a strong target rank by its weakest row."""
+    from core.graph.artist_graph import expand_discovery_node
+    rows = [
+        ("aid", "Foo", None, "f_dz", None, 1, 0),   # Foo's weak Deezer row comes FIRST
+        ("aid", "Foo", "f_sp", None, None, 5, 0),   # Foo's strong Spotify row
+        ("aid", "Bar", "b_sp", None, None, 2, 0),
+        ("bid", "A", "aid", None, None, 1, 0),
+    ]
+    g = expand_discovery_node(rows, {"a"}, "A", per=1)
+    assert [n["label"] for n in g["nodes"]] == ["Foo"]   # occ 5 beats Bar's 2 (old code: occ 1 lost)
+    assert g["edges"][0]["weight"] == 5

--- a/tests/test_artist_graph.py
+++ b/tests/test_artist_graph.py
@@ -130,22 +130,19 @@ def test_discovery_keeps_owned_to_unowned_only():
     assert ("a", "x") in e and ("a", "y") in e and ("a", "b") not in e
 
 
-def test_discovery_enriches_from_cache_source_scoped():
-    from core.graph.artist_graph import enrich_discovery_nodes
+def test_discovery_enriches_from_row_columns():
+    """similar_artists rows carry their own image_url/genres (cols [7]/[8]); 7-tuples still work."""
     rows = [
-        ("aid", "X", None, "12345", None, 5, 70),   # X has Deezer id 12345
+        ("aid", "X", None, "12345", None, 5, 88, "http://img", '["Pop"]'),  # extended 9-tuple
+        ("aid", "Y", "yid", None, None, 2, 40),                             # plain 7-tuple
         ("bid", "A", "aid", None, None, 1, 40),
     ]
     g = build_discovery_map(rows, {"a"})
     x = next(n for n in g["nodes"] if n["key"] == "x")
+    y = next(n for n in g["nodes"] if n["key"] == "y")
     assert x["ids"] == [["deezer", "12345"]]        # ids carry their source
-    # The cache has an iTunes artist with the SAME numeric id — it must NOT win (source-scoped keys).
-    cache = {
-        ("itunes", "12345"): {"image_url": "http://WRONG", "genres": ["Wrong"], "popularity": 1},
-        ("deezer", "12345"): {"image_url": "http://img", "genres": ["Pop"], "popularity": 88},
-    }
-    enrich_discovery_nodes(g["nodes"], cache)
-    assert x["image_url"] == "http://img" and x["genres"] == ["Pop"] and x["popularity"] == 88
+    assert x["image_url"] == "http://img" and x["genres"] == '["Pop"]' and x["popularity"] == 88
+    assert y["image_url"] is None and y["genres"] is None and y["popularity"] == 40
 
 
 def test_discovery_merges_duplicate_multisource_rows():

--- a/web_server.py
+++ b/web_server.py
@@ -9874,6 +9874,39 @@ def set_album_art(album_id):
         return jsonify({"error": str(e)}), 500
 
 
+@app.route('/api/graph/library', methods=['GET'])
+def get_library_graph():
+    """Library "Taste Map": owned artists as nodes, wired by direct similarity — for the sigma.js graph.
+
+    Returns {"nodes": [{key,label,owned,popularity,thumb,genres}], "edges": [{source,target,weight}]}.
+    Built in-memory from similar_artists (a SQL self-join to resolve source IDs is too slow at 75k rows).
+    """
+    try:
+        from core.graph.artist_graph import build_taste_map
+        db = get_database()
+        conn = db._get_connection()
+        try:
+            cur = conn.cursor()
+            owned = set()
+            meta = {}
+            for name, thumb, genres in cur.execute("SELECT name, thumb_url, genres FROM artists"):
+                key = (name or "").strip().lower()
+                owned.add(key)
+                meta[key] = {"thumb_url": thumb, "genres": genres}
+            rows = cur.execute(
+                "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
+                "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
+                "FROM similar_artists"
+            ).fetchall()
+        finally:
+            conn.close()
+        graph = build_taste_map(rows, owned, artist_meta=meta)
+        return jsonify({**graph, "counts": {"nodes": len(graph["nodes"]), "edges": len(graph["edges"])}})
+    except Exception as e:
+        logger.error("[library-graph] failed: %s", e, exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route('/api/library/export/m3u', methods=['GET'])
 def export_library_m3u():
     """Download an extended-M3U playlist of the entire library. Always current (built on request)."""

--- a/web_server.py
+++ b/web_server.py
@@ -9892,11 +9892,13 @@ def get_library_graph():
             owned = set()
             meta = {}
             artists = []
-            for name, thumb, genres in cur.execute("SELECT name, thumb_url, genres FROM artists"):
+            for name, thumb, genres, aid, source in cur.execute(
+                "SELECT name, thumb_url, genres, id, server_source FROM artists"
+            ):
                 key = (name or "").strip().lower()
                 owned.add(key)
                 meta[key] = {"thumb_url": thumb, "genres": genres}
-                artists.append((name, genres, thumb))
+                artists.append((name, genres, thumb, aid, source))
             rows = cur.execute(
                 "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
                 "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "

--- a/web_server.py
+++ b/web_server.py
@@ -9876,23 +9876,27 @@ def set_album_art(album_id):
 
 @app.route('/api/graph/library', methods=['GET'])
 def get_library_graph():
-    """Library "Taste Map": owned artists as nodes, wired by direct similarity — for the sigma.js graph.
+    """Library "Taste Map": EVERY library artist as a node, grouped by genre + wired by similarity.
 
-    Returns {"nodes": [{key,label,owned,popularity,thumb,genres}], "edges": [{source,target,weight}]}.
-    Built in-memory from similar_artists (a SQL self-join to resolve source IDs is too slow at 75k rows).
+    Returns {"nodes": [{key,label,kind,owned,primary_genre,popularity,thumb} | {key,label,kind,genre}],
+    "edges": [{source,target,weight,kind}]}. Every artist is included (attached to a per-genre hub node
+    so a force layout clusters them); similarity edges come from similar_artists (resolved in-memory —
+    a SQL self-join is too slow at 75k rows).
     """
     try:
-        from core.graph.artist_graph import build_taste_map
+        from core.graph.artist_graph import build_genre_grouped_map
         db = get_database()
         conn = db._get_connection()
         try:
             cur = conn.cursor()
             owned = set()
             meta = {}
+            artists = []
             for name, thumb, genres in cur.execute("SELECT name, thumb_url, genres FROM artists"):
                 key = (name or "").strip().lower()
                 owned.add(key)
                 meta[key] = {"thumb_url": thumb, "genres": genres}
+                artists.append((name, genres, thumb))
             rows = cur.execute(
                 "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
                 "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
@@ -9900,8 +9904,13 @@ def get_library_graph():
             ).fetchall()
         finally:
             conn.close()
-        graph = build_taste_map(rows, owned, artist_meta=meta)
-        return jsonify({**graph, "counts": {"nodes": len(graph["nodes"]), "edges": len(graph["edges"])}})
+        graph = build_genre_grouped_map(artists, rows, owned, artist_meta=meta)
+        n_artists = sum(1 for n in graph["nodes"] if n.get("kind") == "artist")
+        n_genres = sum(1 for n in graph["nodes"] if n.get("kind") == "genre")
+        return jsonify({**graph, "counts": {
+            "nodes": len(graph["nodes"]), "edges": len(graph["edges"]),
+            "artists": n_artists, "genres": n_genres,
+        }})
     except Exception as e:
         logger.error("[library-graph] failed: %s", e, exc_info=True)
         return jsonify({"error": str(e)}), 500

--- a/web_server.py
+++ b/web_server.py
@@ -10023,6 +10023,34 @@ def expand_discovery_graph():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route('/api/library/artist/<int:artist_id>/thumb', methods=['GET'])
+def get_library_artist_thumb(artist_id):
+    """Browser-loadable thumb URL for ONE library artist, by library DB id.
+
+    Used by the Artist Web side panel. Two deliberate choices:
+    - Lazily per-click, not eagerly for every node: normalize_image_url registers the URL in the
+      image cache (a DB write transaction each) — doing that for ~5k artists per graph load takes
+      minutes; one artist per panel open is instant.
+    - By LIBRARY id against the artists table — the generic /api/artist/<id>/image resolver sends
+      whatever id it gets to external providers, so a library row id returned whichever Deezer/iTunes
+      artist happened to own that number (wrong photo, essentially always).
+    """
+    try:
+        db = get_database()
+        conn = db._get_connection()
+        try:
+            cur = conn.cursor()
+            row = cur.execute("SELECT thumb_url FROM artists WHERE id = ?", (artist_id,)).fetchone()
+        finally:
+            conn.close()
+        thumb = row['thumb_url'] if row else None
+        url = fix_artist_image_url(thumb) if thumb else None
+        return jsonify({"success": True, "image_url": url})
+    except Exception as e:
+        logger.error("[artist-thumb] failed: %s", e, exc_info=True)
+        return jsonify({"success": False, "image_url": None}), 500
+
+
 @app.route('/api/library/export/m3u', methods=['GET'])
 def export_library_m3u():
     """Download an extended-M3U playlist of the entire library. Always current (built on request)."""

--- a/web_server.py
+++ b/web_server.py
@@ -9829,7 +9829,6 @@ def _derive_album_folder(db, album_id):
 def _overwrite_cover_jpg(url, folder):
     """Download ``url`` and OVERWRITE cover.jpg in ``folder`` (the picker is *replacing* art, so the
     existing-file guard in download_cover_art doesn't apply). Returns True on success."""
-    import urllib.request
     req = urllib.request.Request(url, headers={"User-Agent": "SoulSync/1.0", "Accept": "image/*"})
     with urllib.request.urlopen(req, timeout=15) as resp:   # noqa: S310 (user-chosen art URL)
         data = resp.read()

--- a/web_server.py
+++ b/web_server.py
@@ -9986,6 +9986,57 @@ def _discovery_cache_lookup(cur, ids):
     return lookup
 
 
+@app.route('/api/graph/discovery/expand', methods=['POST'])
+def expand_discovery_graph():
+    """Expand-on-click for the Discovery Web: one node's similar artists, minus what's on screen.
+
+    POST JSON: ``key`` (normalized artist name), ``ids`` (external ids — for unowned candidates whose
+    similars are keyed by id), ``exclude`` (node keys already in the graph — JSON body because artist
+    names can contain commas), ``per`` (max new nodes). Same node/edge shape as /api/graph/discovery.
+    """
+    try:
+        from core.graph.artist_graph import expand_discovery_node
+        payload = request.get_json(silent=True) or {}
+        node_key = str(payload.get('key') or '').strip().lower()
+        if not node_key:
+            return jsonify({"error": "missing key"}), 400
+        node_ids = [i for i in (payload.get('ids') or []) if i]
+        exclude = {k for k in (payload.get('exclude') or []) if k}
+        try:
+            per = int(payload.get('per') or 10)
+        except (TypeError, ValueError):
+            per = 10
+        per = max(1, min(per, 30))
+        db = get_database()
+        conn = db._get_connection()
+        try:
+            cur = conn.cursor()
+            owned = set()
+            owned_meta = {}
+            for name, thumb, genres, aid in cur.execute("SELECT name, thumb_url, genres, id FROM artists"):
+                key = (name or "").strip().lower()
+                owned.add(key)
+                owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
+            rows = cur.execute(
+                "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
+                "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
+                "FROM similar_artists"
+            ).fetchall()
+
+            base = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta, per=per, exclude=exclude)
+            need_ids = {eid for n in base["nodes"] if n.get("kind") == "discovery" for eid in n.get("ids", [])}
+            cache_lookup = _discovery_cache_lookup(cur, need_ids)
+        finally:
+            conn.close()
+
+        graph = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta,
+                                      cache_lookup=cache_lookup, per=per, exclude=exclude)
+        return jsonify({**graph, "counts": {"nodes": len(graph["nodes"]), "edges": len(graph["edges"])}})
+    except Exception as e:
+        logger.error("[discovery-expand] failed: %s", e, exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
 @app.route('/api/library/export/m3u', methods=['GET'])
 def export_library_m3u():
     """Download an extended-M3U playlist of the entire library. Always current (built on request)."""

--- a/web_server.py
+++ b/web_server.py
@@ -9902,7 +9902,7 @@ def get_library_graph():
             rows = cur.execute(
                 "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
                 "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
-                "FROM similar_artists"
+                "FROM similar_artists WHERE profile_id = ?", (get_current_profile_id(),)
             ).fetchall()
         finally:
             conn.close()
@@ -9927,34 +9927,19 @@ def get_discovery_graph():
     count), each with its top ``per`` unowned candidates. The frontend expands from here on click.
     """
     try:
-        from core.graph.artist_graph import build_discovery_map
+        from core.graph.artist_graph import build_discovery_map, enrich_discovery_nodes
         seed = max(1, min(int(request.args.get('seed', 30)), 120))
         per = max(1, min(int(request.args.get('per', 6)), 20))
         db = get_database()
         conn = db._get_connection()
         try:
             cur = conn.cursor()
-            owned = set()
-            owned_meta = {}
-            for name, thumb, genres, aid in cur.execute("SELECT name, thumb_url, genres, id FROM artists"):
-                key = (name or "").strip().lower()
-                owned.add(key)
-                owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
-            rows = cur.execute(
-                "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
-                "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
-                "FROM similar_artists"
-            ).fetchall()
-
-            # Pass 1: shape the graph (no enrichment) to learn which candidate ids we actually need.
-            base = build_discovery_map(rows, owned, owned_meta, seed_count=seed, per_anchor=per)
-            need_ids = {eid for n in base["nodes"] if n.get("kind") == "discovery" for eid in n.get("ids", [])}
-            cache_lookup = _discovery_cache_lookup(cur, need_ids)
+            owned, owned_meta, rows = _discovery_load_inputs(cur)
+            graph = build_discovery_map(rows, owned, owned_meta, seed_count=seed, per_anchor=per)
+            _discovery_enrich(cur, graph, enrich_discovery_nodes)
         finally:
             conn.close()
 
-        # Pass 2: rebuild with enrichment (cheap, in-memory).
-        graph = build_discovery_map(rows, owned, owned_meta, cache_lookup=cache_lookup, seed_count=seed, per_anchor=per)
         n_owned = sum(1 for n in graph["nodes"] if n.get("kind") == "owned")
         n_disc = sum(1 for n in graph["nodes"] if n.get("kind") == "discovery")
         return jsonify({**graph, "counts": {
@@ -9966,23 +9951,53 @@ def get_discovery_graph():
         return jsonify({"error": str(e)}), 500
 
 
-def _discovery_cache_lookup(cur, ids):
-    """Look up cached artist metadata (image/genres/popularity) for a set of external ids.
+def _discovery_load_inputs(cur):
+    """Shared input load for the discovery routes: owned artists + this profile's similar_artists.
 
-    Returns {external_id: {"image_url", "genres", "popularity"}} from metadata_cache_entities.
-    Queried in batches so we never blow the SQL variable limit.
+    similar_artists is per-profile (unique on profile_id + source + name); without the filter, a
+    multi-profile install double-counts every anchor->target pair and leaks one profile's discovery
+    taste into another's graph.
+    """
+    owned = set()
+    owned_meta = {}
+    for name, thumb, genres, aid in cur.execute("SELECT name, thumb_url, genres, id FROM artists"):
+        key = (name or "").strip().lower()
+        owned.add(key)
+        owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
+    rows = cur.execute(
+        "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
+        "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
+        "FROM similar_artists WHERE profile_id = ?", (get_current_profile_id(),)
+    ).fetchall()
+    return owned, owned_meta, rows
+
+
+def _discovery_enrich(cur, graph, enrich_fn):
+    """Single-pass enrichment: collect the built candidates' (source, id) pairs, look them up in the
+    metadata cache, and fill the nodes in place (no second build)."""
+    need = {(src, eid) for n in graph["nodes"] if n.get("kind") == "discovery"
+            for src, eid in n.get("ids", [])}
+    enrich_fn(graph["nodes"], _discovery_cache_lookup(cur, need))
+
+
+def _discovery_cache_lookup(cur, pairs):
+    """Cached artist metadata (image/genres/popularity) for a set of (source, external_id) pairs.
+
+    Keys stay source-scoped: metadata_cache_entities is unique per (source, entity_type, entity_id),
+    and Deezer/iTunes ids share the numeric space — an unscoped id lookup can return the wrong
+    artist's metadata. Batched so we never blow the SQL variable limit.
     """
     lookup = {}
-    ids = [i for i in ids if i]
-    for i in range(0, len(ids), 400):
-        batch = ids[i:i + 400]
-        placeholders = ",".join("?" * len(batch))
-        for eid, image_url, genres, popularity in cur.execute(
-            f"SELECT entity_id, image_url, genres, popularity FROM metadata_cache_entities "
-            f"WHERE entity_type='artist' AND entity_id IN ({placeholders})", batch
+    pairs = [(s, e) for s, e in pairs if s and e]
+    for i in range(0, len(pairs), 200):
+        batch = pairs[i:i + 200]
+        cond = " OR ".join("(source = ? AND entity_id = ?)" for _ in batch)
+        params = [v for p in batch for v in p]
+        for source, eid, image_url, genres, popularity in cur.execute(
+            f"SELECT source, entity_id, image_url, genres, popularity FROM metadata_cache_entities "
+            f"WHERE entity_type='artist' AND ({cond})", params
         ):
-            if eid not in lookup:
-                lookup[eid] = {"image_url": image_url, "genres": genres, "popularity": popularity}
+            lookup.setdefault((source, eid), {"image_url": image_url, "genres": genres, "popularity": popularity})
     return lookup
 
 
@@ -9995,7 +10010,7 @@ def expand_discovery_graph():
     names can contain commas), ``per`` (max new nodes). Same node/edge shape as /api/graph/discovery.
     """
     try:
-        from core.graph.artist_graph import expand_discovery_node
+        from core.graph.artist_graph import expand_discovery_node, enrich_discovery_nodes
         payload = request.get_json(silent=True) or {}
         node_key = str(payload.get('key') or '').strip().lower()
         if not node_key:
@@ -10011,26 +10026,11 @@ def expand_discovery_graph():
         conn = db._get_connection()
         try:
             cur = conn.cursor()
-            owned = set()
-            owned_meta = {}
-            for name, thumb, genres, aid in cur.execute("SELECT name, thumb_url, genres, id FROM artists"):
-                key = (name or "").strip().lower()
-                owned.add(key)
-                owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
-            rows = cur.execute(
-                "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
-                "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
-                "FROM similar_artists"
-            ).fetchall()
-
-            base = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta, per=per, exclude=exclude)
-            need_ids = {eid for n in base["nodes"] if n.get("kind") == "discovery" for eid in n.get("ids", [])}
-            cache_lookup = _discovery_cache_lookup(cur, need_ids)
+            owned, owned_meta, rows = _discovery_load_inputs(cur)
+            graph = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta, per=per, exclude=exclude)
+            _discovery_enrich(cur, graph, enrich_discovery_nodes)
         finally:
             conn.close()
-
-        graph = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta,
-                                      cache_lookup=cache_lookup, per=per, exclude=exclude)
         return jsonify({**graph, "counts": {"nodes": len(graph["nodes"]), "edges": len(graph["edges"])}})
     except Exception as e:
         logger.error("[discovery-expand] failed: %s", e, exc_info=True)
@@ -28495,10 +28495,16 @@ def add_to_watchlist():
             return jsonify({"success": False, "error": "Missing artist_id or artist_name"}), 400
 
         database = get_database()
+        # Callers that KNOW the id's source (e.g. the Discovery Web, whose candidates carry
+        # [source, id] pairs) can pass it explicitly — numeric Deezer/iTunes ids are ambiguous and
+        # the detection below can otherwise mistake them for a library DB row id.
+        explicit_source = (data.get('source') or '').strip().lower()
+        if explicit_source not in ('spotify', 'deezer', 'itunes', 'discogs', 'musicbrainz'):
+            explicit_source = None
         # Detect source from ID — check if it's a library DB ID first
         is_numeric_id = artist_id.isdigit()
-        source = None
-        if is_numeric_id:
+        source = explicit_source
+        if is_numeric_id and not explicit_source:
             # Could be a library DB ID, iTunes ID, Deezer ID, or Discogs ID
             # Check if this is a library DB artist and use their actual source IDs
             try:
@@ -28539,8 +28545,8 @@ def add_to_watchlist():
                         source = 'musicbrainz'
             except Exception as e:
                 logger.debug("watchlist artist source lookup failed: %s", e)
+        fallback_source = _get_metadata_fallback_source()   # always defined — image block below reads it
         if not source:
-            fallback_source = _get_metadata_fallback_source()
             source = fallback_source if is_numeric_id else 'spotify'
         success = database.add_artist_to_watchlist(artist_id, artist_name, profile_id=get_current_profile_id(), source=source)
         if success:

--- a/web_server.py
+++ b/web_server.py
@@ -10023,6 +10023,35 @@ def expand_discovery_graph():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route('/api/graph/discovery/preview/<deezer_id>', methods=['GET'])
+def get_discovery_preview(deezer_id):
+    """30-second Deezer preview for a discovery candidate's top track (hear it before you add it).
+
+    Deliberately Deezer-only + explicit: the generic top-tracks endpoint routes by the CONFIGURED
+    primary source and resolves ids via the library DB — a candidate isn't in the library, and its
+    Deezer id would be garbage to a Spotify query (whose previews are deprecated anyway).
+    """
+    try:
+        if not str(deezer_id).isdigit():
+            return jsonify({"success": False, "reason": "not_a_deezer_id"}), 400
+        client = _get_deezer_client()
+        if not client:
+            return jsonify({"success": False, "reason": "deezer_unavailable"}), 503
+        tracks = client.get_artist_top_tracks(str(deezer_id), limit=3) or []
+        for t in tracks:
+            if t.get('preview_url'):
+                return jsonify({
+                    "success": True,
+                    "track": t.get('name'),
+                    "artist": ((t.get('artists') or [{}])[0] or {}).get('name'),
+                    "preview_url": t['preview_url'],
+                })
+        return jsonify({"success": False, "reason": "no_preview"})
+    except Exception as e:
+        logger.error("[discovery-preview] failed: %s", e, exc_info=True)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
 @app.route('/api/library/artist/<int:artist_id>/thumb', methods=['GET'])
 def get_library_artist_thumb(artist_id):
     """Browser-loadable thumb URL for ONE library artist, by library DB id.

--- a/web_server.py
+++ b/web_server.py
@@ -9923,20 +9923,31 @@ def get_discovery_graph():
     """Discovery Web: owned artists as anchors + their UNOWNED similar artists as discovery candidates.
 
     Candidates are enriched from the metadata cache (image/genres/popularity) so they render as real
-    artists you could add, not bare dots. Hybrid seed view: the top ``seed`` owned anchors (by neighbor
-    count), each with its top ``per`` unowned candidates. The frontend expands from here on click.
+    artists you could add, not bare dots. Returns the WHOLE frontier by default — its real size is
+    modest (only artists whose similars were fetched can anchor); ``seed``/``per`` query params
+    optionally trim to the top anchors / top candidates per anchor.
     """
     try:
-        from core.graph.artist_graph import build_discovery_map, enrich_discovery_nodes
-        seed = max(1, min(int(request.args.get('seed', 30)), 120))
-        per = max(1, min(int(request.args.get('per', 6)), 20))
+        from core.graph.artist_graph import build_discovery_map
+
+        def _opt_int(name):
+            raw = request.args.get(name)
+            if raw is None:
+                return None
+            try:
+                v = int(raw)
+            except (TypeError, ValueError):
+                return None
+            return max(1, v) if v > 0 else None
+
+        seed = _opt_int('seed')
+        per = _opt_int('per')
         db = get_database()
         conn = db._get_connection()
         try:
             cur = conn.cursor()
             owned, owned_meta, rows = _discovery_load_inputs(cur)
             graph = build_discovery_map(rows, owned, owned_meta, seed_count=seed, per_anchor=per)
-            _discovery_enrich(cur, graph, enrich_discovery_nodes)
         finally:
             conn.close()
 
@@ -9957,6 +9968,10 @@ def _discovery_load_inputs(cur):
     similar_artists is per-profile (unique on profile_id + source + name); without the filter, a
     multi-profile install double-counts every anchor->target pair and leaks one profile's discovery
     taste into another's graph.
+
+    Rows include the table's OWN image_url/genres columns (~99% of rows carry image + real
+    popularity) — enriching from metadata_cache_entities instead measured 18-250s per request
+    (random reads into a 1.3M-row table), for data these rows already have.
     """
     owned = set()
     owned_meta = {}
@@ -9966,39 +9981,11 @@ def _discovery_load_inputs(cur):
         owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
     rows = cur.execute(
         "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
-        "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
+        "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity, "
+        "image_url, genres "
         "FROM similar_artists WHERE profile_id = ?", (get_current_profile_id(),)
     ).fetchall()
     return owned, owned_meta, rows
-
-
-def _discovery_enrich(cur, graph, enrich_fn):
-    """Single-pass enrichment: collect the built candidates' (source, id) pairs, look them up in the
-    metadata cache, and fill the nodes in place (no second build)."""
-    need = {(src, eid) for n in graph["nodes"] if n.get("kind") == "discovery"
-            for src, eid in n.get("ids", [])}
-    enrich_fn(graph["nodes"], _discovery_cache_lookup(cur, need))
-
-
-def _discovery_cache_lookup(cur, pairs):
-    """Cached artist metadata (image/genres/popularity) for a set of (source, external_id) pairs.
-
-    Keys stay source-scoped: metadata_cache_entities is unique per (source, entity_type, entity_id),
-    and Deezer/iTunes ids share the numeric space — an unscoped id lookup can return the wrong
-    artist's metadata. Batched so we never blow the SQL variable limit.
-    """
-    lookup = {}
-    pairs = [(s, e) for s, e in pairs if s and e]
-    for i in range(0, len(pairs), 200):
-        batch = pairs[i:i + 200]
-        cond = " OR ".join("(source = ? AND entity_id = ?)" for _ in batch)
-        params = [v for p in batch for v in p]
-        for source, eid, image_url, genres, popularity in cur.execute(
-            f"SELECT source, entity_id, image_url, genres, popularity FROM metadata_cache_entities "
-            f"WHERE entity_type='artist' AND ({cond})", params
-        ):
-            lookup.setdefault((source, eid), {"image_url": image_url, "genres": genres, "popularity": popularity})
-    return lookup
 
 
 @app.route('/api/graph/discovery/expand', methods=['POST'])
@@ -10010,7 +9997,7 @@ def expand_discovery_graph():
     names can contain commas), ``per`` (max new nodes). Same node/edge shape as /api/graph/discovery.
     """
     try:
-        from core.graph.artist_graph import expand_discovery_node, enrich_discovery_nodes
+        from core.graph.artist_graph import expand_discovery_node
         payload = request.get_json(silent=True) or {}
         node_key = str(payload.get('key') or '').strip().lower()
         if not node_key:
@@ -10028,7 +10015,6 @@ def expand_discovery_graph():
             cur = conn.cursor()
             owned, owned_meta, rows = _discovery_load_inputs(cur)
             graph = expand_discovery_node(rows, owned, node_key, node_ids, owned_meta, per=per, exclude=exclude)
-            _discovery_enrich(cur, graph, enrich_discovery_nodes)
         finally:
             conn.close()
         return jsonify({**graph, "counts": {"nodes": len(graph["nodes"]), "edges": len(graph["edges"])}})

--- a/web_server.py
+++ b/web_server.py
@@ -9918,6 +9918,74 @@ def get_library_graph():
         return jsonify({"error": str(e)}), 500
 
 
+@app.route('/api/graph/discovery', methods=['GET'])
+def get_discovery_graph():
+    """Discovery Web: owned artists as anchors + their UNOWNED similar artists as discovery candidates.
+
+    Candidates are enriched from the metadata cache (image/genres/popularity) so they render as real
+    artists you could add, not bare dots. Hybrid seed view: the top ``seed`` owned anchors (by neighbor
+    count), each with its top ``per`` unowned candidates. The frontend expands from here on click.
+    """
+    try:
+        from core.graph.artist_graph import build_discovery_map
+        seed = max(1, min(int(request.args.get('seed', 30)), 120))
+        per = max(1, min(int(request.args.get('per', 6)), 20))
+        db = get_database()
+        conn = db._get_connection()
+        try:
+            cur = conn.cursor()
+            owned = set()
+            owned_meta = {}
+            for name, thumb, genres, aid in cur.execute("SELECT name, thumb_url, genres, id FROM artists"):
+                key = (name or "").strip().lower()
+                owned.add(key)
+                owned_meta[key] = {"thumb_url": thumb, "genres": genres, "id": aid}
+            rows = cur.execute(
+                "SELECT source_artist_id, similar_artist_name, similar_artist_spotify_id, "
+                "similar_artist_deezer_id, similar_artist_itunes_id, occurrence_count, popularity "
+                "FROM similar_artists"
+            ).fetchall()
+
+            # Pass 1: shape the graph (no enrichment) to learn which candidate ids we actually need.
+            base = build_discovery_map(rows, owned, owned_meta, seed_count=seed, per_anchor=per)
+            need_ids = {eid for n in base["nodes"] if n.get("kind") == "discovery" for eid in n.get("ids", [])}
+            cache_lookup = _discovery_cache_lookup(cur, need_ids)
+        finally:
+            conn.close()
+
+        # Pass 2: rebuild with enrichment (cheap, in-memory).
+        graph = build_discovery_map(rows, owned, owned_meta, cache_lookup=cache_lookup, seed_count=seed, per_anchor=per)
+        n_owned = sum(1 for n in graph["nodes"] if n.get("kind") == "owned")
+        n_disc = sum(1 for n in graph["nodes"] if n.get("kind") == "discovery")
+        return jsonify({**graph, "counts": {
+            "nodes": len(graph["nodes"]), "edges": len(graph["edges"]),
+            "owned": n_owned, "discovery": n_disc,
+        }})
+    except Exception as e:
+        logger.error("[discovery-graph] failed: %s", e, exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+def _discovery_cache_lookup(cur, ids):
+    """Look up cached artist metadata (image/genres/popularity) for a set of external ids.
+
+    Returns {external_id: {"image_url", "genres", "popularity"}} from metadata_cache_entities.
+    Queried in batches so we never blow the SQL variable limit.
+    """
+    lookup = {}
+    ids = [i for i in ids if i]
+    for i in range(0, len(ids), 400):
+        batch = ids[i:i + 400]
+        placeholders = ",".join("?" * len(batch))
+        for eid, image_url, genres, popularity in cur.execute(
+            f"SELECT entity_id, image_url, genres, popularity FROM metadata_cache_entities "
+            f"WHERE entity_type='artist' AND entity_id IN ({placeholders})", batch
+        ):
+            if eid not in lookup:
+                lookup[eid] = {"image_url": image_url, "genres": genres, "popularity": popularity}
+    return lookup
+
+
 @app.route('/api/library/export/m3u', methods=['GET'])
 def export_library_m3u():
     """Download an extended-M3U playlist of the entire library. Always current (built on request)."""

--- a/webui/index.html
+++ b/webui/index.html
@@ -3212,10 +3212,39 @@
                                 <div class="artmap-brand"><svg class="artmap-brand-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="5" r="1.6"/><circle cx="19" cy="5" r="1.6"/><circle cx="5" cy="19" r="1.6"/><circle cx="19" cy="19" r="1.6"/><line x1="12" y1="12" x2="5" y2="5"/><line x1="12" y1="12" x2="19" y2="5"/><line x1="12" y1="12" x2="5" y2="19"/><line x1="12" y1="12" x2="19" y2="19"/></svg><span class="artmap-brand-text">Artist Web</span></div>
                                 <div class="artmap-stats" id="artist-web-stats"></div>
                             </div>
+
+                            <!-- Center: search (mirrors Artist Map) -->
+                            <div class="artmap-nav-center">
+                                <div class="artmap-search-wrap">
+                                    <svg class="artmap-search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                                    <input type="text" id="artist-web-search" placeholder="Search artists... (S)" oninput="artWebSearch(this.value)" onkeydown="if(event.key==='Enter')artWebSearchEnter()">
+                                </div>
+                            </div>
+
+                            <!-- Right: tools -->
+                            <div class="artmap-nav-right">
+                                <button class="artmap-tool-btn" id="artweb-filter-btn" onclick="artWebToggleFilter()" title="Filter by genre">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
+                                    <span>Filter</span>
+                                </button>
+                                <div class="artmap-zoom-group">
+                                    <button class="artmap-tool-btn artmap-zoom" onclick="artWebZoom(0.7)" title="Zoom in (+)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+                                    <button class="artmap-tool-btn artmap-zoom" onclick="artWebZoom(1.4)" title="Zoom out (-)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
+                                    <button class="artmap-tool-btn artmap-zoom" onclick="artWebFitToView()" title="Fit to view (F)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg></button>
+                                </div>
+                            </div>
                         </div>
                         <div class="artmap-content-row">
+                            <div class="artmap-genre-sidebar" id="artweb-genre-sidebar" style="display:none;">
+                                <div class="artmap-genre-sidebar-header">
+                                    <span>Genres</span>
+                                    <input type="text" class="artmap-genre-sidebar-search" placeholder="Filter..." oninput="artWebFilterGenreList(this.value)">
+                                </div>
+                                <div class="artmap-genre-sidebar-list" id="artweb-genre-sidebar-list"></div>
+                            </div>
                             <div id="artist-web-canvas" style="flex:1; min-width:0; min-height:0;"></div>
                         </div>
+                        <div class="artist-map-search-results" id="artist-web-search-results"></div>
                     </div>
 
                     <!-- Discovery Adventurousness — living wave dial. Drag the orb; the line waves

--- a/webui/index.html
+++ b/webui/index.html
@@ -3223,6 +3223,10 @@
 
                             <!-- Right: tools -->
                             <div class="artmap-nav-right">
+                                <div class="artweb-lens-toggle" title="How to organize the graph">
+                                    <button class="artweb-lens-btn active" data-lens="genre" onclick="artWebSetLens('genre')">Genre</button>
+                                    <button class="artweb-lens-btn" data-lens="community" onclick="artWebSetLens('community')">Communities</button>
+                                </div>
                                 <button class="artmap-tool-btn" id="artweb-filter-btn" onclick="artWebToggleFilter()" title="Filter by genre">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                                     <span>Filter</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3227,6 +3227,10 @@
                                     <button class="artweb-lens-btn active" data-lens="genre" onclick="artWebSetLens('genre')">Genre</button>
                                     <button class="artweb-lens-btn" data-lens="community" onclick="artWebSetLens('community')">Communities</button>
                                 </div>
+                                <button class="artmap-tool-btn" id="artweb-path-btn" onclick="artWebTogglePathMode()" title="Trace how two artists connect">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.2"/><circle cx="19" cy="18" r="2.2"/><path d="M7 6h6a4 4 0 0 1 4 4v4" stroke-dasharray="1 3"/></svg>
+                                    <span>Path</span>
+                                </button>
                                 <button class="artmap-tool-btn" id="artweb-filter-btn" onclick="artWebToggleFilter()" title="Filter by genre">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                                     <span>Filter</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3183,6 +3183,41 @@
                         <div class="artist-map-search-results" id="artist-map-search-results"></div>
                     </div>
 
+                    <!-- Artist Web Hub (sigma.js similarity graph — sibling of the canvas Artist Map) -->
+                    <div class="artmap-hub">
+                        <div class="artmap-hub-bg"></div>
+                        <div class="artmap-hub-content">
+                            <div class="artmap-hub-header">
+                                <svg class="artmap-hub-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="5" r="1.6"/><circle cx="19" cy="5" r="1.6"/><circle cx="5" cy="19" r="1.6"/><circle cx="19" cy="19" r="1.6"/><line x1="12" y1="12" x2="5" y2="5"/><line x1="12" y1="12" x2="19" y2="5"/><line x1="12" y1="12" x2="5" y2="19"/><line x1="12" y1="12" x2="19" y2="19"/></svg>
+                                <div>
+                                    <h2 class="artmap-hub-title">Artist Web</h2>
+                                    <p class="artmap-hub-subtitle">Your library as an interactive similarity graph</p>
+                                </div>
+                            </div>
+                            <div class="artmap-hub-cards">
+                                <div class="artmap-hub-card" onclick="openArtistWeb()">
+                                    <div class="artmap-hub-card-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2"/><circle cx="7" cy="8" r="1.5"/><circle cx="17" cy="8" r="1.5"/><circle cx="8" cy="16" r="1.5"/><circle cx="16" cy="16" r="1.5"/><line x1="12" y1="12" x2="7" y2="8"/><line x1="12" y1="12" x2="17" y2="8"/><line x1="12" y1="12" x2="8" y2="16"/><line x1="12" y1="12" x2="16" y2="16"/></svg></div>
+                                    <div class="artmap-hub-card-text"><h3>Taste Map</h3><p>Every artist in your library, wired together by similarity</p></div>
+                                    <svg class="artmap-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Artist Web (fullscreen sigma graph, hidden by default) -->
+                    <div class="artist-map-container" id="artist-web-container" style="display:none;">
+                        <div class="artist-map-toolbar">
+                            <div class="artmap-nav-left">
+                                <button class="artmap-back" onclick="closeArtistWeb()" title="Back to Discover (Esc)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M19 12H5"/><path d="M12 19l-7-7 7-7"/></svg></button>
+                                <div class="artmap-brand"><svg class="artmap-brand-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="2"/><circle cx="5" cy="5" r="1.6"/><circle cx="19" cy="5" r="1.6"/><circle cx="5" cy="19" r="1.6"/><circle cx="19" cy="19" r="1.6"/><line x1="12" y1="12" x2="5" y2="5"/><line x1="12" y1="12" x2="19" y2="5"/><line x1="12" y1="12" x2="5" y2="19"/><line x1="12" y1="12" x2="19" y2="19"/></svg><span class="artmap-brand-text">Artist Web</span></div>
+                                <div class="artmap-stats" id="artist-web-stats"></div>
+                            </div>
+                        </div>
+                        <div class="artmap-content-row">
+                            <div id="artist-web-canvas" style="flex:1; min-width:0; min-height:0;"></div>
+                        </div>
+                    </div>
+
                     <!-- Discovery Adventurousness — living wave dial. Drag the orb; the line waves
                          calmer/greener at left (safe) and wilder/redder at right (obscure). Syncs with
                          Settings → Discovery. -->
@@ -8804,6 +8839,11 @@
     <script src="{{ url_for('static', filename='api-monitor.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='library.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='beatport-ui.js', v=static_v) }}"></script>
+    <!-- Artist Web graph stack (sigma.js): graphology = data model, sigma = WebGL renderer,
+         graphology-library = utils incl. forceAtlas2 layout. CDN/UMD (SoulSync is vanilla). -->
+    <script src="https://cdn.jsdelivr.net/npm/graphology@0.25.4/dist/graphology.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/graphology-library/dist/graphology-library.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sigma@2.4.0/build/sigma.min.js"></script>
     <script src="{{ url_for('static', filename='discover-section-controller.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='discover.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='enrichment.js', v=static_v) }}"></script>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3236,6 +3236,10 @@
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.2"/><circle cx="19" cy="18" r="2.2"/><path d="M7 6h6a4 4 0 0 1 4 4v4" stroke-dasharray="1 3"/></svg>
                                     <span>Path</span>
                                 </button>
+                                <button class="artmap-tool-btn" id="artweb-edges-btn" onclick="artWebToggleEdges()" title="Show only the stronger connections">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="4" y1="7" x2="20" y2="7"/><line x1="4" y1="12" x2="20" y2="12" stroke-opacity="0.4"/><line x1="4" y1="17" x2="20" y2="17" stroke-opacity="0.2"/></svg>
+                                    <span>Edges</span>
+                                </button>
                                 <button class="artmap-tool-btn" id="artweb-filter-btn" onclick="artWebToggleFilter()" title="Filter by genre">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
                                     <span>Filter</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3275,6 +3275,8 @@
                             <div id="artist-web-legend" class="artweb-legend" style="display:none;"></div>
                         </div>
                         <div class="artist-map-search-results" id="artist-web-search-results"></div>
+                        <!-- Hover tooltip (reuses the Artist Map tooltip styling) — identify a node without clicking -->
+                        <div class="artist-map-tooltip" id="artist-web-tooltip"></div>
                     </div>
 
                     <!-- Discovery Adventurousness — living wave dial. Drag the orb; the line waves

--- a/webui/index.html
+++ b/webui/index.html
@@ -3195,9 +3195,14 @@
                                 </div>
                             </div>
                             <div class="artmap-hub-cards">
-                                <div class="artmap-hub-card" onclick="openArtistWeb()">
+                                <div class="artmap-hub-card" onclick="openArtistWeb('genre')">
                                     <div class="artmap-hub-card-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="2"/><circle cx="7" cy="8" r="1.5"/><circle cx="17" cy="8" r="1.5"/><circle cx="8" cy="16" r="1.5"/><circle cx="16" cy="16" r="1.5"/><line x1="12" y1="12" x2="7" y2="8"/><line x1="12" y1="12" x2="17" y2="8"/><line x1="12" y1="12" x2="8" y2="16"/><line x1="12" y1="12" x2="16" y2="16"/></svg></div>
                                     <div class="artmap-hub-card-text"><h3>Taste Map</h3><p>Every artist in your library, wired together by similarity</p></div>
+                                    <svg class="artmap-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
+                                </div>
+                                <div class="artmap-hub-card" onclick="openArtistWeb('discovery')">
+                                    <div class="artmap-hub-card-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><polygon points="15.5 8.5 13 13 8.5 15.5 11 11 15.5 8.5"/></svg></div>
+                                    <div class="artmap-hub-card-text"><h3>Discovery Web</h3><p>Artists you don't have yet, mapped from the ones you do</p></div>
                                     <svg class="artmap-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
                                 </div>
                             </div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3227,6 +3227,11 @@
                                     <button class="artweb-lens-btn active" data-lens="genre" onclick="artWebSetLens('genre')">Genre</button>
                                     <button class="artweb-lens-btn" data-lens="community" onclick="artWebSetLens('community')">Communities</button>
                                 </div>
+                                <div class="artweb-lens-toggle" title="Size nodes by">
+                                    <button class="artweb-lens-btn artweb-size-btn active" data-size="popularity" onclick="artWebSetSize('popularity')">Popular</button>
+                                    <button class="artweb-lens-btn artweb-size-btn" data-size="connections" onclick="artWebSetSize('connections')">Links</button>
+                                    <button class="artweb-lens-btn artweb-size-btn" data-size="influence" onclick="artWebSetSize('influence')" title="Betweenness — who bridges the network">Influence</button>
+                                </div>
                                 <button class="artmap-tool-btn" id="artweb-path-btn" onclick="artWebTogglePathMode()" title="Trace how two artists connect">
                                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="6" r="2.2"/><circle cx="19" cy="18" r="2.2"/><path d="M7 6h6a4 4 0 0 1 4 4v4" stroke-dasharray="1 3"/></svg>
                                     <span>Path</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3260,6 +3260,7 @@
                                     <button class="artmap-tool-btn artmap-zoom" onclick="artWebZoom(1.4)" title="Zoom out (-)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="5" y1="12" x2="19" y2="12"/></svg></button>
                                     <button class="artmap-tool-btn artmap-zoom" onclick="artWebFitToView()" title="Fit to view (F)"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 3H5a2 2 0 0 0-2 2v3"/><path d="M21 8V5a2 2 0 0 0-2-2h-3"/><path d="M3 16v3a2 2 0 0 0 2 2h3"/><path d="M16 21h3a2 2 0 0 0 2-2v-3"/></svg></button>
                                 </div>
+                                <button class="artmap-tool-btn" onclick="artWebShowHelp()" title="Guide &amp; shortcuts" style="font-weight:700;">?</button>
                             </div>
                         </div>
                         <div class="artmap-content-row">

--- a/webui/index.html
+++ b/webui/index.html
@@ -3271,6 +3271,8 @@
                                 <div class="artmap-genre-sidebar-list" id="artweb-genre-sidebar-list"></div>
                             </div>
                             <div id="artist-web-canvas" style="flex:1; min-width:0; min-height:0;"></div>
+                            <!-- Color legend (decodes the node colors per lens) — populated per render -->
+                            <div id="artist-web-legend" class="artweb-legend" style="display:none;"></div>
                         </div>
                         <div class="artist-map-search-results" id="artist-web-search-results"></div>
                     </div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3200,6 +3200,11 @@
                                     <div class="artmap-hub-card-text"><h3>Taste Map</h3><p>Every artist in your library, wired together by similarity</p></div>
                                     <svg class="artmap-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
                                 </div>
+                                <div class="artmap-hub-card" onclick="openArtistWeb('community')">
+                                    <div class="artmap-hub-card-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="7" cy="8" r="2.5"/><circle cx="17" cy="8" r="2.5"/><circle cx="12" cy="17" r="2.5"/><line x1="8.8" y1="9.8" x2="10.5" y2="15"/><line x1="15.2" y1="9.8" x2="13.5" y2="15"/><line x1="9.5" y1="8" x2="14.5" y2="8"/></svg></div>
+                                    <div class="artmap-hub-card-text"><h3>Communities</h3><p>Your library's real scenes, found from who sounds alike — not genre tags</p></div>
+                                    <svg class="artmap-hub-card-arrow" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14"/><path d="M12 5l7 7-7 7"/></svg>
+                                </div>
                                 <div class="artmap-hub-card" onclick="openArtistWeb('discovery')">
                                     <div class="artmap-hub-card-icon"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="9"/><polygon points="15.5 8.5 13 13 8.5 15.5 11 11 15.5 8.5"/></svg></div>
                                     <div class="artmap-hub-card-text"><h3>Discovery Web</h3><p>Artists you don't have yet, mapped from the ones you do</p></div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -3226,6 +3226,7 @@
                                 <div class="artweb-lens-toggle" title="How to organize the graph">
                                     <button class="artweb-lens-btn active" data-lens="genre" onclick="artWebSetLens('genre')">Genre</button>
                                     <button class="artweb-lens-btn" data-lens="community" onclick="artWebSetLens('community')">Communities</button>
+                                    <button class="artweb-lens-btn" data-lens="discovery" onclick="artWebSetLens('discovery')">Discovery</button>
                                 </div>
                                 <div class="artweb-lens-toggle" title="Size nodes by">
                                     <button class="artweb-lens-btn artweb-size-btn active" data-size="popularity" onclick="artWebSetSize('popularity')">Popular</button>

--- a/webui/index.html
+++ b/webui/index.html
@@ -8903,9 +8903,9 @@
     <script src="{{ url_for('static', filename='beatport-ui.js', v=static_v) }}"></script>
     <!-- Artist Web graph stack (sigma.js): graphology = data model, sigma = WebGL renderer,
          graphology-library = utils incl. forceAtlas2 layout. CDN/UMD (SoulSync is vanilla). -->
-    <script src="https://cdn.jsdelivr.net/npm/graphology@0.25.4/dist/graphology.umd.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/graphology-library/dist/graphology-library.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sigma@2.4.0/build/sigma.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/graphology@0.25.4/dist/graphology.umd.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/graphology-library/dist/graphology-library.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/sigma@2.4.0/build/sigma.min.js"></script>
     <script src="{{ url_for('static', filename='discover-section-controller.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='discover.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='enrichment.js', v=static_v) }}"></script>

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6374,6 +6374,10 @@ let _artistWeb = {
     genreColor: null,                 // (genre) -> color, set at render
     index: [],                        // [{key,label}] artist nodes, for client-side search
     searchMatch: null,                // Set<key> of search hits, or null when search is empty
+    focusSet: null,                   // Set<key> currently emphasized (hover node+neighbors, or selection)
+    focusRoot: null,                  // the node at the center of the focus (gets a halo)
+    selectedKey: null,                // click-selected node (survives hover-out)
+    selectedFocus: null,              // the focus set to restore when hover clears
 };
 
 // White pill label (black text, 10px padding) — custom sigma labelRenderer, per Boulder's spec.
@@ -6436,8 +6440,13 @@ async function openArtistWeb() {
     const statsEl = document.getElementById('artist-web-stats');
     host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Building your artist web…</div>';
 
-    // Esc closes (mirrors the artist map).
-    _artistWeb.onKey = (e) => { if (e.key === 'Escape') closeArtistWeb(); };
+    // Esc: dismiss an open detail panel first, otherwise leave the web (mirrors the artist map).
+    _artistWeb.onKey = (e) => {
+        if (e.key !== 'Escape') return;
+        const p = document.getElementById('artweb-panel');
+        if (p && p.style.display !== 'none') _artWebClearSelection();
+        else closeArtistWeb();
+    };
     document.addEventListener('keydown', _artistWeb.onKey);
 
     // Resolve the CDN globals. graphology's UMD default export IS the Graph class.
@@ -6512,14 +6521,23 @@ async function openArtistWeb() {
         host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow (reference look)
         if (_artistWeb.sigma) _artistWeb.sigma.kill();
         _artistWeb.graph = graph;
+        _artistWeb.searchMatch = _artistWeb.focusSet = _artistWeb.focusRoot = null;
+        _artistWeb.selectedKey = _artistWeb.selectedFocus = null;
         _artistWeb.sigma = new window.Sigma(graph, host, {
             renderLabels: true,
             labelRenderedSizeThreshold: 20,   // only large nodes (genre hubs) label by default; artists on zoom
             labelRenderer: _webDrawLabel,     // white pill labels
-            // Reducers: recolor/dim per frame from UI state (search now; hover/select later). Data is untouched.
+            // Reducers: recolor/dim per frame from UI state (search / hover / selection). Data is untouched.
             nodeReducer: (node, data) => _artWebNodeReducer(node, data),
             edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
         });
+
+        // Interaction: hover highlights a node + its neighbors; click opens the side panel.
+        const sig = _artistWeb.sigma;
+        sig.on('enterNode', ({ node }) => _artWebHover(node));
+        sig.on('leaveNode', () => _artWebHover(null));
+        sig.on('clickNode', ({ node }) => _artWebClickNode(node));
+        sig.on('clickStage', () => _artWebClearSelection());
     } catch (err) {
         console.error('[Artist Web] load failed', err);
         host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
@@ -6536,6 +6554,7 @@ function closeArtistWeb() {
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');
     if (results) { results.style.display = 'none'; results.innerHTML = ''; }
+    _artWebClosePanel();
 }
 
 // ---- Artist Web reducers: the single place UI state turns into per-frame styling -------------
@@ -6545,15 +6564,17 @@ const _WEB_DIM_EDGE = 'rgba(255,255,255,0.02)';
 function _artWebNodeReducer(node, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
-    // Search: matched nodes pop (labeled), everything else dims out.
-    if (st.searchMatch) {
-        if (st.searchMatch.has(node)) {
+    const active = st.focusSet || st.searchMatch;   // focus (hover/select) wins over search
+    if (active) {
+        if (active.has(node)) {
             res.color = data.baseColor || data.color;
             res.forceLabel = true;
             res.zIndex = 2;
+            if (node === st.focusRoot) res.highlighted = true;   // sigma draws a halo on the root
         } else {
             res.color = _WEB_DIM_NODE;
             res.label = '';
+            res.zIndex = 0;
         }
     }
     return res;
@@ -6562,10 +6583,14 @@ function _artWebNodeReducer(node, data) {
 function _artWebEdgeReducer(edge, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
-    if (st.searchMatch && _artistWeb.graph) {
+    const active = st.focusSet || st.searchMatch;
+    if (active && _artistWeb.graph) {
         const g = _artistWeb.graph;
         const s = g.source(edge), t = g.target(edge);
-        if (!(st.searchMatch.has(s) || st.searchMatch.has(t))) res.color = _WEB_DIM_EDGE;
+        // Focus (hover/select): show only edges fully inside the set → clean neighborhood.
+        // Search: show any edge touching a match.
+        const show = st.focusSet ? (active.has(s) && active.has(t)) : (active.has(s) || active.has(t));
+        if (show) res.zIndex = 1; else res.color = _WEB_DIM_EDGE;
     }
     return res;
 }
@@ -6642,6 +6667,134 @@ function artWebFitToView() {
     if (input) input.value = '';
     _artistWeb.searchMatch = null;
     _artistWeb.sigma.refresh();
+}
+
+// ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
+function _artWebHover(node) {
+    const st = _artistWeb;
+    if (!st.sigma) return;
+    if (node) {
+        const set = new Set([node]);
+        st.graph.forEachNeighbor(node, nb => set.add(nb));
+        st.focusSet = set;
+        st.focusRoot = node;
+    } else {
+        // Hover-out restores the click-selection's highlight (if any), else clears.
+        st.focusSet = st.selectedFocus || null;
+        st.focusRoot = st.selectedKey || null;
+    }
+    st.sigma.refresh();
+}
+
+function _artWebClickNode(node) {
+    const st = _artistWeb;
+    if (!st.graph || !st.graph.hasNode(node)) return;
+    const set = new Set([node]);
+    st.graph.forEachNeighbor(node, nb => set.add(nb));
+    st.selectedKey = node; st.selectedFocus = set;
+    st.focusSet = set; st.focusRoot = node;
+    st.searchMatch = null;                      // a click supersedes a search dim
+    st.sigma.refresh();
+    if (st.graph.getNodeAttribute(node, 'kind') === 'genre') _artWebShowGenre(node);
+    else _artWebShowArtist(node);
+}
+
+function _artWebClearSelection() {
+    const st = _artistWeb;
+    st.selectedKey = st.selectedFocus = st.focusSet = st.focusRoot = null;
+    if (st.sigma) st.sigma.refresh();
+    _artWebClosePanel();
+}
+
+// Focus the camera on an artist and open its card (used by the genre panel's member list).
+function _artWebGoToArtist(key) {
+    const sig = _artistWeb.sigma;
+    if (!sig || !_artistWeb.graph.hasNode(key)) return;
+    _artWebClickNode(key);
+    const disp = sig.getNodeDisplayData(key);
+    if (disp) sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 });
+}
+
+// ---- Artist Web side panel (mirrors the Artist Map card design/interactions) -------------------
+function _artWebEnsurePanel() {
+    let p = document.getElementById('artweb-panel');
+    if (p) return p;
+    const container = document.getElementById('artist-web-container');
+    if (!container) return null;
+    if (!container.style.position) container.style.position = 'relative';
+    p = document.createElement('div');
+    p.id = 'artweb-panel';
+    p.style.cssText = 'position:absolute;top:66px;right:14px;width:300px;max-height:calc(100% - 88px);'
+        + 'background:rgba(20,18,26,0.92);backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);'
+        + 'border:1px solid rgba(255,255,255,0.1);border-radius:16px;display:none;flex-direction:column;'
+        + 'overflow:hidden;z-index:20;box-shadow:0 14px 44px rgba(0,0,0,0.55);';
+    p.innerHTML = '<div id="artweb-panel-body" style="flex:1;overflow-y:auto;padding:16px;-webkit-overflow-scrolling:touch;"></div>';
+    container.appendChild(p);
+    return p;
+}
+
+function _artWebClosePanel() {
+    const p = document.getElementById('artweb-panel');
+    if (p) p.style.display = 'none';
+}
+
+function _artWebShowArtist(node) {
+    const p = _artWebEnsurePanel();
+    if (!p) return;
+    const g = _artistWeb.graph;
+    const a = g.getNodeAttributes(node);
+    const color = a.baseColor || '#1db954';
+    const conn = g.degree(node);
+    const pop = Math.max(0, Math.min(100, Math.round(a.popularity || 0)));
+    const detailPath = (a.artistId != null && typeof buildArtistDetailPath === 'function')
+        ? buildArtistDetailPath(a.artistId, a.source) : null;
+
+    document.getElementById('artweb-panel-body').innerHTML = `
+        <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>
+        <div style="text-align:center;">
+            <div style="width:110px;height:110px;margin:0 auto;border-radius:50%;overflow:hidden;border:2px solid ${color};box-shadow:0 8px 28px ${_webHexToRgba(color, 0.45)};background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;">
+                ${a.thumb ? `<img src="${escapeHtml(a.thumb)}" style="width:100%;height:100%;object-fit:cover;" onerror="this.style.display='none'">` : '<span style="font-size:34px;opacity:0.5;">&#9835;</span>'}
+            </div>
+            <div style="font-size:18px;font-weight:800;margin-top:12px;">${escapeHtml(a.label)}</div>
+            ${a.genre ? `<div style="font-size:11px;color:${color};margin-top:3px;">${escapeHtml(a.genre)}</div>` : ''}
+        </div>
+        <div style="display:flex;gap:8px;margin-top:16px;">
+            ${_miniStat('Popularity', pop, 270)}
+            ${_miniStat('Connections', conn)}
+        </div>
+        <div style="margin-top:8px;height:6px;background:rgba(255,255,255,0.08);border-radius:3px;overflow:hidden;">
+            <div style="height:100%;width:${pop}%;background:${color};"></div>
+        </div>
+        <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
+            <button onclick="artMapExploreArtist('${escapeForInlineJs(a.label)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
+            ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
+        </div>`;
+    p.style.display = 'flex';
+}
+
+function _artWebShowGenre(node) {
+    const p = _artWebEnsurePanel();
+    if (!p) return;
+    const g = _artistWeb.graph;
+    const genre = g.getNodeAttribute(node, 'genre') || 'Genre';
+    const color = g.getNodeAttribute(node, 'baseColor') || '#1db954';
+    const members = [];
+    g.forEachNeighbor(node, (nb, attrs) => { if (attrs.kind === 'artist') members.push({ key: nb, label: attrs.label, pop: attrs.popularity || 0 }); });
+    members.sort((x, y) => y.pop - x.pop);
+
+    document.getElementById('artweb-panel-body').innerHTML = `
+        <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>
+        <div style="font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(255,255,255,0.4);">Genre</div>
+        <div style="font-size:20px;font-weight:800;color:${color};margin-top:2px;">${escapeHtml(genre)}</div>
+        <div style="font-size:12px;color:rgba(255,255,255,0.55);margin-top:6px;">${members.length} artist${members.length === 1 ? '' : 's'} in your library</div>
+        <div style="font-size:10px;letter-spacing:0.1em;text-transform:uppercase;color:rgba(255,255,255,0.4);margin:16px 2px 8px;">Top artists</div>
+        ${members.slice(0, 30).map((m, i) => `
+            <div onclick="_artWebGoToArtist('${escapeForInlineJs(m.key)}')" style="display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:9px;cursor:pointer;"
+                 onmouseover="this.style.background='rgba(255,255,255,0.06)'" onmouseout="this.style.background='transparent'">
+                <span style="width:18px;text-align:center;font-size:11px;font-weight:700;color:rgba(255,255,255,0.35);">${i + 1}</span>
+                <span style="flex:1;min-width:0;font-size:12.5px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(m.label)}</span>
+            </div>`).join('') || '<div style="color:rgba(255,255,255,0.4);padding:8px;">No artists</div>'}`;
+    p.style.display = 'flex';
 }
 
 // Filter-by-genre lives in a later phase; stubs keep the toolbar buttons inert-but-safe for now.

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6382,20 +6382,21 @@ let _artistWeb = {
     genreCounts: null,                // {genre: artistCount} for the filter sidebar
 };
 
-// White pill label (black text, 10px padding) — custom sigma labelRenderer, per Boulder's spec.
+// White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
+// rendered size, so a small artist gets a small tag and a big genre hub gets a big one.
 function _webDrawLabel(context, data, settings) {
     if (!data.label) return;
-    const size = settings.labelSize || 12;
     const font = settings.labelFont || 'Arial';
     const weight = settings.labelWeight || 'normal';
-    context.font = `${weight} ${size}px ${font}`;
-    const pad = 10;
+    const fontSize = Math.max(8, Math.min(18, (data.size || 6) * 0.85));   // scale to node size, clamped
+    const pad = Math.max(3, Math.round(fontSize * 0.45));
+    context.font = `${weight} ${fontSize}px ${font}`;
     const tw = context.measureText(data.label).width;
-    const boxW = tw + pad * 2, boxH = size + pad * 2;
+    const boxW = tw + pad * 2, boxH = fontSize + pad * 2;
     const x = Math.round(data.x + data.size + 4);   // sits just right of the node
     const y = Math.round(data.y - boxH / 2);
     context.fillStyle = '#ffffff';
-    if (context.roundRect) { context.beginPath(); context.roundRect(x, y, boxW, boxH, 6); context.fill(); }
+    if (context.roundRect) { context.beginPath(); context.roundRect(x, y, boxW, boxH, 5); context.fill(); }
     else context.fillRect(x, y, boxW, boxH);
     context.fillStyle = '#000000';
     context.textBaseline = 'middle';

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6774,8 +6774,8 @@ function _artWebShowArtist(node) {
     document.getElementById('artweb-panel-body').innerHTML = `
         <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>
         <div style="text-align:center;">
-            <div style="width:110px;height:110px;margin:0 auto;border-radius:50%;overflow:hidden;border:2px solid ${color};box-shadow:0 8px 28px ${_webHexToRgba(color, 0.45)};background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;">
-                ${a.thumb ? `<img src="${escapeHtml(a.thumb)}" style="width:100%;height:100%;object-fit:cover;" onerror="this.style.display='none'">` : '<span style="font-size:34px;opacity:0.5;">&#9835;</span>'}
+            <div id="artweb-avatar" style="width:110px;height:110px;margin:0 auto;border-radius:50%;overflow:hidden;border:2px solid ${color};box-shadow:0 8px 28px ${_webHexToRgba(color, 0.45)};background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;">
+                <span style="font-size:34px;opacity:0.5;">&#9835;</span>
             </div>
             <div style="font-size:18px;font-weight:800;margin-top:12px;">${escapeHtml(a.label)}</div>
             ${a.genre ? `<div style="font-size:11px;color:${color};margin-top:3px;">${escapeHtml(a.genre)}</div>` : ''}
@@ -6792,6 +6792,21 @@ function _artWebShowArtist(node) {
             ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
         </div>`;
     p.style.display = 'flex';
+
+    // Resolve the artist photo via the app's image resolver (thumb_url is a Plex path, not loadable
+    // directly). Guarded by selectedKey so a fast re-click doesn't drop the wrong image in.
+    if (a.artistId != null) {
+        const forNode = node;
+        fetch(`/api/artist/${encodeURIComponent(a.artistId)}/image?name=${encodeURIComponent(a.label || '')}`)
+            .then(r => r.json())
+            .then(d => {
+                if (!d || !d.success || !d.image_url) return;
+                if (_artistWeb.selectedKey !== forNode) return;   // selection moved on
+                const el = document.getElementById('artweb-avatar');
+                if (el) el.innerHTML = `<img src="${escapeHtml(d.image_url)}" style="width:100%;height:100%;object-fit:cover;" onerror="this.parentNode.innerHTML='<span style=\\'font-size:34px;opacity:0.5;\\'>&#9835;</span>'">`;
+            })
+            .catch(() => {});
+    }
 }
 
 function _artWebShowGenre(node) {

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6420,7 +6420,7 @@ function _webDrawLabel(context, data, settings) {
 // Distinct colors for the most-common genres; everything in the long tail falls back to gray.
 const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00bcd4', '#ffd54f',
     '#f44336', '#8bc34a', '#ff5722', '#7c4dff', '#26c6da', '#cddc39', '#ff4081', '#009688', '#c0846b'];
-const WEB_GENRE_FALLBACK = '#5a5a66';
+const WEB_GENRE_FALLBACK = '#6b7aa8';   // slate-periwinkle for "Other" — a real color, not dead gray
 const WEB_CANVAS_BG = '#111016';   // near-black charcoal (reference look: colors glow on dark)
 
 // Edge opacity scales with weight (consensus): weak links stay faint so they don't clutter; strong,
@@ -6447,7 +6447,7 @@ function _webGenreColorMap(nodes) {
     nodes.forEach(n => { if (n.kind === 'artist' && n.cluster) counts[n.cluster] = (counts[n.cluster] || 0) + 1; });
     const ranked = Object.keys(counts).filter(g => g !== 'Other').sort((a, b) => counts[b] - counts[a]);
     const map = { 'Other': WEB_GENRE_FALLBACK };
-    ranked.forEach((g, i) => { if (i < WEB_PALETTE.length) map[g] = WEB_PALETTE[i]; });
+    ranked.forEach((g, i) => { map[g] = WEB_PALETTE[i % WEB_PALETTE.length]; });   // cycle, never gray
     return { color: (g) => map[g] || WEB_GENRE_FALLBACK, counts };
 }
 
@@ -6650,7 +6650,7 @@ function _artWebBuildCommunity(data, Graph) {
         let rep = best ? graph.getNodeAttribute(best, 'label') : ('Group ' + cid);
         if (countsByRep[rep] != null) rep = rep + ' · ' + cid;   // guard rare rep-name collision
         repOf[cid] = rep;
-        colorByRep[rep] = i < WEB_PALETTE.length ? WEB_PALETTE[i] : WEB_GENRE_FALLBACK;
+        colorByRep[rep] = WEB_PALETTE[i % WEB_PALETTE.length];   // cycle palette; no community goes gray
         countsByRep[rep] = members[cid].length;
         if (best) graph.setNodeAttribute(best, '_rep', true);
     });

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6382,6 +6382,13 @@ let _artistWeb = {
     selectedFocus: null,              // the focus set to restore when hover clears
     genreFilter: null,                // Set<genre> persistent filter (dims everything outside it)
     genreCounts: null,                // {genre: artistCount} for the filter sidebar
+    // Shortest-path mode: click two artists to trace how they connect (via the similarity graph).
+    pathMode: false,
+    pathSource: null, pathTarget: null,
+    pathNodes: null,                  // Set<key> on the path (highlighted)
+    pathPairs: null,                  // Set<"a|b"> consecutive path edges (highlighted)
+    pathResult: null,                 // the node-key array, once complete
+    simGraph: null,                   // cached similarity-only graph for pathfinding (lens-independent)
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6455,9 +6462,10 @@ async function openArtistWeb() {
     const statsEl = document.getElementById('artist-web-stats');
     host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Building your artist web…</div>';
 
-    // Esc: dismiss an open detail panel first, otherwise leave the web (mirrors the artist map).
+    // Esc: exit path mode, else dismiss an open detail panel, else leave the web.
     _artistWeb.onKey = (e) => {
         if (e.key !== 'Escape') return;
+        if (_artistWeb.pathMode) { _artWebExitPath(); return; }
         const p = document.getElementById('artweb-panel');
         if (p && p.style.display !== 'none') _artWebClearSelection();
         else closeArtistWeb();
@@ -6473,6 +6481,7 @@ async function openArtistWeb() {
 
     try {
         _artistWeb.data = await (await fetch('/api/graph/library')).json();
+        _artistWeb.simGraph = null;   // rebuild pathfinding graph for this (possibly new) data
         _artistWeb.lens = _artistWeb.lens || 'genre';
         _artWebSyncLensButtons();
         _artWebRenderLens();
@@ -6509,6 +6518,8 @@ function _artWebRenderLens() {
     // Reset per-render UI state + chrome.
     _artistWeb.searchMatch = _artistWeb.focusSet = _artistWeb.focusRoot = null;
     _artistWeb.selectedKey = _artistWeb.selectedFocus = null;
+    _artistWeb.pathSource = _artistWeb.pathTarget = _artistWeb.pathResult = null;
+    _artistWeb.pathNodes = _artistWeb.pathPairs = null;
     _artistWeb.genreFilter = null;
     _artistWeb.index = [];
     _artWebClosePanel();
@@ -6683,7 +6694,10 @@ function _artWebMountSigma(host, graph) {
     sig.on('enterNode', ({ node }) => _artWebHover(node));
     sig.on('leaveNode', () => _artWebHover(null));
     sig.on('clickNode', ({ node }) => _artWebClickNode(node));
-    sig.on('clickStage', () => _artWebClearSelection());
+    sig.on('clickStage', () => {
+        if (_artistWeb.pathMode) { _artWebClearPath(); _artWebPathHint('Click an artist, then a second one, to trace how they connect.'); }
+        else _artWebClearSelection();
+    });
 }
 
 function closeArtistWeb() {
@@ -6701,6 +6715,12 @@ function closeArtistWeb() {
     if (results) { results.style.display = 'none'; results.innerHTML = ''; }
     const sb = document.getElementById('artweb-genre-sidebar');
     if (sb) sb.style.display = 'none';
+    _artistWeb.pathMode = false;
+    _artistWeb.pathNodes = _artistWeb.pathPairs = _artistWeb.pathResult = _artistWeb.pathSource = _artistWeb.pathTarget = null;
+    const pathBtn = document.getElementById('artweb-path-btn');
+    if (pathBtn) pathBtn.classList.remove('active');
+    const hint = document.getElementById('artweb-path-hint');
+    if (hint) hint.style.display = 'none';
     _artWebClosePanel();
 }
 
@@ -6712,6 +6732,19 @@ const _WEB_DIM_NODE = '#2b2b34';
 function _artWebNodeReducer(node, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
+    // Shortest-path mode takes priority: the chain lights up, everything else goes dark.
+    if (st.pathNodes) {
+        if (st.pathNodes.has(node)) {
+            res.color = data.baseColor || data.color;
+            res.zIndex = 3;
+            const isEnd = (node === st.pathSource || node === st.pathTarget);
+            res.forceLabel = isEnd || !!st.pathResult;   // label the whole chain once complete
+            if (isEnd) res.highlighted = true;
+        } else {
+            res.color = _WEB_DIM_NODE; res.label = ''; res.zIndex = 0;
+        }
+        return res;
+    }
     // Persistent genre filter dims anything outside the chosen genres, regardless of focus/search.
     if (st.genreFilter && !st.genreFilter.has(data.genre)) {
         res.color = _WEB_DIM_NODE; res.label = ''; res.zIndex = 0;
@@ -6743,6 +6776,21 @@ function _artWebEdgeReducer(edge, data) {
     // conveyed by node position + color. Only similarity edges are drawn.
     if (data.kind === 'membership') { res.hidden = true; return res; }
     const g = _artistWeb.graph;
+    // Shortest-path mode: only the consecutive edges along the chain show (bright + thick), rest hidden.
+    if (st.pathNodes) {
+        if (g && st.pathPairs && st.pathPairs.size) {
+            const s = g.source(edge), t = g.target(edge);
+            const key = s < t ? s + '|' + t : t + '|' + s;
+            if (st.pathPairs.has(key)) {
+                res.zIndex = 3;
+                res.color = _webHexToRgba(data.baseColor || '#ffffff', 0.95);
+                res.size = (data.size || 0.7) * 2.4;
+                return res;
+            }
+        }
+        res.hidden = true;
+        return res;
+    }
     if (st.genreFilter && g) {
         const sg = g.getNodeAttribute(g.source(edge), 'genre');
         const tg = g.getNodeAttribute(g.target(edge), 'genre');
@@ -6843,7 +6891,7 @@ function artWebFitToView() {
 // ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
 function _artWebHover(node) {
     const st = _artistWeb;
-    if (!st.sigma) return;
+    if (!st.sigma || st.pathMode) return;   // no hover-dim while tracing a path
     if (node) {
         const set = new Set([node]);
         st.graph.forEachNeighbor(node, nb => set.add(nb));
@@ -6860,6 +6908,7 @@ function _artWebHover(node) {
 function _artWebClickNode(node) {
     const st = _artistWeb;
     if (!st.graph || !st.graph.hasNode(node)) return;
+    if (st.pathMode) { _artWebPathClick(node); return; }
     const set = new Set([node]);
     st.graph.forEachNeighbor(node, nb => set.add(nb));
     st.selectedKey = node; st.selectedFocus = set;
@@ -6891,6 +6940,149 @@ function _artWebGoToArtist(key) {
     _artWebClickNode(key);
     const disp = sig.getNodeDisplayData(key);
     if (disp) sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 });
+}
+
+// ---- Artist Web shortest path: click two artists, trace how they connect via similarity ---------
+// Pathfinding runs on a SIMILARITY-only graph (not the displayed one) so a path means "sounds like ->
+// sounds like", never "both are tagged Rock" (which membership-to-hub edges would allow).
+function _artWebSimGraph() {
+    if (_artistWeb.simGraph) return _artistWeb.simGraph;
+    const Graph = window.graphology && (window.graphology.Graph || window.graphology);
+    const data = _artistWeb.data;
+    if (!Graph || !data) return null;
+    // UNDIRECTED: similarity pairs are stored once (sorted), so a directed graph would miss reverse
+    // traversals and report "no connection" for most pairs.
+    const g = new Graph({ type: 'undirected' });
+    (data.edges || []).forEach(e => {
+        if (e.kind !== 'similarity') return;
+        if (!g.hasNode(e.source)) g.addNode(e.source);
+        if (!g.hasNode(e.target)) g.addNode(e.target);
+        if (!g.hasEdge(e.source, e.target)) g.addEdge(e.source, e.target, { weight: e.weight || 1 });
+    });
+    _artistWeb.simGraph = g;
+    return g;
+}
+
+function artWebTogglePathMode() {
+    const st = _artistWeb;
+    if (st.pathMode) { _artWebExitPath(); return; }
+    st.pathMode = true;
+    const btn = document.getElementById('artweb-path-btn');
+    if (btn) btn.classList.add('active');
+    _artWebClearSelection();
+    _artWebClearPath();
+    _artWebPathHint('Click an artist, then a second one, to trace how they connect.');
+}
+
+function _artWebPathClick(node) {
+    const st = _artistWeb, g = st.graph;
+    if (!g || !g.hasNode(node)) return;
+    if (g.getNodeAttribute(node, 'kind') === 'genre') { _artWebPathHint('Pick artists, not genre hubs.'); return; }
+    const label = g.getNodeAttribute(node, 'label') || node;
+
+    if (!st.pathSource || st.pathResult) {
+        // (Re)start from this node.
+        st.pathSource = node; st.pathTarget = null; st.pathResult = null;
+        st.pathNodes = new Set([node]); st.pathPairs = new Set();
+        st.searchMatch = st.focusSet = st.focusRoot = null;
+        _artWebClosePanel();
+        st.sigma.refresh();
+        _artWebPathHint(`Start: <b>${escapeHtml(label)}</b> — now click a second artist.`);
+        return;
+    }
+    if (node === st.pathSource) return;
+    const path = _artWebComputePath(st.pathSource, node);
+    if (!path || path.length < 2) {
+        _artWebPathHint(`No similarity path between <b>${escapeHtml(g.getNodeAttribute(st.pathSource, 'label'))}</b> and <b>${escapeHtml(label)}</b>.`);
+        return;
+    }
+    st.pathTarget = node;
+    st.pathResult = path;
+    st.pathNodes = new Set(path);
+    st.pathPairs = new Set();
+    for (let i = 0; i + 1 < path.length; i++) {
+        const a = path[i], b = path[i + 1];
+        st.pathPairs.add(a < b ? a + '|' + b : b + '|' + a);
+    }
+    st.sigma.refresh();
+    _artWebShowPathPanel(path);
+    _artWebHidePathHint();
+}
+
+function _artWebComputePath(a, b) {
+    const sp = window.graphologyLibrary && window.graphologyLibrary.shortestPath;
+    const g = _artWebSimGraph();
+    if (!sp || !sp.bidirectional || !g || !g.hasNode(a) || !g.hasNode(b)) return null;
+    try { return sp.bidirectional(g, a, b); } catch (e) { return null; }
+}
+
+function _artWebClearPath() {
+    const st = _artistWeb;
+    st.pathSource = st.pathTarget = st.pathResult = st.pathNodes = st.pathPairs = null;
+    if (st.sigma) st.sigma.refresh();
+}
+
+function _artWebExitPath() {
+    _artistWeb.pathMode = false;
+    const btn = document.getElementById('artweb-path-btn');
+    if (btn) btn.classList.remove('active');
+    _artWebHidePathHint();
+    _artWebClosePanel();
+    _artWebClearPath();
+}
+
+function _artWebShowPathPanel(path) {
+    const p = _artWebEnsurePanel();
+    if (!p) return;
+    const g = _artistWeb.graph;
+    const hops = path.length - 1;
+    const between = path.length - 2;
+    const rows = path.map((k, i) => {
+        const label = g.getNodeAttribute(k, 'label') || k;
+        const color = g.getNodeAttribute(k, 'baseColor') || '#1db954';
+        const tag = i === 0 ? 'start' : (i === path.length - 1 ? 'end' : '');
+        return `<div onclick="_artWebCameraTo('${escapeForInlineJs(k)}')" style="display:flex;align-items:center;gap:10px;padding:7px 8px;border-radius:9px;cursor:pointer;" onmouseover="this.style.background='rgba(255,255,255,0.06)'" onmouseout="this.style.background='transparent'">
+            <span style="width:11px;height:11px;border-radius:50%;flex:none;background:${color};box-shadow:0 0 0 ${tag ? '2px rgba(255,255,255,0.5)' : '0'};"></span>
+            <span style="flex:1;min-width:0;font-size:13px;font-weight:${tag ? '800' : '600'};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(label)}</span>
+            ${tag ? `<span style="font-size:9px;letter-spacing:0.08em;text-transform:uppercase;color:rgba(255,255,255,0.4);">${tag}</span>` : ''}
+        </div>${i < path.length - 1 ? '<div style="margin-left:13px;height:10px;border-left:2px solid rgba(255,255,255,0.12);"></div>' : ''}`;
+    }).join('');
+    document.getElementById('artweb-panel-body').innerHTML = `
+        <button onclick="_artWebExitPath()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Done</button>
+        <div style="font-size:10px;letter-spacing:0.12em;text-transform:uppercase;color:rgba(255,255,255,0.4);">Connection path</div>
+        <div style="font-size:20px;font-weight:800;margin:3px 0 2px;">${hops} hop${hops === 1 ? '' : 's'} apart</div>
+        <div style="font-size:11.5px;color:rgba(255,255,255,0.5);margin-bottom:14px;">${between === 0 ? 'directly similar' : `via ${between} artist${between === 1 ? '' : 's'} in between`}</div>
+        ${rows}`;
+    p.style.display = 'flex';
+}
+
+// Pan/zoom the camera to a node WITHOUT triggering a selection (used by path + genre member lists).
+function _artWebCameraTo(key) {
+    const sig = _artistWeb.sigma;
+    if (!sig || !_artistWeb.graph || !_artistWeb.graph.hasNode(key)) return;
+    const d = sig.getNodeDisplayData(key);
+    if (d) sig.getCamera().animate({ x: d.x, y: d.y, ratio: 0.12 }, { duration: 500 });
+}
+
+function _artWebPathHint(html) {
+    let el = document.getElementById('artweb-path-hint');
+    if (!el) {
+        const container = document.getElementById('artist-web-container');
+        if (!container) return;
+        el = document.createElement('div');
+        el.id = 'artweb-path-hint';
+        el.style.cssText = 'position:absolute;top:70px;left:50%;transform:translateX(-50%);z-index:25;'
+            + 'background:rgba(20,18,26,0.94);border:1px solid rgba(255,255,255,0.12);border-radius:999px;'
+            + 'padding:8px 16px;font-size:12.5px;color:rgba(255,255,255,0.88);box-shadow:0 8px 24px rgba(0,0,0,0.5);pointer-events:none;';
+        container.appendChild(el);
+    }
+    el.innerHTML = html;
+    el.style.display = 'block';
+}
+
+function _artWebHidePathHint() {
+    const el = document.getElementById('artweb-path-hint');
+    if (el) el.style.display = 'none';
 }
 
 // ---- Artist Web side panel (mirrors the Artist Map card design/interactions) -------------------

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6389,6 +6389,10 @@ let _artistWeb = {
     pathPairs: null,                  // Set<"a|b"> consecutive path edges (highlighted)
     pathResult: null,                 // the node-key array, once complete
     simGraph: null,                   // cached similarity-only graph for pathfinding (lens-independent)
+    // Cursor force-field: nodes near the pointer nudge away, then spring back to their layout home.
+    cursorFX: true,
+    cursor: null, cursorActive: false, cursorRAF: null,
+    cursorRadius: 0, cursorPush: 0, home: null,
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6539,6 +6543,22 @@ function _artWebRenderLens() {
     if (sbHeader) sbHeader.textContent = _artistWeb.lens === 'community' ? 'Communities' : 'Genres';
 
     _artWebRunLayout(built.graph);
+
+    // Capture resting ("home") positions + size the cursor force-field to the layout's coordinate
+    // range (FA2 output scale is unknown up front), so radius/push are proportional, not guessed.
+    const home = {};
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    built.graph.forEachNode((k, a) => {
+        home[k] = { x: a.x, y: a.y };
+        if (a.x < minX) minX = a.x; if (a.x > maxX) maxX = a.x;
+        if (a.y < minY) minY = a.y; if (a.y > maxY) maxY = a.y;
+    });
+    const span = Math.max(maxX - minX, maxY - minY) || 1;
+    _artistWeb.home = home;
+    _artistWeb.cursorRadius = span * 0.05;   // ~5% of the graph span
+    _artistWeb.cursorPush = span * 0.02;     // nudge up to ~2% — subtle, so hover/click still land
+    _artistWeb.cursor = null; _artistWeb.cursorActive = false;
+
     _artWebMountSigma(host, built.graph);
 }
 
@@ -6680,6 +6700,7 @@ function _artWebRunLayout(graph) {
 function _artWebMountSigma(host, graph) {
     host.innerHTML = '';
     host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow
+    if (_artistWeb.cursorRAF) { cancelAnimationFrame(_artistWeb.cursorRAF); _artistWeb.cursorRAF = null; }
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     _artistWeb.graph = graph;
     _artistWeb.sigma = new window.Sigma(graph, host, {
@@ -6698,6 +6719,56 @@ function _artWebMountSigma(host, graph) {
         if (_artistWeb.pathMode) { _artWebClearPath(); _artWebPathHint('Click an artist, then a second one, to trace how they connect.'); }
         else _artWebClearSelection();
     });
+
+    // Cursor force-field: track the pointer in graph space; the rAF loop nudges nearby nodes.
+    if (_artistWeb.cursorFX) {
+        sig.getMouseCaptor().on('mousemovebody', (e) => {
+            try { _artistWeb.cursor = sig.viewportToGraph({ x: e.x, y: e.y }); } catch (_) { return; }
+            _artistWeb.cursorActive = true;
+            _artWebStartCursorFX();
+        });
+        host.addEventListener('mouseleave', () => { _artistWeb.cursorActive = false; _artWebStartCursorFX(); });
+    }
+}
+
+// Cursor force-field loop: nodes within radius get pushed away from the pointer (relative to their
+// home), and ease back home when the pointer moves off. Purely visual — never touches the data/layout.
+function _artWebStartCursorFX() {
+    if (!_artistWeb.cursorRAF) _artistWeb.cursorRAF = requestAnimationFrame(_artWebCursorTick);
+}
+
+function _artWebCursorTick() {
+    const st = _artistWeb;
+    st.cursorRAF = null;
+    if (!st.sigma || !st.cursorFX || !st.home || !st.graph) return;
+    const g = st.graph, home = st.home;
+    const active = st.cursorActive && st.cursor;
+    const cx = active ? st.cursor.x : 0, cy = active ? st.cursor.y : 0;
+    const R = st.cursorRadius, PUSH = st.cursorPush, EASE = 0.2;
+    let moving = false;
+    g.forEachNode((k, a) => {
+        const h = home[k];
+        if (!h) return;
+        let tx = h.x, ty = h.y;
+        if (active) {
+            const dx = h.x - cx, dy = h.y - cy;          // measure from HOME → stable, no feedback jitter
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            if (dist < R && dist > 0.0001) {
+                const force = (1 - dist / R) * PUSH;      // closer to pointer → stronger push
+                tx = h.x + (dx / dist) * force;
+                ty = h.y + (dy / dist) * force;
+            }
+        }
+        const nx = a.x + (tx - a.x) * EASE;
+        const ny = a.y + (ty - a.y) * EASE;
+        if (Math.abs(nx - a.x) > 0.0005 || Math.abs(ny - a.y) > 0.0005) {
+            g.setNodeAttribute(k, 'x', nx);
+            g.setNodeAttribute(k, 'y', ny);
+            moving = true;
+        }
+    });
+    if (moving) st.sigma.refresh();
+    if (moving || active) st.cursorRAF = requestAnimationFrame(_artWebCursorTick);   // else settled → stop
 }
 
 function closeArtistWeb() {
@@ -6709,6 +6780,8 @@ function closeArtistWeb() {
     document.querySelectorAll('#discover-page > .discover-container > *').forEach(el => {
         if (el.id !== 'artist-web-container' && el._prevDisplay !== undefined) el.style.display = el._prevDisplay;
     });
+    if (_artistWeb.cursorRAF) { cancelAnimationFrame(_artistWeb.cursorRAF); _artistWeb.cursorRAF = null; }
+    _artistWeb.cursorActive = false;
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6551,7 +6551,10 @@ async function openArtistWeb() {
 
 function closeArtistWeb() {
     const container = document.getElementById('artist-web-container');
-    if (container) container.style.display = 'none';
+    // Stamp _prevDisplay='none' so if another overlay (Artist Map) later runs its sibling-restore,
+    // it keeps this container hidden instead of falling back to '' and un-hiding a dead (sigma-killed)
+    // Web. Matters on the Explore-in-Map hand-off, where the Map's open skips recording _prevDisplay.
+    if (container) { container.style.display = 'none'; container._prevDisplay = 'none'; }
     document.querySelectorAll('#discover-page > .discover-container > *').forEach(el => {
         if (el.id !== 'artist-web-container' && el._prevDisplay !== undefined) el.style.display = el._prevDisplay;
     });

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6738,7 +6738,9 @@ function _artWebEnsurePanel() {
     if (p) return p;
     const container = document.getElementById('artist-web-container');
     if (!container) return null;
-    if (!container.style.position) container.style.position = 'relative';
+    // NOTE: do NOT set container.style.position — .artist-map-container is `position:fixed; inset:0`
+    // in CSS, which already anchors this absolute panel. An inline `relative` would clobber the CSS
+    // `fixed`, collapse the fullscreen overlay, and displace the sigma canvas (clicks freeze).
     p = document.createElement('div');
     p.id = 'artweb-panel';
     p.style.cssText = 'position:absolute;top:66px;right:14px;width:300px;max-height:calc(100% - 88px);'

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6378,6 +6378,8 @@ let _artistWeb = {
     focusRoot: null,                  // the node at the center of the focus (gets a halo)
     selectedKey: null,                // click-selected node (survives hover-out)
     selectedFocus: null,              // the focus set to restore when hover clears
+    genreFilter: null,                // Set<genre> persistent filter (dims everything outside it)
+    genreCounts: null,                // {genre: artistCount} for the filter sidebar
 };
 
 // White pill label (black text, 10px padding) — custom sigma labelRenderer, per Boulder's spec.
@@ -6465,6 +6467,8 @@ async function openArtistWeb() {
 
         const { color: genreColor, counts: genreCounts } = _webGenreColorMap(nodes);
         _artistWeb.genreColor = genreColor;
+        _artistWeb.genreCounts = genreCounts;
+        _artistWeb.genreFilter = null;
         _artistWeb.index = [];
         _artistWeb.searchMatch = null;
 
@@ -6554,6 +6558,8 @@ function closeArtistWeb() {
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');
     if (results) { results.style.display = 'none'; results.innerHTML = ''; }
+    const sb = document.getElementById('artweb-genre-sidebar');
+    if (sb) sb.style.display = 'none';
     _artWebClosePanel();
 }
 
@@ -6564,6 +6570,11 @@ const _WEB_DIM_EDGE = 'rgba(255,255,255,0.02)';
 function _artWebNodeReducer(node, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
+    // Persistent genre filter dims anything outside the chosen genres, regardless of focus/search.
+    if (st.genreFilter && !st.genreFilter.has(data.genre)) {
+        res.color = _WEB_DIM_NODE; res.label = ''; res.zIndex = 0;
+        return res;
+    }
     const active = st.focusSet || st.searchMatch;   // focus (hover/select) wins over search
     if (active) {
         if (active.has(node)) {
@@ -6583,9 +6594,14 @@ function _artWebNodeReducer(node, data) {
 function _artWebEdgeReducer(edge, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
+    const g = _artistWeb.graph;
+    if (st.genreFilter && g) {
+        const sg = g.getNodeAttribute(g.source(edge), 'genre');
+        const tg = g.getNodeAttribute(g.target(edge), 'genre');
+        if (!(st.genreFilter.has(sg) && st.genreFilter.has(tg))) { res.color = _WEB_DIM_EDGE; return res; }
+    }
     const active = st.focusSet || st.searchMatch;
-    if (active && _artistWeb.graph) {
-        const g = _artistWeb.graph;
+    if (active && g) {
         const s = g.source(edge), t = g.target(edge);
         // Focus (hover/select): show only edges fully inside the set → clean neighborhood.
         // Search: show any edge touching a match.
@@ -6797,9 +6813,64 @@ function _artWebShowGenre(node) {
     p.style.display = 'flex';
 }
 
-// Filter-by-genre lives in a later phase; stubs keep the toolbar buttons inert-but-safe for now.
-function artWebToggleFilter() { /* Phase C */ }
-function artWebFilterGenreList() { /* Phase C */ }
+// ---- Artist Web filter by genre: multi-select sidebar; dims everything outside the chosen genres --
+function artWebToggleFilter() {
+    const sb = document.getElementById('artweb-genre-sidebar');
+    const btn = document.getElementById('artweb-filter-btn');
+    if (!sb) return;
+    const open = sb.style.display !== 'none';
+    if (open) {
+        sb.style.display = 'none';
+        if (btn) btn.classList.remove('active');
+    } else {
+        _artWebPopulateGenreList('');
+        sb.style.display = 'flex';
+        if (btn) btn.classList.add('active');
+    }
+}
+
+function _artWebPopulateGenreList(query) {
+    const list = document.getElementById('artweb-genre-sidebar-list');
+    if (!list) return;
+    const counts = _artistWeb.genreCounts || {};
+    const color = _artistWeb.genreColor || (() => WEB_GENRE_FALLBACK);
+    const active = _artistWeb.genreFilter;
+    const q = (query || '').trim().toLowerCase();
+    const genres = Object.keys(counts).sort((a, b) => counts[b] - counts[a])
+        .filter(g => !q || g.toLowerCase().includes(q));
+
+    const clearRow = active ? `<div onclick="artWebClearGenreFilter()" style="display:flex;align-items:center;gap:8px;padding:6px 8px;margin-bottom:4px;border-radius:8px;cursor:pointer;color:#fff;font-size:12px;font-weight:700;background:rgba(255,255,255,0.06);">&#10005; Clear filter (${active.size})</div>` : '';
+    list.innerHTML = clearRow + (genres.map(g => {
+        const on = active && active.has(g);
+        return `<div onclick="artWebToggleGenre('${escapeForInlineJs(g)}')" style="display:flex;align-items:center;gap:8px;padding:6px 8px;border-radius:8px;cursor:pointer;${on ? 'background:rgba(255,255,255,0.09);' : ''}"
+             onmouseover="this.style.background='rgba(255,255,255,0.06)'" onmouseout="this.style.background='${on ? 'rgba(255,255,255,0.09)' : 'transparent'}'">
+            <span style="width:10px;height:10px;border-radius:50%;flex:none;background:${color(g)};"></span>
+            <span style="flex:1;min-width:0;font-size:12px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;${on ? 'font-weight:700;' : ''}">${escapeHtml(g)}</span>
+            <span style="font-size:10.5px;color:rgba(255,255,255,0.4);">${counts[g]}</span>
+        </div>`;
+    }).join('') || '<div style="color:rgba(255,255,255,0.4);padding:8px;font-size:12px;">No genres</div>');
+}
+
+function artWebToggleGenre(genre) {
+    const st = _artistWeb;
+    if (!st.genreFilter) st.genreFilter = new Set();
+    if (st.genreFilter.has(genre)) st.genreFilter.delete(genre);
+    else st.genreFilter.add(genre);
+    if (st.genreFilter.size === 0) st.genreFilter = null;
+    if (st.sigma) st.sigma.refresh();
+    const qi = document.querySelector('#artweb-genre-sidebar .artmap-genre-sidebar-search');
+    _artWebPopulateGenreList(qi ? qi.value : '');
+}
+
+function artWebClearGenreFilter() {
+    _artistWeb.genreFilter = null;
+    if (_artistWeb.sigma) _artistWeb.sigma.refresh();
+    const qi = document.querySelector('#artweb-genre-sidebar .artmap-genre-sidebar-search');
+    _artWebPopulateGenreList(qi ? qi.value : '');
+}
+
+// Sidebar search box just filters which genres are listed.
+function artWebFilterGenreList(query) { _artWebPopulateGenreList(query); }
 
 async function openArtistMap() {
     const container = document.getElementById('artist-map-container');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6705,8 +6705,9 @@ function closeArtistWeb() {
 }
 
 // ---- Artist Web reducers: the single place UI state turns into per-frame styling -------------
-const _WEB_DIM_NODE = 'rgba(120,120,130,0.12)';
-const _WEB_DIM_EDGE = 'rgba(255,255,255,0.02)';
+// Dimmed nodes fade to a DARK gray (not light — light + WebGL additive blending reads as white).
+// Dimmed edges are hidden outright: thousands of faint edges overlapping accumulate to a white haze.
+const _WEB_DIM_NODE = '#2b2b34';
 
 function _artWebNodeReducer(node, data) {
     const st = _artistWeb;
@@ -6745,7 +6746,7 @@ function _artWebEdgeReducer(edge, data) {
     if (st.genreFilter && g) {
         const sg = g.getNodeAttribute(g.source(edge), 'genre');
         const tg = g.getNodeAttribute(g.target(edge), 'genre');
-        if (!(st.genreFilter.has(sg) && st.genreFilter.has(tg))) { res.color = _WEB_DIM_EDGE; return res; }
+        if (!(st.genreFilter.has(sg) && st.genreFilter.has(tg))) { res.hidden = true; return res; }
     }
     const active = st.focusSet || st.searchMatch;
     if (active && g) {
@@ -6759,7 +6760,7 @@ function _artWebEdgeReducer(edge, data) {
             res.color = _webHexToRgba(data.baseColor || '#888888', 0.75);
             res.size = (data.size || 0.7) * 1.7;
         } else {
-            res.color = _WEB_DIM_EDGE;
+            res.hidden = true;   // hide non-focus edges (faint ones accumulate to a white haze)
         }
     }
     return res;

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6765,8 +6765,11 @@ function _artWebShowArtist(node) {
     const color = a.baseColor || '#1db954';
     const conn = g.degree(node);
     const pop = Math.max(0, Math.min(100, Math.round(a.popularity || 0)));
+    // These are all owned library artists, so the detail page is the library route:
+    // /artist-detail/library/<db id>. (a.source is the server name e.g. 'plex' — NOT a valid
+    // detail source, which is what produced the broken /artist-detail/plex/... link.)
     const detailPath = (a.artistId != null && typeof buildArtistDetailPath === 'function')
-        ? buildArtistDetailPath(a.artistId, a.source) : null;
+        ? buildArtistDetailPath(a.artistId, 'library') : null;
 
     document.getElementById('artweb-panel-body').innerHTML = `
         <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6371,6 +6371,21 @@ function _artMapPanelArtistById(id) {
 // styling, hover/expand interactions — gets built on top of this.
 let _artistWeb = { sigma: null, graph: null, onKey: null };
 
+// Distinct colors for the most-common genres; everything in the long tail falls back to gray.
+const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00bcd4', '#ffd54f',
+    '#f44336', '#8bc34a', '#ff5722', '#7c4dff', '#26c6da', '#cddc39', '#ff4081', '#009688', '#c0846b'];
+const WEB_GENRE_FALLBACK = '#5a5a66';
+
+// Map the top-N genres (by artist count) to palette colors; return a lookup + the per-genre counts.
+function _webGenreColorMap(nodes) {
+    const counts = {};
+    nodes.forEach(n => { if (n.kind === 'artist' && n.primary_genre) counts[n.primary_genre] = (counts[n.primary_genre] || 0) + 1; });
+    const top = Object.keys(counts).sort((a, b) => counts[b] - counts[a]).slice(0, WEB_PALETTE.length);
+    const map = {};
+    top.forEach((g, i) => { map[g] = WEB_PALETTE[i]; });
+    return { color: (g) => map[g] || WEB_GENRE_FALLBACK, counts };
+}
+
 async function openArtistWeb() {
     const container = document.getElementById('artist-web-container');
     if (!container) return;
@@ -6400,27 +6415,59 @@ async function openArtistWeb() {
     try {
         const data = await (await fetch('/api/graph/library')).json();
         const nodes = data.nodes || [], edges = data.edges || [];
-        if (statsEl) statsEl.textContent = `${nodes.length} artists · ${edges.length} connections`;
+        const c = data.counts || {};
+        const simCount = edges.filter(e => e.kind === 'similarity').length;
+        if (statsEl) statsEl.textContent = `${c.artists ?? nodes.length} artists · ${c.genres ?? 0} genres · ${simCount} similarity links`;
+
+        const { color: genreColor, counts: genreCounts } = _webGenreColorMap(nodes);
 
         const graph = new Graph();
         nodes.forEach(n => {
-            graph.addNode(n.key, {
-                label: n.label,
-                x: Math.random(), y: Math.random(),          // scaffold — real layout (forceAtlas2) next
-                size: 3 + Math.sqrt(n.popularity || 0) / 2,
-                color: '#1db954',
-            });
+            if (n.kind === 'genre') {
+                const members = genreCounts[n.genre] || 1;
+                graph.addNode(n.key, {
+                    label: n.label,
+                    x: Math.random(), y: Math.random(),
+                    size: 6 + Math.sqrt(members) * 1.5,      // hub size scales with how many artists it holds
+                    color: genreColor(n.genre),
+                    forceLabel: true,                         // genre hubs are always labeled
+                    isGenre: true,
+                });
+            } else {
+                graph.addNode(n.key, {
+                    label: n.label,
+                    x: Math.random(), y: Math.random(),      // random seed; forceAtlas2 places them below
+                    size: 2 + Math.sqrt(n.popularity || 0) / 3,
+                    color: genreColor(n.primary_genre),
+                });
+            }
         });
         edges.forEach(e => {
             if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
-                graph.addEdge(e.source, e.target, { weight: e.weight, size: 0.6, color: 'rgba(255,255,255,0.08)' });
+                const membership = e.kind === 'membership';
+                graph.addEdge(e.source, e.target, {
+                    weight: e.weight,
+                    size: membership ? 0.4 : 0.8,
+                    color: membership ? 'rgba(255,255,255,0.03)' : 'rgba(29,185,84,0.15)',
+                });
             }
         });
+
+        // Settle the random blob into genre clusters. Barnes-Hut keeps the ~5k-node layout tractable.
+        const fa2 = window.graphologyLibrary && window.graphologyLibrary.layoutForceAtlas2;
+        if (fa2) {
+            fa2.assign(graph, { iterations: 250, settings: { ...fa2.inferSettings(graph), barnesHutOptimize: true } });
+        } else {
+            console.warn('[Artist Web] forceAtlas2 unavailable — nodes stay at random positions');
+        }
 
         host.innerHTML = '';
         if (_artistWeb.sigma) _artistWeb.sigma.kill();
         _artistWeb.graph = graph;
-        _artistWeb.sigma = new window.Sigma(graph, host, { renderLabels: true });
+        _artistWeb.sigma = new window.Sigma(graph, host, {
+            renderLabels: true,
+            labelRenderedSizeThreshold: 20,   // only large nodes (genre hubs) label by default; artists on zoom
+        });
     } catch (err) {
         console.error('[Artist Web] load failed', err);
         host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6392,7 +6392,7 @@ let _artistWeb = {
     // Cursor force-field: nodes near the pointer nudge away, then spring back to their layout home.
     cursorFX: true,
     cursor: null, cursorActive: false, cursorRAF: null,
-    cursorRadius: 0, cursorPush: 0, home: null,
+    cursorRadius: 0, cursorPush: 0, home: null, hoverNode: null,
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6745,12 +6745,21 @@ function _artWebCursorTick() {
     const active = st.cursorActive && st.cursor;
     const cx = active ? st.cursor.x : 0, cy = active ? st.cursor.y : 0;
     const R = st.cursorRadius, PUSH = st.cursorPush, EASE = 0.2;
+
+    // The node nearest the pointer is exempt from the push (stays home) so it never flees your click;
+    // everything else parts around it.
+    let nearest = null;
+    if (active) {
+        let nd = Infinity;
+        g.forEachNode((k, a) => { const dx = a.x - cx, dy = a.y - cy, d = dx * dx + dy * dy; if (d < nd) { nd = d; nearest = k; } });
+    }
+
     let moving = false;
     g.forEachNode((k, a) => {
         const h = home[k];
         if (!h) return;
         let tx = h.x, ty = h.y;
-        if (active) {
+        if (active && k !== nearest && k !== st.hoverNode) {
             const dx = h.x - cx, dy = h.y - cy;          // measure from HOME → stable, no feedback jitter
             const dist = Math.sqrt(dx * dx + dy * dy);
             if (dist < R && dist > 0.0001) {
@@ -6964,6 +6973,7 @@ function artWebFitToView() {
 // ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
 function _artWebHover(node) {
     const st = _artistWeb;
+    st.hoverNode = node || null;   // pin the hovered node so the force-field can't shove it out of reach
     if (!st.sigma || st.pathMode) return;   // no hover-dim while tracing a path
     if (node) {
         const set = new Set([node]);

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6412,6 +6412,15 @@ const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00
 const WEB_GENRE_FALLBACK = '#5a5a66';
 const WEB_CANVAS_BG = '#111016';   // near-black charcoal (reference look: colors glow on dark)
 
+// Edge opacity scales with weight (consensus): weak links stay faint so they don't clutter; strong,
+// high-agreement links come forward. Capped so nothing gets fully opaque at rest.
+function _webEdgeAlpha(weight) {
+    return Math.min(0.4, 0.08 + (weight || 1) * 0.025);
+}
+function _webEdgeSize(weight) {
+    return 0.35 + Math.min(1.3, Math.sqrt(weight || 1) * 0.3);
+}
+
 // '#rrggbb' -> 'rgba(r,g,b,a)' so edges can inherit a cluster color at low alpha (the glowing web).
 function _webHexToRgba(hex, alpha) {
     const h = (hex || '').replace('#', '');
@@ -6554,8 +6563,11 @@ function _artWebBuildGenre(data, Graph) {
             const membership = e.kind === 'membership';
             const base = graph.getNodeAttribute(e.source, 'baseColor') || WEB_GENRE_FALLBACK;
             graph.addEdge(e.source, e.target, {
-                weight: e.weight, size: membership ? 0.35 : 0.7,
-                color: _webHexToRgba(base, 0.22), kind: e.kind,
+                weight: e.weight,
+                size: membership ? 0.35 : _webEdgeSize(e.weight),
+                color: _webHexToRgba(base, _webEdgeAlpha(e.weight)),
+                baseColor: base,   // hex kept so the reducer can brighten it on focus
+                kind: e.kind,
             });
         }
     });
@@ -6624,7 +6636,12 @@ function _artWebBuildCommunity(data, Graph) {
     });
     graph.forEachEdge((edge, attrs, s) => {
         const base = graph.getNodeAttribute(s, 'baseColor') || WEB_GENRE_FALLBACK;
-        graph.setEdgeAttribute(edge, 'color', _webHexToRgba(base, 0.22));
+        const w = attrs.weight || 1;
+        graph.mergeEdgeAttributes(edge, {
+            color: _webHexToRgba(base, _webEdgeAlpha(w)),
+            baseColor: base,
+            size: _webEdgeSize(w),
+        });
     });
 
     const stats = `${graph.order} connected artists · ${commIds.length} communities · ${graph.size} links`;
@@ -6736,7 +6753,14 @@ function _artWebEdgeReducer(edge, data) {
         // Focus (hover/select): show only edges fully inside the set → clean neighborhood.
         // Search: show any edge touching a match.
         const show = st.focusSet ? (active.has(s) && active.has(t)) : (active.has(s) || active.has(t));
-        if (show) res.zIndex = 1; else res.color = _WEB_DIM_EDGE;
+        if (show) {
+            // Brighten + thicken the focused neighborhood's links so relationships read clearly.
+            res.zIndex = 1;
+            res.color = _webHexToRgba(data.baseColor || '#888888', 0.75);
+            res.size = (data.size || 0.7) * 1.7;
+        } else {
+            res.color = _WEB_DIM_EDGE;
+        }
     }
     return res;
 }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6507,11 +6507,11 @@ async function openArtistWeb() {
                 const membership = e.kind === 'membership';
                 // Edge inherits its artist endpoint's cluster color (low alpha) -> the glowing web look.
                 const base = graph.getNodeAttribute(e.source, 'baseColor') || WEB_GENRE_FALLBACK;
-                const alpha = membership ? 0.07 : 0.22;   // membership faintly tints clusters; similarity brighter
                 graph.addEdge(e.source, e.target, {
                     weight: e.weight,
                     size: membership ? 0.35 : 0.7,
-                    color: _webHexToRgba(base, alpha),
+                    color: _webHexToRgba(base, 0.22),
+                    kind: e.kind,   // 'membership' (layout-only, never drawn) | 'similarity' (drawn)
                 });
             }
         });
@@ -6617,6 +6617,10 @@ function _artWebNodeReducer(node, data) {
 function _artWebEdgeReducer(edge, data) {
     const st = _artistWeb;
     const res = Object.assign({}, data);
+    // Membership edges are a layout scaffold only. Drawing them starbursts big hubs (1000+ faint
+    // spokes overlapping accumulate to solid white), so never render them — clustering is already
+    // conveyed by node position + color. Only similarity edges are drawn.
+    if (data.kind === 'membership') { res.hidden = true; return res; }
     const g = _artistWeb.graph;
     if (st.genreFilter && g) {
         const sg = g.getNodeAttribute(g.source(edge), 'genre');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6366,10 +6366,36 @@ function _artMapPanelArtistById(id) {
 }
 
 // ===== Artist Web — sigma.js similarity graph (sibling of the canvas Artist Map) ===============
-// Scaffold: opens the pseudo-page (same takeover as openArtistMap), fetches /api/graph/library, and
-// does a BASIC sigma render with random node positions. The real work — forceAtlas2 layout, reducer
-// styling, hover/expand interactions — gets built on top of this.
-let _artistWeb = { sigma: null, graph: null, onKey: null };
+// A genre-clustered force graph of the whole library. Interaction is driven by REDUCERS: we keep a
+// little UI state here (search matches, hovered/selected node) and node/edge reducers read it to
+// recolor/dim per frame — the graph data is never mutated for visual state.
+let _artistWeb = {
+    sigma: null, graph: null, onKey: null,
+    genreColor: null,                 // (genre) -> color, set at render
+    index: [],                        // [{key,label}] artist nodes, for client-side search
+    searchMatch: null,                // Set<key> of search hits, or null when search is empty
+};
+
+// White pill label (black text, 10px padding) — custom sigma labelRenderer, per Boulder's spec.
+function _webDrawLabel(context, data, settings) {
+    if (!data.label) return;
+    const size = settings.labelSize || 12;
+    const font = settings.labelFont || 'Arial';
+    const weight = settings.labelWeight || 'normal';
+    context.font = `${weight} ${size}px ${font}`;
+    const pad = 10;
+    const tw = context.measureText(data.label).width;
+    const boxW = tw + pad * 2, boxH = size + pad * 2;
+    const x = Math.round(data.x + data.size + 4);   // sits just right of the node
+    const y = Math.round(data.y - boxH / 2);
+    context.fillStyle = '#ffffff';
+    if (context.roundRect) { context.beginPath(); context.roundRect(x, y, boxW, boxH, 6); context.fill(); }
+    else context.fillRect(x, y, boxW, boxH);
+    context.fillStyle = '#000000';
+    context.textBaseline = 'middle';
+    context.textAlign = 'left';
+    context.fillText(data.label, x + pad, data.y);
+}
 
 // Distinct colors for the most-common genres; everything in the long tail falls back to gray.
 const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00bcd4', '#ffd54f',
@@ -6420,6 +6446,9 @@ async function openArtistWeb() {
         if (statsEl) statsEl.textContent = `${c.artists ?? nodes.length} artists · ${c.genres ?? 0} genres · ${simCount} similarity links`;
 
         const { color: genreColor, counts: genreCounts } = _webGenreColorMap(nodes);
+        _artistWeb.genreColor = genreColor;
+        _artistWeb.index = [];
+        _artistWeb.searchMatch = null;
 
         const graph = new Graph();
         nodes.forEach(n => {
@@ -6430,16 +6459,22 @@ async function openArtistWeb() {
                     x: Math.random(), y: Math.random(),
                     size: 6 + Math.sqrt(members) * 1.5,      // hub size scales with how many artists it holds
                     color: genreColor(n.genre),
+                    baseColor: genreColor(n.genre),           // reducers restore from this
                     forceLabel: true,                         // genre hubs are always labeled
-                    isGenre: true,
+                    kind: 'genre', genre: n.genre,
                 });
             } else {
+                const color = genreColor(n.primary_genre);
                 graph.addNode(n.key, {
                     label: n.label,
                     x: Math.random(), y: Math.random(),      // random seed; forceAtlas2 places them below
                     size: 2 + Math.sqrt(n.popularity || 0) / 3,
-                    color: genreColor(n.primary_genre),
+                    color: color, baseColor: color,
+                    kind: 'artist', genre: n.primary_genre,
+                    popularity: n.popularity || 0, thumb: n.thumb || null,
+                    artistId: n.id != null ? n.id : null, source: n.source || null,
                 });
+                _artistWeb.index.push({ key: n.key, label: n.label });
             }
         });
         edges.forEach(e => {
@@ -6467,6 +6502,10 @@ async function openArtistWeb() {
         _artistWeb.sigma = new window.Sigma(graph, host, {
             renderLabels: true,
             labelRenderedSizeThreshold: 20,   // only large nodes (genre hubs) label by default; artists on zoom
+            labelRenderer: _webDrawLabel,     // white pill labels
+            // Reducers: recolor/dim per frame from UI state (search now; hover/select later). Data is untouched.
+            nodeReducer: (node, data) => _artWebNodeReducer(node, data),
+            edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
         });
     } catch (err) {
         console.error('[Artist Web] load failed', err);
@@ -6482,7 +6521,119 @@ function closeArtistWeb() {
     });
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
+    const results = document.getElementById('artist-web-search-results');
+    if (results) { results.style.display = 'none'; results.innerHTML = ''; }
 }
+
+// ---- Artist Web reducers: the single place UI state turns into per-frame styling -------------
+const _WEB_DIM_NODE = 'rgba(120,120,130,0.12)';
+const _WEB_DIM_EDGE = 'rgba(255,255,255,0.02)';
+
+function _artWebNodeReducer(node, data) {
+    const st = _artistWeb;
+    const res = Object.assign({}, data);
+    // Search: matched nodes pop (labeled), everything else dims out.
+    if (st.searchMatch) {
+        if (st.searchMatch.has(node)) {
+            res.color = data.baseColor || data.color;
+            res.forceLabel = true;
+            res.zIndex = 2;
+        } else {
+            res.color = _WEB_DIM_NODE;
+            res.label = '';
+        }
+    }
+    return res;
+}
+
+function _artWebEdgeReducer(edge, data) {
+    const st = _artistWeb;
+    const res = Object.assign({}, data);
+    if (st.searchMatch && _artistWeb.graph) {
+        const g = _artistWeb.graph;
+        const s = g.source(edge), t = g.target(edge);
+        if (!(st.searchMatch.has(s) || st.searchMatch.has(t))) res.color = _WEB_DIM_EDGE;
+    }
+    return res;
+}
+
+// ---- Artist Web search: client-side over loaded artist nodes (instant), mirrors Artist Map UX --
+function artWebSearch(query) {
+    const results = document.getElementById('artist-web-search-results');
+    if (!results) return;
+    const q = (query || '').trim().toLowerCase();
+
+    if (q.length < 2) {
+        results.style.display = 'none';
+        results.innerHTML = '';
+        _artistWeb.searchMatch = null;
+        if (_artistWeb.sigma) _artistWeb.sigma.refresh();
+        return;
+    }
+
+    const hits = _artistWeb.index.filter(n => n.label.toLowerCase().includes(q));
+    // Dim everything that isn't a hit.
+    _artistWeb.searchMatch = new Set(hits.map(n => n.key));
+    if (_artistWeb.sigma) _artistWeb.sigma.refresh();
+
+    results.style.display = 'block';
+    if (!hits.length) {
+        results.innerHTML = '<div class="artist-map-search-item artist-map-search-empty">No artists found</div>';
+        return;
+    }
+    results.innerHTML = hits.slice(0, 8).map(n =>
+        `<div class="artist-map-search-item" onclick="artWebFocusNode('${escapeForInlineJs(n.key)}')">
+            <span class="artist-map-search-type similar">○</span>
+            ${escapeHtml(n.label)}
+            <span class="artist-map-search-go">Focus &rarr;</span>
+        </div>`
+    ).join('');
+}
+
+// Enter key → jump to the first match.
+function artWebSearchEnter() {
+    if (_artistWeb.searchMatch && _artistWeb.searchMatch.size) {
+        artWebFocusNode(_artistWeb.searchMatch.values().next().value);
+    }
+}
+
+// Center the camera on a node and pulse it (also closes the dropdown).
+function artWebFocusNode(key) {
+    const sig = _artistWeb.sigma, graph = _artistWeb.graph;
+    if (!sig || !graph || !graph.hasNode(key)) return;
+    const results = document.getElementById('artist-web-search-results');
+    if (results) { results.style.display = 'none'; results.innerHTML = ''; }
+
+    // Isolate this node as the single search match so it stands out.
+    _artistWeb.searchMatch = new Set([key]);
+    sig.refresh();
+
+    const disp = sig.getNodeDisplayData(key);
+    if (disp) {
+        sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 });
+    }
+}
+
+// ---- Artist Web camera controls ---------------------------------------------------------------
+function artWebZoom(factor) {
+    if (!_artistWeb.sigma) return;
+    const cam = _artistWeb.sigma.getCamera();
+    cam.animate({ ratio: cam.ratio * factor }, { duration: 250 });
+}
+
+function artWebFitToView() {
+    if (!_artistWeb.sigma) return;
+    _artistWeb.sigma.getCamera().animatedReset({ duration: 400 });
+    // Clear any search focus so the whole web is visible again.
+    const input = document.getElementById('artist-web-search');
+    if (input) input.value = '';
+    _artistWeb.searchMatch = null;
+    _artistWeb.sigma.refresh();
+}
+
+// Filter-by-genre lives in a later phase; stubs keep the toolbar buttons inert-but-safe for now.
+function artWebToggleFilter() { /* Phase C */ }
+function artWebFilterGenreList() { /* Phase C */ }
 
 async function openArtistMap() {
     const container = document.getElementById('artist-map-container');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6365,6 +6365,78 @@ function _artMapPanelArtistById(id) {
     _artMapEmitRipple(n.x, n.y, n._hue);
 }
 
+// ===== Artist Web — sigma.js similarity graph (sibling of the canvas Artist Map) ===============
+// Scaffold: opens the pseudo-page (same takeover as openArtistMap), fetches /api/graph/library, and
+// does a BASIC sigma render with random node positions. The real work — forceAtlas2 layout, reducer
+// styling, hover/expand interactions — gets built on top of this.
+let _artistWeb = { sigma: null, graph: null, onKey: null };
+
+async function openArtistWeb() {
+    const container = document.getElementById('artist-web-container');
+    if (!container) return;
+
+    // Pseudo-page takeover: hide the other discover sections, show the web container.
+    document.querySelectorAll('#discover-page > .discover-container > *:not(#artist-web-container)').forEach(el => {
+        el._prevDisplay = el.style.display;
+        el.style.display = 'none';
+    });
+    container.style.display = 'flex';
+
+    const host = document.getElementById('artist-web-canvas');
+    const statsEl = document.getElementById('artist-web-stats');
+    host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Building your artist web…</div>';
+
+    // Esc closes (mirrors the artist map).
+    _artistWeb.onKey = (e) => { if (e.key === 'Escape') closeArtistWeb(); };
+    document.addEventListener('keydown', _artistWeb.onKey);
+
+    // Resolve the CDN globals. graphology's UMD default export IS the Graph class.
+    const Graph = window.graphology && (window.graphology.Graph || window.graphology);
+    if (!Graph || !window.Sigma) {
+        host.innerHTML = '<div style="padding:24px;color:#f88">graphology / sigma didn\'t load — check the CDN &lt;script&gt; tags.</div>';
+        return;
+    }
+
+    try {
+        const data = await (await fetch('/api/graph/library')).json();
+        const nodes = data.nodes || [], edges = data.edges || [];
+        if (statsEl) statsEl.textContent = `${nodes.length} artists · ${edges.length} connections`;
+
+        const graph = new Graph();
+        nodes.forEach(n => {
+            graph.addNode(n.key, {
+                label: n.label,
+                x: Math.random(), y: Math.random(),          // scaffold — real layout (forceAtlas2) next
+                size: 3 + Math.sqrt(n.popularity || 0) / 2,
+                color: '#1db954',
+            });
+        });
+        edges.forEach(e => {
+            if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
+                graph.addEdge(e.source, e.target, { weight: e.weight, size: 0.6, color: 'rgba(255,255,255,0.08)' });
+            }
+        });
+
+        host.innerHTML = '';
+        if (_artistWeb.sigma) _artistWeb.sigma.kill();
+        _artistWeb.graph = graph;
+        _artistWeb.sigma = new window.Sigma(graph, host, { renderLabels: true });
+    } catch (err) {
+        console.error('[Artist Web] load failed', err);
+        host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
+    }
+}
+
+function closeArtistWeb() {
+    const container = document.getElementById('artist-web-container');
+    if (container) container.style.display = 'none';
+    document.querySelectorAll('#discover-page > .discover-container > *').forEach(el => {
+        if (el.id !== 'artist-web-container' && el._prevDisplay !== undefined) el.style.display = el._prevDisplay;
+    });
+    if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
+    if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
+}
+
 async function openArtistMap() {
     const container = document.getElementById('artist-map-container');
     if (!container) return;

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6371,7 +6371,9 @@ function _artMapPanelArtistById(id) {
 // recolor/dim per frame — the graph data is never mutated for visual state.
 let _artistWeb = {
     sigma: null, graph: null, onKey: null,
-    genreColor: null,                 // (genre) -> color, set at render
+    lens: 'genre',                    // 'genre' (all artists by genre) | 'community' (Louvain on similarity)
+    data: null,                       // cached /api/graph/library payload (reused when switching lens)
+    genreColor: null,                 // (group) -> color, set at render
     index: [],                        // [{key,label}] artist nodes, for client-side search
     searchMatch: null,                // Set<key> of search hits, or null when search is empty
     focusSet: null,                   // Set<key> currently emphasized (hover node+neighbors, or selection)
@@ -6461,109 +6463,210 @@ async function openArtistWeb() {
     }
 
     try {
-        const data = await (await fetch('/api/graph/library')).json();
-        const nodes = data.nodes || [], edges = data.edges || [];
-        const c = data.counts || {};
-        const simCount = edges.filter(e => e.kind === 'similarity').length;
-        if (statsEl) statsEl.textContent = `${c.artists ?? nodes.length} artists · ${c.genres ?? 0} genres · ${simCount} similarity links`;
-
-        const { color: genreColor, counts: genreCounts } = _webGenreColorMap(nodes);
-        _artistWeb.genreColor = genreColor;
-        _artistWeb.genreCounts = genreCounts;
-        _artistWeb.genreFilter = null;
-        _artistWeb.index = [];
-        _artistWeb.searchMatch = null;
-
-        const graph = new Graph();
-        nodes.forEach(n => {
-            if (n.kind === 'genre') {
-                const members = genreCounts[n.genre] || 1;
-                graph.addNode(n.key, {
-                    label: n.label,
-                    x: Math.random(), y: Math.random(),
-                    size: 6 + Math.sqrt(members) * 1.5,      // hub size scales with how many artists it holds
-                    color: genreColor(n.genre),
-                    baseColor: genreColor(n.genre),           // reducers restore from this
-                    forceLabel: true,                         // genre hubs are always labeled
-                    kind: 'genre', genre: n.genre,
-                });
-            } else {
-                const color = genreColor(n.cluster);            // color by the cluster it grouped under
-                graph.addNode(n.key, {
-                    label: n.label,
-                    x: Math.random(), y: Math.random(),      // random seed; forceAtlas2 places them below
-                    size: 2 + Math.sqrt(n.popularity || 0) / 3,
-                    color: color, baseColor: color,
-                    kind: 'artist', genre: n.cluster,          // `genre` = cluster (drives filter + edge color)
-                    primaryGenre: n.primary_genre,             // true genre, shown in the panel
-                    popularity: n.popularity || 0, thumb: n.thumb || null,
-                    artistId: n.id != null ? n.id : null, source: n.source || null,
-                });
-                _artistWeb.index.push({ key: n.key, label: n.label });
-            }
-        });
-        edges.forEach(e => {
-            if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
-                const membership = e.kind === 'membership';
-                // Edge inherits its artist endpoint's cluster color (low alpha) -> the glowing web look.
-                const base = graph.getNodeAttribute(e.source, 'baseColor') || WEB_GENRE_FALLBACK;
-                graph.addEdge(e.source, e.target, {
-                    weight: e.weight,
-                    size: membership ? 0.35 : 0.7,
-                    color: _webHexToRgba(base, 0.22),
-                    kind: e.kind,   // 'membership' (layout-only, never drawn) | 'similarity' (drawn)
-                });
-            }
-        });
-
-        // Settle the random blob into SEPARATED genre islands. LinLog + outbound-attraction pushes
-        // clusters apart (vs one round hairball); Barnes-Hut keeps the ~5k-node layout tractable.
-        // Tuning knobs if it drifts: gravity (higher = tighter to center), scalingRatio (higher =
-        // more space between islands), iterations (more = more settled).
-        const fa2 = window.graphologyLibrary && window.graphologyLibrary.layoutForceAtlas2;
-        if (fa2) {
-            fa2.assign(graph, {
-                iterations: 400,
-                settings: {
-                    ...fa2.inferSettings(graph),
-                    barnesHutOptimize: true,
-                    linLogMode: true,                      // clusters separate into islands
-                    outboundAttractionDistribution: true,  // spread the hubs out
-                    adjustSizes: true,                     // don't overlap node circles
-                    gravity: 1.2,
-                    scalingRatio: 3,
-                    slowDown: 4,                           // stability with linLog
-                },
-            });
-        } else {
-            console.warn('[Artist Web] forceAtlas2 unavailable — nodes stay at random positions');
-        }
-
-        host.innerHTML = '';
-        host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow (reference look)
-        if (_artistWeb.sigma) _artistWeb.sigma.kill();
-        _artistWeb.graph = graph;
-        _artistWeb.searchMatch = _artistWeb.focusSet = _artistWeb.focusRoot = null;
-        _artistWeb.selectedKey = _artistWeb.selectedFocus = null;
-        _artistWeb.sigma = new window.Sigma(graph, host, {
-            renderLabels: true,
-            labelRenderedSizeThreshold: 20,   // only large nodes (genre hubs) label by default; artists on zoom
-            labelRenderer: _webDrawLabel,     // white pill labels
-            // Reducers: recolor/dim per frame from UI state (search / hover / selection). Data is untouched.
-            nodeReducer: (node, data) => _artWebNodeReducer(node, data),
-            edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
-        });
-
-        // Interaction: hover highlights a node + its neighbors; click opens the side panel.
-        const sig = _artistWeb.sigma;
-        sig.on('enterNode', ({ node }) => _artWebHover(node));
-        sig.on('leaveNode', () => _artWebHover(null));
-        sig.on('clickNode', ({ node }) => _artWebClickNode(node));
-        sig.on('clickStage', () => _artWebClearSelection());
+        _artistWeb.data = await (await fetch('/api/graph/library')).json();
+        _artistWeb.lens = _artistWeb.lens || 'genre';
+        _artWebSyncLensButtons();
+        _artWebRenderLens();
     } catch (err) {
         console.error('[Artist Web] load failed', err);
         host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
     }
+}
+
+// Switch the organizing lens (genre clusters vs similarity communities) and rebuild.
+function artWebSetLens(lens) {
+    if (!_artistWeb.data || _artistWeb.lens === lens) return;
+    _artistWeb.lens = lens;
+    _artWebSyncLensButtons();
+    const host = document.getElementById('artist-web-canvas');
+    if (host) host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Rebuilding…</div>';
+    setTimeout(_artWebRenderLens, 20);   // let "Rebuilding…" paint before the sync layout blocks
+}
+
+function _artWebSyncLensButtons() {
+    document.querySelectorAll('.artweb-lens-btn').forEach(b =>
+        b.classList.toggle('active', b.dataset.lens === _artistWeb.lens));
+}
+
+// (Re)build the graph for the current lens, run the layout, and mount sigma.
+function _artWebRenderLens() {
+    const host = document.getElementById('artist-web-canvas');
+    const statsEl = document.getElementById('artist-web-stats');
+    const data = _artistWeb.data;
+    if (!host || !data) return;
+    const Graph = window.graphology && (window.graphology.Graph || window.graphology);
+    if (!Graph) return;
+
+    // Reset per-render UI state + chrome.
+    _artistWeb.searchMatch = _artistWeb.focusSet = _artistWeb.focusRoot = null;
+    _artistWeb.selectedKey = _artistWeb.selectedFocus = null;
+    _artistWeb.genreFilter = null;
+    _artistWeb.index = [];
+    _artWebClosePanel();
+    const sidebar = document.getElementById('artweb-genre-sidebar');
+    if (sidebar) sidebar.style.display = 'none';
+    const searchInput = document.getElementById('artist-web-search');
+    if (searchInput) searchInput.value = '';
+
+    const built = _artistWeb.lens === 'community'
+        ? _artWebBuildCommunity(data, Graph)
+        : _artWebBuildGenre(data, Graph);
+
+    _artistWeb.genreColor = built.colorOf;
+    _artistWeb.genreCounts = built.counts;
+    if (statsEl) statsEl.textContent = built.stats;
+    const sbHeader = document.querySelector('#artweb-genre-sidebar .artmap-genre-sidebar-header span');
+    if (sbHeader) sbHeader.textContent = _artistWeb.lens === 'community' ? 'Communities' : 'Genres';
+
+    _artWebRunLayout(built.graph);
+    _artWebMountSigma(host, built.graph);
+}
+
+// ---- Lens A: GENRE — every artist, grouped by genre-anchor hubs (membership edges = layout only) --
+function _artWebBuildGenre(data, Graph) {
+    const nodes = data.nodes || [], edges = data.edges || [];
+    const { color: colorOf, counts } = _webGenreColorMap(nodes);
+    const graph = new Graph();
+    nodes.forEach(n => {
+        if (n.kind === 'genre') {
+            const members = counts[n.genre] || 1;
+            graph.addNode(n.key, {
+                label: n.label, x: Math.random(), y: Math.random(),
+                size: 6 + Math.sqrt(members) * 1.5,
+                color: colorOf(n.genre), baseColor: colorOf(n.genre),
+                forceLabel: true, kind: 'genre', genre: n.genre,
+            });
+        } else {
+            const color = colorOf(n.cluster);
+            graph.addNode(n.key, {
+                label: n.label, x: Math.random(), y: Math.random(),
+                size: 2 + Math.sqrt(n.popularity || 0) / 3,
+                color: color, baseColor: color,
+                kind: 'artist', genre: n.cluster, primaryGenre: n.primary_genre,
+                popularity: n.popularity || 0, thumb: n.thumb || null,
+                artistId: n.id != null ? n.id : null, source: n.source || null,
+            });
+            _artistWeb.index.push({ key: n.key, label: n.label });
+        }
+    });
+    edges.forEach(e => {
+        if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
+            const membership = e.kind === 'membership';
+            const base = graph.getNodeAttribute(e.source, 'baseColor') || WEB_GENRE_FALLBACK;
+            graph.addEdge(e.source, e.target, {
+                weight: e.weight, size: membership ? 0.35 : 0.7,
+                color: _webHexToRgba(base, 0.22), kind: e.kind,
+            });
+        }
+    });
+    const c = data.counts || {};
+    const simCount = edges.filter(e => e.kind === 'similarity').length;
+    const stats = `${c.artists ?? nodes.length} artists · ${c.genres ?? '?'} genres · ${simCount} similarity links`;
+    return { graph, colorOf, counts, stats };
+}
+
+// ---- Lens B: COMMUNITIES — the similarity-connected core, clustered by Louvain, named by hub artist -
+function _artWebBuildCommunity(data, Graph) {
+    const nodes = data.nodes || [], edges = data.edges || [];
+    const simEdges = edges.filter(e => e.kind === 'similarity');
+    const artistByKey = {};
+    nodes.forEach(n => { if (n.kind === 'artist') artistByKey[n.key] = n; });
+
+    const graph = new Graph();
+    // Only artists with at least one similarity link — the discoverable "taste" core.
+    simEdges.forEach(e => [e.source, e.target].forEach(k => {
+        if (!graph.hasNode(k) && artistByKey[k]) {
+            const n = artistByKey[k];
+            graph.addNode(k, {
+                label: n.label, x: Math.random(), y: Math.random(),
+                size: 2 + Math.sqrt(n.popularity || 0) / 3, kind: 'artist',
+                primaryGenre: n.primary_genre, popularity: n.popularity || 0, thumb: n.thumb || null,
+                artistId: n.id != null ? n.id : null, source: n.source || null,
+            });
+        }
+    }));
+    simEdges.forEach(e => {
+        if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
+            graph.addEdge(e.source, e.target, { weight: e.weight, kind: 'similarity', size: 0.7 });
+        }
+    });
+
+    // Louvain community detection on the similarity graph.
+    const louvain = window.graphologyLibrary && window.graphologyLibrary.communitiesLouvain;
+    let comm = {};
+    if (louvain) { try { comm = louvain(graph, { getEdgeWeight: 'weight' }); } catch (e) { comm = {}; } }
+
+    // Group members; name each community by its highest-degree (most central) artist.
+    const members = {};
+    graph.forEachNode(k => { const cid = (comm[k] != null ? comm[k] : 'x'); (members[cid] = members[cid] || []).push(k); });
+    const commIds = Object.keys(members).sort((a, b) => members[b].length - members[a].length);
+    const repOf = {}, colorByRep = {}, countsByRep = {};
+    commIds.forEach((cid, i) => {
+        let best = null, bestDeg = -1;
+        members[cid].forEach(k => { const d = graph.degree(k); if (d > bestDeg) { bestDeg = d; best = k; } });
+        let rep = best ? graph.getNodeAttribute(best, 'label') : ('Group ' + cid);
+        if (countsByRep[rep] != null) rep = rep + ' · ' + cid;   // guard rare rep-name collision
+        repOf[cid] = rep;
+        colorByRep[rep] = i < WEB_PALETTE.length ? WEB_PALETTE[i] : WEB_GENRE_FALLBACK;
+        countsByRep[rep] = members[cid].length;
+        if (best) graph.setNodeAttribute(best, '_rep', true);
+    });
+    graph.forEachNode(k => {
+        const cid = (comm[k] != null ? comm[k] : 'x');
+        const rep = repOf[cid];
+        const color = colorByRep[rep] || WEB_GENRE_FALLBACK;
+        const isRep = graph.getNodeAttribute(k, '_rep') === true;
+        graph.mergeNodeAttributes(k, {
+            color, baseColor: color, genre: rep, forceLabel: isRep,
+            size: isRep ? Math.max(8, graph.getNodeAttribute(k, 'size')) : graph.getNodeAttribute(k, 'size'),
+        });
+        _artistWeb.index.push({ key: k, label: graph.getNodeAttribute(k, 'label') });
+    });
+    graph.forEachEdge((edge, attrs, s) => {
+        const base = graph.getNodeAttribute(s, 'baseColor') || WEB_GENRE_FALLBACK;
+        graph.setEdgeAttribute(edge, 'color', _webHexToRgba(base, 0.22));
+    });
+
+    const stats = `${graph.order} connected artists · ${commIds.length} communities · ${graph.size} links`;
+    return { graph, colorOf: (rep) => colorByRep[rep] || WEB_GENRE_FALLBACK, counts: countsByRep, stats };
+}
+
+// Shared force layout — LinLog + outbound-attraction settles clusters into separated islands.
+function _artWebRunLayout(graph) {
+    const fa2 = window.graphologyLibrary && window.graphologyLibrary.layoutForceAtlas2;
+    if (!fa2) { console.warn('[Artist Web] forceAtlas2 unavailable — nodes stay at random positions'); return; }
+    fa2.assign(graph, {
+        iterations: 400,
+        settings: {
+            ...fa2.inferSettings(graph),
+            barnesHutOptimize: true,
+            linLogMode: true,                      // clusters separate into islands
+            outboundAttractionDistribution: true,  // spread the hubs out
+            adjustSizes: true,                     // don't overlap node circles
+            gravity: 1.2, scalingRatio: 3, slowDown: 4,
+        },
+    });
+}
+
+// Shared sigma mount + interaction wiring (used by both lenses).
+function _artWebMountSigma(host, graph) {
+    host.innerHTML = '';
+    host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow
+    if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
+    _artistWeb.graph = graph;
+    _artistWeb.sigma = new window.Sigma(graph, host, {
+        renderLabels: true,
+        labelRenderedSizeThreshold: 20,
+        labelRenderer: _webDrawLabel,
+        hideEdgesOnMove: true,   // edge cleanup: drop edges while panning/zooming for clarity + perf
+        nodeReducer: (node, data) => _artWebNodeReducer(node, data),
+        edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
+    });
+    const sig = _artistWeb.sigma;
+    sig.on('enterNode', ({ node }) => _artWebHover(node));
+    sig.on('leaveNode', () => _artWebHover(null));
+    sig.on('clickNode', ({ node }) => _artWebClickNode(node));
+    sig.on('clickStage', () => _artWebClearSelection());
 }
 
 function closeArtistWeb() {

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6401,6 +6401,15 @@ function _webDrawLabel(context, data, settings) {
 const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00bcd4', '#ffd54f',
     '#f44336', '#8bc34a', '#ff5722', '#7c4dff', '#26c6da', '#cddc39', '#ff4081', '#009688', '#c0846b'];
 const WEB_GENRE_FALLBACK = '#5a5a66';
+const WEB_CANVAS_BG = '#111016';   // near-black charcoal (reference look: colors glow on dark)
+
+// '#rrggbb' -> 'rgba(r,g,b,a)' so edges can inherit a cluster color at low alpha (the glowing web).
+function _webHexToRgba(hex, alpha) {
+    const h = (hex || '').replace('#', '');
+    if (h.length !== 6) return `rgba(140,140,150,${alpha})`;
+    const r = parseInt(h.slice(0, 2), 16), g = parseInt(h.slice(2, 4), 16), b = parseInt(h.slice(4, 6), 16);
+    return `rgba(${r},${g},${b},${alpha})`;
+}
 
 // Map the top-N genres (by artist count) to palette colors; return a lookup + the per-genre counts.
 function _webGenreColorMap(nodes) {
@@ -6480,10 +6489,13 @@ async function openArtistWeb() {
         edges.forEach(e => {
             if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
                 const membership = e.kind === 'membership';
+                // Edge inherits its artist endpoint's cluster color (low alpha) -> the glowing web look.
+                const base = graph.getNodeAttribute(e.source, 'baseColor') || WEB_GENRE_FALLBACK;
+                const alpha = membership ? 0.07 : 0.22;   // membership faintly tints clusters; similarity brighter
                 graph.addEdge(e.source, e.target, {
                     weight: e.weight,
-                    size: membership ? 0.4 : 0.8,
-                    color: membership ? 'rgba(255,255,255,0.03)' : 'rgba(29,185,84,0.15)',
+                    size: membership ? 0.35 : 0.7,
+                    color: _webHexToRgba(base, alpha),
                 });
             }
         });
@@ -6497,6 +6509,7 @@ async function openArtistWeb() {
         }
 
         host.innerHTML = '';
+        host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow (reference look)
         if (_artistWeb.sigma) _artistWeb.sigma.kill();
         _artistWeb.graph = graph;
         _artistWeb.sigma = new window.Sigma(graph, host, {

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6597,17 +6597,19 @@ function _artWebNodeReducer(node, data) {
         return res;
     }
     const active = st.focusSet || st.searchMatch;   // focus (hover/select) wins over search
-    if (active) {
-        if (active.has(node)) {
-            res.color = data.baseColor || data.color;
-            res.forceLabel = true;
-            res.zIndex = 2;
-            if (node === st.focusRoot) res.highlighted = true;   // sigma draws a halo on the root
-        } else {
-            res.color = _WEB_DIM_NODE;
-            res.label = '';
-            res.zIndex = 0;
-        }
+    if (!active) return res;
+    const searching = !st.focusSet && !!st.searchMatch;   // search labels all its hits (usually few)
+    if (active.has(node)) {
+        res.color = data.baseColor || data.color;
+        res.zIndex = 2;
+        // Only label the hovered/selected node itself (or search hits) — labeling every neighbor
+        // floods the view with white label pills on big genre clusters.
+        res.forceLabel = searching || node === st.focusRoot;
+        if (node === st.focusRoot) res.highlighted = true;   // sigma draws a halo on the root
+    } else {
+        res.color = _WEB_DIM_NODE;
+        res.label = '';
+        res.zIndex = 0;
     }
     return res;
 }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6723,6 +6723,13 @@ function _artWebClearSelection() {
     _artWebClosePanel();
 }
 
+// Hand off to the Artist Map explorer. The Web is a fixed z-index:100 overlay that sits ON TOP of
+// the Map (later in the DOM), so we must close it first or the Map opens invisibly underneath.
+function artWebExploreInMap(name) {
+    closeArtistWeb();
+    if (typeof artMapExploreArtist === 'function') artMapExploreArtist(name);
+}
+
 // Focus the camera on an artist and open its card (used by the genre panel's member list).
 function _artWebGoToArtist(key) {
     const sig = _artistWeb.sigma;
@@ -6788,7 +6795,7 @@ function _artWebShowArtist(node) {
             <div style="height:100%;width:${pop}%;background:${color};"></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
-            <button onclick="artMapExploreArtist('${escapeForInlineJs(a.label)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
+            <button onclick="artWebExploreInMap('${escapeForInlineJs(a.label)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
             ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
         </div>`;
     p.style.display = 'flex';

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6418,13 +6418,14 @@ function _webHexToRgba(hex, alpha) {
     return `rgba(${r},${g},${b},${alpha})`;
 }
 
-// Map the top-N genres (by artist count) to palette colors; return a lookup + the per-genre counts.
+// Map each genre CLUSTER (anchor) to a palette color; "Other" + unknowns are gray. Return the lookup
+// + per-cluster counts (used for hub sizing + the filter list).
 function _webGenreColorMap(nodes) {
     const counts = {};
-    nodes.forEach(n => { if (n.kind === 'artist' && n.primary_genre) counts[n.primary_genre] = (counts[n.primary_genre] || 0) + 1; });
-    const top = Object.keys(counts).sort((a, b) => counts[b] - counts[a]).slice(0, WEB_PALETTE.length);
-    const map = {};
-    top.forEach((g, i) => { map[g] = WEB_PALETTE[i]; });
+    nodes.forEach(n => { if (n.kind === 'artist' && n.cluster) counts[n.cluster] = (counts[n.cluster] || 0) + 1; });
+    const ranked = Object.keys(counts).filter(g => g !== 'Other').sort((a, b) => counts[b] - counts[a]);
+    const map = { 'Other': WEB_GENRE_FALLBACK };
+    ranked.forEach((g, i) => { if (i < WEB_PALETTE.length) map[g] = WEB_PALETTE[i]; });
     return { color: (g) => map[g] || WEB_GENRE_FALLBACK, counts };
 }
 
@@ -6487,13 +6488,14 @@ async function openArtistWeb() {
                     kind: 'genre', genre: n.genre,
                 });
             } else {
-                const color = genreColor(n.primary_genre);
+                const color = genreColor(n.cluster);            // color by the cluster it grouped under
                 graph.addNode(n.key, {
                     label: n.label,
                     x: Math.random(), y: Math.random(),      // random seed; forceAtlas2 places them below
                     size: 2 + Math.sqrt(n.popularity || 0) / 3,
                     color: color, baseColor: color,
-                    kind: 'artist', genre: n.primary_genre,
+                    kind: 'artist', genre: n.cluster,          // `genre` = cluster (drives filter + edge color)
+                    primaryGenre: n.primary_genre,             // true genre, shown in the panel
                     popularity: n.popularity || 0, thumb: n.thumb || null,
                     artistId: n.id != null ? n.id : null, source: n.source || null,
                 });
@@ -6514,10 +6516,25 @@ async function openArtistWeb() {
             }
         });
 
-        // Settle the random blob into genre clusters. Barnes-Hut keeps the ~5k-node layout tractable.
+        // Settle the random blob into SEPARATED genre islands. LinLog + outbound-attraction pushes
+        // clusters apart (vs one round hairball); Barnes-Hut keeps the ~5k-node layout tractable.
+        // Tuning knobs if it drifts: gravity (higher = tighter to center), scalingRatio (higher =
+        // more space between islands), iterations (more = more settled).
         const fa2 = window.graphologyLibrary && window.graphologyLibrary.layoutForceAtlas2;
         if (fa2) {
-            fa2.assign(graph, { iterations: 250, settings: { ...fa2.inferSettings(graph), barnesHutOptimize: true } });
+            fa2.assign(graph, {
+                iterations: 400,
+                settings: {
+                    ...fa2.inferSettings(graph),
+                    barnesHutOptimize: true,
+                    linLogMode: true,                      // clusters separate into islands
+                    outboundAttractionDistribution: true,  // spread the hubs out
+                    adjustSizes: true,                     // don't overlap node circles
+                    gravity: 1.2,
+                    scalingRatio: 3,
+                    slowDown: 4,                           // stability with linLog
+                },
+            });
         } else {
             console.warn('[Artist Web] forceAtlas2 unavailable — nodes stay at random positions');
         }
@@ -6788,7 +6805,7 @@ function _artWebShowArtist(node) {
                 <span style="font-size:34px;opacity:0.5;">&#9835;</span>
             </div>
             <div style="font-size:18px;font-weight:800;margin-top:12px;">${escapeHtml(a.label)}</div>
-            ${a.genre ? `<div style="font-size:11px;color:${color};margin-top:3px;">${escapeHtml(a.genre)}</div>` : ''}
+            ${a.primaryGenre ? `<div style="font-size:11px;color:${color};margin-top:3px;">${escapeHtml(a.primaryGenre)}</div>` : ''}
         </div>
         <div style="display:flex;gap:8px;margin-top:16px;">
             ${_miniStat('Popularity', pop, 270)}

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6371,8 +6371,9 @@ function _artMapPanelArtistById(id) {
 // recolor/dim per frame — the graph data is never mutated for visual state.
 let _artistWeb = {
     sigma: null, graph: null, onKey: null,
-    lens: 'genre',                    // 'genre' (all artists by genre) | 'community' (Louvain on similarity)
+    lens: 'genre',                    // 'genre' | 'community' | 'discovery'
     data: null,                       // cached /api/graph/library payload (reused when switching lens)
+    discoveryData: null,              // cached /api/graph/discovery payload (owned anchors + unowned candidates)
     genreColor: null,                 // (group) -> color, set at render
     index: [],                        // [{key,label}] artist nodes, for client-side search
     searchMatch: null,                // Set<key> of search hits, or null when search is empty
@@ -6425,6 +6426,8 @@ function _webDrawLabel(context, data, settings) {
 const WEB_PALETTE = ['#1db954', '#e91e63', '#3f8cff', '#ff9800', '#9c27b0', '#00bcd4', '#ffd54f',
     '#f44336', '#8bc34a', '#ff5722', '#7c4dff', '#26c6da', '#cddc39', '#ff4081', '#009688', '#c0846b'];
 const WEB_GENRE_FALLBACK = '#6b7aa8';   // slate-periwinkle for "Other" — a real color, not dead gray
+const WEB_OWNED_COLOR = '#5b8def';      // Discovery lens: your library artists (cool blue)
+const WEB_DISCOVERY_COLOR = '#ffb74d';  // Discovery lens: unowned candidates to discover (warm amber)
 const WEB_CANVAS_BG = '#111016';   // near-black charcoal (reference look: colors glow on dark)
 
 // Edge opacity scales with weight (consensus): weak links stay faint so they don't clutter; strong,
@@ -6518,7 +6521,14 @@ function artWebSetLens(lens) {
     _artWebSyncLensButtons();
     const host = document.getElementById('artist-web-canvas');
     if (host) host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Rebuilding…</div>';
-    setTimeout(_artWebRenderLens, 20);   // let "Rebuilding…" paint before the sync layout blocks
+    // Discovery uses its own endpoint — fetch it once, then render.
+    if (lens === 'discovery' && !_artistWeb.discoveryData) {
+        fetch('/api/graph/discovery').then(r => r.json())
+            .then(d => { _artistWeb.discoveryData = d; _artWebRenderLens(); })
+            .catch(() => { if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery.</div>'; });
+    } else {
+        setTimeout(_artWebRenderLens, 20);   // let "Rebuilding…" paint before the sync layout blocks
+    }
 }
 
 function _artWebSyncLensButtons() {
@@ -6606,6 +6616,8 @@ function _artWebRenderLens() {
 
     const built = _artistWeb.lens === 'community'
         ? _artWebBuildCommunity(data, Graph)
+        : _artistWeb.lens === 'discovery'
+        ? _artWebBuildDiscovery(_artistWeb.discoveryData || { nodes: [], edges: [] }, Graph)
         : _artWebBuildGenre(data, Graph);
 
     _artistWeb.genreColor = built.colorOf;
@@ -6766,6 +6778,51 @@ function _artWebBuildCommunity(data, Graph) {
 
     const stats = `${graph.order} connected artists · ${commIds.length} communities · ${graph.size} links`;
     return { graph, colorOf: (rep) => colorByRep[rep] || WEB_GENRE_FALLBACK, counts: countsByRep, stats };
+}
+
+// ---- Lens C: DISCOVERY — owned artists (cool) + their unowned similar candidates (warm) ----------
+function _artWebBuildDiscovery(data, Graph) {
+    const nodes = data.nodes || [], edges = data.edges || [];
+    const graph = new Graph();
+    nodes.forEach(n => {
+        if (n.kind === 'owned') {
+            graph.addNode(n.key, {
+                label: n.label, x: Math.random(), y: Math.random(),
+                size: 7, color: WEB_OWNED_COLOR, baseColor: WEB_OWNED_COLOR,
+                forceLabel: true, kind: 'owned', genre: 'Your library',
+                artistId: n.id != null ? n.id : null, thumb: n.thumb || null,
+            });
+        } else {
+            graph.addNode(n.key, {
+                label: n.label, x: Math.random(), y: Math.random(),
+                size: 3, color: WEB_DISCOVERY_COLOR, baseColor: WEB_DISCOVERY_COLOR,
+                kind: 'discovery', genre: 'Discovery',
+                image_url: n.image_url || null, genresList: n.genres || null,
+                ids: n.ids || [], popularity: n.popularity || 0,
+            });
+        }
+        _artistWeb.index.push({ key: n.key, label: n.label });
+    });
+    let maxW = 1;
+    edges.forEach(e => {
+        if (graph.hasNode(e.source) && graph.hasNode(e.target) && !graph.hasEdge(e.source, e.target)) {
+            if (e.weight > maxW) maxW = e.weight;
+            graph.addEdge(e.source, e.target, {
+                weight: e.weight, size: _webEdgeSize(e.weight),
+                color: _webHexToRgba(WEB_DISCOVERY_COLOR, 0.28), baseColor: WEB_DISCOVERY_COLOR, kind: 'discovery',
+            });
+        }
+    });
+    // Size each discovery candidate by its strongest similarity link (its best reason to check it out).
+    graph.forEachNode((k, a) => {
+        if (a.kind !== 'discovery') return;
+        let w = 1;
+        graph.forEachEdge(k, (e, ea) => { if ((ea.weight || 1) > w) w = ea.weight; });
+        graph.setNodeAttribute(k, 'size', 2.5 + Math.sqrt(w / maxW) * 5);
+    });
+    const c = data.counts || {};
+    const stats = `${c.owned ?? 0} of your artists · ${c.discovery ?? 0} to discover`;
+    return { graph, colorOf: () => WEB_DISCOVERY_COLOR, counts: {}, stats };
 }
 
 // Shared force layout — LinLog + outbound-attraction settles clusters into separated islands.
@@ -7090,7 +7147,9 @@ function _artWebClickNode(node) {
     st.searchMatch = null;                      // a click supersedes a search dim
     _artWebSetSpread(node, set);                // fan the neighbors outward
     st.sigma.refresh();
-    if (st.graph.getNodeAttribute(node, 'kind') === 'genre') _artWebShowGenre(node);
+    const kind = st.graph.getNodeAttribute(node, 'kind');
+    if (kind === 'genre') _artWebShowGenre(node);
+    else if (kind === 'discovery') _artWebShowDiscovery(node);
     else _artWebShowArtist(node);
 }
 
@@ -7361,6 +7420,62 @@ function _artWebShowGenre(node) {
                 <span style="flex:1;min-width:0;font-size:12.5px;font-weight:600;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;">${escapeHtml(m.label)}</span>
             </div>`).join('') || '<div style="color:rgba(255,255,255,0.4);padding:8px;">No artists</div>'}`;
     p.style.display = 'flex';
+}
+
+// ---- Discovery lens: candidate card with "Add to watchlist" ------------------------------------
+function _artWebShowDiscovery(node) {
+    const p = _artWebEnsurePanel();
+    if (!p) return;
+    const g = _artistWeb.graph;
+    const a = g.getNodeAttributes(node);
+    const color = WEB_DISCOVERY_COLOR;
+    let genres = a.genresList;
+    if (typeof genres === 'string') { try { genres = JSON.parse(genres); } catch (e) { genres = [genres]; } }
+    genres = Array.isArray(genres) ? genres.slice(0, 5) : [];
+
+    document.getElementById('artweb-panel-body').innerHTML = `
+        <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>
+        <div style="text-align:center;">
+            <div style="width:110px;height:110px;margin:0 auto;border-radius:50%;overflow:hidden;border:2px solid ${color};box-shadow:0 8px 28px ${_webHexToRgba(color, 0.45)};background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;">
+                ${a.image_url ? `<img src="${escapeHtml(a.image_url)}" style="width:100%;height:100%;object-fit:cover;" onerror="this.parentNode.innerHTML='<span style=\\'font-size:34px;opacity:0.5;\\'>&#9835;</span>'">` : '<span style="font-size:34px;opacity:0.5;">&#9835;</span>'}
+            </div>
+            <div style="font-size:18px;font-weight:800;margin-top:12px;">${escapeHtml(a.label)}</div>
+            <div style="display:inline-block;font-size:10px;letter-spacing:0.08em;text-transform:uppercase;color:${color};border:1px solid ${_webHexToRgba(color, 0.5)};border-radius:999px;padding:2px 9px;margin-top:6px;">Not in your library</div>
+        </div>
+        ${genres.length ? `<div style="display:flex;flex-wrap:wrap;gap:6px;justify-content:center;margin-top:14px;">
+            ${genres.map(gname => `<span style="font-size:10.5px;padding:3px 9px;border-radius:999px;background:${_webHexToRgba(color, 0.16)};border:1px solid ${_webHexToRgba(color, 0.3)};color:#ffd9a3;">${escapeHtml(String(gname))}</span>`).join('')}
+        </div>` : ''}
+        <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
+            <button id="artweb-add-btn" onclick="artWebAddToWatchlist('${escapeForInlineJs(node)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">+ Add to watchlist</button>
+        </div>`;
+    p.style.display = 'flex';
+}
+
+// Add a discovered (unowned) artist to the watchlist. Prefer a Spotify id (non-numeric) so the
+// endpoint treats it as an external artist, not a library DB id (Deezer/iTunes ids are numeric).
+async function artWebAddToWatchlist(key) {
+    const g = _artistWeb.graph;
+    if (!g || !g.hasNode(key)) return;
+    const a = g.getNodeAttributes(key);
+    const ids = a.ids || [];
+    const artistId = ids.find(id => id && /[a-zA-Z]/.test(String(id))) || ids[0];
+    const btn = document.getElementById('artweb-add-btn');
+    if (!artistId) { if (btn) btn.textContent = 'No id available'; return; }
+    if (btn) { btn.textContent = 'Adding…'; btn.disabled = true; }
+    try {
+        const r = await fetch('/api/watchlist/add', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ artist_id: String(artistId), artist_name: a.label }),
+        });
+        const d = await r.json();
+        if (!d.success) throw new Error(d.error || 'failed');
+        if (btn) { btn.textContent = '✓ Added to watchlist'; btn.style.background = 'rgba(255,255,255,0.12)'; btn.style.color = '#fff'; }
+        if (typeof showToast === 'function') showToast(`Added ${a.label} to watchlist`, 'success');
+        if (typeof updateWatchlistCount === 'function') updateWatchlistCount();
+    } catch (e) {
+        if (btn) { btn.textContent = '+ Add to watchlist'; btn.disabled = false; }
+        if (typeof showToast === 'function') showToast(`Couldn't add: ${e.message}`, 'error');
+    }
 }
 
 // ---- Artist Web filter by genre: multi-select sidebar; dims everything outside the chosen genres --

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -7386,6 +7386,30 @@ function artWebFitToView() {
 }
 
 // ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
+// Resolved artist-thumb cache for the hover tooltip, keyed by library artist id. Value: a URL
+// string, '' (tried, none), or null (in-flight) — any non-undefined means "don't refetch".
+const _artWebThumbCache = {};
+let _artWebTipThumbTimer = null;
+
+// Resolve one owned artist's browser-loadable thumb (same endpoint the side-panel avatar uses),
+// cache it, and swap it into the tooltip IF we're still hovering that exact node.
+function _artWebResolveTipThumb(nodeKey, artistId) {
+    _artWebThumbCache[artistId] = null;   // in-flight
+    fetch(`/api/library/artist/${encodeURIComponent(artistId)}/thumb`)
+        .then(r => r.json())
+        .then(d => {
+            const url = (d && d.success && d.image_url) ? d.image_url : '';
+            _artWebThumbCache[artistId] = url;
+            const tip = document.getElementById('artist-web-tooltip');
+            if (url && tip && tip._node === nodeKey && tip.style.display !== 'none') {
+                const slot = tip.querySelector('.artmap-tip-img');
+                if (slot) slot.outerHTML =
+                    `<img class="artmap-tip-img" src="${escapeHtml(url)}" alt="" onerror="this.style.display='none'">`;
+            }
+        })
+        .catch(() => { _artWebThumbCache[artistId] = ''; });
+}
+
 // Hover tooltip — identify any node without clicking (name + genre + connection count). Rebuilt only
 // when the hovered node changes; a plain mousemove just repositions it. Positioned at the pointer.
 function _artWebShowTooltip(nodeKey) {
@@ -7405,7 +7429,12 @@ function _artWebShowTooltip(nodeKey) {
         const noun = kind === 'genre' ? 'artist' : 'connection';
         const badge = kind === 'discovery' ? '<span class="artmap-tip-badge">To discover</span>'
                     : kind === 'genre' ? '<span class="artmap-tip-badge">Genre</span>' : '';
-        const imgSrc = a.thumb || a.image_url;   // discovery candidates store image_url, not thumb
+        // Image: discovery candidates ship a full image_url. Owned artists carry a Plex-RELATIVE
+        // thumb that won't load as-is (like the side panel's avatar), so resolve it lazily via the
+        // same /thumb endpoint and cache it — only for artists you actually pause on (cheap; the
+        // endpoint does a DB write per call so eager-resolving all ~5k would take minutes).
+        const cached = (a.artistId != null) ? _artWebThumbCache[a.artistId] : undefined;
+        const imgSrc = (kind === 'discovery') ? a.image_url : (cached || null);
         const img = imgSrc
             ? `<img class="artmap-tip-img" src="${escapeHtml(imgSrc)}" alt="" onerror="this.style.display='none'">`
             : (kind === 'genre' ? '' : '<div class="artmap-tip-img artmap-tip-img-fallback">&#9835;</div>');
@@ -7415,6 +7444,17 @@ function _artWebShowTooltip(nodeKey) {
         tip.innerHTML = `<div class="artmap-tip-row">${img}<div class="artmap-tip-info">` +
             `<div class="artmap-tip-name">${escapeHtml(a.label || '')}</div>${badge}${connHTML}${genreHTML}</div></div>`;
         tip.style.display = 'block';
+
+        // Kick off a debounced lazy thumb resolve for an owned artist we haven't cached yet — the
+        // ~140ms delay means a fast sweep across nodes doesn't fetch for every one you graze past.
+        if (!imgSrc && kind !== 'genre' && kind !== 'discovery'
+            && a.artistId != null && _artWebThumbCache[a.artistId] === undefined) {
+            clearTimeout(_artWebTipThumbTimer);
+            const aid = a.artistId;
+            _artWebTipThumbTimer = setTimeout(() => {
+                if (tip._node === nodeKey && _artWebThumbCache[aid] === undefined) _artWebResolveTipThumb(nodeKey, aid);
+            }, 140);
+        }
     }
     const m = _artistWeb._mouse;
     if (m) {

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6727,7 +6727,9 @@ function _artWebSetSpread(root, focusSet) {
     if (!st.cursorFX || !st.home) return;
     const neighbors = new Set(focusSet);
     neighbors.delete(root);
-    if (neighbors.size === 0 || neighbors.size > 60) { _artWebClearSpread(); return; }
+    if (neighbors.size === 0) { _artWebClearSpread(); return; }
+    // Genre hubs have hundreds of members — that's fine, the whole cluster just blooms outward from
+    // its label. (Per-frame cost is the full render either way, so member count doesn't hurt perf.)
     st.spreadRoot = root;
     st.spreadSet = neighbors;
     _artWebStartFX();

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6630,11 +6630,14 @@ function _artWebRenderLens() {
     _artistWeb.spreadPush = span * 0.035;    // how far a selected node's neighbors fan out
     _artistWeb.spreadRoot = null; _artistWeb.spreadSet = null;
 
-    // Declutter threshold = median similarity-edge weight (hides the weaker half when toggled on).
+    // Declutter threshold: hide edges below the median weight — but most edges are weight-1
+    // (single-source), so if the median IS the minimum, bump above it to hide that weakest tier.
     const w = [];
     built.graph.forEachEdge((e, a) => { if (a.kind === 'similarity') w.push(a.weight || 1); });
     w.sort((x, y) => x - y);
-    _artistWeb.edgeThreshold = w.length ? w[Math.floor(w.length * 0.5)] : 2;
+    let thr = w.length ? w[Math.floor(w.length * 0.5)] : 2;
+    if (w.length && thr <= w[0]) thr = w[0] + 1;
+    _artistWeb.edgeThreshold = thr;
     _artWebSyncEdgeButton();
 
     _artWebMountSigma(host, built.graph);

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6371,6 +6371,7 @@ function _artMapPanelArtistById(id) {
 // recolor/dim per frame — the graph data is never mutated for visual state.
 let _artistWeb = {
     sigma: null, graph: null, onKey: null,
+    gen: 0,                           // open/close generation — in-flight fetches bail if it changed
     lens: 'genre',                    // 'genre' | 'community' | 'discovery'
     data: null,                       // cached /api/graph/library payload (reused when switching lens)
     discoveryData: null,              // cached /api/graph/discovery payload (owned anchors + unowned candidates)
@@ -6475,6 +6476,11 @@ async function openArtistWeb(lens) {
     const container = document.getElementById('artist-web-container');
     if (!container) return;
 
+    // New generation: any fetch still in flight from a prior open/close bails on resolve.
+    const myGen = ++_artistWeb.gen;
+    // Re-entrancy: drop a stale keydown listener so we never leak/duplicate it.
+    if (_artistWeb.onKey) document.removeEventListener('keydown', _artistWeb.onKey);
+
     // Pseudo-page takeover: hide the other discover sections, show the web container.
     document.querySelectorAll('#discover-page > .discover-container > *:not(#artist-web-container)').forEach(el => {
         el._prevDisplay = el.style.display;
@@ -6486,13 +6492,29 @@ async function openArtistWeb(lens) {
     const statsEl = document.getElementById('artist-web-stats');
     host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Building your artist web…</div>';
 
-    // Esc: exit path mode, else dismiss an open detail panel, else leave the web.
+    // Keyboard: Esc unwinds (path mode -> panel -> close); the toolbar advertises S/F/0/+/- so wire
+    // them (skipping while typing in an input, where Esc just blurs the field).
     _artistWeb.onKey = (e) => {
-        if (e.key !== 'Escape') return;
-        if (_artistWeb.pathMode) { _artWebExitPath(); return; }
-        const p = document.getElementById('artweb-panel');
-        if (p && p.style.display !== 'none') _artWebClearSelection();
-        else closeArtistWeb();
+        const t = e.target;
+        if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA')) {
+            if (e.key === 'Escape') t.blur();
+            return;
+        }
+        if (e.key === 'Escape') {
+            if (_artistWeb.pathMode) { _artWebExitPath(); return; }
+            const p = document.getElementById('artweb-panel');
+            if (p && p.style.display !== 'none') _artWebClearSelection();
+            else closeArtistWeb();
+        } else if (e.key === 's' || e.key === 'S') {
+            const inp = document.getElementById('artist-web-search');
+            if (inp) { e.preventDefault(); inp.focus(); }
+        } else if (e.key === 'f' || e.key === 'F' || e.key === '0') {
+            artWebFitToView();
+        } else if (e.key === '+' || e.key === '=') {
+            artWebZoom(0.77);           // ratio<1 = zoom IN
+        } else if (e.key === '-' || e.key === '_') {
+            artWebZoom(1.3);            // zoom OUT
+        }
     };
     document.addEventListener('keydown', _artistWeb.onKey);
 
@@ -6504,7 +6526,9 @@ async function openArtistWeb(lens) {
     }
 
     try {
-        _artistWeb.data = await (await fetch('/api/graph/library')).json();
+        const payload = await (await fetch('/api/graph/library')).json();
+        if (_artistWeb.gen !== myGen) return;   // closed or reopened while fetching — abandon
+        _artistWeb.data = payload;
         _artistWeb.simGraph = null;   // rebuild pathfinding graph for this (possibly new) data
         _artistWeb.betweenCache = null;
         _artistWeb.discoveryData = null;  // refetch on next Discovery view — ownership may have changed
@@ -6515,6 +6539,7 @@ async function openArtistWeb(lens) {
         if (_artistWeb.lens === 'discovery') _artWebFetchDiscovery(host);
         else _artWebRenderLens();
     } catch (err) {
+        if (_artistWeb.gen !== myGen) return;
         console.error('[Artist Web] load failed', err);
         host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
     }
@@ -6523,14 +6548,20 @@ async function openArtistWeb(lens) {
 // Fetch the discovery payload, then render — only a GOOD payload is cached (a 500 resolves r.json()
 // too, and caching {"error": ...} used to leave the lens permanently blank with no retry).
 function _artWebFetchDiscovery(host) {
+    const myGen = _artistWeb.gen;
     fetch('/api/graph/discovery')
         .then(r => r.json().then(d => ({ ok: r.ok, d: d })))
         .then(({ ok, d }) => {
             if (!ok || d.error || !Array.isArray(d.nodes)) throw new Error(d.error || 'bad response');
             _artistWeb.discoveryData = d;
+            // Bail if the Web was closed/reopened or the user moved off Discovery while fetching —
+            // otherwise a late response mounts a sigma+worker into a hidden host, or rebuilds the
+            // lens the user is now on, clobbering their selection/camera.
+            if (_artistWeb.gen !== myGen || _artistWeb.lens !== 'discovery') return;
             _artWebRenderLens();
         })
         .catch(err => {
+            if (_artistWeb.gen !== myGen || _artistWeb.lens !== 'discovery') return;
             console.error('[Artist Web] discovery load failed', err);
             if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery — switch lenses and back to retry.</div>';
         });
@@ -6541,6 +6572,9 @@ function artWebSetLens(lens) {
     if (!_artistWeb.data || _artistWeb.lens === lens) return;
     _artistWeb.lens = lens;
     _artWebSyncLensButtons();
+    // Tear down the prior lens's FA2 worker + settle timer NOW, before any async discovery fetch —
+    // otherwise the old timer fires mid-fetch and finalizes/animates the detached graph.
+    _artWebKillLiveLayout();
     const host = document.getElementById('artist-web-canvas');
     if (host) host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Rebuilding…</div>';
     // Discovery uses its own endpoint — fetch on first view (see _artWebFetchDiscovery).
@@ -6661,10 +6695,57 @@ function _artWebRenderLens() {
     _artistWeb.edgeThreshold = thr;
     _artWebSyncEdgeButton();
 
-    // Mount FIRST (random scatter is visible immediately), then settle live in a Web Worker — the
-    // graph visibly organizes into islands without ever blocking the UI.
+    // Pre-seed positions (circlepack, grouped by cluster) so FA2 REFINES a structured start instead
+    // of untangling random noise — much faster + calmer settle at library scale. Silent no-op if the
+    // CDN bundle lacks the helper (the builders already set random x/y as a fallback).
+    _artWebPreseed(built.graph);
+
+    // Mount FIRST (the pre-seeded islands are visible immediately), then settle live in a Web Worker —
+    // the graph refines into islands without ever blocking the UI.
     _artWebMountSigma(host, built.graph);
     _artWebStartLiveLayout(built.graph);
+    _artWebRenderLegend(built);
+}
+
+// Color legend — decodes what the node colors mean for the active lens (Discovery = library vs
+// to-discover; Genre/Community = the top groups by size). Without it the palette is meaningless.
+function _artWebRenderLegend(built) {
+    const box = document.getElementById('artist-web-legend');
+    if (!box) return;
+    let items;
+    if (_artistWeb.lens === 'discovery') {
+        items = [
+            { color: WEB_OWNED_COLOR, label: 'Your library' },
+            { color: WEB_DISCOVERY_COLOR, label: 'To discover' },
+        ];
+    } else {
+        const counts = built.counts || {};
+        const colorOf = built.colorOf || (() => WEB_GENRE_FALLBACK);
+        items = Object.keys(counts)
+            .sort((a, b) => counts[b] - counts[a])
+            .slice(0, 8)
+            .map(g => ({ color: colorOf(g), label: g, count: counts[g] }));
+    }
+    if (!items.length) { box.style.display = 'none'; return; }
+    box.innerHTML = items.map(it =>
+        `<div class="artweb-legend-row">` +
+        `<span class="artweb-legend-dot" style="background:${it.color}"></span>` +
+        `<span class="artweb-legend-label">${escapeHtml(it.label)}</span>` +
+        (it.count != null ? `<span class="artweb-legend-count">${it.count}</span>` : '') +
+        `</div>`
+    ).join('');
+    box.style.display = '';
+}
+
+// Circlepack pre-seed: pack nodes into cluster circles (by the 'genre' attribute the builders set on
+// every node) so FA2 starts from structure, not noise. Discovery has no genre grouping — pack flat.
+function _artWebPreseed(graph) {
+    try {
+        const lib = window.graphologyLibrary;
+        const cp = lib && lib.layout && lib.layout.circlepack;
+        if (!cp || graph.order === 0) return;
+        cp.assign(graph, _artistWeb.lens === 'discovery' ? {} : { hierarchyAttributes: ['genre'] });
+    } catch (e) { /* keep the random positions the builders already set */ }
 }
 
 // ---- Live-settle layout: forceAtlas2 in a Web Worker (FA2Layout supervisor) ---------------------
@@ -6953,6 +7034,8 @@ function _artWebMountSigma(host, graph) {
         labelRenderedSizeThreshold: 20,
         labelRenderer: _webDrawLabel,
         hideEdgesOnMove: true,   // edge cleanup: drop edges while panning/zooming for clarity + perf
+        hideLabelsOnMove: true,  // labels re-measure (measureText) per frame — drop them while moving too
+        labelGridCellSize: 150,  // sparser label grid => fewer simultaneous labels/measureText per frame
         nodeReducer: (node, data) => _artWebNodeReducer(node, data),
         edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
     });
@@ -7024,6 +7107,7 @@ function _artWebSpreadTick() {
 }
 
 function closeArtistWeb() {
+    _artistWeb.gen++;   // invalidate any in-flight library/discovery fetch so it can't render into a closed Web
     const container = document.getElementById('artist-web-container');
     // Stamp _prevDisplay='none' so if another overlay (Artist Map) later runs its sibling-restore,
     // it keeps this container hidden instead of falling back to '' and un-hiding a dead (sigma-killed)
@@ -7041,6 +7125,8 @@ function closeArtistWeb() {
     if (results) { results.style.display = 'none'; results.innerHTML = ''; }
     const sb = document.getElementById('artweb-genre-sidebar');
     if (sb) sb.style.display = 'none';
+    const legend = document.getElementById('artist-web-legend');
+    if (legend) legend.style.display = 'none';
     _artistWeb.pathMode = false;
     _artistWeb.pathNodes = _artistWeb.pathPairs = _artistWeb.pathResult = _artistWeb.pathSource = _artistWeb.pathTarget = null;
     const pathBtn = document.getElementById('artweb-path-btn');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6711,6 +6711,11 @@ function _artWebStartLiveLayout(graph) {
         if (statsEl) statsEl.textContent = statsEl.textContent.replace(' · settling…', '');
         if (_artistWeb.sigma && _artistWeb.graph === graph) {
             _artistWeb.sigma.getCamera().animatedReset({ duration: 500 });   // fit the settled web
+            // hideEdgesOnMove leaves the LAST frame of the animation edge-less (nothing re-renders
+            // after the camera stops) — force one refresh once the animation has landed.
+            setTimeout(() => {
+                if (_artistWeb.sigma && _artistWeb.graph === graph) _artistWeb.sigma.refresh();
+            }, 650);
         }
     }, ms);
 }
@@ -7196,19 +7201,29 @@ function artWebFocusNode(key) {
     const disp = sig.getNodeDisplayData(key);
     if (disp) {
         sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 });
+        _artWebRefreshAfter(600);
     }
 }
 
 // ---- Artist Web camera controls ---------------------------------------------------------------
+// hideEdgesOnMove leaves the final frame of any camera ANIMATION edge-less (the last render happens
+// while "moving", and nothing re-renders after the animation stops). Every animated camera move
+// schedules one trailing refresh via this helper.
+function _artWebRefreshAfter(ms) {
+    setTimeout(() => { if (_artistWeb.sigma) _artistWeb.sigma.refresh(); }, ms);
+}
+
 function artWebZoom(factor) {
     if (!_artistWeb.sigma) return;
     const cam = _artistWeb.sigma.getCamera();
     cam.animate({ ratio: cam.ratio * factor }, { duration: 250 });
+    _artWebRefreshAfter(350);
 }
 
 function artWebFitToView() {
     if (!_artistWeb.sigma) return;
     _artistWeb.sigma.getCamera().animatedReset({ duration: 400 });
+    _artWebRefreshAfter(500);
     // Clear any search focus so the whole web is visible again.
     const input = document.getElementById('artist-web-search');
     if (input) input.value = '';
@@ -7271,7 +7286,7 @@ function _artWebGoToArtist(key) {
     if (!sig || !_artistWeb.graph.hasNode(key)) return;
     _artWebClickNode(key);
     const disp = sig.getNodeDisplayData(key);
-    if (disp) sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 });
+    if (disp) { sig.getCamera().animate({ x: disp.x, y: disp.y, ratio: 0.15 }, { duration: 500 }); _artWebRefreshAfter(600); }
 }
 
 // ---- Artist Web shortest path: click two artists, trace how they connect via similarity ---------
@@ -7393,7 +7408,7 @@ function _artWebCameraTo(key) {
     const sig = _artistWeb.sigma;
     if (!sig || !_artistWeb.graph || !_artistWeb.graph.hasNode(key)) return;
     const d = sig.getNodeDisplayData(key);
-    if (d) sig.getCamera().animate({ x: d.x, y: d.y, ratio: 0.12 }, { duration: 500 });
+    if (d) { sig.getCamera().animate({ x: d.x, y: d.y, ratio: 0.12 }, { duration: 500 }); _artWebRefreshAfter(600); }
 }
 
 function _artWebPathHint(html) {

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6801,13 +6801,22 @@ function _artWebBuildCommunity(data, Graph) {
 // ---- Lens C: DISCOVERY — owned artists (cool) + their unowned similar candidates (warm) ----------
 function _artWebBuildDiscovery(data, Graph) {
     const nodes = data.nodes || [], edges = data.edges || [];
+    // Count each anchor's candidates up front — anchor size scales with its frontier, and only the
+    // biggest ~25 get an always-on label (the full frontier has ~300 anchors; labeling them all
+    // would wall the view with pills — the rest label on zoom/hover).
+    const anchorDeg = {};
+    edges.forEach(e => { anchorDeg[e.source] = (anchorDeg[e.source] || 0) + 1; });
+    const starAnchors = new Set(Object.keys(anchorDeg).sort((a, b) => anchorDeg[b] - anchorDeg[a]).slice(0, 25));
+
     const graph = new Graph();
     nodes.forEach(n => {
         if (n.kind === 'owned') {
+            const deg = anchorDeg[n.key] || 1;
             graph.addNode(n.key, {
                 label: n.label, x: Math.random(), y: Math.random(),
-                size: 7, color: WEB_OWNED_COLOR, baseColor: WEB_OWNED_COLOR,
-                forceLabel: true, kind: 'owned', genre: 'Your library',
+                size: 5 + Math.sqrt(deg) * 0.9,
+                color: WEB_OWNED_COLOR, baseColor: WEB_OWNED_COLOR,
+                forceLabel: starAnchors.has(n.key), kind: 'owned', genre: 'Your library',
                 artistId: n.id != null ? n.id : null, thumb: n.thumb || null,
             });
         } else {
@@ -6827,7 +6836,10 @@ function _artWebBuildDiscovery(data, Graph) {
             if (e.weight > maxW) maxW = e.weight;
             graph.addEdge(e.source, e.target, {
                 weight: e.weight, size: _webEdgeSize(e.weight),
-                color: _webHexToRgba(WEB_DISCOVERY_COLOR, 0.28), baseColor: WEB_DISCOVERY_COLOR, kind: 'discovery',
+                // Weight-scaled alpha (like the other lenses) — a fixed alpha washed out around
+                // dense anchors once the full frontier's ~4.4k edges rendered at once.
+                color: _webHexToRgba(WEB_DISCOVERY_COLOR, _webEdgeAlpha(e.weight)),
+                baseColor: WEB_DISCOVERY_COLOR, kind: 'discovery',
             });
         }
     });

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6384,6 +6384,8 @@ let _artistWeb = {
     genreCounts: null,                // {genre: artistCount} for the filter sidebar
     sizeBy: 'popularity',             // node-size metric: popularity | connections | influence(betweenness)
     betweenCache: null,               // cached betweenness scores (computed once on the similarity graph)
+    edgeDeclutter: false,             // when on, hide the weaker half of similarity edges at rest
+    edgeThreshold: 2,                 // weight cutoff for declutter (computed per render)
     // Shortest-path mode: click two artists to trace how they connect (via the similarity graph).
     pathMode: false,
     pathSource: null, pathTarget: null,
@@ -6627,6 +6629,13 @@ function _artWebRenderLens() {
     _artistWeb.home = home;
     _artistWeb.spreadPush = span * 0.035;    // how far a selected node's neighbors fan out
     _artistWeb.spreadRoot = null; _artistWeb.spreadSet = null;
+
+    // Declutter threshold = median similarity-edge weight (hides the weaker half when toggled on).
+    const w = [];
+    built.graph.forEachEdge((e, a) => { if (a.kind === 'similarity') w.push(a.weight || 1); });
+    w.sort((x, y) => x - y);
+    _artistWeb.edgeThreshold = w.length ? w[Math.floor(w.length * 0.5)] : 2;
+    _artWebSyncEdgeButton();
 
     _artWebMountSigma(host, built.graph);
 }
@@ -6932,6 +6941,11 @@ function _artWebEdgeReducer(edge, data) {
     // spokes overlapping accumulate to solid white), so never render them — clustering is already
     // conveyed by node position + color. Only similarity edges are drawn.
     if (data.kind === 'membership') { res.hidden = true; return res; }
+    // Declutter (resting view only): hide the weaker half of similarity edges. Hover/select/path/search
+    // below still reveal the full detail for whatever you're inspecting.
+    if (st.edgeDeclutter && !st.pathNodes && !st.focusSet && !st.searchMatch && (data.weight || 1) < st.edgeThreshold) {
+        res.hidden = true; return res;
+    }
     const g = _artistWeb.graph;
     // Shortest-path mode: only the consecutive edges along the chain show (bright + thick), rest hidden.
     if (st.pathNodes) {
@@ -7404,6 +7418,21 @@ function artWebClearGenreFilter() {
 
 // Sidebar search box just filters which genres are listed.
 function artWebFilterGenreList(query) { _artWebPopulateGenreList(query); }
+
+// ---- Edge declutter toggle: show all connections vs only the stronger (high-consensus) ones -------
+function artWebToggleEdges() {
+    _artistWeb.edgeDeclutter = !_artistWeb.edgeDeclutter;
+    _artWebSyncEdgeButton();
+    if (_artistWeb.sigma) _artistWeb.sigma.refresh();
+}
+
+function _artWebSyncEdgeButton() {
+    const btn = document.getElementById('artweb-edges-btn');
+    if (!btn) return;
+    btn.classList.toggle('active', _artistWeb.edgeDeclutter);
+    const label = btn.querySelector('span');
+    if (label) label.textContent = _artistWeb.edgeDeclutter ? 'Strong' : 'Edges';
+}
 
 async function openArtistMap() {
     const container = document.getElementById('artist-map-container');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6399,6 +6399,8 @@ let _artistWeb = {
     cursorFX: true,                   // master flag (one switch to disable the effect)
     fxRAF: null, home: null,          // rAF handle + captured resting positions
     spreadRoot: null, spreadSet: null, spreadPush: 0,
+    spreadActive: null,               // Set of nodes currently displaced/pushed — the FX tick animates
+                                      // only these, never a full ~5k-node sweep per frame.
     fa2: null, fa2Timer: null,        // live-settle worker layout supervisor + its stop timer
     previewAudio: null, previewKey: null,   // 30s Deezer preview playback (discovery candidates)
 };
@@ -6683,7 +6685,7 @@ function _artWebRenderLens() {
     // Home positions are captured AFTER the layout settles (_artWebFinishLayout); until then the
     // selection-spread effect stays dormant (its guards check st.home).
     _artistWeb.home = null;
-    _artistWeb.spreadRoot = _artistWeb.spreadSet = null;
+    _artistWeb.spreadRoot = _artistWeb.spreadSet = _artistWeb.spreadActive = null;
 
     // Declutter threshold: hide edges below the median weight — but most edges are weight-1
     // (single-source), so if the median IS the minimum, bump above it to hide that weakest tier.
@@ -7084,23 +7086,36 @@ function _artWebSpreadTick() {
     const set = st.spreadSet, root = st.spreadRoot;
     const rootHome = root && home[root] ? home[root] : null;
     const PUSH = st.spreadPush, EASE = 0.18;
+
+    // Animate only the pushed/displaced nodes, not all ~5k every frame. `spreadActive` accumulates
+    // any pushed node and drops it once it eases back home (and isn't currently pushed).
+    if (!st.spreadActive) st.spreadActive = new Set();
+    if (set) set.forEach(k => st.spreadActive.add(k));
+
     let moving = false;
-    g.forEachNode((k, a) => {
+    st.spreadActive.forEach(k => {
         const h = home[k];
-        if (!h) return;
+        if (!h) { st.spreadActive.delete(k); return; }
+        const ax = g.getNodeAttribute(k, 'x'), ay = g.getNodeAttribute(k, 'y');
         let tx = h.x, ty = h.y;
-        if (set && rootHome && set.has(k)) {
+        const pushed = set && rootHome && set.has(k);
+        if (pushed) {
             const dx = h.x - rootHome.x, dy = h.y - rootHome.y;
             const dist = Math.sqrt(dx * dx + dy * dy) || 0.0001;
             tx = h.x + (dx / dist) * PUSH;   // push each neighbor outward from the selected node
             ty = h.y + (dy / dist) * PUSH;
         }
-        const nx = a.x + (tx - a.x) * EASE;
-        const ny = a.y + (ty - a.y) * EASE;
-        if (Math.abs(nx - a.x) > 0.0005 || Math.abs(ny - a.y) > 0.0005) {
+        const nx = ax + (tx - ax) * EASE;
+        const ny = ay + (ty - ay) * EASE;
+        if (Math.abs(nx - ax) > 0.0005 || Math.abs(ny - ay) > 0.0005) {
             g.setNodeAttribute(k, 'x', nx);
             g.setNodeAttribute(k, 'y', ny);
             moving = true;
+        } else if (!pushed) {
+            // Reached home and not being pushed → snap exact + stop tracking it.
+            g.setNodeAttribute(k, 'x', tx);
+            g.setNodeAttribute(k, 'y', ty);
+            st.spreadActive.delete(k);
         }
     });
     if (moving) { st.sigma.refresh(); st.fxRAF = requestAnimationFrame(_artWebSpreadTick); }
@@ -7118,7 +7133,7 @@ function closeArtistWeb() {
     });
     _artWebKillLiveLayout();
     if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
-    _artistWeb.spreadRoot = _artistWeb.spreadSet = null;
+    _artistWeb.spreadRoot = _artistWeb.spreadSet = _artistWeb.spreadActive = null;
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');
@@ -7143,6 +7158,9 @@ const _WEB_DIM_NODE = '#2b2b34';
 
 function _artWebNodeReducer(node, data) {
     const st = _artistWeb;
+    // Resting fast-path: nothing highlighting/filtering → render base attrs as-is, no per-node
+    // clone. This is the common case and runs once per node (~5k) on EVERY refresh (hover, pan, etc).
+    if (!st.pathNodes && !st.genreFilter && !st.focusSet && !st.searchMatch) return data;
     const res = Object.assign({}, data);
     // Shortest-path mode takes priority: the chain lights up, everything else goes dark.
     if (st.pathNodes) {
@@ -7182,11 +7200,17 @@ function _artWebNodeReducer(node, data) {
 
 function _artWebEdgeReducer(edge, data) {
     const st = _artistWeb;
-    const res = Object.assign({}, data);
     // Membership edges are a layout scaffold only. Drawing them starbursts big hubs (1000+ faint
     // spokes overlapping accumulate to solid white), so never render them — clustering is already
     // conveyed by node position + color. Only similarity edges are drawn.
-    if (data.kind === 'membership') { res.hidden = true; return res; }
+    if (data.kind === 'membership') { const r = Object.assign({}, data); r.hidden = true; return r; }
+    // Resting fast-path: no path/focus/search/genre-filter/declutter active → the ~35k similarity
+    // edges render as-is with NO clone and NO source/target lookups. This is the biggest per-refresh
+    // allocation sink; refresh fires on every hover, click, search keystroke, and spread frame.
+    if (!st.pathNodes && !st.focusSet && !st.searchMatch && !st.genreFilter && !st.edgeDeclutter) {
+        return data;
+    }
+    const res = Object.assign({}, data);
     // Declutter (resting view only): hide the weaker half of SIMILARITY edges. Scoped to that kind —
     // the threshold is computed from similarity weights, and applying it to the Discovery lens's
     // (mostly weight-1) edges hid essentially all of them, leaving candidates as floating dots.

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6389,10 +6389,10 @@ let _artistWeb = {
     pathPairs: null,                  // Set<"a|b"> consecutive path edges (highlighted)
     pathResult: null,                 // the node-key array, once complete
     simGraph: null,                   // cached similarity-only graph for pathfinding (lens-independent)
-    // Cursor force-field: nodes near the pointer nudge away, then spring back to their layout home.
-    cursorFX: true,
-    cursor: null, cursorActive: false, cursorRAF: null,
-    cursorRadius: 0, cursorPush: 0, home: null, hoverNode: null,
+    // Node-spread effect: selecting a node fans its neighbors outward; they settle back on deselect.
+    cursorFX: true,                   // master flag (one switch to disable the effect)
+    fxRAF: null, home: null,          // rAF handle + captured resting positions
+    spreadRoot: null, spreadSet: null, spreadPush: 0,
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6555,9 +6555,8 @@ function _artWebRenderLens() {
     });
     const span = Math.max(maxX - minX, maxY - minY) || 1;
     _artistWeb.home = home;
-    _artistWeb.cursorRadius = span * 0.05;   // ~5% of the graph span
-    _artistWeb.cursorPush = span * 0.02;     // nudge up to ~2% — subtle, so hover/click still land
-    _artistWeb.cursor = null; _artistWeb.cursorActive = false;
+    _artistWeb.spreadPush = span * 0.035;    // how far a selected node's neighbors fan out
+    _artistWeb.spreadRoot = null; _artistWeb.spreadSet = null;
 
     _artWebMountSigma(host, built.graph);
 }
@@ -6700,7 +6699,7 @@ function _artWebRunLayout(graph) {
 function _artWebMountSigma(host, graph) {
     host.innerHTML = '';
     host.style.background = WEB_CANVAS_BG;   // dark charcoal so the cluster colors glow
-    if (_artistWeb.cursorRAF) { cancelAnimationFrame(_artistWeb.cursorRAF); _artistWeb.cursorRAF = null; }
+    if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     _artistWeb.graph = graph;
     _artistWeb.sigma = new window.Sigma(graph, host, {
@@ -6719,54 +6718,51 @@ function _artWebMountSigma(host, graph) {
         if (_artistWeb.pathMode) { _artWebClearPath(); _artWebPathHint('Click an artist, then a second one, to trace how they connect.'); }
         else _artWebClearSelection();
     });
-
-    // Cursor force-field: track the pointer in graph space; the rAF loop nudges nearby nodes.
-    if (_artistWeb.cursorFX) {
-        sig.getMouseCaptor().on('mousemovebody', (e) => {
-            try { _artistWeb.cursor = sig.viewportToGraph({ x: e.x, y: e.y }); } catch (_) { return; }
-            _artistWeb.cursorActive = true;
-            _artWebStartCursorFX();
-        });
-        host.addEventListener('mouseleave', () => { _artistWeb.cursorActive = false; _artWebStartCursorFX(); });
-    }
 }
 
-// Cursor force-field loop: nodes within radius get pushed away from the pointer (relative to their
-// home), and ease back home when the pointer moves off. Purely visual — never touches the data/layout.
-function _artWebStartCursorFX() {
-    if (!_artistWeb.cursorRAF) _artistWeb.cursorRAF = requestAnimationFrame(_artWebCursorTick);
-}
-
-function _artWebCursorTick() {
+// ---- Node-spread effect: selecting a node fans its neighbors outward, then they settle back -------
+// Set the spread to a node's neighbors (skips huge hubs so the whole screen doesn't heave).
+function _artWebSetSpread(root, focusSet) {
     const st = _artistWeb;
-    st.cursorRAF = null;
+    if (!st.cursorFX || !st.home) return;
+    const neighbors = new Set(focusSet);
+    neighbors.delete(root);
+    if (neighbors.size === 0 || neighbors.size > 60) { _artWebClearSpread(); return; }
+    st.spreadRoot = root;
+    st.spreadSet = neighbors;
+    _artWebStartFX();
+}
+
+function _artWebClearSpread() {
+    const st = _artistWeb;
+    st.spreadRoot = null; st.spreadSet = null;
+    _artWebStartFX();   // loop eases any pushed nodes back home, then stops
+}
+
+function _artWebStartFX() {
+    if (!_artistWeb.fxRAF) _artistWeb.fxRAF = requestAnimationFrame(_artWebSpreadTick);
+}
+
+// Each frame: nodes in the spread set ease toward (home pushed away from the selected node); every
+// other node eases toward home. The loop runs only WHILE things are moving, so it's not continuous.
+function _artWebSpreadTick() {
+    const st = _artistWeb;
+    st.fxRAF = null;
     if (!st.sigma || !st.cursorFX || !st.home || !st.graph) return;
     const g = st.graph, home = st.home;
-    const active = st.cursorActive && st.cursor;
-    const cx = active ? st.cursor.x : 0, cy = active ? st.cursor.y : 0;
-    const R = st.cursorRadius, PUSH = st.cursorPush, EASE = 0.2;
-
-    // The node nearest the pointer is exempt from the push (stays home) so it never flees your click;
-    // everything else parts around it.
-    let nearest = null;
-    if (active) {
-        let nd = Infinity;
-        g.forEachNode((k, a) => { const dx = a.x - cx, dy = a.y - cy, d = dx * dx + dy * dy; if (d < nd) { nd = d; nearest = k; } });
-    }
-
+    const set = st.spreadSet, root = st.spreadRoot;
+    const rootHome = root && home[root] ? home[root] : null;
+    const PUSH = st.spreadPush, EASE = 0.18;
     let moving = false;
     g.forEachNode((k, a) => {
         const h = home[k];
         if (!h) return;
         let tx = h.x, ty = h.y;
-        if (active && k !== nearest && k !== st.hoverNode) {
-            const dx = h.x - cx, dy = h.y - cy;          // measure from HOME → stable, no feedback jitter
-            const dist = Math.sqrt(dx * dx + dy * dy);
-            if (dist < R && dist > 0.0001) {
-                const force = (1 - dist / R) * PUSH;      // closer to pointer → stronger push
-                tx = h.x + (dx / dist) * force;
-                ty = h.y + (dy / dist) * force;
-            }
+        if (set && rootHome && set.has(k)) {
+            const dx = h.x - rootHome.x, dy = h.y - rootHome.y;
+            const dist = Math.sqrt(dx * dx + dy * dy) || 0.0001;
+            tx = h.x + (dx / dist) * PUSH;   // push each neighbor outward from the selected node
+            ty = h.y + (dy / dist) * PUSH;
         }
         const nx = a.x + (tx - a.x) * EASE;
         const ny = a.y + (ty - a.y) * EASE;
@@ -6776,8 +6772,7 @@ function _artWebCursorTick() {
             moving = true;
         }
     });
-    if (moving) st.sigma.refresh();
-    if (moving || active) st.cursorRAF = requestAnimationFrame(_artWebCursorTick);   // else settled → stop
+    if (moving) { st.sigma.refresh(); st.fxRAF = requestAnimationFrame(_artWebSpreadTick); }
 }
 
 function closeArtistWeb() {
@@ -6789,8 +6784,8 @@ function closeArtistWeb() {
     document.querySelectorAll('#discover-page > .discover-container > *').forEach(el => {
         if (el.id !== 'artist-web-container' && el._prevDisplay !== undefined) el.style.display = el._prevDisplay;
     });
-    if (_artistWeb.cursorRAF) { cancelAnimationFrame(_artistWeb.cursorRAF); _artistWeb.cursorRAF = null; }
-    _artistWeb.cursorActive = false;
+    if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
+    _artistWeb.spreadRoot = _artistWeb.spreadSet = null;
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');
@@ -6973,7 +6968,6 @@ function artWebFitToView() {
 // ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
 function _artWebHover(node) {
     const st = _artistWeb;
-    st.hoverNode = node || null;   // pin the hovered node so the force-field can't shove it out of reach
     if (!st.sigma || st.pathMode) return;   // no hover-dim while tracing a path
     if (node) {
         const set = new Set([node]);
@@ -6997,6 +6991,7 @@ function _artWebClickNode(node) {
     st.selectedKey = node; st.selectedFocus = set;
     st.focusSet = set; st.focusRoot = node;
     st.searchMatch = null;                      // a click supersedes a search dim
+    _artWebSetSpread(node, set);                // fan the neighbors outward
     st.sigma.refresh();
     if (st.graph.getNodeAttribute(node, 'kind') === 'genre') _artWebShowGenre(node);
     else _artWebShowArtist(node);
@@ -7005,6 +7000,7 @@ function _artWebClickNode(node) {
 function _artWebClearSelection() {
     const st = _artistWeb;
     st.selectedKey = st.selectedFocus = st.focusSet = st.focusRoot = null;
+    _artWebClearSpread();               // let the fanned-out neighbors settle back home
     if (st.sigma) st.sigma.refresh();
     _artWebClosePanel();
 }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6403,6 +6403,7 @@ let _artistWeb = {
                                       // only these, never a full ~5k-node sweep per frame.
     fa2: null, fa2Timer: null,        // live-settle worker layout supervisor + its stop timer
     previewAudio: null, previewKey: null,   // 30s Deezer preview playback (discovery candidates)
+    _hoverNode: null, _mouse: null, _mouseBound: false,   // hover tooltip: current node + last pointer
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6543,8 +6544,22 @@ async function openArtistWeb(lens) {
     } catch (err) {
         if (_artistWeb.gen !== myGen) return;
         console.error('[Artist Web] load failed', err);
-        host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
+        _artWebStateCard(host, 'Failed to load the artist web.', _artistWeb.lens || 'genre');
     }
+}
+
+// Centered empty/error card in the canvas. retryLens set => a Retry button re-opens that lens.
+// Replacing the canvas with a message: tear down any live graph first so no WebGL context / FA2
+// worker leaks (e.g. a lens switch whose fetch failed, or a zero-candidate discovery).
+function _artWebStateCard(host, msg, retryLens) {
+    if (!host) return;
+    _artWebKillLiveLayout();
+    if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
+    if (_artistWeb.sigma) { try { _artistWeb.sigma.kill(); } catch (e) { /* ignore */ } _artistWeb.sigma = null; }
+    _artistWeb.graph = null;
+    const btn = retryLens
+        ? `<button class="artweb-state-btn" onclick="openArtistWeb('${retryLens}')">Retry</button>` : '';
+    host.innerHTML = `<div class="artweb-state-card"><div class="artweb-state-msg">${escapeHtml(msg)}</div>${btn}</div>`;
 }
 
 // Fetch the discovery payload, then render — only a GOOD payload is cached (a 500 resolves r.json()
@@ -6565,7 +6580,7 @@ function _artWebFetchDiscovery(host) {
         .catch(err => {
             if (_artistWeb.gen !== myGen || _artistWeb.lens !== 'discovery') return;
             console.error('[Artist Web] discovery load failed', err);
-            if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery — switch lenses and back to retry.</div>';
+            _artWebStateCard(host, 'Failed to load discovery.', 'discovery');
         });
 }
 
@@ -6696,6 +6711,12 @@ function _artWebRenderLens() {
     if (w.length && thr <= w[0]) thr = w[0] + 1;
     _artistWeb.edgeThreshold = thr;
     _artWebSyncEdgeButton();
+
+    // Empty discovery: a valid payload with zero candidates should GUIDE, not show a blank canvas.
+    if (_artistWeb.lens === 'discovery' && built.graph.order === 0) {
+        _artWebStateCard(host, 'No discovery candidates yet — add artists to your Watchlist so SoulSync can fetch similar artists to explore.', null);
+        return;
+    }
 
     // Pre-seed positions (circlepack, grouped by cluster) so FA2 REFINES a structured start instead
     // of untangling random noise — much faster + calmer settle at library scale. Silent no-op if the
@@ -7042,6 +7063,15 @@ function _artWebMountSigma(host, graph) {
         edgeReducer: (edge, data) => _artWebEdgeReducer(edge, data),
     });
     const sig = _artistWeb.sigma;
+    // Track the pointer over the canvas so the hover tooltip positions itself (sigma node events
+    // don't carry client coords reliably across versions). Bound once — the host element is static.
+    if (!_artistWeb._mouseBound) {
+        host.addEventListener('mousemove', (e) => {
+            _artistWeb._mouse = { x: e.clientX, y: e.clientY };
+            if (_artistWeb._hoverNode) _artWebShowTooltip(_artistWeb._hoverNode);
+        });
+        _artistWeb._mouseBound = true;
+    }
     sig.on('enterNode', ({ node }) => _artWebHover(node));
     sig.on('leaveNode', () => _artWebHover(null));
     sig.on('clickNode', ({ node }) => _artWebClickNode(node));
@@ -7142,6 +7172,9 @@ function closeArtistWeb() {
     if (sb) sb.style.display = 'none';
     const legend = document.getElementById('artist-web-legend');
     if (legend) legend.style.display = 'none';
+    _artistWeb._hoverNode = null;
+    const tt = document.getElementById('artist-web-tooltip');
+    if (tt) { tt.style.display = 'none'; tt._node = null; }
     _artistWeb.pathMode = false;
     _artistWeb.pathNodes = _artistWeb.pathPairs = _artistWeb.pathResult = _artistWeb.pathSource = _artistWeb.pathTarget = null;
     const pathBtn = document.getElementById('artweb-path-btn');
@@ -7342,9 +7375,48 @@ function artWebFitToView() {
 }
 
 // ---- Artist Web hover + selection: highlight a node and its neighbors -------------------------
+// Hover tooltip — identify any node without clicking (name + genre + connection count). Rebuilt only
+// when the hovered node changes; a plain mousemove just repositions it. Positioned at the pointer.
+function _artWebShowTooltip(nodeKey) {
+    const tip = document.getElementById('artist-web-tooltip');
+    if (!tip) return;
+    const g = _artistWeb.graph;
+    if (!nodeKey || !g || !g.hasNode(nodeKey)) { tip.style.display = 'none'; tip._node = null; return; }
+    if (tip._node !== nodeKey) {
+        tip._node = nodeKey;
+        const a = g.getNodeAttributes(nodeKey);
+        const kind = a.kind;
+        // True connection count: similarity links only (skip the membership scaffold edge). Genre
+        // hubs have no similarity edges — their degree IS the member count.
+        let conn = 0;
+        if (kind === 'genre') { conn = g.degree(nodeKey); }
+        else { g.forEachEdge(nodeKey, (e, attr) => { if (attr.kind === 'similarity') conn++; }); }
+        const noun = kind === 'genre' ? 'artist' : 'connection';
+        const badge = kind === 'discovery' ? '<span class="artmap-tip-badge">To discover</span>'
+                    : kind === 'genre' ? '<span class="artmap-tip-badge">Genre</span>' : '';
+        const img = a.thumb
+            ? `<img class="artmap-tip-img" src="${escapeHtml(a.thumb)}" alt="" onerror="this.style.display='none'">`
+            : (kind === 'genre' ? '' : '<div class="artmap-tip-img artmap-tip-img-fallback">&#9835;</div>');
+        const gen = a.primaryGenre || '';
+        const genreHTML = gen ? `<div class="artmap-tip-genres"><span>${escapeHtml(gen)}</span></div>` : '';
+        const connHTML = conn ? `<div class="artmap-tip-conn">${conn} ${noun}${conn === 1 ? '' : 's'}</div>` : '';
+        tip.innerHTML = `<div class="artmap-tip-row">${img}<div class="artmap-tip-info">` +
+            `<div class="artmap-tip-name">${escapeHtml(a.label || '')}</div>${badge}${connHTML}${genreHTML}</div></div>`;
+        tip.style.display = 'block';
+    }
+    const m = _artistWeb._mouse;
+    if (m) {
+        tip.style.left = Math.min(m.x + 16, window.innerWidth - tip.offsetWidth - 10) + 'px';
+        tip.style.top = Math.min(m.y - 10, window.innerHeight - tip.offsetHeight - 10) + 'px';
+    }
+}
+
 function _artWebHover(node) {
     const st = _artistWeb;
-    if (!st.sigma || st.pathMode) return;   // no hover-dim while tracing a path
+    if (!st.sigma) return;
+    st._hoverNode = node;
+    _artWebShowTooltip(node);                // tooltip shows even in path mode (helps pick the 2 nodes)
+    if (st.pathMode) return;                 // ...but no hover-dim while tracing a path
     if (node) {
         const set = new Set([node]);
         st.graph.forEachNeighbor(node, nb => set.add(nb));

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6453,6 +6453,17 @@ function _webGenreColorMap(nodes) {
     return { color: (g) => map[g] || WEB_GENRE_FALLBACK, counts };
 }
 
+// The top-N most popular artists — always labeled + a size tier, so they anchor the map as landmarks.
+const WEB_STAR_COUNT = 20;
+const WEB_STAR_SIZE = 8;
+function _webTopArtists(artistNodes, n) {
+    return new Set(artistNodes
+        .filter(a => (a.popularity || 0) > 0)
+        .sort((x, y) => (y.popularity || 0) - (x.popularity || 0))
+        .slice(0, n)
+        .map(a => a.key));
+}
+
 async function openArtistWeb() {
     const container = document.getElementById('artist-web-container');
     if (!container) return;
@@ -6562,7 +6573,7 @@ function _artWebApplySize(mode) {
     g.forEachNode((k, a) => {
         if (a.kind !== 'artist') return;   // genre hubs stay sized by member count
         const size = 2 + Math.sqrt(metric(k, a) / max) * 3.5;   // 2..5.5 — matches the original build scale
-        g.setNodeAttribute(k, 'size', size);
+        g.setNodeAttribute(k, 'size', a.isStar ? Math.max(size, 6) : size);   // stars stay landmark-sized
     });
     if (st.sigma) st.sigma.refresh();
 }
@@ -6624,6 +6635,7 @@ function _artWebRenderLens() {
 function _artWebBuildGenre(data, Graph) {
     const nodes = data.nodes || [], edges = data.edges || [];
     const { color: colorOf, counts } = _webGenreColorMap(nodes);
+    const stars = _webTopArtists(nodes.filter(n => n.kind === 'artist'), WEB_STAR_COUNT);
     const graph = new Graph();
     nodes.forEach(n => {
         if (n.kind === 'genre') {
@@ -6636,13 +6648,15 @@ function _artWebBuildGenre(data, Graph) {
             });
         } else {
             const color = colorOf(n.cluster);
+            const star = stars.has(n.key);
             graph.addNode(n.key, {
                 label: n.label, x: Math.random(), y: Math.random(),
-                size: 2 + Math.sqrt(n.popularity || 0) / 3,
+                size: star ? WEB_STAR_SIZE : 2 + Math.sqrt(n.popularity || 0) / 3,
                 color: color, baseColor: color,
                 kind: 'artist', genre: n.cluster, primaryGenre: n.primary_genre,
                 popularity: n.popularity || 0, thumb: n.thumb || null,
                 artistId: n.id != null ? n.id : null, source: n.source || null,
+                isStar: star, forceLabel: star,   // top artists are always-labeled landmarks
             });
             _artistWeb.index.push({ key: n.key, label: n.label });
         }
@@ -6672,17 +6686,20 @@ function _artWebBuildCommunity(data, Graph) {
     const simEdges = edges.filter(e => e.kind === 'similarity');
     const artistByKey = {};
     nodes.forEach(n => { if (n.kind === 'artist') artistByKey[n.key] = n; });
+    const stars = _webTopArtists(nodes.filter(n => n.kind === 'artist'), WEB_STAR_COUNT);
 
     const graph = new Graph();
     // Only artists with at least one similarity link — the discoverable "taste" core.
     simEdges.forEach(e => [e.source, e.target].forEach(k => {
         if (!graph.hasNode(k) && artistByKey[k]) {
             const n = artistByKey[k];
+            const star = stars.has(k);
             graph.addNode(k, {
                 label: n.label, x: Math.random(), y: Math.random(),
-                size: 2 + Math.sqrt(n.popularity || 0) / 3, kind: 'artist',
+                size: star ? WEB_STAR_SIZE : 2 + Math.sqrt(n.popularity || 0) / 3, kind: 'artist',
                 primaryGenre: n.primary_genre, popularity: n.popularity || 0, thumb: n.thumb || null,
                 artistId: n.id != null ? n.id : null, source: n.source || null,
+                isStar: star,
             });
         }
     }));
@@ -6717,8 +6734,10 @@ function _artWebBuildCommunity(data, Graph) {
         const rep = repOf[cid];
         const color = colorByRep[rep] || WEB_GENRE_FALLBACK;
         const isRep = graph.getNodeAttribute(k, '_rep') === true;
+        const isStar = graph.getNodeAttribute(k, 'isStar') === true;
         graph.mergeNodeAttributes(k, {
-            color, baseColor: color, genre: rep, forceLabel: isRep,
+            color, baseColor: color, genre: rep,
+            forceLabel: isRep || isStar,   // community leaders AND top artists are labeled landmarks
             size: isRep ? Math.max(8, graph.getNodeAttribute(k, 'size')) : graph.getNodeAttribute(k, 'size'),
         });
         _artistWeb.index.push({ key: k, label: graph.getNodeAttribute(k, 'label') });

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6484,11 +6484,15 @@ async function openArtistWeb(lens) {
     // Re-entrancy: drop a stale keydown listener so we never leak/duplicate it.
     if (_artistWeb.onKey) document.removeEventListener('keydown', _artistWeb.onKey);
 
-    // Pseudo-page takeover: hide the other discover sections, show the web container.
-    document.querySelectorAll('#discover-page > .discover-container > *:not(#artist-web-container)').forEach(el => {
-        el._prevDisplay = el.style.display;
-        el.style.display = 'none';
-    });
+    // Pseudo-page takeover: hide the other discover sections, show the web container. Only snapshot
+    // when NOT already open — a re-entrant open (the error-card Retry button) would otherwise
+    // overwrite each sibling's real _prevDisplay ('') with 'none', blanking Discover on close.
+    if (container.style.display !== 'flex') {
+        document.querySelectorAll('#discover-page > .discover-container > *:not(#artist-web-container)').forEach(el => {
+            el._prevDisplay = el.style.display;
+            el.style.display = 'none';
+        });
+    }
     container.style.display = 'flex';
 
     const host = document.getElementById('artist-web-canvas');
@@ -6517,6 +6521,8 @@ async function openArtistWeb(lens) {
             artWebZoom(0.77);           // ratio<1 = zoom IN
         } else if (e.key === '-' || e.key === '_') {
             artWebZoom(1.3);            // zoom OUT
+        } else if (e.key === '?') {
+            artWebShowHelp();           // the first-run hint advertises "? for the guide"
         }
     };
     document.addEventListener('keydown', _artistWeb.onKey);
@@ -6715,6 +6721,8 @@ function _artWebRenderLens() {
 
     // Empty discovery: a valid payload with zero candidates should GUIDE, not show a blank canvas.
     if (_artistWeb.lens === 'discovery' && built.graph.order === 0) {
+        const lg = document.getElementById('artist-web-legend');
+        if (lg) lg.style.display = 'none';   // don't leave the prior lens's legend over the card
         _artWebStateCard(host, 'No discovery candidates yet — add artists to your Watchlist so SoulSync can fetch similar artists to explore.', null);
         return;
     }
@@ -6809,7 +6817,8 @@ function _artWebStartLiveLayout(graph) {
     const statsEl = document.getElementById('artist-web-stats');
     if (statsEl && statsEl.textContent.indexOf('· settling') === -1) statsEl.textContent += ' · settling…';
     // Run time scales with graph size (a worker iterates as fast as it can; this is wall-clock).
-    const ms = Math.min(6000, 1200 + graph.order * 0.8);
+    const ms = Math.min(11000, 1600 + graph.order * 1.6);   // ~2x the settle budget — more iterations,
+                                                            // tighter islands (the pre-seed makes them pay off)
     _artistWeb.fa2Timer = setTimeout(() => {
         _artWebKillLiveLayout();
         _artWebFinishLayout(graph);
@@ -7034,7 +7043,7 @@ function _artWebRunLayout(graph) {
     const fa2 = window.graphologyLibrary && window.graphologyLibrary.layoutForceAtlas2;
     if (!fa2) { console.warn('[Artist Web] forceAtlas2 unavailable — nodes stay at random positions'); return; }
     fa2.assign(graph, {
-        iterations: 400,
+        iterations: 800,
         settings: {
             ...fa2.inferSettings(graph),
             barnesHutOptimize: true,
@@ -7166,6 +7175,7 @@ function closeArtistWeb() {
     if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
     _artistWeb.spreadRoot = _artistWeb.spreadSet = _artistWeb.spreadActive = null;
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }
+    _artistWeb.graph = null;   // so a late async re-select (expand-after-close) can't refresh a dead graph
     if (_artistWeb.onKey) { document.removeEventListener('keydown', _artistWeb.onKey); _artistWeb.onKey = null; }
     const results = document.getElementById('artist-web-search-results');
     if (results) { results.style.display = 'none'; results.innerHTML = ''; }
@@ -7395,8 +7405,9 @@ function _artWebShowTooltip(nodeKey) {
         const noun = kind === 'genre' ? 'artist' : 'connection';
         const badge = kind === 'discovery' ? '<span class="artmap-tip-badge">To discover</span>'
                     : kind === 'genre' ? '<span class="artmap-tip-badge">Genre</span>' : '';
-        const img = a.thumb
-            ? `<img class="artmap-tip-img" src="${escapeHtml(a.thumb)}" alt="" onerror="this.style.display='none'">`
+        const imgSrc = a.thumb || a.image_url;   // discovery candidates store image_url, not thumb
+        const img = imgSrc
+            ? `<img class="artmap-tip-img" src="${escapeHtml(imgSrc)}" alt="" onerror="this.style.display='none'">`
             : (kind === 'genre' ? '' : '<div class="artmap-tip-img artmap-tip-img-fallback">&#9835;</div>');
         const gen = a.primaryGenre || '';
         const genreHTML = gen ? `<div class="artmap-tip-genres"><span>${escapeHtml(gen)}</span></div>` : '';
@@ -7731,9 +7742,11 @@ async function artWebTogglePreview(key) {
     const btn = document.getElementById('artweb-preview-btn');
     if (!dz) { if (btn) btn.textContent = 'No preview available'; return; }
     if (btn) { btn.textContent = 'Loading preview…'; btn.disabled = true; }
+    const myGen = st.gen;   // if the Web is closed/reopened mid-fetch, don't start orphaned audio
     try {
         const r = await fetch(`/api/graph/discovery/preview/${encodeURIComponent(dz[1])}`);
         const d = await r.json();
+        if (st.gen !== myGen) return;
         if (!d.success || !d.preview_url) throw new Error(d.reason || 'no preview');
         // Pause the main player so the preview doesn't talk over it.
         if (typeof audioPlayer !== 'undefined' && audioPlayer && !audioPlayer.paused) audioPlayer.pause();
@@ -7741,6 +7754,7 @@ async function artWebTogglePreview(key) {
         audio.volume = 0.9;
         audio.onended = () => { if (st.previewKey === key) _artWebStopPreview(); };
         await audio.play();
+        if (st.gen !== myGen) { try { audio.pause(); } catch (e) {} return; }   // closed during play()
         st.previewAudio = audio;
         st.previewKey = key;
         if (btn) { btn.textContent = `⏸ ${d.track || 'Playing preview'}`; btn.disabled = false; }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6541,6 +6541,7 @@ async function openArtistWeb(lens) {
         _artWebSyncLensButtons();
         if (_artistWeb.lens === 'discovery') _artWebFetchDiscovery(host);
         else _artWebRenderLens();
+        _artWebMaybeFirstRunHint();
     } catch (err) {
         if (_artistWeb.gen !== myGen) return;
         console.error('[Artist Web] load failed', err);
@@ -7612,6 +7613,74 @@ function _artWebPathHint(html) {
 function _artWebHidePathHint() {
     const el = document.getElementById('artweb-path-hint');
     if (el) el.style.display = 'none';
+}
+
+// One-time first-run hint (a self-dismissing pill), so a cold user knows where to start.
+function _artWebMaybeFirstRunHint() {
+    try {
+        if (localStorage.getItem('artweb_seen_hint')) return;
+        localStorage.setItem('artweb_seen_hint', '1');
+    } catch (e) { return; }
+    const container = document.getElementById('artist-web-container');
+    if (!container) return;
+    let el = document.getElementById('artweb-firstrun-hint');
+    if (!el) {
+        el = document.createElement('div');
+        el.id = 'artweb-firstrun-hint';
+        el.style.cssText = 'position:absolute;bottom:20px;left:50%;transform:translateX(-50%);z-index:25;'
+            + 'background:rgba(20,18,26,0.94);border:1px solid rgba(255,255,255,0.12);border-radius:999px;'
+            + 'padding:9px 18px;font-size:12.5px;color:rgba(255,255,255,0.88);box-shadow:0 8px 24px rgba(0,0,0,0.5);'
+            + 'transition:opacity .4s ease;';
+        container.appendChild(el);
+    }
+    el.innerHTML = 'Hover to identify · click an artist to explore · <b>?</b> for the guide';
+    el.style.display = 'block'; el.style.opacity = '1';
+    setTimeout(() => { el.style.opacity = '0'; setTimeout(() => { el.style.display = 'none'; }, 400); }, 8000);
+}
+
+// Guide modal — explains the lenses, colors, and tools (reuses the Artist Map shortcuts-modal styling).
+function artWebShowHelp() {
+    const existing = document.getElementById('artweb-help-overlay');
+    if (existing) { existing.remove(); return; }
+    const overlay = document.createElement('div');
+    overlay.id = 'artweb-help-overlay';
+    overlay.className = 'modal-overlay';
+    overlay.style.zIndex = '10002';
+    overlay.onclick = (e) => { if (e.target === overlay) overlay.remove(); };
+    overlay.innerHTML = `
+        <div class="artmap-shortcuts-modal artweb-help-modal">
+            <div class="artmap-shortcuts-header">
+                <h3>Artist Web — Guide</h3>
+                <button class="watch-all-close" onclick="document.getElementById('artweb-help-overlay').remove()">&times;</button>
+            </div>
+            <div class="artweb-help-body">
+                <div class="artweb-help-section">
+                    <h4>Three lenses</h4>
+                    <p><b>Genre</b> — your artists grouped by genre. <b>Communities</b> — clusters found from who's
+                       actually similar to whom, named by each cluster's hub artist. <b>Discovery</b> — your library
+                       (blue) wired to unowned similar artists (amber) you could add.</p>
+                </div>
+                <div class="artweb-help-section">
+                    <h4>Explore</h4>
+                    <p><b>Hover</b> to identify a node · <b>click</b> an artist for details + play. On Discovery,
+                       click a candidate to add it to your watchlist, or an owned node to grow its frontier.</p>
+                </div>
+                <div class="artweb-help-section">
+                    <h4>Tools</h4>
+                    <p><b>Path</b> — click two artists to trace how they connect · <b>Size by</b> Popular / Links /
+                       Influence · <b>Edges</b> — strong connections only · <b>Filter</b> — by genre. The
+                       <b>legend</b> (bottom-left) decodes the colors.</p>
+                </div>
+                <div class="artmap-shortcuts-grid">
+                    <div class="artmap-shortcut"><kbd>S</kbd><span>Focus search</span></div>
+                    <div class="artmap-shortcut"><kbd>F</kbd> / <kbd>0</kbd><span>Fit to view</span></div>
+                    <div class="artmap-shortcut"><kbd>+</kbd> / <kbd>-</kbd><span>Zoom in / out</span></div>
+                    <div class="artmap-shortcut"><kbd>Esc</kbd><span>Back / close</span></div>
+                </div>
+            </div>
+        </div>
+    `;
+    document.body.appendChild(overlay);
 }
 
 // ---- Artist Web side panel (mirrors the Artist Map card design/interactions) -------------------

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -7414,11 +7414,13 @@ function _artWebShowArtist(node) {
         </div>`;
     p.style.display = 'flex';
 
-    // Resolve the artist photo via the app's image resolver (thumb_url is a Plex path, not loadable
-    // directly). Guarded by selectedKey so a fast re-click doesn't drop the wrong image in.
+    // Resolve the artist's OWN thumb by library id (normalized lazily server-side). The old call —
+    // /api/artist/<library-db-id>/image — sent the library row id to external providers as if it
+    // were THEIR id, so Deezer/iTunes returned whichever artist owns that number: wrong photo,
+    // essentially always. Guarded by selectedKey so a fast re-click can't drop in a stale image.
     if (a.artistId != null) {
         const forNode = node;
-        fetch(`/api/artist/${encodeURIComponent(a.artistId)}/image?name=${encodeURIComponent(a.label || '')}`)
+        fetch(`/api/library/artist/${encodeURIComponent(a.artistId)}/thumb`)
             .then(r => r.json())
             .then(d => {
                 if (!d || !d.success || !d.image_url) return;

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6399,6 +6399,7 @@ let _artistWeb = {
     fxRAF: null, home: null,          // rAF handle + captured resting positions
     spreadRoot: null, spreadSet: null, spreadPush: 0,
     fa2: null, fa2Timer: null,        // live-settle worker layout supervisor + its stop timer
+    previewAudio: null, previewKey: null,   // 30s Deezer preview playback (discovery candidates)
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -7439,6 +7440,60 @@ function _artWebEnsurePanel() {
 function _artWebClosePanel() {
     const p = document.getElementById('artweb-panel');
     if (p) p.style.display = 'none';
+    _artWebStopPreview();   // panel gone -> its preview stops (single choke point: all closes route here)
+}
+
+// ---- 30s Deezer preview playback (discovery candidates): hear it before you add it -------------
+function _artWebStopPreview() {
+    const st = _artistWeb;
+    if (st.previewAudio) {
+        try { st.previewAudio.pause(); } catch (e) { /* ignore */ }
+        st.previewAudio = null;
+    }
+    st.previewKey = null;
+    const btn = document.getElementById('artweb-preview-btn');
+    if (btn) { btn.textContent = '▶ Preview top track'; btn.disabled = false; }
+}
+
+async function artWebTogglePreview(key) {
+    const st = _artistWeb, g = st.graph;
+    if (!g || !g.hasNode(key)) return;
+    if (st.previewKey === key) { _artWebStopPreview(); return; }   // same node -> toggle off
+    _artWebStopPreview();
+    const pairs = g.getNodeAttribute(key, 'ids') || [];
+    const dz = pairs.find(p => p && p[0] === 'deezer');
+    const btn = document.getElementById('artweb-preview-btn');
+    if (!dz) { if (btn) btn.textContent = 'No preview available'; return; }
+    if (btn) { btn.textContent = 'Loading preview…'; btn.disabled = true; }
+    try {
+        const r = await fetch(`/api/graph/discovery/preview/${encodeURIComponent(dz[1])}`);
+        const d = await r.json();
+        if (!d.success || !d.preview_url) throw new Error(d.reason || 'no preview');
+        // Pause the main player so the preview doesn't talk over it.
+        if (typeof audioPlayer !== 'undefined' && audioPlayer && !audioPlayer.paused) audioPlayer.pause();
+        const audio = new Audio(d.preview_url);
+        audio.volume = 0.9;
+        audio.onended = () => { if (st.previewKey === key) _artWebStopPreview(); };
+        await audio.play();
+        st.previewAudio = audio;
+        st.previewKey = key;
+        if (btn) { btn.textContent = `⏸ ${d.track || 'Playing preview'}`; btn.disabled = false; }
+    } catch (e) {
+        _artWebStopPreview();
+        if (btn) { btn.textContent = 'Preview unavailable'; btn.disabled = false; }
+    }
+}
+
+// "Play radio" from an owned node — hands off to the artist-detail page's radio machinery
+// (startArtistRadioById, the shared parameterized core). Audio starts under the graph overlay.
+function artWebPlayArtist(key) {
+    const g = _artistWeb.graph;
+    if (!g || !g.hasNode(key)) return;
+    const a = g.getNodeAttributes(key);
+    if (a.artistId == null) return;
+    _artWebStopPreview();
+    if (typeof startArtistRadioById === 'function') startArtistRadioById(a.artistId, a.label || '');
+    else if (typeof showToast === 'function') showToast('Player not available', 'error');
 }
 
 function _artWebShowArtist(node) {
@@ -7472,6 +7527,7 @@ function _artWebShowArtist(node) {
             <div style="height:100%;width:${pop}%;background:${color};"></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
+            ${a.artistId != null ? `<button onclick="artWebPlayArtist('${escapeForInlineJs(node)}')" style="background:#1db954;border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">&#9654; Play radio</button>` : ''}
             ${_artistWeb.lens === 'discovery' ? `<button id="artweb-expand-btn" onclick="artWebExpandNode('${escapeForInlineJs(node)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">${a.expanded ? 'Expanded ✓' : 'Expand connections ✦'}</button>` : ''}
             <button onclick="artWebExploreInMap('${escapeForInlineJs(a.label)}')" style="background:${_artistWeb.lens === 'discovery' ? 'rgba(255,255,255,0.06)' : color};border:${_artistWeb.lens === 'discovery' ? '1px solid rgba(255,255,255,0.12)' : 'none'};color:${_artistWeb.lens === 'discovery' ? '#fff' : '#0b0b0f'};border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
             ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
@@ -7548,6 +7604,7 @@ function _artWebShowDiscovery(node) {
             ${genres.map(gname => `<span style="font-size:10.5px;padding:3px 9px;border-radius:999px;background:${_webHexToRgba(color, 0.16)};border:1px solid ${_webHexToRgba(color, 0.3)};color:#ffd9a3;">${escapeHtml(String(gname))}</span>`).join('')}
         </div>` : ''}
         <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
+            ${(a.ids || []).some(pr => pr && pr[0] === 'deezer') ? `<button id="artweb-preview-btn" onclick="artWebTogglePreview('${escapeForInlineJs(node)}')" style="background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.14);color:#fff;border-radius:10px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;">&#9654; Preview top track</button>` : ''}
             <button id="artweb-add-btn" onclick="artWebAddToWatchlist('${escapeForInlineJs(node)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">+ Add to watchlist</button>
         </div>`;
     p.style.display = 'flex';

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6561,7 +6561,7 @@ function _artWebApplySize(mode) {
     max = max || 1;
     g.forEachNode((k, a) => {
         if (a.kind !== 'artist') return;   // genre hubs stay sized by member count
-        const size = 2 + Math.sqrt(metric(k, a) / max) * 11;   // 2..13
+        const size = 2 + Math.sqrt(metric(k, a) / max) * 3.5;   // 2..5.5 — matches the original build scale
         g.setNodeAttribute(k, 'size', size);
     });
     if (st.sigma) st.sigma.refresh();

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6382,6 +6382,8 @@ let _artistWeb = {
     selectedFocus: null,              // the focus set to restore when hover clears
     genreFilter: null,                // Set<genre> persistent filter (dims everything outside it)
     genreCounts: null,                // {genre: artistCount} for the filter sidebar
+    sizeBy: 'popularity',             // node-size metric: popularity | connections | influence(betweenness)
+    betweenCache: null,               // cached betweenness scores (computed once on the similarity graph)
     // Shortest-path mode: click two artists to trace how they connect (via the similarity graph).
     pathMode: false,
     pathSource: null, pathTarget: null,
@@ -6486,6 +6488,7 @@ async function openArtistWeb() {
     try {
         _artistWeb.data = await (await fetch('/api/graph/library')).json();
         _artistWeb.simGraph = null;   // rebuild pathfinding graph for this (possibly new) data
+        _artistWeb.betweenCache = null;
         _artistWeb.lens = _artistWeb.lens || 'genre';
         _artWebSyncLensButtons();
         _artWebRenderLens();
@@ -6510,6 +6513,60 @@ function _artWebSyncLensButtons() {
         b.classList.toggle('active', b.dataset.lens === _artistWeb.lens));
 }
 
+// ---- "Size by" toggle: scale nodes by popularity | connections (degree) | influence (betweenness) --
+function _artWebSyncSizeButtons() {
+    document.querySelectorAll('.artweb-size-btn').forEach(b =>
+        b.classList.toggle('active', b.dataset.size === _artistWeb.sizeBy));
+}
+
+// Betweenness = "influence" (who bridges the taste network). Computed on the SIMILARITY graph (small,
+// ~1k nodes → fast) not the 5k display graph, and cached — a genre-hub-laden graph would be slow.
+function _artWebBetweenness() {
+    if (_artistWeb.betweenCache) return _artistWeb.betweenCache;
+    const g = _artWebSimGraph();
+    const c = window.graphologyLibrary && window.graphologyLibrary.metrics && window.graphologyLibrary.metrics.centrality;
+    const fn = c && (c.betweenness || c.betweennessCentrality);
+    let res = {};
+    if (fn && g) { try { res = fn(g); } catch (e) { res = {}; } }
+    _artistWeb.betweenCache = res;
+    return res;
+}
+
+function artWebSetSize(mode) {
+    if (_artistWeb.sizeBy === mode || !_artistWeb.graph) return;
+    // Influence needs a (one-time) betweenness pass — show a hint + defer so it paints first.
+    if (mode === 'influence' && !_artistWeb.betweenCache) {
+        _artistWeb.sizeBy = mode; _artWebSyncSizeButtons();
+        _artWebPathHint('Computing influence…');
+        setTimeout(() => { _artWebApplySize(mode); _artWebHidePathHint(); }, 30);
+    } else {
+        _artWebApplySize(mode);
+    }
+}
+
+function _artWebApplySize(mode) {
+    const st = _artistWeb, g = st.graph;
+    if (!g) return;
+    st.sizeBy = mode;
+    _artWebSyncSizeButtons();
+    const sg = (mode === 'connections') ? _artWebSimGraph() : null;
+    const btw = (mode === 'influence') ? _artWebBetweenness() : null;
+    const metric = (k, a) => {
+        if (mode === 'connections') return (sg && sg.hasNode(k)) ? sg.degree(k) : 0;
+        if (mode === 'influence') return btw[k] || 0;
+        return a.popularity || 0;   // popularity
+    };
+    let max = 0;
+    g.forEachNode((k, a) => { if (a.kind === 'artist') { const v = metric(k, a); if (v > max) max = v; } });
+    max = max || 1;
+    g.forEachNode((k, a) => {
+        if (a.kind !== 'artist') return;   // genre hubs stay sized by member count
+        const size = 2 + Math.sqrt(metric(k, a) / max) * 11;   // 2..13
+        g.setNodeAttribute(k, 'size', size);
+    });
+    if (st.sigma) st.sigma.refresh();
+}
+
 // (Re)build the graph for the current lens, run the layout, and mount sigma.
 function _artWebRenderLens() {
     const host = document.getElementById('artist-web-canvas');
@@ -6525,6 +6582,8 @@ function _artWebRenderLens() {
     _artistWeb.pathSource = _artistWeb.pathTarget = _artistWeb.pathResult = null;
     _artistWeb.pathNodes = _artistWeb.pathPairs = null;
     _artistWeb.genreFilter = null;
+    _artistWeb.sizeBy = 'popularity';   // build sizes by popularity; user can re-pick per view
+    _artWebSyncSizeButtons();
     _artistWeb.index = [];
     _artWebClosePanel();
     const sidebar = document.getElementById('artweb-genre-sidebar');

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6469,7 +6469,7 @@ function _webTopArtists(artistNodes, n) {
         .map(a => a.key));
 }
 
-async function openArtistWeb() {
+async function openArtistWeb(lens) {
     const container = document.getElementById('artist-web-container');
     if (!container) return;
 
@@ -6506,13 +6506,32 @@ async function openArtistWeb() {
         _artistWeb.simGraph = null;   // rebuild pathfinding graph for this (possibly new) data
         _artistWeb.betweenCache = null;
         _artistWeb.discoveryData = null;  // refetch on next Discovery view — ownership may have changed
+        // The hub cards deep-link a lens: Taste Map -> 'genre', Discovery Web -> 'discovery'.
+        if (lens === 'genre' || lens === 'community' || lens === 'discovery') _artistWeb.lens = lens;
         _artistWeb.lens = _artistWeb.lens || 'genre';
         _artWebSyncLensButtons();
-        _artWebRenderLens();
+        if (_artistWeb.lens === 'discovery') _artWebFetchDiscovery(host);
+        else _artWebRenderLens();
     } catch (err) {
         console.error('[Artist Web] load failed', err);
         host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load the artist web.</div>';
     }
+}
+
+// Fetch the discovery payload, then render — only a GOOD payload is cached (a 500 resolves r.json()
+// too, and caching {"error": ...} used to leave the lens permanently blank with no retry).
+function _artWebFetchDiscovery(host) {
+    fetch('/api/graph/discovery')
+        .then(r => r.json().then(d => ({ ok: r.ok, d: d })))
+        .then(({ ok, d }) => {
+            if (!ok || d.error || !Array.isArray(d.nodes)) throw new Error(d.error || 'bad response');
+            _artistWeb.discoveryData = d;
+            _artWebRenderLens();
+        })
+        .catch(err => {
+            console.error('[Artist Web] discovery load failed', err);
+            if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery — switch lenses and back to retry.</div>';
+        });
 }
 
 // Switch the organizing lens (genre clusters vs similarity communities) and rebuild.
@@ -6522,21 +6541,9 @@ function artWebSetLens(lens) {
     _artWebSyncLensButtons();
     const host = document.getElementById('artist-web-canvas');
     if (host) host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Rebuilding…</div>';
-    // Discovery uses its own endpoint — fetch it once, then render. Only a GOOD payload is cached:
-    // a 500 resolves r.json() too, and caching {"error": ...} used to leave the lens permanently
-    // blank ("0 artists") with no retry until a full page reload.
+    // Discovery uses its own endpoint — fetch on first view (see _artWebFetchDiscovery).
     if (lens === 'discovery' && !_artistWeb.discoveryData) {
-        fetch('/api/graph/discovery')
-            .then(r => r.json().then(d => ({ ok: r.ok, d: d })))
-            .then(({ ok, d }) => {
-                if (!ok || d.error || !Array.isArray(d.nodes)) throw new Error(d.error || 'bad response');
-                _artistWeb.discoveryData = d;
-                _artWebRenderLens();
-            })
-            .catch(err => {
-                console.error('[Artist Web] discovery load failed', err);
-                if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery — switch lenses and back to retry.</div>';
-            });
+        _artWebFetchDiscovery(host);
     } else {
         setTimeout(_artWebRenderLens, 20);   // let "Rebuilding…" paint before the sync layout blocks
     }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6505,6 +6505,7 @@ async function openArtistWeb() {
         _artistWeb.data = await (await fetch('/api/graph/library')).json();
         _artistWeb.simGraph = null;   // rebuild pathfinding graph for this (possibly new) data
         _artistWeb.betweenCache = null;
+        _artistWeb.discoveryData = null;  // refetch on next Discovery view — ownership may have changed
         _artistWeb.lens = _artistWeb.lens || 'genre';
         _artWebSyncLensButtons();
         _artWebRenderLens();
@@ -6521,11 +6522,21 @@ function artWebSetLens(lens) {
     _artWebSyncLensButtons();
     const host = document.getElementById('artist-web-canvas');
     if (host) host.innerHTML = '<div style="padding:24px;color:rgba(255,255,255,.4)">Rebuilding…</div>';
-    // Discovery uses its own endpoint — fetch it once, then render.
+    // Discovery uses its own endpoint — fetch it once, then render. Only a GOOD payload is cached:
+    // a 500 resolves r.json() too, and caching {"error": ...} used to leave the lens permanently
+    // blank ("0 artists") with no retry until a full page reload.
     if (lens === 'discovery' && !_artistWeb.discoveryData) {
-        fetch('/api/graph/discovery').then(r => r.json())
-            .then(d => { _artistWeb.discoveryData = d; _artWebRenderLens(); })
-            .catch(() => { if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery.</div>'; });
+        fetch('/api/graph/discovery')
+            .then(r => r.json().then(d => ({ ok: r.ok, d: d })))
+            .then(({ ok, d }) => {
+                if (!ok || d.error || !Array.isArray(d.nodes)) throw new Error(d.error || 'bad response');
+                _artistWeb.discoveryData = d;
+                _artWebRenderLens();
+            })
+            .catch(err => {
+                console.error('[Artist Web] discovery load failed', err);
+                if (host) host.innerHTML = '<div style="padding:24px;color:#f88">Failed to load discovery — switch lenses and back to retry.</div>';
+            });
     } else {
         setTimeout(_artWebRenderLens, 20);   // let "Rebuilding…" paint before the sync layout blocks
     }
@@ -7001,9 +7012,11 @@ function _artWebEdgeReducer(edge, data) {
     // spokes overlapping accumulate to solid white), so never render them — clustering is already
     // conveyed by node position + color. Only similarity edges are drawn.
     if (data.kind === 'membership') { res.hidden = true; return res; }
-    // Declutter (resting view only): hide the weaker half of similarity edges. Hover/select/path/search
-    // below still reveal the full detail for whatever you're inspecting.
-    if (st.edgeDeclutter && !st.pathNodes && !st.focusSet && !st.searchMatch && (data.weight || 1) < st.edgeThreshold) {
+    // Declutter (resting view only): hide the weaker half of SIMILARITY edges. Scoped to that kind —
+    // the threshold is computed from similarity weights, and applying it to the Discovery lens's
+    // (mostly weight-1) edges hid essentially all of them, leaving candidates as floating dots.
+    if (st.edgeDeclutter && data.kind === 'similarity' && !st.pathNodes && !st.focusSet && !st.searchMatch
+        && (data.weight || 1) < st.edgeThreshold) {
         res.hidden = true; return res;
     }
     const g = _artistWeb.graph;
@@ -7424,6 +7437,9 @@ function _artWebShowGenre(node) {
 }
 
 // ---- Discovery lens: candidate card with "Add to watchlist" ------------------------------------
+// Deliberately NO expand button here: similar_artists only has rows for artists whose similars
+// SoulSync fetched (owned/watchlist), so expanding an unowned candidate always returns empty
+// (validated 0/176 on real data). The trail opens up after the candidate is watchlisted + scanned.
 function _artWebShowDiscovery(node) {
     const p = _artWebEnsurePanel();
     if (!p) return;
@@ -7452,21 +7468,22 @@ function _artWebShowDiscovery(node) {
     p.style.display = 'flex';
 }
 
-// Add a discovered (unowned) artist to the watchlist. Prefer a Spotify id (non-numeric) so the
-// endpoint treats it as an external artist, not a library DB id (Deezer/iTunes ids are numeric).
+// Add a discovered (unowned) artist to the watchlist. ids are [source, id] PAIRS — we send the id
+// WITH its source so the endpoint never has to guess (a bare numeric Deezer/iTunes id used to be
+// mistaken for a library DB row id and could watch a completely different artist).
 async function artWebAddToWatchlist(key) {
     const g = _artistWeb.graph;
     if (!g || !g.hasNode(key)) return;
     const a = g.getNodeAttributes(key);
-    const ids = a.ids || [];
-    const artistId = ids.find(id => id && /[a-zA-Z]/.test(String(id))) || ids[0];
+    const pairs = a.ids || [];
+    const pair = pairs.find(p => p && p[0] === 'spotify') || pairs[0];
     const btn = document.getElementById('artweb-add-btn');
-    if (!artistId) { if (btn) btn.textContent = 'No id available'; return; }
+    if (!pair) { if (btn) btn.textContent = 'No id available'; return; }
     if (btn) { btn.textContent = 'Adding…'; btn.disabled = true; }
     try {
         const r = await fetch('/api/watchlist/add', {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ artist_id: String(artistId), artist_name: a.label }),
+            body: JSON.stringify({ artist_id: String(pair[1]), artist_name: a.label, source: pair[0] }),
         });
         const d = await r.json();
         if (!d.success) throw new Error(d.error || 'failed');
@@ -7493,7 +7510,8 @@ async function artWebExpandNode(key) {
         g.forEachNode(k => exclude.push(k));
         const r = await fetch('/api/graph/discovery/expand', {
             method: 'POST', headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ key: key, ids: a.ids || [], exclude: exclude, per: 10 }),
+            // a.ids holds [source, id] pairs; the expand matcher wants the flat ids.
+            body: JSON.stringify({ key: key, ids: (a.ids || []).map(p => p[1]), exclude: exclude, per: 10 }),
         });
         const d = await r.json();
         if (d.error) throw new Error(d.error);

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -7590,6 +7590,12 @@ function _artWebShowDiscovery(node) {
     let genres = a.genresList;
     if (typeof genres === 'string') { try { genres = JSON.parse(genres); } catch (e) { genres = [genres]; } }
     genres = Array.isArray(genres) ? genres.slice(0, 5) : [];
+    // Unowned artists still get a detail page: /artist-detail/<source>/<external id> synthesizes
+    // name + image + discography from the source (same pattern as the discover recommendation cards).
+    // ids pairs are ordered spotify > deezer > itunes; the first is the best detail source.
+    const pair = (a.ids || [])[0];
+    const detailPath = (pair && typeof buildArtistDetailPath === 'function')
+        ? buildArtistDetailPath(pair[1], pair[0]) : null;
 
     document.getElementById('artweb-panel-body').innerHTML = `
         <button onclick="_artWebClearSelection()" style="background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.1);color:rgba(255,255,255,0.7);border-radius:8px;padding:4px 10px;font-size:11px;cursor:pointer;margin-bottom:14px;">&#10005; Close</button>
@@ -7606,6 +7612,7 @@ function _artWebShowDiscovery(node) {
         <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
             ${(a.ids || []).some(pr => pr && pr[0] === 'deezer') ? `<button id="artweb-preview-btn" onclick="artWebTogglePreview('${escapeForInlineJs(node)}')" style="background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.14);color:#fff;border-radius:10px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;">&#9654; Preview top track</button>` : ''}
             <button id="artweb-add-btn" onclick="artWebAddToWatchlist('${escapeForInlineJs(node)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">+ Add to watchlist</button>
+            ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
         </div>`;
     p.style.display = 'flex';
 }

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -7376,7 +7376,8 @@ function _artWebShowArtist(node) {
             <div style="height:100%;width:${pop}%;background:${color};"></div>
         </div>
         <div style="display:flex;flex-direction:column;gap:8px;margin-top:18px;">
-            <button onclick="artWebExploreInMap('${escapeForInlineJs(a.label)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
+            ${_artistWeb.lens === 'discovery' ? `<button id="artweb-expand-btn" onclick="artWebExpandNode('${escapeForInlineJs(node)}')" style="background:${color};border:none;color:#0b0b0f;border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">${a.expanded ? 'Expanded ✓' : 'Expand connections ✦'}</button>` : ''}
+            <button onclick="artWebExploreInMap('${escapeForInlineJs(a.label)}')" style="background:${_artistWeb.lens === 'discovery' ? 'rgba(255,255,255,0.06)' : color};border:${_artistWeb.lens === 'discovery' ? '1px solid rgba(255,255,255,0.12)' : 'none'};color:${_artistWeb.lens === 'discovery' ? '#fff' : '#0b0b0f'};border-radius:10px;padding:10px;font-size:13px;font-weight:800;cursor:pointer;">Explore in Artist Map &rarr;</button>
             ${detailPath ? `<a href="${detailPath}" style="text-align:center;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);color:#fff;border-radius:10px;padding:9px;font-size:12px;text-decoration:none;">Open artist page (discography)</a>` : ''}
         </div>`;
     p.style.display = 'flex';
@@ -7475,6 +7476,81 @@ async function artWebAddToWatchlist(key) {
     } catch (e) {
         if (btn) { btn.textContent = '+ Add to watchlist'; btn.disabled = false; }
         if (typeof showToast === 'function') showToast(`Couldn't add: ${e.message}`, 'error');
+    }
+}
+
+// Expand-on-click (Discovery lens, owned nodes): fetch the node's similar artists and grow the graph
+// around it. New nodes land in a ring around the parent — no full re-layout, the map grows in place.
+async function artWebExpandNode(key) {
+    const st = _artistWeb, g = st.graph;
+    if (!g || !g.hasNode(key) || st.lens !== 'discovery') return;
+    const a = g.getNodeAttributes(key);
+    const btn = document.getElementById('artweb-expand-btn');
+    if (a.expanded) return;
+    if (btn) { btn.textContent = 'Expanding…'; btn.disabled = true; }
+    try {
+        const exclude = [];
+        g.forEachNode(k => exclude.push(k));
+        const r = await fetch('/api/graph/discovery/expand', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ key: key, ids: a.ids || [], exclude: exclude, per: 10 }),
+        });
+        const d = await r.json();
+        if (d.error) throw new Error(d.error);
+        const newNodes = (d.nodes || []).filter(n => n.key && !g.hasNode(n.key));
+        if (!newNodes.length) {
+            g.setNodeAttribute(key, 'expanded', true);
+            if (btn) btn.textContent = 'No new connections';
+            return;
+        }
+
+        // Ring placement around the parent's home position (stable even mid-spread-animation).
+        const home = st.home || (st.home = {});
+        const ph = home[key] || { x: a.x, y: a.y };
+        const R = (st.spreadPush || 0.1) * 2.2;
+        newNodes.forEach((n, i) => {
+            const th = (2 * Math.PI * i) / newNodes.length + Math.random() * 0.4;
+            const x = ph.x + Math.cos(th) * R, y = ph.y + Math.sin(th) * R;
+            if (n.kind === 'owned') {
+                g.addNode(n.key, {
+                    label: n.label, x: x, y: y, size: 7,
+                    color: WEB_OWNED_COLOR, baseColor: WEB_OWNED_COLOR,
+                    forceLabel: true, kind: 'owned', genre: 'Your library',
+                    artistId: n.id != null ? n.id : null, thumb: n.thumb || null,
+                });
+            } else {
+                g.addNode(n.key, {
+                    label: n.label, x: x, y: y, size: 3.5,
+                    color: WEB_DISCOVERY_COLOR, baseColor: WEB_DISCOVERY_COLOR,
+                    kind: 'discovery', genre: 'Discovery',
+                    image_url: n.image_url || null, genresList: n.genres || null,
+                    ids: n.ids || [], popularity: n.popularity || 0,
+                });
+            }
+            home[n.key] = { x: x, y: y };
+            st.index.push({ key: n.key, label: n.label });   // searchable immediately
+        });
+        (d.edges || []).forEach(e => {
+            if (g.hasNode(e.source) && g.hasNode(e.target) && !g.hasEdge(e.source, e.target)) {
+                g.addEdge(e.source, e.target, {
+                    weight: e.weight, size: _webEdgeSize(e.weight),
+                    color: _webHexToRgba(WEB_DISCOVERY_COLOR, 0.28), baseColor: WEB_DISCOVERY_COLOR, kind: 'discovery',
+                });
+            }
+        });
+        g.setNodeAttribute(key, 'expanded', true);
+
+        // Re-select the node: focus set now includes the new neighbors, panel re-renders ("Expanded").
+        _artWebClickNode(key);
+        const statsEl = document.getElementById('artist-web-stats');
+        if (statsEl) {
+            let own = 0, disc = 0;
+            g.forEachNode((k2, a2) => { if (a2.kind === 'owned') own++; else if (a2.kind === 'discovery') disc++; });
+            statsEl.textContent = `${own} of your artists · ${disc} to discover`;
+        }
+    } catch (e) {
+        if (btn) { btn.textContent = 'Expand connections ✦'; btn.disabled = false; }
+        if (typeof showToast === 'function') showToast(`Expand failed: ${e.message}`, 'error');
     }
 }
 

--- a/webui/static/discover.js
+++ b/webui/static/discover.js
@@ -6398,6 +6398,7 @@ let _artistWeb = {
     cursorFX: true,                   // master flag (one switch to disable the effect)
     fxRAF: null, home: null,          // rAF handle + captured resting positions
     spreadRoot: null, spreadSet: null, spreadPush: 0,
+    fa2: null, fa2Timer: null,        // live-settle worker layout supervisor + its stop timer
 };
 
 // White pill label (black text) — custom sigma labelRenderer. Font + padding scale with the node's
@@ -6644,21 +6645,10 @@ function _artWebRenderLens() {
     const sbHeader = document.querySelector('#artweb-genre-sidebar .artmap-genre-sidebar-header span');
     if (sbHeader) sbHeader.textContent = _artistWeb.lens === 'community' ? 'Communities' : 'Genres';
 
-    _artWebRunLayout(built.graph);
-
-    // Capture resting ("home") positions + size the cursor force-field to the layout's coordinate
-    // range (FA2 output scale is unknown up front), so radius/push are proportional, not guessed.
-    const home = {};
-    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-    built.graph.forEachNode((k, a) => {
-        home[k] = { x: a.x, y: a.y };
-        if (a.x < minX) minX = a.x; if (a.x > maxX) maxX = a.x;
-        if (a.y < minY) minY = a.y; if (a.y > maxY) maxY = a.y;
-    });
-    const span = Math.max(maxX - minX, maxY - minY) || 1;
-    _artistWeb.home = home;
-    _artistWeb.spreadPush = span * 0.035;    // how far a selected node's neighbors fan out
-    _artistWeb.spreadRoot = null; _artistWeb.spreadSet = null;
+    // Home positions are captured AFTER the layout settles (_artWebFinishLayout); until then the
+    // selection-spread effect stays dormant (its guards check st.home).
+    _artistWeb.home = null;
+    _artistWeb.spreadRoot = _artistWeb.spreadSet = null;
 
     // Declutter threshold: hide edges below the median weight — but most edges are weight-1
     // (single-source), so if the median IS the minimum, bump above it to hide that weakest tier.
@@ -6670,7 +6660,80 @@ function _artWebRenderLens() {
     _artistWeb.edgeThreshold = thr;
     _artWebSyncEdgeButton();
 
+    // Mount FIRST (random scatter is visible immediately), then settle live in a Web Worker — the
+    // graph visibly organizes into islands without ever blocking the UI.
     _artWebMountSigma(host, built.graph);
+    _artWebStartLiveLayout(built.graph);
+}
+
+// ---- Live-settle layout: forceAtlas2 in a Web Worker (FA2Layout supervisor) ---------------------
+// The worker streams positions into the graph; sigma re-renders each frame, so the user watches the
+// blob organize. Falls back to the synchronous pass when the worker build is unavailable or throws.
+function _artWebStartLiveLayout(graph) {
+    _artWebKillLiveLayout();
+    const lib = window.graphologyLibrary;
+    const FA2Layout = lib && lib.FA2Layout;
+    const fa2 = lib && lib.layoutForceAtlas2;
+    if (!FA2Layout || !fa2 || graph.order === 0) {
+        _artWebRunLayout(graph);          // sync fallback (blocks briefly, but always works)
+        _artWebFinishLayout(graph);
+        return;
+    }
+    let layout = null;
+    try {
+        layout = new FA2Layout(graph, {
+            settings: {
+                ...fa2.inferSettings(graph),
+                barnesHutOptimize: true,
+                linLogMode: true,                      // clusters separate into islands
+                outboundAttractionDistribution: true,  // spread the hubs out
+                adjustSizes: true,                     // don't overlap node circles
+                gravity: 1.2, scalingRatio: 3, slowDown: 4,
+            },
+        });
+        layout.start();
+    } catch (e) {
+        console.warn('[Artist Web] worker layout unavailable — falling back to sync', e);
+        try { if (layout) layout.kill(); } catch (_) { /* ignore */ }
+        _artWebRunLayout(graph);
+        _artWebFinishLayout(graph);
+        return;
+    }
+    _artistWeb.fa2 = layout;
+    const statsEl = document.getElementById('artist-web-stats');
+    if (statsEl && statsEl.textContent.indexOf('· settling') === -1) statsEl.textContent += ' · settling…';
+    // Run time scales with graph size (a worker iterates as fast as it can; this is wall-clock).
+    const ms = Math.min(6000, 1200 + graph.order * 0.8);
+    _artistWeb.fa2Timer = setTimeout(() => {
+        _artWebKillLiveLayout();
+        _artWebFinishLayout(graph);
+        if (statsEl) statsEl.textContent = statsEl.textContent.replace(' · settling…', '');
+        if (_artistWeb.sigma && _artistWeb.graph === graph) {
+            _artistWeb.sigma.getCamera().animatedReset({ duration: 500 });   // fit the settled web
+        }
+    }, ms);
+}
+
+function _artWebKillLiveLayout() {
+    if (_artistWeb.fa2Timer) { clearTimeout(_artistWeb.fa2Timer); _artistWeb.fa2Timer = null; }
+    if (_artistWeb.fa2) { try { _artistWeb.fa2.kill(); } catch (e) { /* ignore */ } _artistWeb.fa2 = null; }
+}
+
+// Post-layout bookkeeping: capture resting ("home") positions + scale interaction distances to the
+// settled coordinate range (FA2 output scale is unknown up front).
+function _artWebFinishLayout(graph) {
+    const home = {};
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    graph.forEachNode((k, a) => {
+        home[k] = { x: a.x, y: a.y };
+        if (a.x < minX) minX = a.x; if (a.x > maxX) maxX = a.x;
+        if (a.y < minY) minY = a.y; if (a.y > maxY) maxY = a.y;
+    });
+    const span = Math.max(maxX - minX, maxY - minY) || 1;
+    _artistWeb.home = home;
+    _artistWeb.spreadPush = span * 0.035;    // how far a selected node's neighbors fan out
+    _artistWeb.spreadRoot = null;
+    _artistWeb.spreadSet = null;
 }
 
 // ---- Lens A: GENRE — every artist, grouped by genre-anchor hubs (membership edges = layout only) --
@@ -6963,6 +7026,7 @@ function closeArtistWeb() {
     document.querySelectorAll('#discover-page > .discover-container > *').forEach(el => {
         if (el.id !== 'artist-web-container' && el._prevDisplay !== undefined) el.style.display = el._prevDisplay;
     });
+    _artWebKillLiveLayout();
     if (_artistWeb.fxRAF) { cancelAnimationFrame(_artistWeb.fxRAF); _artistWeb.fxRAF = null; }
     _artistWeb.spreadRoot = _artistWeb.spreadSet = null;
     if (_artistWeb.sigma) { _artistWeb.sigma.kill(); _artistWeb.sigma = null; }

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -5247,14 +5247,19 @@ async function checkArtistEnhanceEligibility(artistId) {
 }
 
 async function playArtistRadio() {
-    try {
-        const artistId = artistDetailPageState.currentArtistId;
-        const artistName = artistDetailPageState.currentArtistName || '';
-        if (!artistId) {
-            showToast('No artist selected', 'error');
-            return;
-        }
+    const artistId = artistDetailPageState.currentArtistId;
+    const artistName = artistDetailPageState.currentArtistName || '';
+    if (!artistId) {
+        showToast('No artist selected', 'error');
+        return;
+    }
+    return startArtistRadioById(artistId, artistName);
+}
 
+// Parameterized core of the artist-detail Radio button — also driven by the Artist Web graph panel
+// ("Play radio" on an owned node), so both entry points share one implementation.
+async function startArtistRadioById(artistId, artistName) {
+    try {
         // Get tracks from this artist's library
         const resp = await fetch(`/api/library/artist/${artistId}/enhanced`);
         if (!resp.ok) throw new Error('Failed to load artist data');

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -35532,6 +35532,10 @@ div.artist-hero-badge {
 }
 .artweb-lens-btn:hover { color: #fff; }
 .artweb-lens-btn.active { background: rgba(255,255,255,0.14); color: #fff; }
+/* Toolbar toggle buttons (Path, Filter) when engaged */
+#artist-web-container .artmap-tool-btn.active {
+    background: rgba(29,185,84,0.28); border-color: rgba(29,185,84,0.5); color: #fff;
+}
 .artist-map-toolbar {
     display: flex; align-items: center; justify-content: space-between;
     padding: 8px 16px; background: linear-gradient(180deg, rgba(14,14,22,0.98) 0%, rgba(14,14,22,0.92) 100%);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -35519,6 +35519,19 @@ div.artist-hero-badge {
     position: fixed; inset: 0; z-index: 100;
     background: #0a0a14; flex-direction: column;
 }
+/* Artist Web "Group by" lens toggle (Genre | Communities) */
+.artweb-lens-toggle {
+    display: inline-flex; align-items: center; gap: 2px;
+    background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 9px; padding: 2px;
+}
+.artweb-lens-btn {
+    border: none; background: transparent; color: rgba(255,255,255,0.6);
+    font-size: 12px; font-weight: 600; padding: 5px 11px; border-radius: 7px; cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+}
+.artweb-lens-btn:hover { color: #fff; }
+.artweb-lens-btn.active { background: rgba(255,255,255,0.14); color: #fff; }
 .artist-map-toolbar {
     display: flex; align-items: center; justify-content: space-between;
     padding: 8px 16px; background: linear-gradient(180deg, rgba(14,14,22,0.98) 0%, rgba(14,14,22,0.92) 100%);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -173,10 +173,12 @@ body.max-performance .sidebar::after {
     top: 0;
     bottom: 0;
     width: 10px;
-    /* Low on purpose: this strip belongs WITH the sidebar, so any fullscreen overlay that covers
-       the sidebar (artist map/web at z 100, modals higher) must cover it too. It was z 100, which
-       tied the overlays and poked through them. */
-    z-index: 5;
+    /* z:1 on purpose: the artist map/web overlays live INSIDE .page (position:relative; z-index:1),
+       so their z:100 is trapped in the page's stacking context — at root level the whole page paints
+       at z:1. The strip must TIE that (not beat it): tie -> DOM order wins -> the page (later in the
+       DOM) and any fullscreen overlay inside it paint over the strip. Anything higher (the old 100,
+       even 5) pokes through the overlays. */
+    z-index: 1;
     opacity: 0;
     transition: opacity 0.5s ease;
     pointer-events: none;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -173,7 +173,10 @@ body.max-performance .sidebar::after {
     top: 0;
     bottom: 0;
     width: 10px;
-    z-index: 100;
+    /* Low on purpose: this strip belongs WITH the sidebar, so any fullscreen overlay that covers
+       the sidebar (artist map/web at z 100, modals higher) must cover it too. It was z 100, which
+       tied the overlays and poked through them. */
+    z-index: 5;
     opacity: 0;
     transition: opacity 0.5s ease;
     pointer-events: none;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -35735,6 +35735,13 @@ div.artist-hero-badge {
     padding: 8px 18px; border-radius: 8px; cursor: pointer; font-size: 13px; transition: all 0.15s ease;
 }
 .artweb-state-btn:hover { background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.25); }
+/* Artist Web guide modal (extends the shared shortcuts-modal) */
+.artweb-help-modal { max-width: 520px; }
+.artweb-help-body { padding: 4px 4px 2px; }
+.artweb-help-section { margin-bottom: 14px; }
+.artweb-help-section h4 { margin: 0 0 5px; font-size: 12px; text-transform: uppercase; letter-spacing: 0.04em; color: rgba(255,255,255,0.5); }
+.artweb-help-section p { margin: 0; font-size: 13px; line-height: 1.55; color: rgba(255,255,255,0.78); }
+.artweb-help-section b { color: rgba(255,255,255,0.95); font-weight: 600; }
 #artist-map-canvas { flex: 1; display: block; cursor: grab; }
 #artist-map-canvas:active { cursor: grabbing; }
 #artist-map-loading {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -35710,7 +35710,20 @@ div.artist-hero-badge {
     background: rgba(255,255,255,0.06); color: rgba(255,255,255,0.5);
     text-transform: capitalize;
 }
-.artmap-content-row { display: flex; flex: 1; overflow: hidden; }
+.artmap-content-row { display: flex; flex: 1; overflow: hidden; position: relative; }
+/* Artist Web color legend — floating bottom-left over the canvas, decodes node colors per lens */
+.artweb-legend {
+    position: absolute; left: 14px; bottom: 14px; z-index: 6;
+    display: flex; flex-direction: column; gap: 5px;
+    padding: 10px 12px; max-width: 220px;
+    background: rgba(14, 13, 20, 0.72); backdrop-filter: blur(6px);
+    border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 10px;
+    pointer-events: none;
+}
+.artweb-legend-row { display: flex; align-items: center; gap: 8px; font-size: 11px; color: rgba(255,255,255,0.72); }
+.artweb-legend-dot { width: 10px; height: 10px; border-radius: 50%; flex: 0 0 auto; box-shadow: 0 0 6px rgba(0,0,0,0.4); }
+.artweb-legend-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.artweb-legend-count { margin-left: auto; color: rgba(255,255,255,0.38); font-variant-numeric: tabular-nums; }
 #artist-map-canvas { flex: 1; display: block; cursor: grab; }
 #artist-map-canvas:active { cursor: grabbing; }
 #artist-map-loading {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -35724,6 +35724,17 @@ div.artist-hero-badge {
 .artweb-legend-dot { width: 10px; height: 10px; border-radius: 50%; flex: 0 0 auto; box-shadow: 0 0 6px rgba(0,0,0,0.4); }
 .artweb-legend-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .artweb-legend-count { margin-left: auto; color: rgba(255,255,255,0.38); font-variant-numeric: tabular-nums; }
+/* Artist Web empty/error state card — centered, with an optional Retry action */
+.artweb-state-card {
+    position: absolute; inset: 0; display: flex; flex-direction: column;
+    align-items: center; justify-content: center; gap: 14px; text-align: center; padding: 24px;
+}
+.artweb-state-msg { color: rgba(255,255,255,0.5); font-size: 14px; max-width: 380px; line-height: 1.5; }
+.artweb-state-btn {
+    background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.14); color: rgba(255,255,255,0.85);
+    padding: 8px 18px; border-radius: 8px; cursor: pointer; font-size: 13px; transition: all 0.15s ease;
+}
+.artweb-state-btn:hover { background: rgba(255,255,255,0.12); border-color: rgba(255,255,255,0.25); }
 #artist-map-canvas { flex: 1; display: block; cursor: grab; }
 #artist-map-canvas:active { cursor: grabbing; }
 #artist-map-loading {


### PR DESCRIPTION
# artist web — your library as a living similarity graph

a new sigma.js/webgl graph of your library artists, sibling to the canvas artist map. same data, whole different way to look at it — everything's wired together by real similarity and it settles itself into islands you can wander around.

## three ways to look at it

- **genre** — every artist, grouped into genre islands
- **communities** — clusters found from who's *actually* similar to whom (louvain), each one named after its hub artist. shows you the scenes your genre tags miss
- **discovery** — your library (blue) wired out to unowned similar artists (amber) you could add. click an owned node to grow its frontier, click a candidate to add it to your watchlist

## what you can do

- **hover** any node to identify it (name, genre, connections, photo) · **click** for details + play radio
- **path mode** — click two artists to trace how they connect
- **size by** popularity / links / influence, filter by genre, declutter down to just the strong links
- **search**, a color **legend**, a **?** guide, and keyboard shortcuts (s / f / +/- / esc)
- discovery candidates get a **30s preview** so you can hear one before you add it

## under the hood

- layout runs forceatlas2 in a **web worker** (never freezes the ui), pre-seeded with circlepack so it settles fast and tight even on a big library
- tuned the render hot paths (no per-frame allocation) so ~5k nodes stays smooth
- backend graph builders (`core/graph/artist_graph.py`) are pure + unit tested

