### PR TITLE
Prefer commercial sources for library discographies

### DIFF
--- a/core/metadata/library_discography.py
+++ b/core/metadata/library_discography.py
@@ -1,0 +1,345 @@
+"""Library artist discography policy.
+
+The library view intentionally uses commercial catalogues instead of the
+configured metadata primary source.  iTunes is preferred, Deezer is the only
+external fallback, and locally owned releases omitted by both catalogues are
+merged back into the result.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from difflib import SequenceMatcher
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from core.metadata.lookup import MetadataLookupOptions
+
+logger = logging.getLogger(__name__)
+
+COMMERCIAL_DISCOGRAPHY_SOURCES: Sequence[str] = ("itunes", "deezer")
+
+_SOURCE_ID_FIELDS = {
+    "itunes": "itunes_album_id",
+    "deezer": "deezer_id",
+    "musicbrainz": "musicbrainz_release_id",
+    "spotify": "spotify_album_id",
+}
+
+_VARIANT_TERMS = (
+    "anniversary",
+    "clean",
+    "collector",
+    "deluxe",
+    "edition",
+    "expanded",
+    "explicit",
+    "legacy",
+    "mono",
+    "remaster",
+    "remastered",
+    "reissue",
+    "redux",
+    "special",
+    "stereo",
+    "super deluxe",
+    "version",
+)
+_VARIANT_GROUP_RE = re.compile(
+    r"\s*[\(\[][^\)\]]*(?:" + "|".join(re.escape(term) for term in _VARIANT_TERMS) + r")[^\)\]]*[\)\]]\s*",
+    re.IGNORECASE,
+)
+_VARIANT_TRAILING_RE = re.compile(
+    r"\s*[-–—:]?\s*(?:\d+(?:st|nd|rd|th)\s+)?(?:"
+    + "|".join(re.escape(term) for term in _VARIANT_TERMS)
+    + r")(?:\s+(?:edition|version|remaster|remastered))?\s*$",
+    re.IGNORECASE,
+)
+_SUBTITLE_SEPARATORS = (":", " - ", " – ", " — ")
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_STOP_TOKENS = {"a", "an", "and", "of", "the"}
+_SERIES_TOKENS = {"cd", "chapter", "disc", "part", "pt", "vol", "volume"}
+
+
+def _ascii_casefold(value: Any) -> str:
+    normalized = unicodedata.normalize("NFKD", str(value or ""))
+    return normalized.encode("ascii", "ignore").decode("ascii").casefold().strip()
+
+
+def _normalized_title(value: Any) -> str:
+    return " ".join(_TOKEN_RE.findall(_ascii_casefold(value)))
+
+
+def _canonical_title(value: Any) -> str:
+    cleaned = _ascii_casefold(value)
+    previous = None
+    while cleaned != previous:
+        previous = cleaned
+        cleaned = _VARIANT_GROUP_RE.sub(" ", cleaned)
+        cleaned = _VARIANT_TRAILING_RE.sub("", cleaned)
+    return " ".join(_TOKEN_RE.findall(cleaned))
+
+
+def _is_base_title_with_subtitle(left: Any, right: Any) -> bool:
+    left_raw = _ascii_casefold(left)
+    right_raw = _ascii_casefold(right)
+    for shorter, longer in ((left_raw, right_raw), (right_raw, left_raw)):
+        if not shorter or len(shorter) < 4:
+            continue
+        if any(longer.startswith(shorter + separator) for separator in _SUBTITLE_SEPARATORS):
+            return True
+    return False
+
+
+def _significant_tokens(value: str) -> set[str]:
+    return {token for token in value.split() if token not in _STOP_TOKENS}
+
+
+def titles_represent_same_release(left: Any, right: Any) -> bool:
+    """Return whether two same-artist release titles represent one catalogue item.
+
+    The comparison is deliberately conservative but understands common commercial
+    edition suffixes, subtitles, and catalogue titles that include the artist name.
+    """
+    left_normal = _normalized_title(left)
+    right_normal = _normalized_title(right)
+    if not left_normal or not right_normal:
+        return False
+    if left_normal == right_normal:
+        return True
+    if _is_base_title_with_subtitle(left, right):
+        return True
+
+    left_canonical = _canonical_title(left)
+    right_canonical = _canonical_title(right)
+    if left_canonical == right_canonical:
+        return True
+
+    left_tokens = _significant_tokens(left_canonical)
+    right_tokens = _significant_tokens(right_canonical)
+    if left_tokens and right_tokens:
+        smaller, larger = sorted((left_tokens, right_tokens), key=len)
+        extra_tokens = larger - smaller
+        has_distinct_series_suffix = any(
+            token.isdigit() or token in _SERIES_TOKENS
+            for token in extra_tokens
+        )
+        if len(smaller) >= 2 and smaller.issubset(larger) and not has_distinct_series_suffix:
+            return True
+
+        shared = left_tokens & right_tokens
+        smaller_coverage = len(shared) / min(len(left_tokens), len(right_tokens))
+        jaccard = len(shared) / len(left_tokens | right_tokens)
+        if smaller_coverage >= 0.9 and jaccard >= 0.65:
+            return True
+
+    return SequenceMatcher(None, left_canonical, right_canonical).ratio() >= 0.9
+
+
+def _release_title(release: Mapping[str, Any]) -> str:
+    return str(release.get("title") or release.get("name") or "").strip()
+
+
+def _sort_releases(releases: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    def release_year(item: Mapping[str, Any]) -> int:
+        value = item.get("release_date") or item.get("year") or ""
+        try:
+            return int(str(value)[:4])
+        except (TypeError, ValueError):
+            return 0
+
+    return sorted((dict(release) for release in releases), key=release_year, reverse=True)
+
+
+def _iter_release_buckets(discography: Mapping[str, Any]) -> Iterable[tuple[str, Mapping[str, Any]]]:
+    for bucket in ("albums", "eps", "singles"):
+        for release in discography.get(bucket, []) or []:
+            yield bucket, release
+
+
+def _stamp_source(discography: Mapping[str, Any], source: str) -> Dict[str, Any]:
+    stamped: Dict[str, Any] = dict(discography)
+    for bucket in ("albums", "eps", "singles"):
+        stamped[bucket] = [
+            {**dict(release), "source": str(release.get("source") or source)}
+            for release in discography.get(bucket, []) or []
+        ]
+    stamped["source"] = source
+    return stamped
+
+
+def _local_release_source(
+    local_id: str,
+    source_refs: Mapping[str, Mapping[str, Any]],
+    active_source: Optional[str],
+) -> tuple[str, str]:
+    refs = source_refs.get(local_id, {}) or {}
+    source_order: List[str] = []
+    if active_source:
+        source_order.append(active_source)
+    source_order.extend(["itunes", "deezer", "musicbrainz", "spotify"])
+
+    seen = set()
+    for source in source_order:
+        if source in seen:
+            continue
+        seen.add(source)
+        field = _SOURCE_ID_FIELDS.get(source)
+        value = refs.get(field) if field else None
+        if value is not None and str(value).strip():
+            return source, str(value).strip()
+
+    return "library", f"library:{local_id}"
+
+
+def _local_release_is_represented(
+    release: Mapping[str, Any],
+    local_bucket: str,
+    source_refs: Mapping[str, Any],
+    external_releases: Sequence[tuple[str, Mapping[str, Any]]],
+) -> bool:
+    local_title = _release_title(release)
+
+    for external_bucket, external in external_releases:
+        external_source = str(external.get("source") or "").strip().lower()
+        external_id = str(external.get("id") or "").strip()
+        source_field = _SOURCE_ID_FIELDS.get(external_source)
+        source_id = source_refs.get(source_field) if source_field else None
+        if source_id is not None and str(source_id).strip() == external_id:
+            return True
+
+        same_single_class = (local_bucket == "singles") == (external_bucket == "singles")
+        if same_single_class and titles_represent_same_release(local_title, _release_title(external)):
+            return True
+
+    return False
+
+
+def merge_owned_releases(
+    discography: Mapping[str, Any],
+    owned_releases: Optional[Mapping[str, Sequence[Mapping[str, Any]]]],
+    owned_source_refs: Optional[Mapping[str, Mapping[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Append locally owned releases missing from an external discography.
+
+    External cards always win when a provider ID or title match exists.  Only a
+    genuinely omitted local release is appended, with the best available provider
+    ID stamped on the card so track lookup and wishlist actions remain source-aware.
+    """
+    merged = {
+        **dict(discography),
+        "albums": [dict(release) for release in discography.get("albums", []) or []],
+        "eps": [dict(release) for release in discography.get("eps", []) or []],
+        "singles": [dict(release) for release in discography.get("singles", []) or []],
+    }
+    if not owned_releases:
+        return merged
+
+    source_refs = owned_source_refs or {}
+    active_source = str(merged.get("source") or "").strip().lower() or None
+    external_releases = list(_iter_release_buckets(merged))
+    seen_local_ids = set()
+
+    for bucket, album_type in (("albums", "album"), ("eps", "ep"), ("singles", "single")):
+        for release in owned_releases.get(bucket, []) or []:
+            local_id = str(release.get("local_album_id") or release.get("id") or "").strip()
+            if not local_id or local_id in seen_local_ids:
+                continue
+            seen_local_ids.add(local_id)
+
+            refs = source_refs.get(local_id, {}) or {}
+            if _local_release_is_represented(release, bucket, refs, external_releases):
+                continue
+
+            source, provider_id = _local_release_source(local_id, source_refs, active_source)
+            title = _release_title(release) or provider_id
+            card = {
+                **dict(release),
+                "id": provider_id,
+                "local_album_id": local_id,
+                "name": title,
+                "title": title,
+                "album_type": str(release.get("album_type") or album_type).lower(),
+                "source": source,
+                "owned": True,
+                "secondary_types": list(release.get("secondary_types") or []),
+                "downloadable": source != "library",
+            }
+            merged[bucket].append(card)
+            external_releases.append((bucket, card))
+
+    for bucket in ("albums", "eps", "singles"):
+        merged[bucket] = _sort_releases(merged[bucket])
+
+    merged["success"] = bool(merged["albums"] or merged["eps"] or merged["singles"])
+    if merged["success"]:
+        merged["error"] = None
+    return merged
+
+
+def get_library_artist_discography(
+    artist_id: str,
+    artist_name: str,
+    artist_source_ids: Mapping[str, Any],
+    owned_releases: Optional[Mapping[str, Sequence[Mapping[str, Any]]]] = None,
+    owned_source_refs: Optional[Mapping[str, Mapping[str, Any]]] = None,
+    *,
+    lookup: Optional[Callable[..., Dict[str, Any]]] = None,
+    limit: int = 200,
+    skip_cache: bool = False,
+    max_pages: int = 0,
+) -> Dict[str, Any]:
+    """Build the commercial discography used by library artist pages.
+
+    iTunes is attempted first and Deezer only when iTunes returns no releases.
+    The configured primary metadata source is intentionally ignored here.
+    """
+    if lookup is None:
+        from core.metadata.discography import get_artist_detail_discography
+
+        lookup = get_artist_detail_discography
+
+    attempted_sources: List[str] = []
+    selected: Optional[Dict[str, Any]] = None
+
+    for source in COMMERCIAL_DISCOGRAPHY_SOURCES:
+        source_id = artist_source_ids.get(source)
+        if source_id is None or not str(source_id).strip():
+            continue
+
+        attempted_sources.append(source)
+        try:
+            result = lookup(
+                artist_id,
+                artist_name=artist_name,
+                options=MetadataLookupOptions(
+                    source_override=source,
+                    allow_fallback=False,
+                    skip_cache=skip_cache,
+                    max_pages=max_pages,
+                    limit=limit,
+                    artist_source_ids={source: str(source_id).strip()},
+                ),
+            )
+        except Exception as exc:
+            logger.debug("Commercial discography lookup failed for %s: %s", source, exc)
+            continue
+        if result.get("success"):
+            selected = _stamp_source(result, source)
+            break
+
+    if selected is None:
+        selected = {
+            "success": False,
+            "albums": [],
+            "eps": [],
+            "singles": [],
+            "source": "library",
+            "source_priority": attempted_sources,
+            "error": f'No commercial releases found for artist "{artist_name or artist_id}"',
+        }
+    else:
+        selected["source_priority"] = attempted_sources
+
+    return merge_owned_releases(selected, owned_releases, owned_source_refs)

