### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.8.5)'
+        description: 'Version tag (e.g. 2.8.51)'
         required: true
-        default: '2.8.5'
+        default: '2.8.51'
 
 jobs:
   build-and-push:

--- a/RELEASE_2.8.51_discord.md
+++ b/RELEASE_2.8.51_discord.md
@@ -1,0 +1,5 @@
+**SoulSync 2.8.51** 🩹 quick hotfix on top of 2.8.5
+
+**#983** — on a fresh install, opening a watchlist artist's settings could error out with `no such column: preferred_metadata_source` (a restart worked around it). first-run setup was rebuilding the watchlist table and dropping a couple of newer columns; they survive now, so it works from the first boot. upgraders were never affected.
+
+grab it the usual way — `docker pull` the `latest`/`2.8.51` tag.

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -2601,6 +2601,8 @@ class MusicDatabase:
                             discogs_artist_id TEXT,
                             musicbrainz_artist_id TEXT,
                             amazon_artist_id TEXT,
+                            preferred_metadata_source TEXT DEFAULT NULL,
+                            auto_download INTEGER NOT NULL DEFAULT 1,
                             profile_id INTEGER DEFAULT 1,
                             UNIQUE(profile_id, spotify_artist_id),
                             UNIQUE(profile_id, itunes_artist_id)
@@ -2630,7 +2632,9 @@ class MusicDatabase:
                             deezer_artist_id TEXT,
                             discogs_artist_id TEXT,
                             musicbrainz_artist_id TEXT,
