### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.8.4)'
+        description: 'Version tag (e.g. 2.8.5)'
         required: true
-        default: '2.8.4'
+        default: '2.8.5'
 
 jobs:
   build-and-push:

--- a/RELEASE_2.8.5_discord.md
+++ b/RELEASE_2.8.5_discord.md
@@ -1,0 +1,13 @@
+**SoulSync 2.8.5** is out 🎉
+
+a focused bug-fix release — thanks to everyone who reported this week 🙏
+
+🖤 **Import & Stats black screen (#979)** — on some setups (mostly Windows) those two pages loaded blank because the OS handed the app's JS bundle over with the wrong file type and the browser refused to run it. we force the correct type now, so they load for everyone.
+
+🎵 **iTunes singles fixed (#980)** — iTunes singles were landing in "Unknown Artist" with no album tag. they now file into the right artist/album and tag properly.
+
+💿 **no more "01-" on single-disc albums (#981)** — `$disc`/`$discnum` in a file template was stamping a disc number even on 1-disc albums. now they vanish on single-disc (like `$cdnum`) and only show for real multi-disc sets — for both import and rename/reorganize.
+
+🛟 **library safety + repair** — cleanup never deletes a configured root folder and self-heals a missing staging folder (#976) · repair "Fix All" now works for libraries outside the transfer path and stops pulling media-server files into transfer (#978) · discography backfill only touches artists you own (#977).
+
+enjoy! 🎶

--- a/core/auto_import_worker.py
+++ b/core/auto_import_worker.py
@@ -511,9 +511,18 @@ class AutoImportWorker:
         runs `_process_one_candidate` in parallel up to `max_workers`.
         """
         staging = self._resolve_staging_path()
-        if not staging or not os.path.isdir(staging):
-            logger.warning(f"[Auto-Import] Staging path not found or invalid: {self.staging_path}")
+        if not staging:
+            logger.warning(f"[Auto-Import] Staging path not configured: {self.staging_path}")
             return
+        if not os.path.isdir(staging):
+            # #976: self-heal a missing staging folder instead of erroring the
+            # whole import feature (an earlier empty-folder cleanup could delete it).
+            try:
+                os.makedirs(staging, exist_ok=True)
+                logger.warning(f"[Auto-Import] Staging folder was missing — recreated: {staging}")
+            except Exception as e:
+                logger.warning(f"[Auto-Import] Staging path not found and could not be recreated ({staging}): {e}")
+                return
 
         candidates = self._enumerate_folders(staging)
         logger.info(f"[Auto-Import] Scan cycle: {len(candidates)} candidates in {staging}")

--- a/core/imports/context.py
+++ b/core/imports/context.py
@@ -388,6 +388,21 @@ def build_import_album_info(
         )
     )
 
+    # #980: an explicit single can reach import with NO album name — the source's
+    # collection name never made it into the context (e.g. an iTunes single). With
+    # an empty album the track lands in "Unknown Artist/Unknown Album", gets no
+    # album tag, and won't match its release in the discography. A single's album
+    # is effectively its title (how iTunes/streaming model singles), so fall back
+    # to the track title rather than dropping it into Unknown.
+    if (
+        is_album
+        and not normalized_album
+        and (album_type or "").strip().lower() == "single"
+        and clean_track_name
+        and clean_track_name != "Unknown Track"
+    ):
+        album_name = clean_track_name
+
     return {
         "is_album": is_album,
         "album_name": album_name,

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -228,6 +228,35 @@ def protected_root_dirs():
     return roots
 
 
+def ensure_staging_dir():
+    """Recreate the configured staging/import folder if it went missing.
+
+    Belt-and-suspenders for issue #976: even though the cleanups now protect
+    the staging root, if the folder is missing for any reason (an older build
+    that deleted it, a manual delete, a transient hiccup) the import feature
+    errors until it's back. Recreating it after a cleanup sweep means it
+    self-heals within one automation cycle instead of waiting for the next
+    Auto-Import scan.
+
+    Only creates it when its PARENT already exists, so we never fabricate a
+    not-yet-mounted volume path (which would mask the real mount).
+    """
+    try:
+        from core.imports.paths import docker_resolve_path
+        raw = config_manager.get('soulseek.staging_path', './Staging') or ''
+        if not raw:
+            return
+        staging = os.path.normpath(docker_resolve_path(raw))
+        if os.path.isdir(staging):
+            return
+        parent = os.path.dirname(staging)
+        if parent and os.path.isdir(parent):
+            os.makedirs(staging, exist_ok=True)
+            logger.info(f"Recreated missing staging/import folder: {staging}")
+    except Exception as e:
+        logger.debug(f"ensure_staging_dir: could not ensure staging folder: {e}")
+
+
 def cleanup_empty_directories(download_path, moved_file_path):
     """Remove empty directories after a move, ignoring hidden files.
 

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -206,11 +206,41 @@ def safe_move_file(src, dst):
         raise
 
 
-def cleanup_empty_directories(download_path, moved_file_path):
-    """Remove empty directories after a move, ignoring hidden files."""
+def protected_root_dirs():
+    """Configured root folders that must NEVER be auto-removed as 'empty'.
+
+    The user's staging / download / transfer roots. Deleting one breaks the
+    import feature — issue #976: when a staging folder is nested under the
+    download folder (common on UnRaid single-share setups), the post-import
+    cleanup walked up past it and `rmdir`'d the staging root, because the
+    cleanups only protected the *download* root. Every empty-folder cleanup
+    consults this so no configured root is ever removed, however it's nested.
+    """
+    roots = set()
     try:
+        from core.imports.paths import docker_resolve_path
+        for key in ('soulseek.staging_path', 'soulseek.download_path', 'soulseek.transfer_path'):
+            raw = config_manager.get(key, '') or ''
+            if raw:
+                roots.add(os.path.normpath(docker_resolve_path(raw)))
+    except Exception as e:
+        logger.debug(f"protected_root_dirs: could not resolve configured roots: {e}")
+    return roots
+
+
+def cleanup_empty_directories(download_path, moved_file_path):
+    """Remove empty directories after a move, ignoring hidden files.
+
+    Never removes a configured root folder (staging/download/transfer), even
+    when it is empty and nested under `download_path` (issue #976).
+    """
+    try:
+        protected = protected_root_dirs()
+        protected.add(os.path.normpath(download_path))
         current_dir = os.path.dirname(moved_file_path)
         while current_dir != download_path and current_dir.startswith(download_path):
+            if os.path.normpath(current_dir) in protected:
+                break  # #976: never delete a configured root, even nested + empty
             is_empty = not any(not f.startswith(".") for f in os.listdir(current_dir))
             if is_empty:
                 logger.warning(f"Removing empty directory: {current_dir}")

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -257,8 +257,10 @@ def _replace_template_variables(template: str, context: dict) -> str:
         "title": clean_context.get("title", "Unknown Track"),
         "track": f"{_coerce_int(clean_context.get('track_number', 1), 1):02d}",
         "cdnum": cdnum_value,
-        "disc": str(_coerce_int(clean_context.get("disc_number", 1), 1)),
-        "discnum": str(_coerce_int(clean_context.get("disc_number", 1), 1)),
+        # #981: ${disc}/${discnum} vanish on single-disc albums, matching ${cdnum}
+        # (a track on disc 2+ still shows even if total_discs wasn't populated).
+        "disc": (str(_disc_number) if (_total_discs > 1 or _disc_number > 1) else ""),
+        "discnum": (str(_disc_number) if (_total_discs > 1 or _disc_number > 1) else ""),
         "year": str(clean_context.get("year", "")),
         "quality": clean_context.get("quality", ""),
     }
@@ -296,8 +298,10 @@ def get_file_path_from_template_raw(template: str, context: dict) -> tuple[str, 
 
     quality_value = context.get("quality", "")
     disc_number = _coerce_int(context.get("disc_number", 1), 1)
-    disc_value = f"{disc_number:02d}"
-    disc_value_raw = str(disc_number)
+    # #981: single-disc albums drop $disc/$discnum (like $cdnum) so no "01-" prefix.
+    _multi_disc = _coerce_int(context.get("total_discs", 1), 1) > 1 or disc_number > 1
+    disc_value = f"{disc_number:02d}" if _multi_disc else ""
+    disc_value_raw = str(disc_number) if _multi_disc else ""
 
     path_parts = full_path.split("/")
     if len(path_parts) > 1:
@@ -367,8 +371,14 @@ def get_file_path_from_template(context: dict, template_type: str = "album_path"
     path_parts = full_path.split("/")
     quality_value = context.get("quality", "")
     disc_number = _coerce_int(context.get("disc_number", 1), 1)
-    disc_value = f"{disc_number:02d}"
-    disc_value_raw = str(disc_number)
+    # #981: $disc/$discnum are empty on single-disc albums, same as $cdnum — a
+    # single-disc album shouldn't stamp "01-" on every filename. Multi-disc is
+    # either 2+ total discs OR a track that's itself on disc 2+ (so a known disc-3
+    # track still shows even if total_discs wasn't populated). The leading-dash
+    # cleanup below drops the orphaned separator (e.g. "$disc-$track" -> "$track").
+    _multi_disc = _coerce_int(context.get("total_discs", 1), 1) > 1 or disc_number > 1
+    disc_value = f"{disc_number:02d}" if _multi_disc else ""
+    disc_value_raw = str(disc_number) if _multi_disc else ""
 
     if len(path_parts) > 1:
         folder_parts = path_parts[:-1]

--- a/core/repair_jobs/discography_backfill.py
+++ b/core/repair_jobs/discography_backfill.py
@@ -432,10 +432,21 @@ class DiscographyBackfillJob(RepairJob):
             if 'deezer_id' in columns:
                 select.append("deezer_id")
 
+            # Only artists actually IN the library — those you own at least one track
+            # or album by. The `artists` table also carries bare rows for featured/
+            # guest and re-identified artists (a "feat." on a single track, an
+            # unknown-artist fix, etc.). Without this filter the backfill pulled their
+            # ENTIRE discography and wishlisted it, flooding the wishlist with artists
+            # "not in my library" (#977).
             cursor.execute(f"""
                 SELECT {', '.join(select)}
                 FROM artists
                 WHERE name IS NOT NULL AND name != '' AND name != 'Unknown Artist'
+                  AND (
+                    EXISTS (SELECT 1 FROM tracks t
+                            WHERE t.artist_id = artists.id AND COALESCE(t.file_path, '') != '')
+                    OR EXISTS (SELECT 1 FROM albums al WHERE al.artist_id = artists.id)
+                  )
                 ORDER BY name
             """)
             return [dict(row) for row in cursor.fetchall()]

--- a/core/repair_jobs/library_reorganize.py
+++ b/core/repair_jobs/library_reorganize.py
@@ -277,6 +277,11 @@ class LibraryReorganizeJob(RepairJob):
                                 details={
                                     'from': t.get('current_path') or '',
                                     'to': t.get('new_path') or '',
+                                    # Authoritative absolute paths (the from/to above are
+                                    # display-trimmed) — the fix handler moves THESE, so it
+                                    # works for libraries not rooted under transfer_path (#978).
+                                    'from_abs': t.get('current_path_abs') or '',
+                                    'to_abs': t.get('new_path_abs') or '',
                                     'album_id': str(album_id),
                                     'album_title': album_title,
                                     'source': preview.get('source'),

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -3391,17 +3391,31 @@ class RepairWorker:
             logger.warning("Path mismatch fix: missing from/to in details")
             return {'success': False, 'error': 'Missing from/to paths in finding details'}
 
+        # Prefer the authoritative ABSOLUTE paths the preview computed (#978). The
+        # from/to above are display-TRIMMED for the UI; rebuilding them from the
+        # transfer folder broke every library not rooted under transfer_path
+        # (Plex/media-server, Docker host<->container splits) — the trimmed `from`
+        # was already absolute, os.path.join returned it unchanged, and the guard
+        # then rejected it as "escapes transfer folder" ("Fix All fixes nothing").
+        # The live reorganize executor moves these _abs paths directly; do the same.
         transfer = self.transfer_folder
-        src = os.path.normpath(os.path.join(transfer, rel_from))
-        dst = os.path.normpath(os.path.join(transfer, rel_to))
+        transfer_norm = os.path.normpath(transfer) if transfer else ''
+        abs_from = details.get('from_abs') or ''
+        abs_to = details.get('to_abs') or ''
+        if abs_from and abs_to:
+            src = os.path.normpath(abs_from)
+            dst = os.path.normpath(abs_to)
+        else:
+            # Legacy finding written before _abs was persisted — reconstruct from the
+            # transfer folder and keep the safety guard (re-scan to refresh a finding
+            # whose library lives outside transfer_path).
+            src = os.path.normpath(os.path.join(transfer, rel_from))
+            dst = os.path.normpath(os.path.join(transfer, rel_to))
+            if not src.startswith(transfer_norm + os.sep) or not dst.startswith(transfer_norm + os.sep):
+                logger.warning("Path mismatch fix: legacy finding escapes transfer folder — re-scan to refresh. src=%s, dst=%s, transfer=%s", src, dst, transfer_norm)
+                return {'success': False, 'error': 'Path escapes transfer folder (legacy finding — re-scan the library to refresh)'}
 
-        logger.info("Path mismatch fix: src=%s dst=%s transfer=%s", src, dst, transfer)
-
-        # Safety: both paths must be inside transfer folder
-        transfer_norm = os.path.normpath(transfer)
-        if not src.startswith(transfer_norm + os.sep) or not dst.startswith(transfer_norm + os.sep):
-            logger.warning("Path mismatch fix: path escapes transfer folder. src=%s, dst=%s, transfer=%s", src, dst, transfer_norm)
-            return {'success': False, 'error': 'Path escapes transfer folder'}
+        logger.info("Path mismatch fix: src=%s dst=%s", src, dst)
 
         if not os.path.isfile(src):
             # Source may have been moved already — check if destination already exists

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -3460,8 +3460,19 @@ class RepairWorker:
             try:
                 conn = self.db._get_connection()
                 cursor = conn.cursor()
-                # Try exact match
-                cursor.execute("UPDATE tracks SET file_path = ? WHERE file_path = ?", (dst, src))
+                # Prefer updating the exact track by id — authoritative, the way the
+                # live reorganize executor does it. Path-matching below is a fallback:
+                # it can MISS for media-server libraries whose stored file_path differs
+                # from the resolved path we just moved, which is exactly the #978
+                # population (so without this the file moves but the DB stays stale).
+                try:
+                    tid = int(entity_id) if entity_id not in (None, '') else None
+                except (TypeError, ValueError):
+                    tid = None
+                if tid is not None:
+                    cursor.execute("UPDATE tracks SET file_path = ? WHERE id = ?", (dst, tid))
+                if tid is None or cursor.rowcount == 0:
+                    cursor.execute("UPDATE tracks SET file_path = ? WHERE file_path = ?", (dst, src))
                 if cursor.rowcount == 0:
                     cursor.execute("UPDATE tracks SET file_path = ? WHERE file_path = ?",
                                    (dst, os.path.normpath(src)))

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -2243,9 +2243,17 @@ class RepairWorker:
         except Exception as e:
             logger.warning(f"Tag write failed during unknown artist fix: {e}")
 
-        # Step 2: Move file if expected path differs
-        final_path = resolved
-        if expected_path:
+        # Step 2: Move file if expected path differs — but ONLY when the file lives
+        # under the SoulSync transfer folder. For a media-server / non-transfer
+        # library the resolved file is elsewhere, and building the destination from
+        # transfer_folder would YANK it into the transfer folder, away from its real
+        # library (same class as #978). There we just re-tag + fix the DB metadata and
+        # leave the file where it is (physical reorg is Library Reorganize's job).
+        transfer_norm = os.path.normpath(self.transfer_folder) if self.transfer_folder else ''
+        under_transfer = bool(transfer_norm) and os.path.normpath(resolved).lower().startswith(
+            transfer_norm.lower() + os.sep)
+        final_path = resolved if under_transfer else file_path
+        if expected_path and under_transfer:
             expected_abs = os.path.normpath(os.path.join(self.transfer_folder, expected_path))
             if os.path.normpath(resolved).lower() != expected_abs.lower():
                 try:

--- a/core/webui/mimetypes_fix.py
+++ b/core/webui/mimetypes_fix.py
@@ -1,0 +1,33 @@
+"""Force correct MIME types for web assets, independent of the host OS.
+
+Python's ``mimetypes`` reads the OS type registry, and on Windows the ``.js``
+extension is frequently mapped to ``text/plain`` (by installed software or an old
+default). Flask's static serving then hands the React bundle out as text/plain —
+and browsers REFUSE a ``<script type="module">`` served with a non-JS MIME type
+(strict MIME checking per the HTML spec). The result: the module-loaded pages
+(Import, Stats) render as a black screen while the classic-script shell keeps
+working. Registering the types at startup overrides the bad registry lookup for
+this process. (Bug #979)
+"""
+
+from __future__ import annotations
+
+import mimetypes
+
+# ext -> the type we always want served, regardless of the OS registry.
+_WEB_TYPES = {
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+    ".json": "application/json",
+    ".svg": "image/svg+xml",
+    ".webmanifest": "application/manifest+json",
+}
+
+
+def ensure_web_mimetypes() -> None:
+    """Register the correct MIME type for each web asset extension. ``add_type``
+    overrides any earlier (e.g. registry-sourced) mapping, so this is safe to call
+    once at startup and idempotent."""
+    for ext, ctype in _WEB_TYPES.items():
+        mimetypes.add_type(ctype, ext)

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,40 +1,19 @@
-# soulsync 2.8.4 — `dev` → `main`
+# soulsync 2.8.5 — `dev` → `main`
 
-the headliner is **Artist Web** — an interactive, WebGL map of your whole library that doubles as a discovery tool. on top of that, **Quality Profiles** land (a big contributor PR), the Discover **Adventurousness dial** goes from "looks pretty" to actually reshaping your recs, and a batch of fixes + contributor PRs.
+a focused bug-fix release. no new features — just a batch of import, library, repair, and webui fixes, several from user reports this week.
 
 ---
 
-## what's new
+## 🐛 fixes
 
-### 🕸️ Artist Web — your library as a living map
-- **a real similarity graph** — every artist you own, laid out by how they relate. it settles live (physics running in a background worker so the UI never freezes), and you can pan/zoom around thousands of nodes smoothly.
-- **three lenses / front doors** — **Taste Map** (clustered by genre), **Communities** (who groups with who), and the **Discovery Web** (below).
-- **Discovery Web** — the map's discovery mode: your owned artists become anchors, and it grows out to **similar artists you *don't* own yet**. click any node to **expand the map** from there, follow the thread, and **add anything to your watchlist** on the spot.
-- **play from the map** — start **artist radio** off an owned node, or hear a **30s preview** on a candidate you don't own, without leaving the graph.
-- **it explains itself** — a first-run hint + a guide modal, hover tooltips with the artist's photo, and real empty/error states so it never feels broken.
+### import & metadata
+- **Import & Stats were a black screen for some people (#979)** — those two pages are the React-built ones, loaded as module scripts. on setups where the OS handed the `.js` bundle over with the wrong MIME type (common on Windows), the browser refused to run it and the page went black while everything else worked. we now force the correct type ourselves, so the OS can't blank those pages.
+- **iTunes singles landed in "Unknown Artist" with no album tag (#980)** — an iTunes single reached the importer with no album name, so it dropped into `Unknown Artist/Unknown Album`, got no album tag, and didn't match its release. a single's album is effectively its own title now, so it files correctly and tags properly.
+- **single-disc albums got a "01-" on every track (#981)** — `$disc`/`$discnum` in a file template always stamped the disc number, even on a 1-disc album. they're smart now (like `$cdnum`): empty on single-disc, shown only for real multi-disc sets. applies to both fresh imports and rename/reorganize.
 
-### 🎚️ Quality Profiles (#974 — thanks @nick2000713)
-- the single global quality setting becomes **named, editable Quality Profiles**. quality targets, upgrade behavior, AcoustID strictness, downsampling, and lossy-copy rules all resolve **per profile**.
-- **Auto-Import can run its own profile** independent of your default, wishlist/library rows can carry their own, and there's an **"upgrade until target"** cutoff that lives on the profile itself.
-- a Manage view shows what's active for what (default vs. Auto-Import vs. per-item), separate from previewing/editing a profile.
-
-### 🧭 the Adventurousness dial, for real this time
-- turns out the dial was mostly cosmetic — moving it barely changed anything (a browser-cache bug was serving the same recs). now it genuinely **drives which artists surface**, not just how they're sorted.
-- **deeper the further you push it** — the far right reaches real deep cuts (validated on a live library: safe end = your household names, adventurous end = obscure-but-relevant picks), with a distinct middle instead of two ends that felt the same.
-- **genre diversity** so one genre can't hog the row, **freshness rotation** so you get different deep cuts each visit, and adaptive **"🧭 off your usual path"** chips at the exploratory end.
-
-### 🐛 fixes
-- **repair job stop button actually cancels (#970)** — hitting stop now interrupts the running scan and flips responsively to "Stopping…", instead of the job grinding on.
-- **playlist stuck "syncing" (#972)** — a socket-driven sync could leave a playlist wedged in the syncing state server-side. fixed.
-- **JioSaavn worker no longer wedges (#964)** — a single unresolvable row could jam the whole enrichment worker; it skips and moves on now.
-- **duplicate cleanup is safer** — quarantines instead of hard-deleting, and surfaces Docker permission failures instead of swallowing them.
-- **Jellyfin playlist align** — reorders correctly without relying on the user-scoped Move endpoint.
-- **matching + sync** — "(live)" vs "- live" no longer blocks a legit match; a stale match-cache no longer blocks the durable manual-match self-heal.
-- **Tidal downloads** — added instrumentation that logs the request rate right before Tidal pushes back (429/deauth), to chase down a download-only rate-limit some users hit.
-
-### 🤝 contributor PRs
-- **Quality Profiles (#974 — @nick2000713)** — the whole feature above.
-- **JioSaavn enrichment service (#964 — thanks HellRa1SeR)** — JioSaavn graduates from experimental metadata to a full enrichment worker.
-- **unicode / Japanese dedup matching (#965, #967 — thanks bluejorts)** — self-titled tracks match correctly, and normalization preserves all scripts instead of only CJK.
+### library safety & repair
+- **never delete a configured root folder during cleanup (#976)** — the empty-dir cleanup could remove a folder you'd set as a root; it leaves configured roots alone now, and self-heals a missing staging/import folder if a sweep removed it.
+- **repair "Fix All" for libraries outside the transfer path (#978)** — path-mismatch "Fix All" did nothing for libraries stored outside the transfer folder; it works everywhere now, updates the DB by track id for media-server parity, and the unknown-artist fix no longer yanks media-server files into the transfer folder.
+- **discography backfill only touches artists you own (#977)** — the repair backfill was reaching beyond your owned artists; scoped back to what you actually have.
 
 enjoy 🎶

--- a/tests/imports/test_import_paths.py
+++ b/tests/imports/test_import_paths.py
@@ -153,6 +153,41 @@ def test_get_file_path_from_template_raw_handles_quality_and_disc_placeholders(m
     assert filename == "3 - Song One [FLAC 16bit]"
 
 
+def test_disc_placeholder_drops_on_single_disc_album(monkeypatch):
+    """#981: $disc must NOT stamp '01-' on every track of a single-disc album
+    (reported on 'The Best of Snoop Dogg (2005)'). Empty like $cdnum; the
+    leading-dash cleanup removes the orphaned separator."""
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _Config({}))
+    folder_path, filename = import_paths.get_file_path_from_template_raw(
+        "$artist/$album/$disc-$track - $title",
+        {"artist": "Snoop Dogg", "album": "The Best of Snoop Dogg (2005)",
+         "title": "Bitch Please", "track_number": 7, "disc_number": 1, "total_discs": 1},
+    )
+    assert filename == "07 - Bitch Please"          # not "01-07 - Bitch Please"
+
+
+def test_disc_placeholder_kept_on_multi_disc_album(monkeypatch):
+    """The disc prefix stays for a genuine multi-disc album."""
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _Config({}))
+    folder_path, filename = import_paths.get_file_path_from_template_raw(
+        "$artist/$album/$disc-$track - $title",
+        {"artist": "A", "album": "B", "title": "Song",
+         "track_number": 7, "disc_number": 2, "total_discs": 2},
+    )
+    assert filename == "02-07 - Song"
+
+
+def test_disc_placeholder_kept_when_track_is_on_disc_two_without_total(monkeypatch):
+    """A track known to be on disc 2 shows its disc even if total_discs wasn't
+    populated — disc_number > 1 is itself proof of a multi-disc release."""
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _Config({}))
+    folder_path, filename = import_paths.get_file_path_from_template_raw(
+        "$artist/$album/$disc-$track - $title",
+        {"artist": "A", "album": "B", "title": "Song", "track_number": 3, "disc_number": 2},
+    )
+    assert filename == "02-03 - Song"
+
+
 def test_get_file_path_from_template_raw_substitutes_cdnum_for_multi_disc(monkeypatch):
     """$cdnum should expand to 'CDxx' on multi-disc albums (regression).
 

--- a/tests/imports/test_import_singles_route_through_album_path.py
+++ b/tests/imports/test_import_singles_route_through_album_path.py
@@ -114,6 +114,35 @@ def test_explicit_compilation_routes_through_album_path() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_single_with_empty_album_falls_back_to_track_title() -> None:
+    """#980: an iTunes single reached import with no album name at all — the
+    collection name never made it into the context. It was flagged is_album (good)
+    but with album_name='' it landed in Unknown Artist/Unknown Album, got no album
+    tag, and didn't match its release. A single's album is effectively its title,
+    so an empty single album falls back to the track title."""
+    context = _make_context(
+        album_type="single",
+        total_tracks=1,
+        album_name="",           # source dropped the collection name
+        track_name="CHAOSRIFT",
+    )
+    info = build_import_album_info(context)
+    assert info["is_album"] is True
+    assert info["album_name"] == "CHAOSRIFT"   # not '' → not Unknown Album
+
+
+def test_single_with_real_album_name_is_not_overridden() -> None:
+    """The fallback only fills an EMPTY album — a real single name is preserved."""
+    context = _make_context(
+        album_type="single",
+        total_tracks=1,
+        album_name="Hello (Single Version)",
+        track_name="Hello",
+    )
+    info = build_import_album_info(context)
+    assert info["album_name"] == "Hello (Single Version)"
+
+
 def test_normal_album_still_detected_as_album() -> None:
     """Multi-track albums must keep being detected — the original
     heuristic is preserved as a fallback when album_type is generic."""

--- a/tests/repair_jobs/test_discography_backfill_scope.py
+++ b/tests/repair_jobs/test_discography_backfill_scope.py
@@ -1,0 +1,35 @@
+"""Regression for #977 — the discography backfill only backfills artists you
+actually OWN music by. The `artists` table also carries bare rows for featured/
+guest and re-identified artists; without an ownership filter the backfill pulled
+their entire discography and wishlisted it ("artists which are not in my library").
+"""
+import types
+
+from database.music_database import MusicDatabase
+from core.repair_jobs.discography_backfill import DiscographyBackfillJob
+
+
+def _seed(db):
+    with db._get_connection() as conn:
+        # Owned artist — has an owned track (+ album).
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES (1, 'Owned Artist', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) VALUES (1, 'Alb', 1, 'test')")
+        conn.execute("INSERT INTO tracks (id, title, file_path, artist_id, album_id, server_source) "
+                     "VALUES (1, 'T', '/music/Owned/a.flac', 1, 1, 'test')")
+        # Artist known via an owned album but no individual track rows — still in library.
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES (2, 'Album Only Artist', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) VALUES (2, 'Alb2', 2, 'test')")
+        # Orphan feat/guest/re-identified row — bare (id, name), no owned track, no album.
+        conn.execute("INSERT INTO artists (id, name) VALUES (3, 'Feat Guest')")
+        conn.commit()
+
+
+def test_backfill_scope_excludes_non_library_artists(tmp_path):
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    _seed(db)
+    job = DiscographyBackfillJob()
+    names = {a['name'] for a in job._get_library_artists(types.SimpleNamespace(db=db))}
+
+    assert 'Owned Artist' in names          # owned track → in library
+    assert 'Album Only Artist' in names     # owned album → in library
+    assert 'Feat Guest' not in names        # bare orphan row → NOT backfilled (the #977 fix)

--- a/tests/test_cleanup_protected_roots.py
+++ b/tests/test_cleanup_protected_roots.py
@@ -1,0 +1,75 @@
+"""Regression for #976 — the import/staging folder gets deleted on the host.
+
+Empty-folder cleanups walk UP from a moved file removing empty dirs, stopping
+only at the *download* root. When a user's staging folder is nested under the
+download folder (common on UnRaid single-share setups), auto-import empties
+staging and the cleanup then `rmdir`'d the staging root itself — breaking the
+import feature until the folder was manually recreated.
+
+The fix: every empty-folder cleanup treats all configured roots
+(staging/download/transfer) as protected and never removes them, however nested.
+"""
+import os
+
+import core.imports.file_ops as file_ops
+from core.imports.file_ops import cleanup_empty_directories, protected_root_dirs
+
+
+def _patch_roots(monkeypatch, mapping):
+    def fake_get(key, default=None):
+        return mapping.get(key, default)
+    monkeypatch.setattr(file_ops.config_manager, 'get', fake_get)
+
+
+def test_nested_staging_root_is_not_deleted(tmp_path, monkeypatch):
+    """The exact #976 case: staging nested under downloads. After the last file
+    is moved out of staging, cleanup must NOT delete the staging root."""
+    downloads = tmp_path / "downloads"
+    staging = downloads / "staging"            # nested under downloads
+    album = staging / "Artist - Album"
+    os.makedirs(album)
+    moved_file = str(album / "01 - song.flac")  # already moved to library (dir empty)
+
+    _patch_roots(monkeypatch, {
+        'soulseek.staging_path': str(staging),
+        'soulseek.download_path': str(downloads),
+        'soulseek.transfer_path': str(tmp_path / "library"),
+    })
+
+    cleanup_empty_directories(str(downloads), moved_file)
+
+    assert staging.is_dir(), "staging root must survive cleanup (#976)"
+    assert not album.exists(), "the empty album subfolder should still be removed"
+
+
+def test_transient_subfolders_still_removed(tmp_path, monkeypatch):
+    """The cleanup still does its job — empty download subfolders are pruned up
+    to (but not including) the protected download root."""
+    downloads = tmp_path / "downloads"
+    sub = downloads / "Some Artist" / "Some Album"
+    os.makedirs(sub)
+    moved_file = str(sub / "1.flac")
+
+    _patch_roots(monkeypatch, {
+        'soulseek.staging_path': str(tmp_path / "staging"),   # separate, not nested
+        'soulseek.download_path': str(downloads),
+        'soulseek.transfer_path': str(tmp_path / "library"),
+    })
+
+    cleanup_empty_directories(str(downloads), moved_file)
+
+    assert not sub.exists()
+    assert not (downloads / "Some Artist").exists()   # walked up, empty → removed
+    assert downloads.is_dir()                          # download root protected
+
+
+def test_protected_roots_reads_all_three_configs(tmp_path, monkeypatch):
+    _patch_roots(monkeypatch, {
+        'soulseek.staging_path': str(tmp_path / "s"),
+        'soulseek.download_path': str(tmp_path / "d"),
+        'soulseek.transfer_path': str(tmp_path / "t"),
+    })
+    roots = protected_root_dirs()
+    assert os.path.normpath(str(tmp_path / "s")) in roots
+    assert os.path.normpath(str(tmp_path / "d")) in roots
+    assert os.path.normpath(str(tmp_path / "t")) in roots

--- a/tests/test_cleanup_protected_roots.py
+++ b/tests/test_cleanup_protected_roots.py
@@ -12,7 +12,11 @@ The fix: every empty-folder cleanup treats all configured roots
 import os
 
 import core.imports.file_ops as file_ops
-from core.imports.file_ops import cleanup_empty_directories, protected_root_dirs
+from core.imports.file_ops import (
+    cleanup_empty_directories,
+    ensure_staging_dir,
+    protected_root_dirs,
+)
 
 
 def _patch_roots(monkeypatch, mapping):
@@ -61,6 +65,40 @@ def test_transient_subfolders_still_removed(tmp_path, monkeypatch):
     assert not sub.exists()
     assert not (downloads / "Some Artist").exists()   # walked up, empty → removed
     assert downloads.is_dir()                          # download root protected
+
+
+def test_ensure_staging_recreates_when_parent_exists(tmp_path, monkeypatch):
+    """#976 self-heal: a missing staging folder is recreated so the import
+    feature doesn't error until the next Auto-Import scan."""
+    downloads = tmp_path / "downloads"
+    staging = downloads / "staging"
+    downloads.mkdir()                       # parent exists, staging does not
+    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+
+    assert not staging.exists()
+    ensure_staging_dir()
+    assert staging.is_dir()
+
+
+def test_ensure_staging_skips_when_parent_missing(tmp_path, monkeypatch):
+    """Mount safety: never fabricate a not-yet-mounted volume path — if the
+    parent doesn't exist we leave it alone rather than mask a missing mount."""
+    staging = tmp_path / "not_mounted_yet" / "staging"   # parent absent
+    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+
+    ensure_staging_dir()
+    assert not staging.exists()
+    assert not staging.parent.exists()      # didn't fabricate the mount path either
+
+
+def test_ensure_staging_noop_when_present(tmp_path, monkeypatch):
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    (staging / "keep.flac").write_text("x")
+    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+
+    ensure_staging_dir()
+    assert (staging / "keep.flac").is_file()   # untouched
 
 
 def test_protected_roots_reads_all_three_configs(tmp_path, monkeypatch):

--- a/tests/test_repair_worker_path_mismatch.py
+++ b/tests/test_repair_worker_path_mismatch.py
@@ -59,6 +59,28 @@ def test_abs_paths_outside_transfer_are_moved(tmp_path):
         assert conn.execute("SELECT file_path FROM tracks WHERE id=10").fetchone()[0] == os.path.normpath(str(dst))
 
 
+def test_media_server_path_updates_db_by_track_id(tmp_path):
+    """The real cross-path case: the DB stores a media-server path that DIFFERS from
+    the resolved abs path we move. The DB row must still be updated to the new
+    location (by track id, like the live executor) instead of staying stale."""
+    db, w = _worker(tmp_path)
+    lib = tmp_path / "plex_library"
+    src = lib / "Artist" / "Wrong Folder" / "song.flac"
+    dst = lib / "Artist" / "Album" / "01 - song.flac"
+    os.makedirs(src.parent, exist_ok=True)
+    src.write_text("audio")
+    # DB stores a DIFFERENT (media-server) path than the resolved abs src.
+    _insert_track(db, 20, "/plex/media/Artist/Wrong Folder/song.flac")
+
+    details = {'from': 'x', 'to': 'y', 'from_abs': str(src), 'to_abs': str(dst)}
+    res = w._fix_path_mismatch('track', '20', str(src), details)
+    assert res['success'] is True, res
+    assert dst.is_file() and not src.exists()
+    with db._get_connection() as conn:
+        # Updated by id despite the stored path not matching the moved path.
+        assert conn.execute("SELECT file_path FROM tracks WHERE id=20").fetchone()[0] == os.path.normpath(str(dst))
+
+
 def test_legacy_finding_without_abs_outside_transfer_is_guarded(tmp_path):
     """Old findings (no _abs) whose reconstructed path escapes the transfer folder
     are rejected with a clear 're-scan' message — never silently mangled."""

--- a/tests/test_repair_worker_path_mismatch.py
+++ b/tests/test_repair_worker_path_mismatch.py
@@ -1,0 +1,85 @@
+"""Regression for #978 — 'Fix All fixes nothing' on path_mismatch findings.
+
+A path_mismatch finding stores display-TRIMMED from/to for the UI, but ALSO the
+authoritative absolute paths the preview computed (from_abs/to_abs).
+_fix_path_mismatch must move the ABSOLUTE paths so it works for libraries NOT
+rooted under transfer_path (Plex/media-server, Docker host<->container splits) —
+the case that used to hit the "Path escapes transfer folder" guard and silently
+do nothing (both single-fix and Fix All share this handler).
+"""
+import os
+
+from database.music_database import MusicDatabase
+from core.repair_worker import RepairWorker
+
+
+def _worker(tmp_path):
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES (1, 'A', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) VALUES (1, 'Alb', 1, 'test')")
+        conn.commit()
+    w = RepairWorker(database=db)
+    w._config_manager = None
+    w.transfer_folder = str(tmp_path / "Transfer")
+    os.makedirs(w.transfer_folder, exist_ok=True)
+    return db, w
+
+
+def _insert_track(db, tid, path):
+    with db._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO tracks (id, title, file_path, artist_id, album_id, server_source) "
+            "VALUES (?, 'T', ?, 1, 1, 'test')", (tid, path))
+        conn.commit()
+
+
+def test_abs_paths_outside_transfer_are_moved(tmp_path):
+    """The reported bug: files live in a media-server library NOT under
+    transfer_path. With the authoritative _abs paths, the fix moves the file
+    instead of rejecting it as 'escapes transfer folder'."""
+    db, w = _worker(tmp_path)
+    lib = tmp_path / "plex_library"          # outside w.transfer_folder
+    src = lib / "Artist" / "Wrong Folder" / "song.flac"
+    dst = lib / "Artist" / "Album" / "01 - song.flac"
+    os.makedirs(src.parent, exist_ok=True)
+    src.write_text("audio")
+    _insert_track(db, 10, str(src))
+
+    details = {
+        'from': 'Artist/Wrong Folder/song.flac',   # display-trimmed (unusable as-is here)
+        'to': 'Artist/Album/01 - song.flac',
+        'from_abs': str(src),
+        'to_abs': str(dst),
+    }
+    res = w._fix_path_mismatch('track', '10', str(src), details)
+    assert res['success'] is True, res
+    assert dst.is_file() and not src.exists()
+    with db._get_connection() as conn:
+        assert conn.execute("SELECT file_path FROM tracks WHERE id=10").fetchone()[0] == os.path.normpath(str(dst))
+
+
+def test_legacy_finding_without_abs_outside_transfer_is_guarded(tmp_path):
+    """Old findings (no _abs) whose reconstructed path escapes the transfer folder
+    are rejected with a clear 're-scan' message — never silently mangled."""
+    _db, w = _worker(tmp_path)
+    details = {'from': '/abs/outside/song.flac', 'to': '/abs/outside/new.flac'}
+    res = w._fix_path_mismatch('track', '11', '/abs/outside/song.flac', details)
+    assert res['success'] is False
+    assert 'escapes transfer folder' in res['error']
+
+
+def test_legacy_finding_under_transfer_still_works(tmp_path):
+    """Old findings whose files DO live under transfer_path keep working via the
+    reconstruct-from-transfer fallback."""
+    db, w = _worker(tmp_path)
+    src = os.path.join(w.transfer_folder, "A", "Wrong", "s.flac")
+    dst = os.path.join(w.transfer_folder, "A", "Album", "01 - s.flac")
+    os.makedirs(os.path.dirname(src), exist_ok=True)
+    with open(src, "w") as f:
+        f.write("x")
+    _insert_track(db, 12, src)
+    details = {'from': 'A/Wrong/s.flac', 'to': 'A/Album/01 - s.flac'}   # no _abs
+    res = w._fix_path_mismatch('track', '12', src, details)
+    assert res['success'] is True, res
+    assert os.path.isfile(dst) and not os.path.exists(src)

--- a/tests/test_repair_worker_unknown_artist_path.py
+++ b/tests/test_repair_worker_unknown_artist_path.py
@@ -1,0 +1,61 @@
+"""Regression — _fix_unknown_artist must NOT move a media-server file (one that
+lives outside the transfer folder) INTO the transfer folder. Same class as #978:
+the move destination was built from transfer_folder. For non-transfer libraries
+we re-tag + fix DB metadata and leave the file where the media server has it.
+"""
+import os
+
+from database.music_database import MusicDatabase
+from core.repair_worker import RepairWorker
+
+
+def _worker(tmp_path):
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES ('a_unknown', 'Unknown Artist', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) VALUES (1, 'Alb', 'a_unknown', 'test')")
+        conn.commit()
+    w = RepairWorker(database=db)
+    w._config_manager = None
+    w.transfer_folder = str(tmp_path / "Transfer")
+    os.makedirs(w.transfer_folder, exist_ok=True)
+    return db, w
+
+
+def _insert_track(db, tid, path):
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO tracks (id, title, file_path, artist_id, album_id, server_source) "
+                     "VALUES (?, 'T', ?, 'a_unknown', 1, 'test')", (tid, path))
+        conn.commit()
+
+
+def test_media_server_file_not_moved_into_transfer(tmp_path):
+    db, w = _worker(tmp_path)
+    ext = tmp_path / "plex" / "Old" / "song.flac"        # OUTSIDE transfer folder
+    os.makedirs(ext.parent, exist_ok=True)
+    ext.write_bytes(b"\x00" * 32)
+    _insert_track(db, 5, str(ext))
+
+    details = {'track_id': 5, 'corrected_artist': 'New Artist',
+               'expected_path': 'New Artist/Album/01 - song.flac'}
+    w._fix_unknown_artist('track', '5', str(ext), details)
+
+    assert ext.is_file()                                          # stayed put
+    assert not (tmp_path / "Transfer" / "New Artist").exists()    # NOT yanked into transfer
+    with db._get_connection() as conn:
+        assert conn.execute("SELECT file_path FROM tracks WHERE id=5").fetchone()[0] == str(ext)
+        assert conn.execute("SELECT a.name FROM tracks t JOIN artists a ON a.id=t.artist_id WHERE t.id=5").fetchone()[0] == 'New Artist'
+
+
+def test_transfer_file_still_moves(tmp_path):
+    db, w = _worker(tmp_path)
+    src = os.path.join(w.transfer_folder, "Unknown", "song.flac")
+    os.makedirs(os.path.dirname(src), exist_ok=True)
+    with open(src, "wb") as f:
+        f.write(b"\x00" * 32)
+    _insert_track(db, 6, src)
+    details = {'track_id': 6, 'corrected_artist': 'New Artist',
+               'expected_path': 'New Artist/Album/01 - song.flac'}
+    w._fix_unknown_artist('track', '6', src, details)
+    dst = os.path.join(w.transfer_folder, "New Artist", "Album", "01 - song.flac")
+    assert os.path.isfile(dst) and not os.path.exists(src)

--- a/tests/webui/test_mimetypes_fix.py
+++ b/tests/webui/test_mimetypes_fix.py
@@ -1,0 +1,29 @@
+"""#979: the React pages (module-loaded) go black when the OS registry serves .js
+as text/plain, because browsers refuse a <script type="module"> with a non-JS
+MIME. ensure_web_mimetypes() must override any such mapping."""
+
+from __future__ import annotations
+
+import mimetypes
+
+from core.webui.mimetypes_fix import ensure_web_mimetypes
+
+
+def test_js_is_forced_to_javascript_even_if_registry_says_text_plain():
+    mimetypes.add_type("text/plain", ".js")     # simulate a broken Windows registry
+    ensure_web_mimetypes()
+    assert mimetypes.guess_type("main-Dg73FktO.js")[0] == "text/javascript"
+    assert mimetypes.guess_type("chunk.mjs")[0] == "text/javascript"
+
+
+def test_css_and_manifest_types():
+    mimetypes.add_type("text/plain", ".css")
+    ensure_web_mimetypes()
+    assert mimetypes.guess_type("main.css")[0] == "text/css"
+    assert mimetypes.guess_type("app.webmanifest")[0] == "application/manifest+json"
+
+
+def test_idempotent():
+    ensure_web_mimetypes()
+    ensure_web_mimetypes()
+    assert mimetypes.guess_type("x.js")[0] == "text/javascript"

--- a/web_server.py
+++ b/web_server.py
@@ -15408,9 +15408,14 @@ def _search_track_in_album_context(original_search: dict, artist: dict) -> dict:
 def _cleanup_empty_directories(download_path, moved_file_path):
     """Cleans up empty directories after a file move, ignoring hidden files."""
     import os
+    from core.imports.file_ops import protected_root_dirs
     try:
+        protected = protected_root_dirs()
+        protected.add(os.path.normpath(download_path))
         current_dir = os.path.dirname(moved_file_path)
         while current_dir != download_path and current_dir.startswith(download_path):
+            if os.path.normpath(current_dir) in protected:
+                break  # #976: never delete a configured root, even nested + empty
             is_empty = not any(not f.startswith('.') for f in os.listdir(current_dir))
             if is_empty:
                 logger.warning(f"Removing empty directory: {current_dir}")
@@ -15430,16 +15435,22 @@ def _sweep_empty_download_directories():
     empty only after all sibling downloads in a batch have been processed.
     """
     import os
+    from core.imports.file_ops import protected_root_dirs
     try:
         download_path = docker_resolve_path(config_manager.get('soulseek.download_path', './downloads'))
         if not os.path.isdir(download_path):
             return 0
 
+        # #976: never sweep away a configured root (e.g. a staging folder nested
+        # under downloads), only its transient sub-folders.
+        protected = protected_root_dirs()
+        protected.add(os.path.normpath(download_path))
+
         removed = 0
         # os.walk bottom-up: deepest directories first so parents become empty after children removed
         for dirpath, _dirnames, _filenames in os.walk(download_path, topdown=False):
-            # Never remove the root download directory itself
-            if os.path.normpath(dirpath) == os.path.normpath(download_path):
+            # Never remove a configured root directory itself
+            if os.path.normpath(dirpath) in protected:
                 continue
             # Re-read actual contents — os.walk's lists are stale after child removal
             try:

--- a/web_server.py
+++ b/web_server.py
@@ -20,6 +20,11 @@ from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from core.webui.mimetypes_fix import ensure_web_mimetypes
+# Register correct web-asset MIME types before the app serves anything — a bad OS
+# registry (Windows: .js -> text/plain) otherwise blanks the module-loaded React
+# pages (Import/Stats) via strict module MIME checking. (#979)
+ensure_web_mimetypes()
 from flask import Flask, abort, render_template, request, jsonify, redirect, send_file, send_from_directory, Response, session, g
 from flask_socketio import SocketIO, emit, join_room, leave_room
 from utils.logging_config import get_logger, setup_logging

--- a/web_server.py
+++ b/web_server.py
@@ -15473,6 +15473,11 @@ def _sweep_empty_download_directories():
 
         if removed > 0:
             logger.warning(f"[Folder Cleanup] Removed {removed} empty director{'y' if removed == 1 else 'ies'} from downloads folder")
+        # #976: a sweep must never leave the import/staging folder missing —
+        # recreate it if it went absent (e.g. an older build deleted it) so the
+        # import feature self-heals instead of erroring until the next scan.
+        from core.imports.file_ops import ensure_staging_dir
+        ensure_staging_dir()
         return removed
     except Exception as e:
         logger.error(f"[Folder Cleanup] Error sweeping empty directories: {e}")

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.8.4"
+_SOULSYNC_BASE_VERSION = "2.8.5"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,19 +3404,16 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '2.8.4': [
-        { date: 'July 2026 — 2.8.4 release' },
-        { title: 'Artist Web — your library as a map', desc: 'an interactive WebGL graph of every artist you own, laid out by how they relate. it settles live (physics in a background worker, so the UI never freezes) and pans/zooms smoothly across thousands of nodes. three lenses: Taste Map (by genre), Communities, and the Discovery Web.', page: 'discover' },
-        { title: 'Discovery Web', desc: 'the map\'s discovery mode — your owned artists anchor a graph that grows out to similar artists you don\'t own yet. click any node to expand the map from there, follow the thread, and add anything to your watchlist on the spot.', page: 'discover' },
-        { title: 'Play from the map', desc: 'start artist radio off an owned node, or hear a 30s preview on a candidate you don\'t own — without leaving the graph. plus a first-run hint, a guide modal, and hover tooltips with the artist\'s photo.', page: 'discover' },
-        { title: 'Quality Profiles (#974)', desc: 'the single global quality setting becomes named, editable profiles — targets, upgrade behavior, AcoustID strictness, downsampling + lossy-copy all resolve per profile. Auto-Import can run its own, and there\'s an "upgrade until target" cutoff. (thanks @nick2000713.)', page: 'settings' },
-        { title: 'The Adventurousness dial, for real', desc: 'it was mostly cosmetic before (a browser-cache bug served the same recs). now it actually drives which artists surface — deeper the further you push it, genre-diverse so one genre can\'t hog the row, freshly rotated each visit, with "off your usual path" chips at the exploratory end.', page: 'discover' },
-        { title: 'Repair stop button actually cancels (#970)', desc: 'hitting stop now interrupts the running scan and flips responsively to "Stopping…", instead of the job grinding on to completion.', page: 'tools' },
-        { title: 'Playlist stuck "syncing" fixed (#972)', desc: 'a socket-driven sync could leave a playlist wedged in the syncing state server-side. fixed.', page: 'sync' },
-        { title: 'JioSaavn full enrichment worker (#964)', desc: 'JioSaavn graduates from experimental metadata to a full enrichment worker — and no longer wedges the whole worker on a single unresolvable row. (thanks HellRa1SeR.)', page: 'settings' },
-        { title: 'Unicode / Japanese dedup matching (#965)', desc: 'self-titled tracks match correctly and normalization preserves all scripts instead of only CJK, so the duplicate detector stops mis-grouping Japanese titles. (#967 — thanks bluejorts.)', page: 'tools' },
-        { title: 'Safer duplicate cleanup', desc: 'the duplicate cleaner quarantines instead of hard-deleting, and surfaces Docker permission failures instead of silently swallowing them.', page: 'tools' },
-        { title: 'Earlier versions', desc: '2.8.3 rebuilt Discover — a Spotify-level redesign plus a real recommendation engine (genre/novelty scoring, "why this rec" chips, self-filling popularity data). 2.8.2 fixed the Spotify Docker boot hang (#949) + added Max Performance mode; 2.8.1 added playlist export to Spotify & Deezer (#945); 2.8.0 brought the Unverified-queue cleanup (#934); 2.7.0 made multi-user real.' },
+    '2.8.5': [
+        { date: 'July 2026 — 2.8.5 release' },
+        { title: 'A focused bug-fix release', desc: 'no new features this time — just a batch of import, library, repair, and webui fixes, several straight from user reports this week.' },
+        { title: 'Import & Stats black screen fixed (#979)', desc: 'those two React-built pages could load as a blank black screen on some setups (mostly Windows, where the OS handed the app\'s JS bundle over with the wrong file type and the browser refused to run it). we force the correct type now, so they load for everyone.', page: 'import' },
+        { title: 'iTunes singles no longer "Unknown Artist" (#980)', desc: 'an iTunes single reached the importer with no album name, so it dropped into Unknown Artist / Unknown Album, got no album tag, and didn\'t match its release. a single\'s album is its own title now, so it files and tags correctly.', page: 'import' },
+        { title: 'No more "01-" on single-disc albums (#981)', desc: '$disc / $discnum in a file template always stamped the disc number, even on a 1-disc album. they\'re smart now like $cdnum — empty on single-disc, shown only for real multi-disc sets. applies to both import and rename/reorganize.', page: 'tools' },
+        { title: 'Cleanup never deletes a configured root (#976)', desc: 'the empty-dir cleanup could remove a folder you\'d set as a root; it leaves configured roots alone now, and self-heals a missing staging/import folder if a sweep removed it.', page: 'tools' },
+        { title: 'Repair "Fix All" works outside the transfer path (#978)', desc: 'path-mismatch "Fix All" did nothing for libraries stored outside the transfer folder; it works everywhere now, updates the DB by track id for media-server parity, and stops pulling media-server files into transfer.', page: 'tools' },
+        { title: 'Discography backfill only touches artists you own (#977)', desc: 'the repair backfill was reaching beyond your owned artists; scoped back to what you actually have.', page: 'tools' },
+        { title: 'Earlier versions', desc: '2.8.4 added Artist Web (an interactive WebGL map of your whole library + a discovery graph), named Quality Profiles (#974), and made the Discover adventurousness dial actually reshape your recs. 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949) + added Max Performance mode; 2.8.1 added playlist export to Spotify & Deezer (#945); 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3447,51 +3444,24 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "Artist Web — your library as a map",
-        description: "an interactive WebGL graph of your whole library that doubles as a discovery tool.",
+        title: "2.8.5 — bug fixes",
+        description: "a focused fix release across import, library, repair, and the webui — several straight from user reports this week.",
         features: [
-            "every artist you own, laid out by how they relate — it settles live (physics in a background worker, so the UI never freezes) and pans/zooms smoothly across thousands of nodes",
-            "three lenses / front doors: Taste Map (clustered by genre), Communities (who groups with who), and the Discovery Web",
-            "the Discovery Web — your owned artists anchor a map that grows out to similar artists you don't own yet; click any node to expand from there, follow the thread, and add anything to your watchlist on the spot",
-            "play from the map — artist radio off an owned node, or a 30s preview on a candidate you don't own, without leaving the graph; plus a first-run hint, a guide modal, and hover tooltips with the artist's photo",
-        ],
-        usage_note: "open Artist Web from Discover — drag to pan, scroll to zoom, click a node to expand or play.",
-    },
-    {
-        title: "Quality Profiles",
-        description: "the single global quality setting becomes named, editable profiles (#974, thanks @nick2000713).",
-        features: [
-            "targets, upgrade behavior, AcoustID strictness, downsampling, and lossy-copy rules all resolve per profile — not one global setting",
-            "Auto-Import can run its own profile independent of your default; wishlist/library rows can carry their own; and there's an \"upgrade until target\" cutoff that lives on the profile",
-            "a Manage view shows what's active for what (default vs. Auto-Import vs. per-item), separate from previewing/editing a profile",
+            "#979 — Import & Stats loaded as a black screen on some setups (mostly Windows, where the OS served the app's JS bundle with the wrong MIME type and the browser refused it). we force the correct type now, so they load for everyone",
+            "#980 — iTunes singles were landing in \"Unknown Artist\" with no album tag; a single's album is its own title now, so they file and tag correctly",
+            "#981 — $disc/$discnum stamped a \"01-\" prefix on single-disc albums; they're smart now like $cdnum (empty on single-disc, shown only for real multi-disc), for both import and rename/reorganize",
+            "#976 — cleanup never deletes a folder you've set as a root, and self-heals a missing staging/import folder if a sweep removed it",
+            "#978 — repair \"Fix All\" now works for libraries outside the transfer path and stops pulling media-server files into transfer; #977 — discography backfill only touches artists you own",
         ],
     },
     {
-        title: "The Adventurousness dial, for real this time",
-        description: "the Discover dial goes from cosmetic to actually reshaping your recs.",
+        title: "Earlier in 2.8.4",
+        description: "2.8.4 was the Artist Web + Quality Profiles release.",
         features: [
-            "it was mostly cosmetic before — a browser-cache bug was serving the same recs no matter where you set it. now it genuinely drives which artists surface, not just how they're sorted",
-            "deeper the further you push it — the far right reaches real deep cuts, with a distinct middle instead of two ends that felt the same",
-            "genre diversity so one genre can't hog the row, freshness rotation so you get different deep cuts each visit, and \"🧭 off your usual path\" chips at the exploratory end",
-        ],
-    },
-    {
-        title: "Fixes this release",
-        description: "repair jobs, sync, dedup, and matching.",
-        features: [
-            "#970 — the repair-job stop button actually cancels the running scan (instant \"Stopping…\"), instead of grinding on",
-            "#972 — a playlist could get stuck \"syncing\" server-side after a socket-driven sync; fixed",
-            "#964 — the JioSaavn worker no longer wedges the whole enrichment worker on a single unresolvable row",
-            "duplicate cleanup quarantines instead of hard-deleting (and surfaces Docker permission failures); Jellyfin playlist align + a couple of match/sync fixes",
-        ],
-    },
-    {
-        title: "Community contributions",
-        description: "great PRs from contributors this release.",
-        features: [
-            "#974 — named Quality Profiles (the feature above). thanks @nick2000713",
-            "#964 — JioSaavn graduates from experimental metadata to a full enrichment worker. thanks HellRa1SeR",
-            "#965/#967 — unicode / Japanese dedup matching: self-titled tracks match, and normalization preserves all scripts, not just CJK. thanks bluejorts",
+            "Artist Web — an interactive WebGL map of your whole library, laid out by how artists relate, in three lenses (Taste Map, Communities, Discovery Web); the Discovery Web grows out to similar artists you don't own, and you can play artist radio / 30s previews right from the graph",
+            "Quality Profiles (#974, thanks @nick2000713) — the single global quality setting becomes named, editable profiles (targets, upgrade behavior, AcoustID strictness, downsampling, lossy-copy), with an \"upgrade until target\" cutoff and a per-profile Auto-Import option",
+            "the Adventurousness dial went from cosmetic to actually reshaping your recs — deeper the further you push it, genre-diverse, freshly rotated, with \"off your usual path\" chips",
+            "fixes: repair stop button actually cancels (#970), playlists no longer stuck \"syncing\" (#972), JioSaavn worker no longer wedges (#964), safer duplicate cleanup; contributor PRs for JioSaavn enrichment (#964, HellRa1SeR) and unicode/Japanese dedup matching (#965/#967, bluejorts)",
         ],
     },
     {


### PR DESCRIPTION
# soulsync 2.8.5 — `dev` → `main`

a focused bug-fix release. no new features — just a batch of import, library, repair, and webui fixes, several from user reports this week.

---

## 🐛 fixes

### import & metadata
- **Import & Stats were a black screen for some people (#979)** — those two pages are the React-built ones, loaded as module scripts. on setups where the OS handed the `.js` bundle over with the wrong MIME type (common on Windows), the browser refused to run it and the page went black while everything else worked. we now force the correct type ourselves, so the OS can't blank those pages.
- **iTunes singles landed in "Unknown Artist" with no album tag (#980)** — an iTunes single reached the importer with no album name, so it dropped into `Unknown Artist/Unknown Album`, got no album tag, and didn't match its release. a single's album is effectively its own title now, so it files correctly and tags properly.
- **single-disc albums got a "01-" on every track (#981)** — `$disc`/`$discnum` in a file template always stamped the disc number, even on a 1-disc album. they're smart now (like `$cdnum`): empty on single-disc, shown only for real multi-disc sets. applies to both fresh imports and rename/reorganize.

### library safety & repair
- **never delete a configured root folder during cleanup (#976)** — the empty-dir cleanup could remove a folder you'd set as a root; it leaves configured roots alone now, and self-heals a missing staging/import folder if a sweep removed it.
- **repair "Fix All" for libraries outside the transfer path (#978)** — path-mismatch "Fix All" did nothing for libraries stored outside the transfer folder; it works everywhere now, updates the DB by track id for media-server parity, and the unknown-artist fix no longer yanks media-server files into the transfer folder.
- **discography backfill only touches artists you own (#977)** — the repair backfill was reaching beyond your owned artists; scoped back to what you actually have.

enjoy 🎶