--- a/tests/metadata/test_library_discography.py
+++ b/tests/metadata/test_library_discography.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from core.metadata.library_discography import (
+    get_library_artist_discography,
+    merge_owned_releases,
+    titles_represent_same_release,
+)
+
+
+def _discography(source, albums=None, eps=None, singles=None, success=True):
+    return {
+        "success": success,
+        "albums": albums or [],
+        "eps": eps or [],
+        "singles": singles or [],
+        "source": source,
+        "source_priority": [source],
+        "error": None if success else "not found",
+    }
+
+
+def test_library_discography_prefers_itunes_and_does_not_call_deezer():
+    calls = []
+
+    def lookup(artist_id, artist_name="", options=None):
+        calls.append(options)
+        return _discography("itunes", albums=[{"id": "it-a1", "title": "Album"}])
+
+    result = get_library_artist_discography(
+        "local-1",
+        "Artist",
+        {"itunes": "it-artist", "deezer": "dz-artist"},
+        lookup=lookup,
+    )
+
+    assert result["source"] == "itunes"
+    assert result["source_priority"] == ["itunes"]
+    assert result["albums"][0]["source"] == "itunes"
+    assert len(calls) == 1
+    assert calls[0].source_override == "itunes"
+    assert calls[0].allow_fallback is False
+    assert calls[0].artist_source_ids == {"itunes": "it-artist"}
+
+
+def test_library_discography_falls_back_only_to_deezer():
+    calls = []
+
+    def lookup(artist_id, artist_name="", options=None):
+        calls.append(options.source_override)
+        if options.source_override == "itunes":
+            return _discography("itunes", success=False)
+        return _discography("deezer", albums=[{"id": "dz-a1", "title": "Album"}])
+
+    result = get_library_artist_discography(
+        "local-1",
+        "Artist",
+        {"itunes": "it-artist", "deezer": "dz-artist", "musicbrainz": "mb-artist"},
+        lookup=lookup,
+    )
+
+    assert calls == ["itunes", "deezer"]
+    assert result["source"] == "deezer"
+    assert result["source_priority"] == ["itunes", "deezer"]
+    assert result["albums"][0]["source"] == "deezer"
+
+
+def test_library_discography_returns_owned_only_when_commercial_sources_fail():
+    def lookup(artist_id, artist_name="", options=None):
+        return _discography(options.source_override, success=False)
+
+    result = get_library_artist_discography(
+        "local-1",
+        "Artist",
+        {"itunes": "it-artist", "deezer": "dz-artist"},
+        owned_releases={
+            "albums": [{"id": "7", "title": "Local Album", "year": 2001, "owned": True}],
+            "eps": [],
+            "singles": [],
+        },
+        owned_source_refs={"7": {"musicbrainz_release_id": "mb-release"}},
+        lookup=lookup,
+    )
+
+    assert result["success"] is True
+    assert result["source"] == "library"
+    assert result["albums"][0]["id"] == "mb-release"
+    assert result["albums"][0]["source"] == "musicbrainz"
+    assert result["albums"][0]["local_album_id"] == "7"
+
+
+def test_merge_keeps_external_card_when_local_provider_id_matches():
+    result = merge_owned_releases(
+        _discography("itunes", albums=[{"id": "it-a1", "title": "Gish (Remastered)", "source": "itunes"}]),
+        {"albums": [{"id": "7", "title": "Gish", "year": 1991}], "eps": [], "singles": []},
+        {"7": {"itunes_album_id": "it-a1"}},
+    )
+
+    assert [release["id"] for release in result["albums"]] == ["it-a1"]
+
+
+def test_merge_does_not_duplicate_common_title_variants():
+    result = merge_owned_releases(
+        _discography(
+            "itunes",
+            albums=[
+                {"id": "it-atum", "title": "ATUM", "source": "itunes"},
+                {"id": "it-rotten", "title": "Rotten Apples: Greatest Hits", "source": "itunes"},
+                {"id": "it-mcis", "title": "Mellon Collie and the Infinite Sadness (30th Anniversary Edition)", "source": "itunes"},
+            ],
+        ),
+        {
+            "albums": [
+                {"id": "1", "title": "ATUM: A Rock Opera in Three Acts"},
+                {"id": "2", "title": "(Rotten Apples) The Smashing Pumpkins Greatest Hits"},
+                {"id": "3", "title": "Mellon Collie and the Infinite Sadness"},
+            ],
+            "eps": [],
+            "singles": [],
+        },
+        {},
+    )
+
+    assert len(result["albums"]) == 3
+
+
+def test_merge_appends_omitted_owned_release_with_best_provider_reference():
+    result = merge_owned_releases(
+        _discography("itunes", albums=[{"id": "it-gish", "title": "Gish", "source": "itunes"}]),
+        {
+            "albums": [
+                {"id": "7", "title": "Gish", "year": 1991},
+                {"id": "8", "title": "Zeitgeist", "year": 2007, "track_count": 12, "owned": True},
+            ],
+            "eps": [],
+            "singles": [],
+        },
+        {
+            "7": {"itunes_album_id": "it-gish"},
+            "8": {"deezer_id": "dz-zeitgeist", "musicbrainz_release_id": "mb-zeitgeist"},
+        },
+    )
+
+    assert [release["title"] for release in result["albums"]] == ["Zeitgeist", "Gish"]
+    zeitgeist = result["albums"][0]
+    assert zeitgeist["id"] == "dz-zeitgeist"
+    assert zeitgeist["source"] == "deezer"
+    assert zeitgeist["owned"] is True
+    assert zeitgeist["downloadable"] is True
+
+
+def test_merge_uses_non_downloadable_library_reference_as_last_resort():
+    result = merge_owned_releases(
+        _discography("itunes"),
+        {"albums": [{"id": "9", "title": "Private Release"}], "eps": [], "singles": []},
+        {},
+    )
+
+    release = result["albums"][0]
+    assert release["id"] == "library:9"
+    assert release["source"] == "library"
+    assert release["downloadable"] is False
+
+
+
+def test_merge_does_not_treat_same_named_single_as_album():
+    result = merge_owned_releases(
+        _discography("itunes", singles=[{"id": "it-s1", "title": "Home", "source": "itunes"}]),
+        {"albums": [{"id": "10", "title": "Home", "year": 2001}], "eps": [], "singles": []},
+        {"10": {"deezer_id": "dz-home-album"}},
+    )
+
+    assert [release["title"] for release in result["albums"]] == ["Home"]
+    assert result["albums"][0]["id"] == "dz-home-album"
+
+def test_title_match_examples_are_conservative_but_edition_aware():
+    assert titles_represent_same_release("Gish", "Gish (Remastered)")
+    assert titles_represent_same_release("ATUM", "ATUM: A Rock Opera in Three Acts")
+    assert titles_represent_same_release(
+        "Rotten Apples: Greatest Hits",
+        "(Rotten Apples) The Smashing Pumpkins Greatest Hits",
+    )
+    assert not titles_represent_same_release("Machina", "Machina II")
+    assert not titles_represent_same_release("Greatest Hits", "Greatest Hits Vol. 2")