-                            amazon_artist_id TEXT
+                            amazon_artist_id TEXT,
+                            preferred_metadata_source TEXT DEFAULT NULL,
+                            auto_download INTEGER NOT NULL DEFAULT 1
                         )
                     """)
 
@@ -2643,7 +2647,8 @@ class MusicDatabase:
                             'include_remixes', 'include_acoustic', 'include_compilations',
                             'include_instrumentals', 'lookback_days',
                             'itunes_artist_id', 'deezer_artist_id', 'discogs_artist_id',
-                            'musicbrainz_artist_id', 'amazon_artist_id', 'profile_id']
+                            'musicbrainz_artist_id', 'amazon_artist_id',
+                            'preferred_metadata_source', 'auto_download', 'profile_id']
                 shared_cols = [c for c in new_cols if c in old_cols]
                 cols_str = ', '.join(shared_cols)
                 cursor.execute(f"INSERT INTO watchlist_artists_new ({cols_str}) SELECT {cols_str} FROM watchlist_artists")
@@ -3573,6 +3578,8 @@ class MusicDatabase:
                             discogs_artist_id TEXT,
                             musicbrainz_artist_id TEXT,
                             amazon_artist_id TEXT,
+                            preferred_metadata_source TEXT DEFAULT NULL,
+                            auto_download INTEGER NOT NULL DEFAULT 1,
                             profile_id INTEGER DEFAULT 1,
                             UNIQUE(profile_id, spotify_artist_id),
                             UNIQUE(profile_id, itunes_artist_id)
@@ -3586,7 +3593,8 @@ class MusicDatabase:
                                 'include_remixes', 'include_acoustic', 'include_compilations',
                                 'include_instrumentals', 'lookback_days',
                                 'itunes_artist_id', 'deezer_artist_id', 'discogs_artist_id',
-                                'musicbrainz_artist_id', 'amazon_artist_id', 'profile_id']
+                                'musicbrainz_artist_id', 'amazon_artist_id',
+                            'preferred_metadata_source', 'auto_download', 'profile_id']
                     shared_cols = [c for c in new_cols if c in col_names]
                     cols_str = ', '.join(shared_cols)
 

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,19 +1,13 @@
-# soulsync 2.8.5 — `dev` → `main`
+# soulsync 2.8.51 — `dev` → `main`
 
-a focused bug-fix release. no new features — just a batch of import, library, repair, and webui fixes, several from user reports this week.
+quick hotfix on top of 2.8.5 for one fresh-install bug.
 
 ---
 
-## 🐛 fixes
+## #983 — watchlist artist settings errored on a fresh install
 
-### import & metadata
-- **Import & Stats were a black screen for some people (#979)** — those two pages are the React-built ones, loaded as module scripts. on setups where the OS handed the `.js` bundle over with the wrong MIME type (common on Windows), the browser refused to run it and the page went black while everything else worked. we now force the correct type ourselves, so the OS can't blank those pages.
-- **iTunes singles landed in "Unknown Artist" with no album tag (#980)** — an iTunes single reached the importer with no album name, so it dropped into `Unknown Artist/Unknown Album`, got no album tag, and didn't match its release. a single's album is effectively its own title now, so it files correctly and tags properly.
-- **single-disc albums got a "01-" on every track (#981)** — `$disc`/`$discnum` in a file template always stamped the disc number, even on a 1-disc album. they're smart now (like `$cdnum`): empty on single-disc, shown only for real multi-disc sets. applies to both fresh imports and rename/reorganize.
+on a brand-new database, opening a watchlist artist's settings could fail with `no such column: preferred_metadata_source` (restarting worked around it).
 
-### library safety & repair
-- **never delete a configured root folder during cleanup (#976)** — the empty-dir cleanup could remove a folder you'd set as a root; it leaves configured roots alone now, and self-heals a missing staging/import folder if a sweep removed it.
-- **repair "Fix All" for libraries outside the transfer path (#978)** — path-mismatch "Fix All" did nothing for libraries stored outside the transfer folder; it works everywhere now, updates the DB by track id for media-server parity, and the unknown-artist fix no longer yanks media-server files into the transfer folder.
-- **discography backfill only touches artists you own (#977)** — the repair backfill was reaching beyond your owned artists; scoped back to what you actually have.
+root cause: first-run setup rebuilds the `watchlist_artists` table (for profile-scoped uniqueness) by copying it from a hardcoded column list — and that list was missing two newer columns (`preferred_metadata_source`, `auto_download`) that get added by later ALTER migrations. on a fresh install the rebuild fires right after those columns are created, silently dropping them. the artist-config endpoint reads `preferred_metadata_source` directly, so it 500'd until a restart's ALTER re-added it. upgraders never hit it — their columns already existed before that rebuild ran.
 
-enjoy 🎶
+fix: added both columns to every rebuild path so they survive. regression tests added that fail on the old code with the exact error and pass on the fix. same bug class as the earlier `amazon_artist_id` fix.

--- a/tests/test_db_watchlist_amazon_id_migration.py
+++ b/tests/test_db_watchlist_amazon_id_migration.py
@@ -118,3 +118,64 @@ def test_fresh_db_has_amazon_artist_id_column(tmp_path: Path) -> None:
     db_path = tmp_path / "fresh_library.db"
     MusicDatabase(str(db_path))
     assert "amazon_artist_id" in _watchlist_columns(db_path)
+
+
+# ── #983: preferred_metadata_source + auto_download were added AFTER the amazon
+#    fix but never added to the rebuild column lists, so the profile-UNIQUE rebuild
+#    dropped them again. On a FRESH install the rebuild fires right after the
+#    columns are added, so the (non-defensive) artist-config endpoint 500'd with
+#    "no such column: preferred_metadata_source" until a restart re-added it. ──
+_OLD_WATCHLIST_WITH_PREFERRED = """
+    CREATE TABLE watchlist_artists (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        spotify_artist_id TEXT UNIQUE,
+        itunes_artist_id TEXT,
+        deezer_artist_id TEXT,
+        discogs_artist_id TEXT,
+        musicbrainz_artist_id TEXT,
+        amazon_artist_id TEXT,
+        artist_name TEXT NOT NULL,
+        date_added TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        last_scan_timestamp TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        preferred_metadata_source TEXT DEFAULT NULL,
+        auto_download INTEGER NOT NULL DEFAULT 1
+    )
+"""
+
+
+def test_fresh_db_has_preferred_metadata_source_column(tmp_path: Path) -> None:
+    """#983 repro: a brand-new database must end up with preferred_metadata_source
+    (and auto_download) — the profile rebuild must not drop them."""
+    db_path = tmp_path / "fresh_library.db"
+    MusicDatabase(str(db_path))
+    cols = _watchlist_columns(db_path)
+    assert "preferred_metadata_source" in cols, f"dropped by the rebuild; columns: {cols}"
+    assert "auto_download" in cols
+
+
+def test_preferred_metadata_source_data_survives_rebuild(tmp_path: Path) -> None:
+    """A stored per-artist source override must carry across the profile rebuild.
+    FAILS on pre-fix code (column + data dropped)."""
+    db_path = tmp_path / "old_library.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(_OLD_WATCHLIST_WITH_PREFERRED)   # nullable spotify + no profile UNIQUE → profile rebuild fires
+        conn.execute(
+            "INSERT INTO watchlist_artists (spotify_artist_id, artist_name, preferred_metadata_source) "
+            "VALUES (?, ?, ?)", ("spfy_x", "Prefers iTunes", "itunes"))
+        conn.commit()
+    finally:
+        conn.close()
+
+    MusicDatabase(str(db_path))
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT preferred_metadata_source FROM watchlist_artists WHERE artist_name = ?",
+            ("Prefers iTunes",)).fetchone()
+    finally:
+        conn.close()
+    assert row is not None and row[0] == "itunes", f"preferred_metadata_source not preserved (got {row!r})"

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.8.5"
+_SOULSYNC_BASE_VERSION = "2.8.51"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,16 +3404,10 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '2.8.5': [
-        { date: 'July 2026 — 2.8.5 release' },
-        { title: 'A focused bug-fix release', desc: 'no new features this time — just a batch of import, library, repair, and webui fixes, several straight from user reports this week.' },
-        { title: 'Import & Stats black screen fixed (#979)', desc: 'those two React-built pages could load as a blank black screen on some setups (mostly Windows, where the OS handed the app\'s JS bundle over with the wrong file type and the browser refused to run it). we force the correct type now, so they load for everyone.', page: 'import' },
-        { title: 'iTunes singles no longer "Unknown Artist" (#980)', desc: 'an iTunes single reached the importer with no album name, so it dropped into Unknown Artist / Unknown Album, got no album tag, and didn\'t match its release. a single\'s album is its own title now, so it files and tags correctly.', page: 'import' },
-        { title: 'No more "01-" on single-disc albums (#981)', desc: '$disc / $discnum in a file template always stamped the disc number, even on a 1-disc album. they\'re smart now like $cdnum — empty on single-disc, shown only for real multi-disc sets. applies to both import and rename/reorganize.', page: 'tools' },
-        { title: 'Cleanup never deletes a configured root (#976)', desc: 'the empty-dir cleanup could remove a folder you\'d set as a root; it leaves configured roots alone now, and self-heals a missing staging/import folder if a sweep removed it.', page: 'tools' },
-        { title: 'Repair "Fix All" works outside the transfer path (#978)', desc: 'path-mismatch "Fix All" did nothing for libraries stored outside the transfer folder; it works everywhere now, updates the DB by track id for media-server parity, and stops pulling media-server files into transfer.', page: 'tools' },
-        { title: 'Discography backfill only touches artists you own (#977)', desc: 'the repair backfill was reaching beyond your owned artists; scoped back to what you actually have.', page: 'tools' },
-        { title: 'Earlier versions', desc: '2.8.4 added Artist Web (an interactive WebGL map of your whole library + a discovery graph), named Quality Profiles (#974), and made the Discover adventurousness dial actually reshape your recs. 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949) + added Max Performance mode; 2.8.1 added playlist export to Spotify & Deezer (#945); 2.7.0 made multi-user real.' },
+    '2.8.51': [
+        { date: 'July 2026 — 2.8.51 hotfix' },
+        { title: 'Watchlist artist settings no longer error on a fresh install (#983)', desc: 'on a brand-new database, opening a watchlist artist\'s settings could fail with "no such column: preferred_metadata_source" (a restart worked around it). the table was being rebuilt during first-run setup from a column list that dropped two newer columns; they survive the rebuild now, so it works from the first boot.', page: 'artists' },
+        { title: 'Earlier versions', desc: '2.8.5 was a fix batch: Import & Stats black screen (#979), iTunes singles landing in Unknown Artist (#980), a stray "01-" on single-disc albums (#981), cleanup deleting a configured root (#976), repair Fix All outside the transfer path (#978), and backfill overreaching past owned artists (#977). 2.8.4 added Artist Web + named Quality Profiles (#974); 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949); 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3444,8 +3438,15 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "2.8.5 — bug fixes",
-        description: "a focused fix release across import, library, repair, and the webui — several straight from user reports this week.",
+        title: "2.8.51 — hotfix",
+        description: "a one-fix follow-up to 2.8.5.",
+        features: [
+            "#983 — on a fresh install, opening a watchlist artist's settings could fail with \"no such column: preferred_metadata_source\" (a restart worked around it). first-run setup was rebuilding the watchlist table from a column list that dropped two newer columns; they survive now, so it works from the first boot",
+        ],
+    },
+    {
+        title: "Earlier in 2.8.5",
+        description: "2.8.5 was a focused fix release across import, library, repair, and the webui.",
         features: [
             "#979 — Import & Stats loaded as a black screen on some setups (mostly Windows, where the OS served the app's JS bundle with the wrong MIME type and the browser refused it). we force the correct type now, so they load for everyone",
             "#980 — iTunes singles were landing in \"Unknown Artist\" with no album tag; a single's album is its own title now, so they file and tag correctly",


### PR DESCRIPTION
# soulsync 2.8.51 — `dev` → `main`

quick hotfix on top of 2.8.5 for one fresh-install bug.

---

## #983 — watchlist artist settings errored on a fresh install

on a brand-new database, opening a watchlist artist's settings could fail with `no such column: preferred_metadata_source` (restarting worked around it).

root cause: first-run setup rebuilds the `watchlist_artists` table (for profile-scoped uniqueness) by copying it from a hardcoded column list — and that list was missing two newer columns (`preferred_metadata_source`, `auto_download`) that get added by later ALTER migrations. on a fresh install the rebuild fires right after those columns are created, silently dropping them. the artist-config endpoint reads `preferred_metadata_source` directly, so it 500'd until a restart's ALTER re-added it. upgraders never hit it — their columns already existed before that rebuild ran.

fix: added both columns to every rebuild path so they survive. regression tests added that fail on the old code with the exact error and pass on the fix. same bug class as the earlier `amazon_artist_id` fix.
