### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.8.51)'
+        description: 'Version tag (e.g. 2.8.6)'
         required: true
-        default: '2.8.51'
+        default: '2.8.6'
 
 jobs:
   build-and-push:

--- a/core/deezer_worker.py
+++ b/core/deezer_worker.py
@@ -9,6 +9,7 @@ from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.deezer_client import DeezerClient
 from core.worker_utils import (
+    _names_equivalent,
     accept_artist_match,
     artist_name_matches,
     interruptible_sleep,
@@ -308,16 +309,19 @@ class DeezerWorker:
 
         if str(result_artist_id) != str(parent_deezer_id):
             # Guard: only correct when the album/track's primary artist is the
-            # SAME artist by name. A mismatch means it's a collab/compilation,
-            # not a stale-id correction.
+            # SAME artist by name — a POSITIVE match. A missing result name
+            # (#988: compilation/collab Deezer payloads often omit it) or a
+            # mismatch means we can't confirm it's the same artist, so we must
+            # NOT rewrite the parent's id — that's how a wrong Deezer id
+            # (The Beatles' id 1) got smeared onto The Outfield.
             parent_name = item.get('artist') or ''
-            if (result_artist_name and parent_name
-                    and not self._name_matches(parent_name, result_artist_name)):
+            if not (result_artist_name and parent_name
+                    and self._name_matches(parent_name, result_artist_name)):
                 logger.info(
                     f"Skipping artist-ID correction from {item['type']} "
-                    f"'{item['name']}': result artist '{result_artist_name}' "
-                    f"≠ parent '{parent_name}' (collab/compilation, not a "
-                    f"correction)"
+                    f"'{item['name']}': cannot verify result artist "
+                    f"'{result_artist_name}' == parent '{parent_name}' "
+                    f"(collab/compilation or missing name, not a correction)"
                 )
                 return True
 
@@ -343,6 +347,23 @@ class DeezerWorker:
                 return
 
             artist_id = row[0]
+            # #988: never overwrite with a Deezer id already owned by a
+            # DIFFERENTLY-named artist — that's the exact smear (Beatles' id 1
+            # onto The Outfield). Same-named holders legitimately share an id.
+            cursor.execute("SELECT name FROM artists WHERE id = ?", (artist_id,))
+            _self_row = cursor.fetchone()
+            this_name = (_self_row[0] if _self_row else '') or (item.get('artist') or '')
+            cursor.execute(
+                "SELECT name FROM artists WHERE deezer_id = ? AND id != ?",
+                (str(correct_deezer_id), artist_id))
+            for (other_name,) in cursor.fetchall():
+                if not _names_equivalent(this_name, other_name):
+                    logger.warning(
+                        f"Refusing Deezer-ID correction: id {correct_deezer_id} is "
+                        f"already held by '{other_name}' (≠ '{this_name}') — avoiding a "
+                        f"shared/duplicate id (artist #{artist_id})")
+                    return
+
             cursor.execute("""
                 UPDATE artists SET
                     deezer_id = ?,

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -539,6 +539,14 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
                     _album_artist_name = _first_sa
                 _album_artists_for_collab = _sa_artists
 
+        # #989: an iTunes single's collection carries a placeholder album artist
+        # ("Unknown Artist") — or none — while the track artist ($artist) is real.
+        # Don't let that bury the file under "Unknown Artist"; fall back to the real
+        # track artist so $albumartist matches $artist.
+        if (not _album_artist_name or _album_artist_name == "Unknown Artist") and \
+                _artist_name and _artist_name != "Unknown Artist":
+            _album_artist_name = _artist_name
+
         template_context = {
             "artist": _artist_name,
             "albumartist": _album_artist_name,

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -1789,12 +1789,19 @@ def reorganize_album(
             except Exception:  # noqa: S110 — finally-block cleanup, logger may be torn down
                 pass
 
-        if cleanup_empty_dir_fn:
-            for src_dir in src_dirs_touched:
+        for src_dir in src_dirs_touched:
+            # Injected pruner (transfer-dir-bounded — works when the library lives
+            # under the transfer folder) PLUS the library-safe upward prune (#985)
+            # for libraries that don't.
+            if cleanup_empty_dir_fn:
                 try:
                     cleanup_empty_dir_fn(src_dir)
                 except Exception:  # noqa: S110 — finally-block cleanup, logger may be torn down
                     pass
+            try:
+                _prune_empty_source_dirs(src_dir)
+            except Exception:  # noqa: S110 — finally-block cleanup, logger may be torn down
+                pass
 
         # Prune empty *destination* siblings — e.g. when a previous
         # failed reorganize attempt left ``Artist/Album-Sibling/`` dirs
@@ -1949,12 +1956,16 @@ def reorganize_album_rename_only(
         _emit(moved=summary['moved'],
               processed=summary['moved'] + summary['skipped'] + summary['failed'])
 
-    if cleanup_empty_dir_fn:
-        for src_dir in src_dirs_touched:
+    for src_dir in src_dirs_touched:
+        if cleanup_empty_dir_fn:
             try:
                 cleanup_empty_dir_fn(src_dir)
             except Exception as e:
                 logger.debug("[Reorganize/rename] cleanup of %s failed: %s", src_dir, e)
+        try:
+            _prune_empty_source_dirs(src_dir)   # #985: library-safe prune (transfer-dir-independent)
+        except Exception as e:
+            logger.debug("[Reorganize/rename] source prune of %s failed: %s", src_dir, e)
 
     return summary
 
@@ -2013,6 +2024,62 @@ def _prune_empty_album_dirs(artist_dir: str) -> None:
                 logger.info(f"[Reorganize] Pruned empty album dir: {album_path}")
         except OSError:
             pass
+
+
+# A disc subfolder inside an album: "Disc 1", "CD 2", "Disk 01", "Vol. 3", etc.
+_DISC_DIR_RE = re.compile(r'^(disc|disk|cd|vol|volume)\s*\.?\s*\d+$', re.IGNORECASE)
+
+
+def _rmdir_if_empty(dir_path: str) -> bool:
+    """rmdir ``dir_path`` if it holds no non-hidden entries (clearing hidden junk like
+    .DS_Store first) and isn't a protected/configured root. Returns True if removed."""
+    try:
+        from core.imports.file_ops import protected_root_dirs
+        if os.path.normpath(dir_path) in protected_root_dirs():
+            return False
+    except Exception as e:
+        logger.debug("[Reorganize] protected-root check failed for %s: %s", dir_path, e)
+    try:
+        entries = os.listdir(dir_path)
+    except OSError:
+        return False
+    if any(not e.startswith('.') for e in entries):
+        return False  # real content remains
+    try:
+        for hidden in entries:
+            try:
+                os.remove(os.path.join(dir_path, hidden))
+            except OSError:
+                pass
+        os.rmdir(dir_path)
+        logger.info(f"[Reorganize] Pruned empty source dir: {dir_path}")
+        return True
+    except OSError:
+        return False
+
+
+def _prune_empty_source_dirs(start_dir: str) -> None:
+    """Prune the emptied SOURCE folders after a reorganize move.
+
+    #985: the injected empty-dir cleanup is bounded by the transfer/download folder,
+    but a Library Reorganize moves files that live in the MEDIA library — usually a
+    different path — so that pruner's ``startswith(transfer_dir)`` guard never matches
+    and the emptied source folders (``Album/Disc 1`` and the old ``Album`` dir) are
+    left behind.
+
+    Removes the moved file's own dir, AND the album dir directly above it IF that dir
+    was a disc subfolder (``Disc N``/``CD N``). It deliberately NEVER climbs to the
+    artist dir or the library root — bounded to the album level — so it can only ever
+    delete the album/disc folders the reorganize actually emptied, never a root
+    (which isn't in the protected set when the library lives outside the transfer
+    folder — exactly this bug's setup).
+    """
+    d = os.path.normpath(start_dir)
+    was_disc = bool(_DISC_DIR_RE.match(os.path.basename(d)))
+    if not _rmdir_if_empty(d):
+        return
+    if was_disc:                          # the parent is the album dir — prune if now empty
+        _rmdir_if_empty(os.path.dirname(d))
 
 
 # Sidecar / cleanup helpers --------------------------------------------------

--- a/core/metadata/album_tracks.py
+++ b/core/metadata/album_tracks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from difflib import SequenceMatcher
 from typing import Any, Callable, Dict, List, Optional
 
 from core.metadata import registry as metadata_registry
@@ -100,18 +101,33 @@ def _search_albums_for_source(source: str, client: Any, query: str, limit: int =
 
 
 def _pick_best_artist_match(search_results: List[Any], artist_name: str) -> Optional[Any]:
+    """Pick the search result whose artist NAME matches, or None.
+
+    Exact (normalized) name wins; otherwise the closest fuzzy match, but only if
+    it's similar enough. Never a blind first result — that handed back an
+    unrelated popular artist (#988: a Deezer name-search for "The Outfield"
+    returning The Beatles) when the source's search doesn't actually contain the
+    artist we asked for. Returning None lets the caller fall back / show nothing
+    instead of the wrong artist's catalogue.
+    """
     if not search_results:
         return None
-
     target_name = _normalize_artist_name(artist_name)
+    if not target_name:
+        return None
+    best, best_ratio = None, 0.0
     for artist in search_results:
         candidate_name = _normalize_artist_name(
             _extract_lookup_value(artist, 'name', 'artist_name', 'title')
         )
+        if not candidate_name:
+            continue
         if candidate_name == target_name:
             return artist
-
-    return search_results[0]
+        ratio = SequenceMatcher(None, target_name, candidate_name).ratio()
+        if ratio > best_ratio:
+            best, best_ratio = artist, ratio
+    return best if best_ratio >= 0.85 else None
 
 
 def _extract_track_items(api_tracks: Any) -> List[Dict[str, Any]]:

--- a/core/metadata/discography.py
+++ b/core/metadata/discography.py
@@ -111,7 +111,14 @@ def _search_albums_for_source(source: str, client: Any, query: str, limit: int =
 
 
 def _pick_best_artist_match(search_results: List[Any], artist_name: str) -> Optional[Any]:
-    """Prefer an exact artist-name match, otherwise use the first result."""
+    """Prefer an exact artist-name match, otherwise use the first result.
+
+    NOTE: intentionally loose — the only caller is the similar-artists / musicmap
+    enrichment, which resolves a suggestion name to a source's *canonical* entry
+    whose name legitimately differs (e.g. a Last.fm map name vs the source's
+    canonical spelling). The strict, name-gated matcher for looking up a KNOWN
+    artist's own discography/top-tracks lives in ``album_tracks`` (#988).
+    """
     if not search_results:
         return None
 

--- a/core/playlists/source_refs.py
+++ b/core/playlists/source_refs.py
@@ -48,6 +48,41 @@ def stable_source_track_id(track: Mapping, existing: Optional[str] = None) -> st
     digest = hashlib.md5(f"{artist}|{title}|{album}".encode("utf-8")).hexdigest()[:16]
     return f"file:{digest}"
 
+
+def coalesce_mirror_track(track: Mapping) -> dict:
+    """Normalize a track dict to the mirror shape, accepting the Spotify shape too.
+
+    The mirror stores ``track_name`` / ``artist_name`` / ``album_name`` /
+    ``source_track_id``. The GET playlist endpoints return Spotify-shaped tracks
+    (``name`` / ``artists[].name`` / ``album.name`` / ``id``) — and feeding those
+    straight back into the mirror wrote all-empty rows (#990), because the mapper
+    used ``t.get('track_name', '')`` with silent defaults. The two shapes are
+    unambiguous, so map the Spotify fields ONLY when the mirror key is absent;
+    everything else (duration_ms, image_url, extra_data, …) is preserved.
+    """
+    if not isinstance(track, Mapping):
+        return {}
+    out = dict(track)
+    if not out.get("track_name"):
+        out["track_name"] = track.get("name") or ""
+    if not out.get("artist_name"):
+        artists = track.get("artists")
+        if isinstance(artists, list) and artists:
+            first = artists[0]
+            out["artist_name"] = (first.get("name") if isinstance(first, Mapping) else str(first)) or ""
+        elif isinstance(track.get("artist"), str):
+            out["artist_name"] = track["artist"]
+    if not out.get("album_name"):
+        album = track.get("album")
+        if isinstance(album, Mapping):
+            out["album_name"] = album.get("name") or ""
+        elif isinstance(album, str):
+            out["album_name"] = album
+    if not out.get("source_track_id") and track.get("id"):
+        out["source_track_id"] = str(track["id"])
+    return out
+
+
 # Synthetic batch playlist_id prefixes that wrap a mirrored_playlists PK.
 # Download/discovery flows build a batch playlist_id as f"{prefix}{pk}" — e.g.
 # auto_mirror_<pk> (core/automation/handlers/sync_playlist.py), youtube_mirrored_<pk>

--- a/core/search/orchestrator.py
+++ b/core/search/orchestrator.py
@@ -150,6 +150,21 @@ def _single_source_response(
 ) -> dict:
     """Run a single-source search — bypasses the fan-out."""
     client, available = resolve_client(requested_source, deps)
+
+    # Explicit Spotify pick that the normal gate rejected (no auth, and 'Spotify
+    # Free' isn't the chosen metadata source). If the no-creds SpotipyFree package
+    # is installed, honor the deliberate selection via the free source instead of
+    # returning nothing — the explicit per-search pick is the user's consent, and
+    # this stays out of every background/fan-out path (which never reaches here).
+    prefer_free = False
+    if not client and requested_source == 'spotify' and deps.spotify_client:
+        try:
+            if deps.spotify_client._free_installed():
+                client = deps.spotify_client
+                prefer_free = True
+        except Exception as e:
+            logger.debug(f"Spotify free-fallback availability check failed: {e}")
+
     if not client:
         return {
             'db_artists': db_artists,
@@ -163,7 +178,7 @@ def _single_source_response(
         }
 
     try:
-        source_results = sources.search_source(query, client, requested_source)
+        source_results = sources.search_source(query, client, requested_source, prefer_free=prefer_free)
     except Exception as e:
         logger.warning(f"Single-source search ({requested_source}) failed: {e}")
         source_results = {'artists': [], 'albums': [], 'tracks': [], 'available': False}

--- a/core/search/sources.py
+++ b/core/search/sources.py
@@ -23,14 +23,21 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 
-def search_kind(client, query: str, kind: str, source_name: Optional[str] = None) -> list:
+def search_kind(client, query: str, kind: str, source_name: Optional[str] = None,
+                prefer_free: bool = False) -> list:
     """Search one result type from a metadata source and normalize it."""
     source_label = source_name or type(client).__name__
+
+    # prefer_free is only ever set for an explicit Spotify pick (see the
+    # orchestrator), so only the SpotifyClient — which accepts the kwarg — ever
+    # receives it. Passing it only when True keeps every other client's signature
+    # untouched.
+    extra = {"prefer_free": True} if prefer_free else {}
 
     if kind == "artists":
         artists = []
         try:
-            artist_objs = client.search_artists(query, limit=10)
+            artist_objs = client.search_artists(query, limit=10, **extra)
             for artist in artist_objs:
                 artists.append({
                     "id": artist.id,
@@ -46,7 +53,7 @@ def search_kind(client, query: str, kind: str, source_name: Optional[str] = None
     if kind == "albums":
         albums = []
         try:
-            album_objs = client.search_albums(query, limit=10)
+            album_objs = client.search_albums(query, limit=10, **extra)
             for album in album_objs:
                 artist_name = ', '.join(album.artists) if album.artists else 'Unknown Artist'
                 albums.append({
@@ -73,7 +80,7 @@ def search_kind(client, query: str, kind: str, source_name: Optional[str] = None
     if kind == "tracks":
         tracks = []
         try:
-            track_objs = client.search_tracks(query, limit=10)
+            track_objs = client.search_tracks(query, limit=10, **extra)
             for track in track_objs:
                 artist_name = ', '.join(track.artists) if track.artists else 'Unknown Artist'
                 tracks.append({
@@ -108,14 +115,15 @@ def search_kind(client, query: str, kind: str, source_name: Optional[str] = None
     raise ValueError(f"Unknown metadata search kind: {kind}")
 
 
-def search_source(query: str, client, source_name: Optional[str] = None) -> dict:
+def search_source(query: str, client, source_name: Optional[str] = None,
+                  prefer_free: bool = False) -> dict:
     """Run all three search-kinds against a single client in parallel."""
     results: dict[str, Any] = {"artists": [], "albums": [], "tracks": []}
     with ThreadPoolExecutor(max_workers=3) as executor:
         futures = {
-            executor.submit(search_kind, client, query, "artists", source_name): "artists",
-            executor.submit(search_kind, client, query, "albums", source_name): "albums",
-            executor.submit(search_kind, client, query, "tracks", source_name): "tracks",
+            executor.submit(search_kind, client, query, "artists", source_name, prefer_free): "artists",
+            executor.submit(search_kind, client, query, "albums", source_name, prefer_free): "albums",
+            executor.submit(search_kind, client, query, "tracks", source_name, prefer_free): "tracks",
         }
         for future in as_completed(futures):
             kind = futures[future]

--- a/core/spotify_client.py
+++ b/core/spotify_client.py
@@ -1569,11 +1569,17 @@ class SpotifyClient:
             return []
 
     @rate_limited
-    def search_tracks(self, query: str, limit: int = 10, allow_fallback: bool = True) -> List[Track]:
+    def search_tracks(self, query: str, limit: int = 10, allow_fallback: bool = True,
+                      prefer_free: bool = False) -> List[Track]:
         """Search for tracks.
 
         When allow_fallback is True, falls back to the configured metadata source
         if Spotify is unavailable or returns an error.
+
+        ``prefer_free`` forces the no-creds SpotipyFree path when the package is
+        installed, even without auth or the 'Spotify Free' source opt-in. The
+        orchestrator sets it only for an EXPLICIT per-search Spotify pick (a
+        deliberate user action = consent), so background flows are unaffected.
         """
         cache = get_metadata_cache()
         effective_limit = min(limit, 50)  # Spotify API max is 50
@@ -1595,7 +1601,7 @@ class SpotifyClient:
         # (no-auth / rate-limited — where auth is already False — plus the
         # budget-bridge and the worker's prefer-free opt-in, where auth is True
         # but we deliberately defer to free). The free branch below then runs.
-        use_spotify = self.is_spotify_authenticated() and not self._free_active()
+        use_spotify = self.is_spotify_authenticated() and not self._free_active() and not prefer_free
 
         if use_spotify:
             try:
@@ -1629,7 +1635,8 @@ class SpotifyClient:
         # Free should serve (no-auth / rate-limited / budget / worker prefer-free) OR
         # when it's simply available (opted-in) and official above returned nothing —
         # so an authed-but-broken official Spotify falls back to Free instead of empty.
-        if allow_fallback and (self._free_active() or self._free_available()):
+        if allow_fallback and (self._free_active() or self._free_available()
+                               or (prefer_free and self._free_installed())):
             try:
                 objs = [Track.from_spotify_track(t)
                         for t in self._free_meta.search_tracks(query, effective_limit)]
@@ -1645,11 +1652,14 @@ class SpotifyClient:
         return []
 
     @rate_limited
-    def search_artists(self, query: str, limit: int = 10, allow_fallback: bool = True) -> List[Artist]:
+    def search_artists(self, query: str, limit: int = 10, allow_fallback: bool = True,
+                       prefer_free: bool = False) -> List[Artist]:
         """Search for artists.
 
         When allow_fallback is True, falls back to the configured metadata source
         if Spotify is unavailable or returns an error.
+
+        ``prefer_free`` forces the no-creds SpotipyFree path (see search_tracks).
         """
         cache = get_metadata_cache()
         # Check Spotify cache first so cached data remains usable even when
@@ -1671,7 +1681,7 @@ class SpotifyClient:
         # (no-auth / rate-limited — where auth is already False — plus the
         # budget-bridge and the worker's prefer-free opt-in, where auth is True
         # but we deliberately defer to free). The free branch below then runs.
-        use_spotify = self.is_spotify_authenticated() and not self._free_active()
+        use_spotify = self.is_spotify_authenticated() and not self._free_active() and not prefer_free
 
         if use_spotify:
             try:
@@ -1708,7 +1718,8 @@ class SpotifyClient:
         # No-creds Spotify (SpotipyFree): keep Spotify catalog/matching when official
         # can't serve (no auth / rate-limited / worker prefer-free) OR when it's opted-in
         # and official above returned nothing — before the iTunes/Deezer fallback.
-        if allow_fallback and (self._free_active() or self._free_available()):
+        if allow_fallback and (self._free_active() or self._free_available()
+                               or (prefer_free and self._free_installed())):
             try:
                 objs = [Artist.from_spotify_artist(a)
                         for a in self._free_meta.search_artists(query, limit)]
@@ -1730,7 +1741,8 @@ class SpotifyClient:
 
     @rate_limited
     def search_albums(self, query: str, limit: int = 10, allow_fallback: bool = True,
-                      artist: str = None, album: str = None) -> List[Album]:
+                      artist: str = None, album: str = None,
+                      prefer_free: bool = False) -> List[Album]:
         """Search for albums.
 
         When allow_fallback is True, falls back to the configured metadata source
@@ -1759,7 +1771,7 @@ class SpotifyClient:
         # (no-auth / rate-limited — where auth is already False — plus the
         # budget-bridge and the worker's prefer-free opt-in, where auth is True
         # but we deliberately defer to free). The free branch below then runs.
-        use_spotify = self.is_spotify_authenticated() and not self._free_active()
+        use_spotify = self.is_spotify_authenticated() and not self._free_active() and not prefer_free
 
         if use_spotify:
             try:
@@ -1792,7 +1804,8 @@ class SpotifyClient:
         # opted-in and official above returned nothing — before the iTunes/Deezer fallback.
         # Albums have no name-search upstream, so resolve via the artist's discography —
         # needs artist + album names.
-        if allow_fallback and (self._free_active() or self._free_available()) and artist and album:
+        if allow_fallback and (self._free_active() or self._free_available()
+                               or (prefer_free and self._free_installed())) and artist and album:
             try:
                 objs = [Album.from_spotify_album(a)
                         for a in self._free_meta.search_albums_via_artist(artist, album, min(limit, 10))]

--- a/core/spotify_client.py
+++ b/core/spotify_client.py
@@ -1614,16 +1614,22 @@ class SpotifyClient:
                     cache.store_search_results('spotify', 'track', query, effective_limit,
                                                [td.get('id') for td in raw_items if td.get('id')])
 
-                return tracks
+                if tracks:
+                    return tracks
+                # Official returned NOTHING (empty, not an error) — fall through to
+                # Free/fallback. #(spotify-free) an authed user whose official API is
+                # dead but who opted into Free would otherwise get a blank page.
 
             except Exception as e:
                 _detect_and_set_rate_limit(e, 'search_tracks')
                 logger.error(f"Error searching tracks via Spotify: {e}")
                 # Fall through to fallback
 
-        # No-creds Spotify (SpotipyFree) before the iTunes/Deezer fallback —
-        # only when official Spotify is unavailable (no auth / rate-limited).
-        if allow_fallback and self._free_active():
+        # No-creds Spotify (SpotipyFree) before the iTunes/Deezer fallback. Runs when
+        # Free should serve (no-auth / rate-limited / budget / worker prefer-free) OR
+        # when it's simply available (opted-in) and official above returned nothing —
+        # so an authed-but-broken official Spotify falls back to Free instead of empty.
+        if allow_fallback and (self._free_active() or self._free_available()):
             try:
                 objs = [Track.from_spotify_track(t)
                         for t in self._free_meta.search_tracks(query, effective_limit)]
@@ -1689,18 +1695,20 @@ class SpotifyClient:
                 query_lower = query.lower().strip()
                 artists.sort(key=lambda a: (0 if a.name.lower().strip() == query_lower else 1))
 
-                return artists
+                if artists:
+                    return artists
+                # Empty official result → fall through to Free/fallback (an authed-but-
+                # broken official Spotify with the Free opt-in shouldn't get a blank page).
 
             except Exception as e:
                 _detect_and_set_rate_limit(e, 'search_artists')
                 logger.error(f"Error searching artists via Spotify: {e}")
                 # Fall through to iTunes fallback
 
-        # No-creds Spotify (SpotipyFree): keep Spotify catalog/matching when
-        # official Spotify can't serve us (no auth / rate-limited), before the
-        # iTunes/Deezer fallback. Gated by _free_active() so it never runs while
-        # auth is healthy.
-        if allow_fallback and self._free_active():
+        # No-creds Spotify (SpotipyFree): keep Spotify catalog/matching when official
+        # can't serve (no auth / rate-limited / worker prefer-free) OR when it's opted-in
+        # and official above returned nothing — before the iTunes/Deezer fallback.
+        if allow_fallback and (self._free_active() or self._free_available()):
             try:
                 objs = [Artist.from_spotify_artist(a)
                         for a in self._free_meta.search_artists(query, limit)]
@@ -1770,19 +1778,21 @@ class SpotifyClient:
                     cache.store_search_results('spotify', 'album', query, min(limit, 10),
                                                [ad.get('id') for ad in raw_items if ad.get('id')])
 
-                return albums
+                if albums:
+                    return albums
+                # Empty official result → fall through to Free/fallback.
 
             except Exception as e:
                 _detect_and_set_rate_limit(e, 'search_albums')
                 logger.error(f"Error searching albums via Spotify: {e}")
                 # Fall through to free / iTunes fallback
 
-        # No-creds Spotify (SpotipyFree): keep Spotify catalog/matching when
-        # official Spotify can't serve us (no auth / rate-limited / budget spent),
-        # before the iTunes/Deezer fallback. Albums have no name-search upstream,
-        # so resolve via the artist's discography — needs artist + album names.
-        # Gated by _free_active() so it never runs while auth is healthy.
-        if allow_fallback and self._free_active() and artist and album:
+        # No-creds Spotify (SpotipyFree): keep Spotify catalog/matching when official
+        # can't serve (no auth / rate-limited / budget / worker prefer-free) OR when it's
+        # opted-in and official above returned nothing — before the iTunes/Deezer fallback.
+        # Albums have no name-search upstream, so resolve via the artist's discography —
+        # needs artist + album names.
+        if allow_fallback and (self._free_active() or self._free_available()) and artist and album:
             try:
                 objs = [Album.from_spotify_album(a)
                         for a in self._free_meta.search_albums_via_artist(artist, album, min(limit, 10))]

--- a/core/webui/mimetypes_fix.py
+++ b/core/webui/mimetypes_fix.py
@@ -31,3 +31,33 @@ def ensure_web_mimetypes() -> None:
     once at startup and idempotent."""
     for ext, ctype in _WEB_TYPES.items():
         mimetypes.add_type(ctype, ext)
+
+
+# MIME types a browser accepts for a <script type="module"> (per the HTML spec's
+# module-script MIME check). Anything else → the module is refused → black screen.
+_JS_MIME_TYPES = frozenset({
+    "text/javascript", "application/javascript",
+    "application/ecmascript", "text/ecmascript",
+})
+
+
+def corrected_script_content_type(path: str, current: str | None) -> str | None:
+    """For a ``.js``/``.mjs`` response, return the Content-Type to serve — forcing a
+    valid JavaScript type when the current one isn't one — else ``None`` to leave it
+    unchanged.
+
+    The registry approach above (``ensure_web_mimetypes``) is fragile across hosts:
+    a Docker base image with a minimal ``/etc/mime.types`` (or an older Python) can
+    still resolve ``.js`` to ``application/octet-stream``/``text/plain``, and the
+    browser then REFUSES the ``type="module"`` React bundle → the Import/Stats pages
+    render as a black screen (#979/#986). Enforcing the header at the HTTP layer is
+    OS/registry-independent and bulletproof. Classic ``<script>`` shells are exempt
+    from this MIME check, which is why only the module-loaded pages went black.
+    """
+    p = (path or "").lower()
+    if not (p.endswith(".js") or p.endswith(".mjs")):
+        return None
+    base = (current or "").split(";")[0].strip().lower()
+    if base in _JS_MIME_TYPES:
+        return None
+    return "text/javascript; charset=utf-8"

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -949,7 +949,12 @@ class MusicDatabase:
             # legitimately sharing an id) are left alone via the DISTINCT-name
             # check, so this only touches genuine corruption.
             try:
-                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_source_id_dedupe_v1'")
+                # v2 re-runs the sweep: #988 found the Deezer album/track "id
+                # correction" path could still smear an id (e.g. The Beatles' id 1
+                # onto The Outfield) after v1 ran, via a blank result-artist-name
+                # bypass. That path is now fully gated (name match + conflict check),
+                # so one more clear heals any smears that slipped through before the fix.
+                cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='_source_id_dedupe_v2'")
                 if not cursor.fetchone():
                     _dedupe_id_cols = [
                         ('deezer_id', 'deezer_match_status'),
@@ -977,7 +982,7 @@ class MusicDatabase:
                             total_cleared += cursor.rowcount
                         except Exception as col_err:
                             logger.debug("Source-id dedupe skipped %s: %s", id_col, col_err)
-                    cursor.execute("CREATE TABLE _source_id_dedupe_v1 (applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+                    cursor.execute("CREATE TABLE _source_id_dedupe_v2 (applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
                     if total_cleared > 0:
                         logger.info(
                             f"Cleared {total_cleared} duplicated source ids shared across "

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -15196,6 +15196,32 @@ class MusicDatabase:
     def mirror_playlist(self, source: str, source_playlist_id: str, name: str,
                         tracks: List[Dict], profile_id: int = 1, **kwargs) -> Optional[int]:
         """Upsert a mirrored playlist and replace all its tracks."""
+        from core.playlists.source_refs import coalesce_mirror_track, stable_source_track_id
+
+        # #990: accept mirror-shaped AND Spotify-shaped tracks (the GET playlist
+        # endpoints return the Spotify shape, which users feed straight back in).
+        tracks = [coalesce_mirror_track(t) for t in (tracks or [])]
+
+        # #990: refuse to REPLACE an existing mirror with an all-empty payload — a
+        # wrong-shaped POST once silently rewrote 21k rows to empty strings and
+        # returned success, breaking sync and hammering Deezer for days. A payload
+        # where every track has neither a name nor an id is unambiguously malformed
+        # (a real playlist always has named tracks); reject it BEFORE any DB write so
+        # the existing mirror is preserved.
+        empty = sum(1 for t in tracks
+                    if not str(t.get("track_name", "")).strip() and not stable_source_track_id(t))
+        if tracks and empty == len(tracks):
+            raise ValueError(
+                f"Refusing to mirror '{name}': all {len(tracks)} tracks are empty after "
+                "mapping (no track_name and no id) — the payload looks malformed. Expected "
+                "mirror-shaped tracks (track_name, artist_name, album_name, source_track_id); "
+                "Spotify-shaped (name, artists, album, id) is also accepted."
+            )
+        if empty:
+            logger.warning(
+                "[Mirror] %s/%d of tracks for playlist '%s' have no name/id — stored anyway",
+                empty, len(tracks), name)
+
         try:
             with self._get_connection() as conn:
                 cursor = conn.cursor()

--- a/tests/database/test_mirrored_playlists.py
+++ b/tests/database/test_mirrored_playlists.py
@@ -1,3 +1,5 @@
+import pytest
+
 from database.music_database import MusicDatabase
 
 
@@ -125,3 +127,48 @@ def test_backfill_leaves_native_ids_untouched(tmp_path):
     db._backfill_mirrored_track_source_ids()
     rows = db.get_mirrored_playlist_tracks(pid)
     assert rows[0]["source_track_id"] == "spotify123"
+
+
+# ── #990: accept the Spotify shape + reject all-empty (silent 21k-empty-rows bug) ──
+def test_mirror_accepts_spotify_shaped_tracks(tmp_path):
+    """The GET playlist endpoints return Spotify-shaped tracks; feeding them straight
+    back must map cleanly instead of storing empty rows."""
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    spotify_tracks = [{
+        "name": "Because of You", "artists": [{"name": "Ne-Yo"}],
+        "album": {"name": "Because of You"}, "id": "sp_track_1", "duration_ms": 217000,
+    }]
+    pid = db.mirror_playlist(source="spotify", source_playlist_id="liked", name="Liked",
+                             tracks=spotify_tracks, profile_id=1)
+    rows = db.get_mirrored_playlist_tracks(pid)
+    assert rows[0]["track_name"] == "Because of You"
+    assert rows[0]["artist_name"] == "Ne-Yo"
+    assert rows[0]["album_name"] == "Because of You"
+    assert rows[0]["source_track_id"] == "sp_track_1"
+    assert rows[0]["duration_ms"] == 217000
+
+
+def test_mirror_rejects_all_empty_payload_and_preserves_existing(tmp_path):
+    """A wrong-shaped payload where every track maps to empty must be rejected —
+    and must NOT wipe the existing mirror (the reported 21k-row disaster)."""
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    pid = db.mirror_playlist(source="spotify", source_playlist_id="liked", name="Liked",
+                             tracks=[{"track_name": "Real Song", "artist_name": "A", "source_track_id": "x1"}],
+                             profile_id=1)
+    with pytest.raises(ValueError):
+        db.mirror_playlist(source="spotify", source_playlist_id="liked", name="Liked",
+                           tracks=[{"duration_ms": 1000}, {"duration_ms": 2000}], profile_id=1)
+    rows = db.get_mirrored_playlist_tracks(pid)          # existing mirror untouched
+    assert len(rows) == 1 and rows[0]["track_name"] == "Real Song"
+
+
+def test_coalesce_mirror_track_shapes():
+    from core.playlists.source_refs import coalesce_mirror_track
+    sp = coalesce_mirror_track({"name": "T", "artists": [{"name": "A"}],
+                                "album": {"name": "Al"}, "id": 7, "duration_ms": 5})
+    assert (sp["track_name"], sp["artist_name"], sp["album_name"], sp["source_track_id"]) == ("T", "A", "Al", "7")
+    assert sp["duration_ms"] == 5                          # non-mapped keys preserved
+    m = {"track_name": "X", "artist_name": "Y", "album_name": "Z", "source_track_id": "id1"}
+    assert coalesce_mirror_track(m) == m                   # mirror shape untouched
+    s = coalesce_mirror_track({"name": "N", "artist": "Solo", "album": "AlbumStr"})
+    assert s["artist_name"] == "Solo" and s["album_name"] == "AlbumStr"

--- a/tests/imports/test_import_paths.py
+++ b/tests/imports/test_import_paths.py
@@ -63,6 +63,51 @@ def test_create_dirs_false_does_not_create_folders(monkeypatch, tmp_path):
     assert not (tmp_path / "Transfer").exists()
 
 
+def test_itunes_single_albumartist_falls_back_to_track_artist(monkeypatch, tmp_path):
+    """#989: an iTunes single's collection carries a placeholder 'Unknown Artist'
+    album artist while the track artist is real. The album_path must use the real
+    artist for $albumartist, not bury the file under 'Unknown Artist'. FAILS pre-fix
+    (the placeholder album-context artist overrode the real track artist)."""
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _album_path_config(tmp_path))
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+    ctx = {
+        "source": "itunes",
+        "artist": {"name": "Forevert", "id": "123456"},
+        "album": {"name": "CHAOSRIFT", "id": "999", "album_type": "single", "total_tracks": 1,
+                  "artists": [{"name": "Unknown Artist"}]},   # placeholder collection artist
+        "track_info": {"name": "CHAOSRIFT", "track_number": 1, "disc_number": 1,
+                       "artists": [{"name": "Forevert"}]},
+        "original_search_result": {"title": "CHAOSRIFT", "clean_title": "CHAOSRIFT",
+                                   "artists": [{"name": "Forevert"}]},
+    }
+    info = {"is_album": True, "album_name": "CHAOSRIFT", "track_number": 1, "disc_number": 1}
+    final_path, _ = import_paths.build_final_path_for_track(
+        ctx, {"name": "Forevert", "id": "123456"}, info, ".flac", create_dirs=False)
+    assert final_path == str(tmp_path / "Transfer" / "Forevert" / "Forevert - CHAOSRIFT" / "01 - CHAOSRIFT.flac")
+    assert "Unknown Artist" not in final_path
+
+
+def test_real_album_artist_still_wins_over_track_artist(monkeypatch, tmp_path):
+    """The #989 guard must not clobber a genuine, different album artist (compilations,
+    'various artists' style releases keep their real collection artist)."""
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _album_path_config(tmp_path))
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+    ctx = {
+        "source": "spotify",
+        "artist": {"name": "Guest Singer"},
+        "album": {"name": "Big Comp", "id": "c1", "album_type": "compilation", "total_tracks": 20,
+                  "artists": [{"name": "Various Artists"}]},
+        "track_info": {"name": "A Song", "track_number": 3, "disc_number": 1,
+                       "artists": [{"name": "Guest Singer"}]},
+        "original_search_result": {"title": "A Song", "clean_title": "A Song",
+                                   "artists": [{"name": "Guest Singer"}]},
+    }
+    info = {"is_album": True, "album_name": "Big Comp", "track_number": 3, "disc_number": 1}
+    final_path, _ = import_paths.build_final_path_for_track(
+        ctx, {"name": "Guest Singer"}, info, ".flac", create_dirs=False)
+    assert "Various Artists" in final_path        # real album artist preserved
+
+
 def test_create_dirs_true_still_creates_folders(monkeypatch, tmp_path):
     # The download/import flow must keep working (default behavior unchanged).
     monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _album_path_config(tmp_path))

--- a/tests/metadata/test_pick_best_artist_match.py
+++ b/tests/metadata/test_pick_best_artist_match.py
@@ -1,0 +1,43 @@
+"""#988: the Deezer (and any source) artist name-search must not hand back an
+unrelated artist when its results don't actually contain the one we asked for.
+
+A browsed-but-not-owned artist (searched via a Spotify URL, primary source =
+Deezer) has no stored Deezer id, so the discography/top-tracks flow name-searches
+Deezer for "The Outfield". The old ``_pick_best_artist_match`` returned
+``search_results[0]`` when no exact match was found — so a search that surfaced
+The Beatles first stamped the whole page with Beatles albums/tracks.
+
+The strict, name-gated matcher lives in ``album_tracks`` (used by the
+discography/top-tracks lookup for a KNOWN artist). The ``discography`` copy stays
+intentionally loose — its only caller is similar-artist/musicmap enrichment,
+which resolves a suggestion to a source's canonical entry whose name differs on
+purpose. So this only tests the strict one.
+"""
+
+from __future__ import annotations
+
+from core.metadata.album_tracks import _pick_best_artist_match as pick
+
+
+def _r(name, aid):
+    return {"name": name, "id": aid}
+
+
+def test_no_name_match_returns_none_not_first_result():
+    # The exact #988 shape: asked for The Outfield, Deezer returned Beatles.
+    results = [_r("The Beatles", "1"), _r("Beatles Tribute Band", "2")]
+    assert pick(results, "The Outfield") is None
+
+
+def test_exact_match_wins_even_if_not_first():
+    results = [_r("The Beatles", "1"), _r("The Outfield", "99")]
+    assert pick(results, "The Outfield")["id"] == "99"
+
+
+def test_close_variant_still_matches():
+    # casing / normalization variants are the same artist
+    assert pick([_r("THE OUTFIELD", "99")], "The Outfield")["id"] == "99"
+
+
+def test_empty_results_is_none():
+    assert pick([], "The Outfield") is None

--- a/tests/search/test_search_orchestrator.py
+++ b/tests/search/test_search_orchestrator.py
@@ -50,7 +50,8 @@ class _Track:
 
 class _Client:
     def __init__(self, *, name='fake', artists=None, albums=None, tracks=None,
-                 fail_search=False, authed=True, connected=True, meta_available=None):
+                 fail_search=False, authed=True, connected=True, meta_available=None,
+                 free_installed=False):
         self.name = name
         self._artists = artists or []
         self._albums = albums or []
@@ -62,18 +63,25 @@ class _Client:
         # explicitly to model the no-creds SpotipyFree fallback: not authed but
         # metadata still available.
         self._meta_available = meta_available
+        self._free_installed_flag = free_installed
+        # Records the prefer_free kwarg the last search call received (None if it
+        # was never passed) — lets a test assert the explicit-pick free routing.
+        self.prefer_free_seen = None
 
-    def search_artists(self, q, limit=10):
+    def search_artists(self, q, limit=10, prefer_free=False):
+        self.prefer_free_seen = prefer_free
         if self._fail:
             raise RuntimeError("client search boom")
         return self._artists
 
-    def search_albums(self, q, limit=10):
+    def search_albums(self, q, limit=10, prefer_free=False):
+        self.prefer_free_seen = prefer_free
         if self._fail:
             raise RuntimeError("client search boom")
         return self._albums
 
-    def search_tracks(self, q, limit=10):
+    def search_tracks(self, q, limit=10, prefer_free=False):
+        self.prefer_free_seen = prefer_free
         if self._fail:
             raise RuntimeError("client search boom")
         return self._tracks
@@ -83,6 +91,9 @@ class _Client:
 
     def is_spotify_metadata_available(self):
         return self._authed if self._meta_available is None else self._meta_available
+
+    def _free_installed(self):
+        return self._free_installed_flag
 
     def is_connected(self):
         return self._connected
@@ -282,6 +293,35 @@ def test_single_source_unavailable_returns_empty_with_source_available_false():
     assert result['source_available'] is False
     assert result['spotify_artists'] == []
     assert result['primary_source'] == 'spotify'
+
+
+def test_single_source_spotify_uses_free_when_unauthed_but_package_installed():
+    # The reported case: no Spotify auth, and 'Spotify Free' isn't the chosen
+    # metadata source (is_spotify_metadata_available False), but the no-creds
+    # SpotipyFree package IS installed. An EXPLICIT Spotify search pick must still
+    # serve results via the free source — and the client must be told prefer_free
+    # so it takes the no-creds path instead of returning a blank page.
+    spot = _Client(authed=False, meta_available=False, free_installed=True,
+                   artists=[_Artist('s1', 'Free Spot Artist')])
+    deps = _build_deps(spotify_client=spot)
+    result = orchestrator.run_enhanced_search('kendrick lamar', 'spotify', deps)
+
+    assert result['source_available'] is True
+    assert result['spotify_artists'][0]['name'] == 'Free Spot Artist'
+    assert spot.prefer_free_seen is True          # client routed to free for this pick
+
+
+def test_single_source_spotify_unavailable_when_package_missing():
+    # Same no-auth / not-'Spotify Free'-source case but SpotipyFree NOT installed →
+    # nothing to serve, so it stays unavailable exactly as before (no regression,
+    # no silent free scraping when the package can't back it).
+    spot = _Client(authed=False, meta_available=False, free_installed=False)
+    deps = _build_deps(spotify_client=spot)
+    result = orchestrator.run_enhanced_search('kendrick lamar', 'spotify', deps)
+
+    assert result['source_available'] is False
+    assert result['spotify_artists'] == []
+    assert spot.prefer_free_seen is None          # search never ran
 
 
 def test_single_source_search_failure_returns_empty():

--- a/tests/test_dedupe_source_ids.py
+++ b/tests/test_dedupe_source_ids.py
@@ -137,8 +137,9 @@ def test_clean_library_is_a_noop(db):
 # ---------------------------------------------------------------------------
 
 def test_startup_migration_clears_shared_source_ids(tmp_path):
-    """The _source_id_dedupe_v1 migration in MusicDatabase init must clear
-    differently-named shared ids and leave same-name cross-server dups."""
+    """The _source_id_dedupe_v2 migration in MusicDatabase init must clear
+    differently-named shared ids and leave same-name cross-server dups.
+    v2 re-runs the sweep to heal smears that slipped through after v1 (#988)."""
     path = str(tmp_path / "music.db")
     db = MusicDatabase(path)  # first init creates the marker on an empty db
 
@@ -152,7 +153,7 @@ def test_startup_migration_clears_shared_source_ids(tmp_path):
                      "VALUES ('3','Radiohead','plex','rh')")
         conn.execute("INSERT INTO artists (id,name,server_source,spotify_artist_id) "
                      "VALUES ('4','Radiohead','jellyfin','rh')")
-        conn.execute("DROP TABLE _source_id_dedupe_v1")
+        conn.execute("DROP TABLE _source_id_dedupe_v2")
         conn.commit()
 
     # Force the one-time migration to run again.
@@ -165,4 +166,4 @@ def test_startup_migration_clears_shared_source_ids(tmp_path):
         assert conn.execute("SELECT deezer_id FROM artists WHERE id='2'").fetchone()[0] is None
         rh = conn.execute("SELECT spotify_artist_id FROM artists WHERE id IN ('3','4')").fetchall()
         assert all(r[0] == 'rh' for r in rh)
-        assert conn.execute("SELECT name FROM sqlite_master WHERE name='_source_id_dedupe_v1'").fetchone()
+        assert conn.execute("SELECT name FROM sqlite_master WHERE name='_source_id_dedupe_v2'").fetchone()

--- a/tests/test_deezer_worker_artist_id_guard.py
+++ b/tests/test_deezer_worker_artist_id_guard.py
@@ -14,6 +14,8 @@ artist and our parent artist.
 
 from __future__ import annotations
 
+import sqlite3
+
 from core.deezer_worker import DeezerWorker
 
 
@@ -68,9 +70,66 @@ def test_no_parent_id_is_noop():
     assert w._corrections == []
 
 
-def test_missing_result_name_preserves_old_behavior():
-    # No artist name on the result → can't name-check; keep the original
-    # "trust the more specific album/track search" behavior.
+def test_missing_result_name_skips_correction():
+    # #988: a missing result artist name (compilation/collab Deezer payloads often
+    # omit it) can NO LONGER bypass the guard — without a positive name match we
+    # can't confirm it's the same artist, so the correction is skipped (id kept).
+    # This blank-name bypass is how The Beatles' id 1 got smeared onto The Outfield.
     w = _worker()
     w._verify_artist_id(_item('Kendrick Lamar', '111'), '525046', None)
-    assert w._corrections == [(1, '525046')]
+    assert w._corrections == []
+
+
+# ── _correct_artist_deezer_id must not smear an id another artist owns (#988) ──
+def _seed_db(tmp_path):
+    path = str(tmp_path / "m.db")
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE artists (id INTEGER PRIMARY KEY, name TEXT, deezer_id TEXT, updated_at TEXT);"
+        "CREATE TABLE tracks (id INTEGER PRIMARY KEY, artist_id INTEGER);"
+        "INSERT INTO artists (id, name, deezer_id) VALUES (1, 'The Beatles', '1');"
+        "INSERT INTO artists (id, name, deezer_id) VALUES (2, 'The Outfield', NULL);"
+        "INSERT INTO tracks (id, artist_id) VALUES (10, 2);"
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+class _DB:
+    def __init__(self, path):
+        self.path = path
+
+    def _get_connection(self):
+        return sqlite3.connect(self.path)   # fresh conn each call (matches real db)
+
+
+def _worker_with_db(path):
+    w = DeezerWorker.__new__(DeezerWorker)
+    w.db = _DB(path)
+    return w
+
+
+def _deezer_id_of(path, artist_id):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute("SELECT deezer_id FROM artists WHERE id = ?", (artist_id,)).fetchone()[0]
+    finally:
+        conn.close()
+
+
+def test_correct_refuses_id_owned_by_a_differently_named_artist(tmp_path):
+    """The exact #988 smear: a track credited to The Outfield resolves to a Deezer
+    release whose primary artist is The Beatles (id 1). Correcting The Outfield's
+    deezer_id to 1 must be REFUSED — id 1 is already owned by The Beatles."""
+    path = _seed_db(tmp_path)
+    _worker_with_db(path)._correct_artist_deezer_id({'type': 'track', 'id': 10, 'artist': 'The Outfield'}, '1')
+    assert _deezer_id_of(path, 2) is None      # The Outfield NOT smeared
+    assert _deezer_id_of(path, 1) == '1'       # The Beatles untouched
+
+
+def test_correct_allows_a_free_id(tmp_path):
+    """A genuinely unclaimed id still corrects (the feature keeps working)."""
+    path = _seed_db(tmp_path)
+    _worker_with_db(path)._correct_artist_deezer_id({'type': 'track', 'id': 10, 'artist': 'The Outfield'}, '777')
+    assert _deezer_id_of(path, 2) == '777'

--- a/tests/test_library_reorganize.py
+++ b/tests/test_library_reorganize.py
@@ -584,3 +584,63 @@ def test_estimate_scope_returns_album_count(monkeypatch):
 
     job = LibraryReorganizeJob()
     assert job.estimate_scope(ctx) == 42
+
+
+# ── #985: emptied source dirs must be pruned even when the library isn't under
+#    the transfer folder (the injected transfer-dir-bounded pruner can't reach it) ──
+import os as _os  # noqa: E402
+
+from core.library_reorganize import _prune_empty_source_dirs  # noqa: E402
+
+
+def test_prune_removes_empty_disc_and_album_keeps_artist(tmp_path):
+    """The reported case: reorganize moved the file out of Album/Disc 1 into a new
+    album dir. The empty Disc 1 AND the now-empty old album dir must be pruned; the
+    artist dir (holding the new album) is kept."""
+    artist = tmp_path / "local_music" / "Ne-Yo"
+    disc = artist / "Because Of You (2007)" / "Disc 1"
+    new_album = artist / "Because of You (Radio Edit) (2007)"
+    disc.mkdir(parents=True)
+    new_album.mkdir(parents=True)
+    (new_album / "01. Because of You.flac").write_text("audio")   # file now lives here
+
+    _prune_empty_source_dirs(str(disc))
+
+    assert not disc.exists()                              # empty disc pruned
+    assert not (artist / "Because Of You (2007)").exists()  # now-empty old album pruned
+    assert artist.exists() and new_album.exists()         # artist + new album kept
+
+
+def test_prune_stops_at_a_dir_with_real_content(tmp_path):
+    leaf = tmp_path / "Artist" / "Album" / "Disc 1"
+    leaf.mkdir(parents=True)
+    (tmp_path / "Artist" / "keep.flac").write_text("x")   # Artist has other content
+    _prune_empty_source_dirs(str(leaf))
+    assert not leaf.exists() and not (tmp_path / "Artist" / "Album").exists()
+    assert (tmp_path / "Artist").exists()                 # stopped — real content
+
+
+def test_prune_clears_hidden_junk_and_prunes_album_for_a_disc(tmp_path):
+    album = tmp_path / "Artist" / "Album"
+    disc = album / "CD 2"
+    disc.mkdir(parents=True)
+    (disc / ".DS_Store").write_text("junk")               # hidden-only → still "empty"
+    _prune_empty_source_dirs(str(disc))
+    assert not disc.exists()                              # disc pruned (hidden cleared)
+    assert not album.exists()                            # album pruned (disc source)
+    assert (tmp_path / "Artist").exists()                # never climbs to the artist
+
+
+def test_prune_never_climbs_above_the_album_or_into_the_library_root(tmp_path):
+    """The safety property: even a flat library (album directly under an UNprotected
+    root) must never lose the root. A non-disc source prunes only its own dir."""
+    root = tmp_path / "local_music"                       # not a configured/protected root
+    old_album = root / "Some Album"
+    old_album.mkdir(parents=True)
+    _prune_empty_source_dirs(str(old_album))              # album-level source, not a disc
+    assert not old_album.exists()                        # emptied album pruned
+    assert root.exists()                                 # library root NEVER removed
+
+
+def test_prune_missing_dir_is_safe(tmp_path):
+    _prune_empty_source_dirs(str(tmp_path / "does" / "not" / "exist"))   # no raise

--- a/tests/test_spotify_free_metadata.py
+++ b/tests/test_spotify_free_metadata.py
@@ -424,3 +424,52 @@ def test_interactive_metadata_availability_unaffected_by_prefer_free():
     assert _metadata_available(prefer_free=False, installed=True) is False
     # ...and authed is available as before.
     assert _metadata_available(prefer_free=False, installed=True, authed=True) is True
+
+
+# ── (spotify-free) fall back to Free when the AUTHED official search returns empty ──
+from unittest.mock import MagicMock  # noqa: E402
+import core.spotify_client as _sc  # noqa: E402
+
+
+def _search_client(official_items, free_result, *, free_available, monkeypatch):
+    c = SpotifyClient.__new__(SpotifyClient)
+    c.sp = MagicMock()
+    c.sp.search.return_value = {'tracks': {'items': official_items}}
+    c._free_meta_client = MagicMock()
+    c._free_meta_client.search_tracks.return_value = free_result
+    fallback = MagicMock()
+    fallback.search_tracks.return_value = ['ITUNES']
+    monkeypatch.setattr(SpotifyClient, '_fallback', fallback)             # property → class-patch
+    monkeypatch.setattr(SpotifyClient, '_fallback_source', 'itunes')     # property → class-patch
+    monkeypatch.setattr(SpotifyClient, 'is_spotify_authenticated', lambda self: True)
+    monkeypatch.setattr(SpotifyClient, '_free_active', lambda self: False)      # authed + healthy
+    monkeypatch.setattr(SpotifyClient, '_free_available', lambda self: free_available)
+    monkeypatch.setattr(_sc, '_is_globally_rate_limited', lambda: True)         # bypass decorator retry loop
+    cache = MagicMock()
+    cache.get_search_results.return_value = None
+    monkeypatch.setattr(_sc, 'get_metadata_cache', lambda: cache)
+    monkeypatch.setattr(_sc.Track, 'from_spotify_track', staticmethod(lambda t: ('T', t.get('id'))))
+    return c
+
+
+def test_authed_official_empty_falls_back_to_free_when_opted_in(monkeypatch):
+    # The reported case: authed but official returns nothing; with Free opted in it
+    # must serve Free results instead of a blank page.
+    c = _search_client([], [{'id': 'free1'}], free_available=True, monkeypatch=monkeypatch)
+    assert c.search_tracks('q', limit=5) == [('T', 'free1')]
+    c._fallback.search_tracks.assert_not_called()          # Free won, not iTunes
+
+
+def test_authed_official_empty_uses_itunes_when_free_not_opted_in(monkeypatch):
+    # Without the opt-in, no unofficial scraping — falls to iTunes as before.
+    c = _search_client([], [{'id': 'free1'}], free_available=False, monkeypatch=monkeypatch)
+    assert c.search_tracks('q', limit=5) == ['ITUNES']
+    c._free_meta_client.search_tracks.assert_not_called()
+
+
+def test_authed_official_nonempty_never_touches_free(monkeypatch):
+    # A working official account is unaffected — Free/iTunes never consulted.
+    c = _search_client([{'id': 'off1'}], [{'id': 'free1'}], free_available=True, monkeypatch=monkeypatch)
+    assert c.search_tracks('q', limit=5) == [('T', 'off1')]
+    c._free_meta_client.search_tracks.assert_not_called()
+    c._fallback.search_tracks.assert_not_called()

--- a/tests/test_spotify_free_metadata.py
+++ b/tests/test_spotify_free_metadata.py
@@ -473,3 +473,33 @@ def test_authed_official_nonempty_never_touches_free(monkeypatch):
     assert c.search_tracks('q', limit=5) == [('T', 'off1')]
     c._free_meta_client.search_tracks.assert_not_called()
     c._fallback.search_tracks.assert_not_called()
+
+
+def test_prefer_free_serves_when_not_authed_and_not_opted_in(monkeypatch):
+    # Boulder's case: no auth, and 'Spotify Free' isn't the chosen metadata source
+    # (free_available=False), so the normal gates are all shut. An explicit Spotify
+    # search pick passes prefer_free=True; with the package installed it must take
+    # the no-creds path. Differential: SAME client, only the flag changes.
+    c = _search_client([], [{'id': 'free1'}], free_available=False, monkeypatch=monkeypatch)
+    monkeypatch.setattr(SpotifyClient, 'is_spotify_authenticated', lambda self: False)
+    monkeypatch.setattr(SpotifyClient, '_free_installed', lambda self: True)
+
+    # Without the flag → no unofficial scraping, falls to iTunes exactly as before.
+    assert c.search_tracks('q', limit=5) == ['ITUNES']
+    c._free_meta_client.search_tracks.assert_not_called()
+
+    # With the flag (the explicit pick) → Free serves instead of a blank page.
+    c._free_meta_client.search_tracks.reset_mock()
+    assert c.search_tracks('q', limit=5, prefer_free=True) == [('T', 'free1')]
+    c._free_meta_client.search_tracks.assert_called_once()
+
+
+def test_prefer_free_inert_when_package_not_installed(monkeypatch):
+    # prefer_free must not conjure free out of nothing: package missing → it stays
+    # off and falls to iTunes (the orchestrator also guards on _free_installed, but
+    # the client is defensive too).
+    c = _search_client([], [{'id': 'free1'}], free_available=False, monkeypatch=monkeypatch)
+    monkeypatch.setattr(SpotifyClient, 'is_spotify_authenticated', lambda self: False)
+    monkeypatch.setattr(SpotifyClient, '_free_installed', lambda self: False)
+    assert c.search_tracks('q', limit=5, prefer_free=True) == ['ITUNES']
+    c._free_meta_client.search_tracks.assert_not_called()

--- a/tests/webui/test_mimetypes_fix.py
+++ b/tests/webui/test_mimetypes_fix.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 import mimetypes
 
-from core.webui.mimetypes_fix import ensure_web_mimetypes
+import pytest
+
+from core.webui.mimetypes_fix import corrected_script_content_type, ensure_web_mimetypes
 
 
 def test_js_is_forced_to_javascript_even_if_registry_says_text_plain():
@@ -27,3 +29,27 @@ def test_idempotent():
     ensure_web_mimetypes()
     ensure_web_mimetypes()
     assert mimetypes.guess_type("x.js")[0] == "text/javascript"
+
+
+# ── #986: HTTP-layer enforcement, independent of the OS mimetypes registry ──
+@pytest.mark.parametrize("path,current", [
+    ("/static/dist/assets/main-Dg73FktO.js", "application/octet-stream"),
+    ("/static/dist/assets/main-Dg73FktO.js", "text/plain"),
+    ("/static/dist/assets/main.js", None),          # Flask couldn't guess → no header
+    ("/static/dist/assets/chunk.mjs", "text/plain"),
+    ("/some.JS", "binary/octet-stream"),            # case-insensitive path
+])
+def test_bad_js_content_type_is_forced(path, current):
+    assert corrected_script_content_type(path, current) == "text/javascript; charset=utf-8"
+
+
+@pytest.mark.parametrize("path,current", [
+    ("/static/dist/assets/main.js", "text/javascript"),          # already valid
+    ("/static/dist/assets/main.js", "application/javascript"),   # also valid for modules
+    ("/sw.js", "text/javascript; charset=utf-8"),                # valid + charset
+    ("/api/stats", "application/json"),                          # not a script
+    ("/static/main.css", "text/css"),                            # not a script
+    ("/report.json", "application/octet-stream"),                # non-.js left alone
+])
+def test_valid_or_non_js_left_unchanged(path, current):
+    assert corrected_script_content_type(path, current) is None

--- a/web_server.py
+++ b/web_server.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from urllib.parse import urljoin, urlparse
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from core.webui.mimetypes_fix import ensure_web_mimetypes
+from core.webui.mimetypes_fix import corrected_script_content_type, ensure_web_mimetypes
 # Register correct web-asset MIME types before the app serves anything — a bad OS
 # registry (Windows: .js -> text/plain) otherwise blanks the module-loaded React
 # pages (Import/Stats) via strict module MIME checking. (#979)
@@ -647,6 +647,21 @@ def _log_slow_request(response):
     except Exception as e:
         logger.debug("slow request log failed: %s", e)
 
+    return response
+
+
+@app.after_request
+def _force_module_script_mimetype(response):
+    """#979/#986: force a valid JS Content-Type on .js/.mjs responses so the
+    React bundle's <script type="module"> is never refused (Import/Stats black
+    screen). HTTP-layer, so it doesn't depend on the OS mimetypes registry —
+    which is unreliable across Docker base images."""
+    try:
+        fixed = corrected_script_content_type(request.path, response.headers.get('Content-Type'))
+        if fixed:
+            response.headers['Content-Type'] = fixed
+    except Exception as e:
+        logger.debug("module-script mimetype fix failed: %s", e)
     return response
 
 

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.8.51"
+_SOULSYNC_BASE_VERSION = "2.8.6"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/web_server.py
+++ b/web_server.py
@@ -36003,6 +36003,10 @@ def mirror_playlist_endpoint():
             logger.debug("mirrored_playlist_created emit failed: %s", e)
 
         return jsonify({"success": True, "playlist_id": playlist_id})
+    except ValueError as ve:
+        # #990: malformed/all-empty track payload — a client error, not a 500.
+        logger.warning(f"mirror-playlist rejected: {ve}")
+        return jsonify({"error": str(ve)}), 400
     except Exception as e:
         logger.error(f"Error mirroring playlist: {e}")
         return jsonify({"error": str(e)}), 500

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,10 +3404,15 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '2.8.51': [
-        { date: 'July 2026 — 2.8.51 hotfix' },
-        { title: 'Watchlist artist settings no longer error on a fresh install (#983)', desc: 'on a brand-new database, opening a watchlist artist\'s settings could fail with "no such column: preferred_metadata_source" (a restart worked around it). the table was being rebuilt during first-run setup from a column list that dropped two newer columns; they survive the rebuild now, so it works from the first boot.', page: 'artists' },
-        { title: 'Earlier versions', desc: '2.8.5 was a fix batch: Import & Stats black screen (#979), iTunes singles landing in Unknown Artist (#980), a stray "01-" on single-disc albums (#981), cleanup deleting a configured root (#976), repair Fix All outside the transfer path (#978), and backfill overreaching past owned artists (#977). 2.8.4 added Artist Web + named Quality Profiles (#974); 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949); 2.7.0 made multi-user real.' },
+    '2.8.6': [
+        { date: 'July 2026 — 2.8.6' },
+        { title: 'Spotify search works without a connected account', desc: 'picking "Spotify" as your search source now returns results even if you haven\'t connected an account — it uses the no-auth Spotify Free source. and if you are connected but the official search comes back empty, it falls back to Free instead of a blank page.', page: 'search' },
+        { title: 'Import & Stats black screen on Docker (#986)', desc: 'a follow-up to the 2.8.5 fix — some Docker setups still got a blank Import/Stats page because the JS module bundle was served with a non-JS content type. we now force the correct type at the HTTP layer, so the module scripts always run.', page: 'import' },
+        { title: 'Mirrored playlists can\'t be silently wiped anymore (#990)', desc: 'a wrong-shaped refresh could overwrite a mirror with thousands of empty rows and still report success. it now accepts the Spotify track shape directly and validates before deleting — a malformed payload is rejected and your existing mirror is left intact.', page: 'playlists' },
+        { title: 'Browsing an artist no longer shows a different artist\'s tracks (#988)', desc: 'a Deezer name-search was accepting the first result even on a poor name match, so e.g. The Outfield could show Beatles tracks. it now requires a real name match before using a result.', page: 'artists' },
+        { title: 'iTunes singles no longer land in "Unknown Artist" (#989)', desc: 'when a single\'s album-artist came back empty, the track could file and tag under "Unknown Artist"; it now falls back to the real track artist.', page: 'import' },
+        { title: 'Library Reorganize cleans up the folders it empties (#985)', desc: 'after moving files it left the old, now-empty disc/album folders behind; it prunes them now — safely, never climbing up to the artist or library root.', page: 'library' },
+        { title: 'Earlier versions', desc: '2.8.51 was a one-fix hotfix (#983 fresh-install watchlist settings). 2.8.5 was a fix batch: Import & Stats black screen (#979), iTunes singles landing in Unknown Artist (#980), a stray "01-" on single-disc albums (#981), cleanup deleting a configured root (#976), repair Fix All outside the transfer path (#978), and backfill overreaching past owned artists (#977). 2.8.4 added Artist Web + named Quality Profiles (#974); 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949); 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3438,7 +3443,19 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "2.8.51 — hotfix",
+        title: "2.8.6 — fix batch",
+        description: "a focused fix release across search, import, library, and playlists.",
+        features: [
+            "Spotify search without a connected account — picking \"Spotify\" as your search source now works even if you haven't authenticated, using the no-auth Spotify Free source; and a connected account whose official search returns empty falls back to Free instead of a blank page",
+            "#986 — a follow-up to the 2.8.5 black-screen fix: some Docker setups still loaded Import & Stats blank because the JS module bundle was served with a non-JS content type. we force the correct type at the HTTP layer now, so the module scripts always run",
+            "#990 — a wrong-shaped playlist refresh could overwrite a mirror with thousands of empty rows and still report success; it accepts the Spotify track shape directly now and validates before deleting, so a malformed payload is rejected and your existing mirror is left intact",
+            "#988 — browsing an artist could surface a completely different artist's tracks (e.g. The Outfield showing Beatles) because a Deezer name-search accepted the first result on a poor match; it requires a real name match now",
+            "#989 — iTunes singles could file and tag under \"Unknown Artist\" when the album-artist came back empty; they fall back to the real track artist now",
+            "#985 — Library Reorganize left the old, now-empty disc/album folders behind after moving files; it prunes them now, safely (never climbing to the artist or library root)",
+        ],
+    },
+    {
+        title: "Earlier in 2.8.51",
         description: "a one-fix follow-up to 2.8.5.",
         features: [
             "#983 — on a fresh install, opening a watchlist artist's settings could fail with \"no such column: preferred_metadata_source\" (a restart worked around it). first-run setup was rebuilding the watchlist table from a column list that dropped two newer columns; they survive now, so it works from the first boot",


### PR DESCRIPTION
# soulsync 2.8.6 — `dev` → `main`

a focused fix batch on top of 2.8.5/2.8.51 — search, import, library, and playlists.

---

## spotify search works without a connected account

picking "Spotify" as your search source returned only library results if you weren't authenticated to a real spotify account — even with the no-auth spotify free source installed. the search gate said "spotify unavailable" and bailed before searching anything.

fix: an explicit "Spotify" search pick now uses the no-creds spotify free source when you're not connected (the explicit pick is your consent — no silent background scraping changes). threaded as a per-request `prefer_free` flag, default off everywhere, so fan-out/background paths and every other source are untouched. separately, a connected account whose official search comes back empty now falls back to free instead of a blank page.

## #986 — import & stats black screen on docker

a follow-up to the 2.8.5 fix. some docker setups still loaded import & stats blank because the JS module bundle was served with a non-JS content type and the browser refused to run it. we now force the correct `text/javascript` content-type at the HTTP layer (an after-request hook), so module scripts always run.

## #990 — mirrored playlists could be silently wiped to empty rows

a wrong-shaped refresh payload (the GET endpoints return the spotify track shape, the POST expected the mirror shape) could overwrite a mirror with thousands of empty rows and still return success. it now coalesces the spotify shape into the mirror keys, and validates before touching the db — if every track maps to empty it rejects with a 400 *before* the delete, so your existing mirror is never wiped.

## #988 — browsing an artist could show a different artist's tracks

a deezer name-search was accepting the first result even on a poor name match, so e.g. The Outfield could show Beatles tracks. it now requires a real name match (0.85 similarity) before using a result, and falls back cleanly otherwise. also hardened the worker path that could smear a stored deezer id onto the wrong artist.

## #989 — itunes singles landing in "unknown artist"

when a single's album-artist came back empty, the track could file and tag under "Unknown Artist". it now falls back to the real track artist when the album-artist is empty/unknown, while a genuine album-artist still wins.

## #985 — library reorganize left empty folders behind

after moving files, reorganize left the old, now-empty disc/album folders behind. it prunes them now — bounded and disc-aware, so it only removes the emptied file/album (and a disc subfolder), and never climbs up to the artist directory or library root.

---

all fixes have root-cause + regression tests; full suite green.