--- a/web_server.py
+++ b/web_server.py
@@ -9214,6 +9214,66 @@ def _build_source_only_artist_detail(artist_id, artist_name, source):
     return jsonify(payload), status
 
 
+def _load_owned_release_source_refs(database, artist_info):
+    """Return provider album IDs keyed by the grouped local album ID.
+
+    The query mirrors ``MusicDatabase.get_artist_discography`` grouping so split
+    media-server album rows resolve to the same local card ID.
+    """
+    refs = {}
+    try:
+        with database._get_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    MIN(a.id) AS local_album_id,
+                    MAX(a.itunes_album_id) AS itunes_album_id,
+                    MAX(a.deezer_id) AS deezer_id,
+                    MAX(a.musicbrainz_release_id) AS musicbrainz_release_id,
+                    MAX(a.spotify_album_id) AS spotify_album_id
+                FROM albums a
+                JOIN artists ar ON ar.id = a.artist_id
+                WHERE ar.name = ? AND ar.server_source = ?
+                GROUP BY a.artist_id, a.title, a.year
+                """,
+                (artist_info.get('name', ''), artist_info.get('server_source', '')),
+            )
+            for row in cursor.fetchall():
+                refs[str(row['local_album_id'])] = {
+                    'itunes_album_id': row['itunes_album_id'],
+                    'deezer_id': row['deezer_id'],
+                    'musicbrainz_release_id': row['musicbrainz_release_id'],
+                    'spotify_album_id': row['spotify_album_id'],
+                }
+    except Exception as exc:
+        logger.debug("Could not load owned release source IDs: %s", exc)
+    return refs
+
+
+def _build_library_commercial_discography(database, artist_info, owned_releases):
+    """Use iTunes → Deezer for a library artist and merge omitted owned albums."""
+    from core.metadata.library_discography import get_library_artist_discography
+    from core.source_ids import source_id_map
+
+    artist_source_ids = source_id_map(
+        artist_info,
+        'artist',
+        providers=('itunes', 'deezer'),
+    )
+    owned_source_refs = _load_owned_release_source_refs(database, artist_info)
+    return get_library_artist_discography(
+        str(artist_info.get('id') or ''),
+        artist_info.get('name', ''),
+        artist_source_ids,
+        owned_releases=owned_releases,
+        owned_source_refs=owned_source_refs,
+        limit=200,
+        skip_cache=False,
+        max_pages=0,
+    )
+
+
 @app.route('/api/artist-detail/<artist_id>')
 def get_artist_detail(artist_id):
     """Get artist detail data.
@@ -9322,52 +9382,31 @@ def get_artist_detail(artist_id):
             if single.get('image_url'):
                 single['image_url'] = fix_artist_image_url(single['image_url'])
 
-        # Get source-priority discography for proper categorization and missing releases
-        artist_detail_discography = None
+        # Library artist pages deliberately use a commercial catalogue rather
+        # than the configured metadata primary source. iTunes is preferred,
+        # Deezer is the only external fallback, and owned local releases omitted
+        # by both catalogues are merged back into the result.
         try:
-            from core.metadata.lookup import MetadataLookupOptions
-            from core.metadata_service import get_artist_detail_discography as _get_artist_detail_discography
-            from core.source_ids import source_id_map
-
-            # Per-source artist IDs, read via the canonical source-ID registry
-            # (same columns as before: spotify_artist_id / deezer_id /
-            # itunes_artist_id / discogs_id / soul_id / amazon_id).
-            artist_source_ids = source_id_map(
-                artist_info, 'artist',
-                providers=('spotify', 'deezer', 'itunes', 'discogs', 'hydrabase', 'amazon'),
+            artist_detail_discography = _build_library_commercial_discography(
+                database, artist_info, owned_releases
             )
-
-            artist_detail_discography = _get_artist_detail_discography(
-                artist_id,
-                artist_name=artist_info['name'],
-                options=MetadataLookupOptions(
-                    allow_fallback=True,
-                    skip_cache=False,
-                    max_pages=0,
-                    # Match the Download Discography endpoint cap (200)
-                    # so the artist detail view sees the same release
-                    # set the modal lists. Spotify already paginates
-                    # all; Deezer/iTunes/Discogs/Hydrabase respect the
-                    # outer limit. 200 matches iTunes/Discogs internal
-                    # caps and covers prolific catalogues.
-                    limit=200,
-                    artist_source_ids=artist_source_ids,
-                ),
-            )
-
             if artist_detail_discography['success']:
                 logger.debug(
-                    "Source-priority discography found - "
+                    "Commercial library discography found - "
+                    f"source={artist_detail_discography.get('source')}, "
                     f"Albums: {len(artist_detail_discography['albums'])}, "
                     f"EPs: {len(artist_detail_discography['eps'])}, "
                     f"Singles: {len(artist_detail_discography['singles'])}"
                 )
                 merged_discography = artist_detail_discography
             else:
-                logger.debug(f"Source-priority discography not found: {artist_detail_discography.get('error', 'Unknown error')}")
+                logger.debug(
+                    "Commercial library discography not found: %s",
+                    artist_detail_discography.get('error', 'Unknown error'),
+                )
                 merged_discography = owned_releases
         except Exception as detail_error:
-            logger.error(f"Error fetching source-priority discography: {detail_error}")
+            logger.error(f"Error fetching commercial library discography: {detail_error}")
             merged_discography = owned_releases
 
         spotify_artist_data = None
@@ -9861,13 +9900,15 @@ def get_artist_discography(artist_id):
         # With server-side resolution, every source gets its OWN stored
         # ID regardless of which one the URL carries.
         artist_source_ids = {}
+        library_db_result = None
+        _db = None
         try:
             _db = get_database()
             _conn = _db._get_connection()
             try:
                 _cur = _conn.cursor()
                 _cur.execute("""
-                    SELECT spotify_artist_id, itunes_artist_id,
+                    SELECT id, spotify_artist_id, itunes_artist_id,
                            deezer_id, musicbrainz_id
                     FROM artists
                     WHERE id = ?
@@ -9887,6 +9928,8 @@ def get_artist_discography(artist_id):
                         artist_source_ids['deezer'] = str(_row['deezer_id'])
                     if _row['musicbrainz_id']:
                         artist_source_ids['musicbrainz'] = str(_row['musicbrainz_id'])
+                    if not effective_override_source:
+                        library_db_result = _db.get_artist_discography(str(_row['id']))
                     logger.info(
                         f"Discography: resolved per-source IDs for artist_id={artist_id} → "
                         f"{artist_source_ids}"
@@ -9896,28 +9939,35 @@ def get_artist_discography(artist_id):
         except Exception as _id_exc:
             logger.debug(f"Could not resolve per-source artist IDs for {artist_id}: {_id_exc}")
 
-        discography = _get_artist_discography(
-            artist_id,
-            artist_name=artist_name,
-            options=MetadataLookupOptions(
-                source_override=effective_override_source,
-                allow_fallback=True,
-                skip_cache=False,
-                max_pages=0,
-                # Discord report: prolific artists (Bach, Beatles
-                # complete box, deep dance/electronic catalogues)
-                # showed only ~50 entries in the Download Discography
-                # modal. Spotify's `max_pages=0` already paginates
-                # through everything (per-page is clamped to 10
-                # internally), but Deezer / iTunes / Discogs /
-                # Hydrabase all honor the outer `limit` as a hard
-                # cap. 200 lines up with iTunes's and Discogs's own
-                # internal caps and covers near-everyone's full
-                # catalogue.
-                limit=200,
-                artist_source_ids=artist_source_ids or None,
-            ),
-        )
+        if library_db_result and library_db_result.get('success') and _db is not None:
+            discography = _build_library_commercial_discography(
+                _db,
+                library_db_result['artist'],
+                library_db_result['owned_releases'],
+            )
+        else:
+            discography = _get_artist_discography(
+                artist_id,
+                artist_name=artist_name,
+                options=MetadataLookupOptions(
+                    source_override=effective_override_source,
+                    allow_fallback=True,
+                    skip_cache=False,
+                    max_pages=0,
+                    # Discord report: prolific artists (Bach, Beatles
+                    # complete box, deep dance/electronic catalogues)
+                    # showed only ~50 entries in the Download Discography
+                    # modal. Spotify's `max_pages=0` already paginates
+                    # through everything (per-page is clamped to 10
+                    # internally), but Deezer / iTunes / Discogs /
+                    # Hydrabase all honor the outer `limit` as a hard
+                    # cap. 200 lines up with iTunes's and Discogs's own
+                    # internal caps and covers near-everyone's full
+                    # catalogue.
+                    limit=200,
+                    artist_source_ids=artist_source_ids or None,
+                ),
+            )
 
         album_list = discography['albums']
         eps_list = discography.get('eps', [])
@@ -10898,10 +10948,11 @@ def library_completion_stream():
                         'album_type': item.get('album_type', 'album')
                     }
 
+                    item_source_override = (item.get('source') or source_override or '').strip().lower() or None
                     if category == 'singles':
-                        result = check_single_completion(db, mapped, artist_name, source_override=source_override, candidate_albums=candidate_albums, candidate_tracks=candidate_tracks)
+                        result = check_single_completion(db, mapped, artist_name, source_override=item_source_override, candidate_albums=candidate_albums, candidate_tracks=candidate_tracks)
                     else:
-                        result = check_album_completion(db, mapped, artist_name, source_override=source_override, candidate_albums=candidate_albums)
+                        result = check_album_completion(db, mapped, artist_name, source_override=item_source_override, candidate_albums=candidate_albums)
 
                     result['id'] = item['id']
                     result['category'] = category

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -2081,10 +2081,17 @@ function createReleaseCard(release) {
                 return;
             }
 
-            // Load tracks for the album (pass name/artist for Hydrabase support)
+            // Load tracks through the release's own provider. Locally merged
+            // cards may use Deezer/MusicBrainz even when the main catalogue is iTunes.
+            const releaseSource = (rel.source || currentArtist.source || '').toString().toLowerCase();
+            if (releaseSource === 'library' || rel.downloadable === false) {
+                hideLoadingOverlay();
+                showToast(`${rel.title} is already in the library and has no external track source.`, 'info');
+                return;
+            }
             const _aat2 = new URLSearchParams({ name: albumData.name || '', artist: currentArtist.name || '' });
-            if (currentArtist.source) {
-                _aat2.set('source', currentArtist.source);
+            if (releaseSource) {
+                _aat2.set('source', releaseSource);
             }
             const response = await fetch(`/api/album/${albumData.id}/tracks?${_aat2}`);
             if (!response.ok) {
@@ -2672,16 +2679,23 @@ function _esc(s) { const d = document.createElement('div'); d.textContent = s; r
 // Artist Detail cards and the Download Discography modal so they can't drift.
 function _classifyReleaseContent(release) {
     const t = (release && (release.title || release.name)) || '';
-    // Title-based classification, shared by all sources and the download modal.
-    // On MusicBrainz artist pages the data-is-live attribute is recomputed
-    // authoritatively from secondary_types in populateDiscographySections (MB tags
-    // live/non-studio reliably), so this title heuristic only governs non-MB here.
+    // Prefer provider classifications when available. Title patterns remain
+    // as a fallback for commercial sources and the Download Discography modal.
+    // MusicBrainz artist cards are subsequently recomputed by
+    // populateDiscographySections using its broader non-studio classification.
+    const secondaryTypes = new Set(
+        (Array.isArray(release?.secondary_types) ? release.secondary_types : [])
+            .map(value => String(value).trim().toLowerCase())
+            .filter(Boolean)
+    );
     const livePattern = /\b(live)\b|\(live[^)]*\)|\[live[^\]]*\]/i;
     const compilationPattern = /\b(greatest hits|best of|collection|anthology|essential)\b/i;
     const featuredPattern = /\(?\bfeat\.?\s|\bft\.?\s|\bfeaturing\b/i;
     return {
-        isLive: livePattern.test(t),
-        isCompilation: (release && release.album_type === 'compilation') || compilationPattern.test(t),
+        isLive: secondaryTypes.has('live') || livePattern.test(t),
+        isCompilation: secondaryTypes.has('compilation')
+            || (release && release.album_type === 'compilation')
+            || compilationPattern.test(t),
         isFeatured: featuredPattern.test(t),
     };
 }
@@ -2689,20 +2703,22 @@ function _classifyReleaseContent(release) {
 function _renderDiscogCard(release, index, completionData) {
     const comp = completionData?.albums?.find(c => c.id === release.id) || completionData?.singles?.find(c => c.id === release.id);
     const status = comp?.status || 'unknown';
-    const isOwned = status === 'completed';
-    const isPartial = status === 'partial' || status === 'nearly_complete';
+    const isOwned = release.owned === true || status === 'completed';
+    const isPartial = !isOwned && (status === 'partial' || status === 'nearly_complete');
     const year = release.release_date ? release.release_date.substring(0, 4) : '';
     const tracks = release.total_tracks || release.track_count || 0;
     const img = release.image_url || '';
     const cc = _classifyReleaseContent(release);
-    const checked = !isOwned;
+    const releaseSource = (release.source || '').toString().toLowerCase();
+    const downloadable = release.downloadable !== false && releaseSource !== 'library';
+    const checked = !isOwned && downloadable;
     const statusClass = isOwned ? 'owned' : isPartial ? 'partial' : '';
     const statusIcon = isOwned ? '✓' : isPartial ? '◐' : '';
 
     const albumName = release.name || release.title || '';
     return `
-        <label class="discog-card ${statusClass}" data-type="${release._type}" data-is-live="${cc.isLive}" data-is-compilation="${cc.isCompilation}" data-is-featured="${cc.isFeatured}" style="animation-delay:${index * 0.03}s">
-            <input type="checkbox" class="discog-card-cb" data-album-id="${release.id}" data-album-name="${_esc(albumName)}" data-tracks="${tracks}" ${checked ? 'checked' : ''} onchange="_updateDiscogFooterCount()">
+        <label class="discog-card ${statusClass}" data-type="${release._type}" data-source="${releaseSource}" data-is-live="${cc.isLive}" data-is-compilation="${cc.isCompilation}" data-is-featured="${cc.isFeatured}" style="animation-delay:${index * 0.03}s">
+            <input type="checkbox" class="discog-card-cb" data-album-id="${release.id}" data-album-name="${_esc(albumName)}" data-source="${releaseSource}" data-tracks="${tracks}" ${checked ? 'checked' : ''} ${downloadable ? '' : 'disabled'} onchange="_updateDiscogFooterCount()">
             <div class="discog-card-art">
                 ${img ? `<img src="${img}" alt="" loading="lazy">` : '<div class="discog-card-art-placeholder">🎵</div>'}
                 ${statusIcon ? `<span class="discog-card-status">${statusIcon}</span>` : ''}
@@ -2789,6 +2805,7 @@ async function startDiscographyDownload() {
             albumEntries.push({
                 id: cb.dataset.albumId,
                 name: cb.dataset.albumName || '',
+                source: (cb.dataset.source || '').toLowerCase() || null,
                 tracks: parseInt(cb.dataset.tracks) || 0
             });
         }
@@ -2856,7 +2873,7 @@ async function startDiscographyDownload() {
         id: e.id,
         name: e.name,
         artist_name: artist.name,
-        source: sourceForBatch,
+        source: e.source || sourceForBatch,
     }));
 
     try {


### PR DESCRIPTION
## Summary

- use iTunes as the primary source for library artist discographies
- fall back to Deezer only when iTunes is unavailable
- keep locally owned releases that are missing from the commercial catalogue
- preserve each release's provider source for completion checks, track lookup, and batch wishlist actions
- integrate with the existing `secondary_types` filtering already present in current `dev`

## Problem

Library artist pages currently depend on the globally configured metadata source. With MusicBrainz selected, the discography can become cluttered with bootlegs, broadcasts, live recordings, deluxe editions, and other release groups that are not useful as a commercial catalogue.

Switching the global metadata source is not desirable because MusicBrainz remains useful for matching and enrichment. Library discographies therefore need their own source policy.

## Implementation

- add a dedicated library-discography service
- query iTunes first and Deezer second, without falling back to MusicBrainz for the commercial catalogue
- merge omitted owned releases conservatively, avoiding duplicate editions and same-named singles
- retain the provider source on every release card
- keep explicit source overrides unchanged
- use per-release sources for completion checks, track lookup, and batch wishlist actions
- preserve compatibility with the current MusicBrainz `secondary_types` filtering and canonical-completion logic in `dev`

## Validation

Validated against current `dev` at `9040201fa4f158d23664fc9c5a0de6479664d630` (SoulSync 2.8.9):

- Ruff passed for the modified Python files and for the full repository
- Python compilation passed
- JavaScript syntax validation passed
- focused regression suite: 146 passed
- full Python suite: 7,646 passed, 2 deselected
- WebUI checks passed with 0 errors and 0 warnings
- WebUI build passed
- WebUI test suite: 96 passed
- canonical-completion regression tests: 3 passed
- deployed the candidate files to a SoulSync 2.8.9 instance and verified the service remained healthy
- live API check for The Smashing Pumpkins returned an iTunes-led catalogue with owned MusicBrainz releases merged back in
- manual UI verification confirmed the commercial discography is shown correctly
- after rerunning canonical resolution following a full import, owned/completion states were restored correctly

## Scope

The pull request changes 4 files and is based directly on current `dev`. Existing canonical completion fixes and current release-type filtering remain intact.