### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 2.8.6)'
+        description: 'Version tag (e.g. 2.8.7)'
         required: true
-        default: '2.8.6'
+        default: '2.8.7'
 
 jobs:
   build-and-push:

--- a/config/settings.py
+++ b/config/settings.py
@@ -885,9 +885,21 @@ class ConfigManager:
         return data
 
     def set(self, key: str, value: Any):
-        # The UI round-trips REDACTED_SENTINEL for any secret the user didn't
-        # touch — never let the mask overwrite the real value (#832 follow-up).
-        if value == self.REDACTED_SENTINEL and key in self._SENSITIVE_PATHS:
+        # Never let a bulk/settings save blank out a stored secret. Two ways it
+        # tried to:
+        #   1. The UI round-trips REDACTED_SENTINEL for an untouched masked field
+        #      (#832) — that mask must not overwrite the real value.
+        #   2. The settings auto-save fires 2s after any input; a masked secret
+        #      field is cleared to '' on focus, so a timer landing in that window
+        #      posted '' and WIPED the real secret. That surfaced as Spotify
+        #      "invalid_client" (an empty secret was being sent) even after the
+        #      user re-entered it (#992).
+        # So an empty ('' / None) value for a sensitive path means "keep the
+        # existing one"; clearing a credential is done via its explicit
+        # disconnect action, never by saving an empty settings form.
+        if key in self._SENSITIVE_PATHS and (
+            value == self.REDACTED_SENTINEL or value is None or value == ''
+        ):
             return
 
         keys = key.split('.')

--- a/core/discovery/sync.py
+++ b/core/discovery/sync.py
@@ -481,6 +481,28 @@ def run_sync_task(
                 playlist_name,
             )
 
+        # #993 — the source cover is pushed only to a BRAND-NEW playlist. Capture
+        # whether the target already exists on the media server BEFORE the sync
+        # creates/updates it (after the sync it always exists, so this must be read
+        # now). An already-present playlist keeps its current cover — the art we set
+        # on a prior sync, or one the user set by hand. Resolve the SAME server +
+        # client the cover push below uses (deps.config_manager, not the module-level
+        # one) so the check and the upload always agree, and default to "pre-existed"
+        # on any error so an unverifiable case never stomps an existing cover.
+        _playlist_preexisted = True
+        # Only probe when a cover might actually be pushed below (there IS a source
+        # cover, and the mode isn't one that always preserves the existing image) —
+        # otherwise the extra playlist-list call is wasted.
+        if playlist_image_url and sync_mode not in ('reconcile', 'append'):
+            try:
+                _cover_server = deps.config_manager.get_active_media_server()
+                _cover_engine = deps.media_server_engine
+                _cover_client = _cover_engine.client(_cover_server) if _cover_engine else None
+                if _cover_client is not None and hasattr(_cover_client, 'get_playlist_by_name'):
+                    _playlist_preexisted = bool(_cover_client.get_playlist_by_name(playlist_name))
+            except Exception as _pre_err:
+                logger.debug(f"[PLAYLIST IMAGE] pre-sync existence check failed (assuming pre-existed): {_pre_err}")
+
         # Run the sync (this is a blocking call within this thread)
         result = deps.run_async(sync_service.sync_playlist(playlist, download_missing=False, profile_id=profile_id, sync_mode=sync_mode))
 
@@ -526,12 +548,15 @@ def run_sync_task(
         # don't want persisted to app.log.
         _synced = getattr(result, 'synced_tracks', 0)
         logger.info(f"[PLAYLIST IMAGE] has_image={bool(playlist_image_url)}, synced_tracks={_synced}")
-        # Modes that edit a playlist in place (reconcile #792, append #811) must
-        # NOT push the source image — doing so re-clobbers a user's custom poster
-        # every sync, the exact bug these modes exist to avoid. Only the
-        # destructive 'replace' (recreate-from-scratch) pushes the image.
+        # Modes that edit a playlist in place (reconcile #792, append #811) must NOT
+        # push the source image, and neither does a sync of a playlist that already
+        # exists (#993) — either re-clobbers a user's custom poster. The source cover
+        # is pushed only to a brand-new playlist (a genuine first mirror); after that
+        # its cover is left alone. A one-off retroactive backfill is future work.
         if sync_mode in ('reconcile', 'append'):
             logger.info(f"[PLAYLIST IMAGE] {sync_mode} mode — preserving existing playlist image")
+        elif playlist_image_url and _synced > 0 and _playlist_preexisted:
+            logger.info("[PLAYLIST IMAGE] playlist already existed — leaving its current cover untouched (#993)")
         elif playlist_image_url and _synced > 0:
             try:
                 active_server = deps.config_manager.get_active_media_server()

--- a/core/discovery/sync.py
+++ b/core/discovery/sync.py
@@ -543,7 +543,12 @@ def run_sync_task(
                 elif active_server in ('jellyfin', 'emby') and _engine and _engine.client('jellyfin'):
                     ok = _engine.client('jellyfin').set_playlist_image(playlist_name, playlist_image_url)
                     logger.info(f"[PLAYLIST IMAGE] Jellyfin upload result: {ok}")
-                # Navidrome doesn't support custom playlist images
+                elif active_server == 'navidrome' and _engine and _engine.client('navidrome'):
+                    # Subsonic has no playlist-cover field, but Navidrome's native
+                    # API accepts a multipart upload (same creds). See
+                    # NavidromeClient.set_playlist_image.
+                    ok = _engine.client('navidrome').set_playlist_image(playlist_name, playlist_image_url)
+                    logger.info(f"[PLAYLIST IMAGE] Navidrome upload result: {ok}")
             except Exception as img_err:
                 logger.error(f"[PLAYLIST IMAGE] Exception: {img_err}")
 

--- a/core/metadata/discography.py
+++ b/core/metadata/discography.py
@@ -82,6 +82,20 @@ def _normalize_artist_name(value: Any) -> str:
     return (value or '').strip().casefold()
 
 
+def _normalize_secondary_types(value: Any) -> List[str]:
+    """Return provider release-group qualifiers (Live, Compilation, ...) as a
+    clean string list. Tolerates None, a bare string, or any iterable."""
+    if not value:
+        return []
+    if isinstance(value, (str, bytes)):
+        value = [value]
+    try:
+        items = list(value)
+    except TypeError:
+        items = [value]
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
 def _search_artists_for_source(source: str, client: Any, artist_name: str, limit: int = 5) -> List[Any]:
     if not client or not hasattr(client, 'search_artists'):
         return []
@@ -158,6 +172,7 @@ def _build_discography_release_dict(release: Any, artist_id: str,
             'total_tracks': typed_album.total_tracks or 0,
             'external_urls': typed_album.external_urls or {},
             'explicit': typed_album.explicit,
+            'secondary_types': _normalize_secondary_types(getattr(typed_album, 'secondary_types', None)),
         }
 
     release_id = _extract_lookup_value(release, 'id', 'album_id', 'release_id')
@@ -177,6 +192,9 @@ def _build_discography_release_dict(release: Any, artist_id: str,
         'total_tracks': _extract_lookup_value(release, 'total_tracks', default=0) or 0,
         'external_urls': _extract_lookup_value(release, 'external_urls', default={}) or {},
         'explicit': _extract_lookup_value(release, 'explicit'),
+        'secondary_types': _normalize_secondary_types(
+            _extract_lookup_value(release, 'secondary_types', 'secondary-types', default=[])
+        ),
     }
 
 
@@ -446,6 +464,7 @@ def _build_artist_detail_release_card(release: Dict[str, Any],
             'owned': None,
             'track_completion': 'checking',
             'explicit': typed_album.explicit,
+            'secondary_types': _normalize_secondary_types(getattr(typed_album, 'secondary_types', None)),
         }
         if typed_album.release_date:
             card['release_date'] = typed_album.release_date
@@ -481,6 +500,9 @@ def _build_artist_detail_release_card(release: Dict[str, Any],
         'owned': None,
         'track_completion': 'checking',
         'explicit': _extract_lookup_value(release, 'explicit'),
+        'secondary_types': _normalize_secondary_types(
+            _extract_lookup_value(release, 'secondary_types', 'secondary-types', default=[])
+        ),
     }
 
     if release_date:

--- a/core/metadata/types.py
+++ b/core/metadata/types.py
@@ -106,6 +106,7 @@ class Album:
     source: str = ''                             # 'spotify' / 'itunes' / etc — set by converter
     external_ids: Dict[str, str] = field(default_factory=dict)
     external_urls: Dict[str, str] = field(default_factory=dict)
+    secondary_types: List[str] = field(default_factory=list)  # provider release-group qualifiers (Live, Compilation, ...)
 
     # ------------------------------------------------------------------
     # Per-source converters. Each one is the SINGLE source of truth for
@@ -364,6 +365,15 @@ class Album:
             if raw.get('id'):
                 external_ids['musicbrainz'] = _str(raw['id'])
 
+            raw_secondary_types = raw.get('secondary_types')
+            if raw_secondary_types is None:
+                raw_secondary_types = raw.get('secondary-types')
+            secondary_types = [
+                _str(value).strip()
+                for value in (raw_secondary_types or [])
+                if _str(value).strip()
+            ]
+
             return cls(
                 id=_str(raw.get('id')),
                 name=_str(raw.get('name')),
@@ -377,6 +387,7 @@ class Album:
                 source='musicbrainz',
                 external_ids=external_ids,
                 external_urls=dict(raw.get('external_urls') or {}),
+                secondary_types=secondary_types,
             )
 
         artist_credit = raw.get('artist-credit') or []
@@ -434,6 +445,7 @@ class Album:
             source='musicbrainz',
             external_ids=external_ids,
             external_urls={},
+            secondary_types=[_str(value).strip() for value in secondary_types if _str(value).strip()],
         )
 
     @classmethod
@@ -614,6 +626,7 @@ class Album:
             'images': images,
             'release_date': self.release_date,
             'album_type': self.album_type,
+            'secondary_types': list(self.secondary_types),
             'total_tracks': self.total_tracks,
             'source': self.source,
             'genres': list(self.genres),

--- a/core/musicbrainz_search.py
+++ b/core/musicbrainz_search.py
@@ -7,7 +7,7 @@ Album art is fetched from Cover Art Archive (free, linked by release MBID).
 """
 
 import threading
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from utils.logging_config import get_logger
@@ -63,6 +63,7 @@ class Album:
     label: Optional[str] = None
     disambiguation: Optional[str] = None
     release_group_id: Optional[str] = None
+    secondary_types: List[str] = field(default_factory=list)  # MB release-group qualifiers (Live, Compilation, ...)
 
 
 def _cover_art_url(mbid: str, scope: str = 'release') -> Optional[str]:
@@ -324,6 +325,7 @@ class MusicBrainzSearchClient:
             external_urls={'musicbrainz': f'https://musicbrainz.org/release-group/{rg_mbid}'} if rg_mbid else {},
             disambiguation=rg.get('disambiguation') or None,
             release_group_id=rg_mbid or None,
+            secondary_types=[str(value) for value in secondary_types if value],
         )
 
     def _release_total_tracks(self, release: Dict[str, Any]) -> int:
@@ -1119,6 +1121,7 @@ class MusicBrainzSearchClient:
             'release_date': release_date,
             'total_tracks': total_tracks,
             'album_type': album_type,
+            'secondary_types': [str(value) for value in secondary_types if value],
             'images': images,
             'tracks': tracks,
             'external_urls': {'musicbrainz': f'https://musicbrainz.org/release/{release_mbid}'},

--- a/core/navidrome_client.py
+++ b/core/navidrome_client.py
@@ -980,6 +980,69 @@ class NavidromeClient(MediaServerClient):
                 return playlist
         return None
 
+    def set_playlist_image(self, playlist_name: str, image_url: str) -> bool:
+        """Upload a cover image to a Navidrome playlist from a URL.
+
+        Subsonic (the API the rest of this client uses) has no playlist-cover
+        field, so the mirrored Spotify/Tidal/Deezer cover can't be pushed via
+        createPlaylist. Navidrome's NATIVE API can: log in with the same
+        username/password for a short-lived JWT and POST the image as multipart
+        to ``/api/playlist/{id}/image``. Matches the Plex/Jellyfin
+        ``set_playlist_image`` signature so the sync layer calls every server
+        the same way. Best-effort — returns False (never raises) on any failure.
+
+        Note: the native update PUT ``/api/playlist/{id}`` is deliberately NOT
+        used — a partial body there blanks the playlist name and silently drops
+        externalImageUrl, so the multipart image POST is the only safe path.
+        """
+        if not self.ensure_connection() or not image_url:
+            return False
+        if not self.username or not self.password:
+            return False
+        try:
+            playlist = self.get_playlist_by_name(playlist_name)
+            playlist_id = getattr(playlist, 'id', '') if playlist else ''
+            if not playlist_id:
+                logger.debug(f"Navidrome playlist '{playlist_name}' not found for cover upload")
+                return False
+
+            # Native login is separate from the Subsonic token auth this client
+            # normally uses, but it's the SAME credentials already in config.
+            login_resp = requests.post(
+                f"{self.base_url}/auth/login",
+                json={'username': self.username, 'password': self.password},
+                timeout=15,
+            )
+            if not login_resp.ok:
+                logger.debug(f"Navidrome native login failed: {login_resp.status_code}")
+                return False
+            token = login_resp.json().get('token')
+            if not token:
+                logger.debug("Navidrome native login returned no token")
+                return False
+
+            img_resp = requests.get(image_url, timeout=15)
+            if not (img_resp.ok and img_resp.content):
+                logger.debug(f"Could not fetch playlist cover for '{playlist_name}'")
+                return False
+            content_type = img_resp.headers.get('Content-Type', 'image/jpeg')
+
+            upload_resp = requests.post(
+                f"{self.base_url}/api/playlist/{playlist_id}/image",
+                headers={'x-nd-authorization': f'Bearer {token}'},
+                files={'image': ('cover.jpg', img_resp.content, content_type)},
+                timeout=15,
+            )
+            if upload_resp.ok:
+                logger.info(f"Set Navidrome playlist poster for '{playlist_name}'")
+                return True
+            logger.debug(f"Navidrome playlist image upload returned {upload_resp.status_code}")
+        except requests.exceptions.RequestException as e:
+            logger.debug(f"Could not set Navidrome playlist poster for '{playlist_name}': {e}")
+        except Exception as e:
+            logger.debug(f"Could not set Navidrome playlist poster for '{playlist_name}': {e}")
+        return False
+
     def create_playlist(self, name: str, tracks, playlist_id: str = None) -> bool:
         """Create a new playlist or update existing one if playlist_id provided"""
         if not self.ensure_connection():

--- a/core/personalized/manager.py
+++ b/core/personalized/manager.py
@@ -111,7 +111,25 @@ class PersonalizedPlaylistManager:
                 (profile_id,),
             )
             rows = cursor.fetchall()
-        return [self._row_to_record(r) for r in rows]
+        return self._drop_unregistered([self._row_to_record(r) for r in rows])
+
+    def _drop_unregistered(self, records: List[PlaylistRecord]) -> List[PlaylistRecord]:
+        """Hide playlists whose ``kind`` is no longer registered.
+
+        A generator that was removed or reverted (e.g. an experimental
+        ``year_mix``) leaves its persisted rows behind; those kinds can
+        never be regenerated or synced, so they shouldn't surface. Fails
+        OPEN: if the registry hasn't been populated in this context
+        (generators not imported), return everything rather than hiding
+        every playlist.
+        """
+        try:
+            known = {spec.kind for spec in self.registry.all()}
+        except Exception:
+            return records
+        if not known:
+            return records
+        return [r for r in records if r.kind in known]
 
     def update_config(self, kind: str, variant: str, profile_id: int, overrides: Dict[str, Any]) -> PlaylistRecord:
         """Patch the per-playlist config with the provided overrides."""

--- a/core/playlists/sources/soulsync_discovery.py
+++ b/core/playlists/sources/soulsync_discovery.py
@@ -51,6 +51,11 @@ class SoulSyncDiscoveryPlaylistSource(PlaylistSource):
             records = manager.list_playlists(profile_id=self._profile_id_getter()) or []
         except Exception:
             return []
+        # Only surface syncable playlists: skip ones that generated empty
+        # (e.g. a no-op generator) — a 0-track playlist can't be mirrored and
+        # is just clutter on the sync board. (Unregistered kinds are already
+        # dropped by the manager.)
+        records = [r for r in records if (getattr(r, 'track_count', 0) or 0) > 0]
         return [self._meta_from_record(r) for r in records]
 
     def get_playlist(self, playlist_id: str) -> Optional[PlaylistDetail]:

--- a/tests/discovery/test_discovery_sync.py
+++ b/tests/discovery/test_discovery_sync.py
@@ -109,6 +109,15 @@ class _FakeJellyfin:
         return True
 
 
+class _FakeNavidrome:
+    def __init__(self):
+        self.image_calls = []
+
+    def set_playlist_image(self, name, url):
+        self.image_calls.append((name, url))
+        return True
+
+
 class _FakeAutomationEngine:
     def __init__(self):
         self.events = []
@@ -133,6 +142,7 @@ def _build_deps(
     config=None,
     plex=None,
     jellyfin=None,
+    navidrome=None,
     automation=None,
     sync_states=None,
     sync_lock=None,
@@ -150,6 +160,7 @@ def _build_deps(
         media_server_engine=_FakeMediaServerEngine(
             plex=plex or _FakePlex(),
             jellyfin=jellyfin or _FakeJellyfin(),
+            navidrome=navidrome or _FakeNavidrome(),
         ),
         automation_engine=automation or _FakeAutomationEngine(),
         run_async=run_async or _run_async_sync,
@@ -362,6 +373,36 @@ def test_playlist_image_uploaded_to_jellyfin(patched_db):
                      playlist_image_url='https://img/y.png', deps=deps)
 
     assert jf.image_calls == [('PJF', 'https://img/y.png')]
+
+
+def test_playlist_image_uploaded_to_navidrome(patched_db):
+    """Navidrome active → navidrome_client.set_playlist_image (#993). Subsonic has
+    no cover field, so this rides the native-API upload path."""
+    nd = _FakeNavidrome()
+    cfg = _FakeConfig(server='navidrome')
+    result = _FakeSyncResult(synced_tracks=4)
+    svc = _FakeSyncService(media_client=_FakeMediaClient(), sync_result=result)
+    deps = _build_deps(sync_service=svc, navidrome=nd, config=cfg)
+
+    ds.run_sync_task('pND', 'PND', [_track()],
+                     playlist_image_url='https://img/z.png', deps=deps)
+
+    assert nd.image_calls == [('PND', 'https://img/z.png')]
+
+
+def test_navidrome_append_mode_preserves_playlist_image(patched_db):
+    """Append edits in place — Navidrome must NOT re-push the source cover over a
+    user's custom one either (same guard as Plex/Jellyfin)."""
+    nd = _FakeNavidrome()
+    cfg = _FakeConfig(server='navidrome')
+    result = _FakeSyncResult(synced_tracks=4)
+    svc = _FakeSyncService(media_client=_FakeMediaClient(), sync_result=result)
+    deps = _build_deps(sync_service=svc, navidrome=nd, config=cfg)
+
+    ds.run_sync_task('pNDa', 'PNDa', [_track()],
+                     playlist_image_url='https://img/z.png', deps=deps, sync_mode='append')
+
+    assert nd.image_calls == []   # preserved, not clobbered
 
 
 def test_append_mode_preserves_playlist_image(patched_db):

--- a/tests/discovery/test_discovery_sync.py
+++ b/tests/discovery/test_discovery_sync.py
@@ -92,8 +92,14 @@ class _FakeConfig:
 
 
 class _FakePlex:
-    def __init__(self):
+    def __init__(self, existing=()):
         self.image_calls = []
+        # Names the test declares already present on the server (#993 existence
+        # probe). Anything not listed reads as a brand-new playlist.
+        self._existing = {n.lower() for n in existing}
+
+    def get_playlist_by_name(self, name):
+        return object() if name.lower() in self._existing else None
 
     def set_playlist_image(self, name, url):
         self.image_calls.append((name, url))
@@ -101,8 +107,12 @@ class _FakePlex:
 
 
 class _FakeJellyfin:
-    def __init__(self):
+    def __init__(self, existing=()):
         self.image_calls = []
+        self._existing = {n.lower() for n in existing}
+
+    def get_playlist_by_name(self, name):
+        return object() if name.lower() in self._existing else None
 
     def set_playlist_image(self, name, url):
         self.image_calls.append((name, url))
@@ -110,8 +120,12 @@ class _FakeJellyfin:
 
 
 class _FakeNavidrome:
-    def __init__(self):
+    def __init__(self, existing=()):
         self.image_calls = []
+        self._existing = {n.lower() for n in existing}
+
+    def get_playlist_by_name(self, name):
+        return object() if name.lower() in self._existing else None
 
     def set_playlist_image(self, name, url):
         self.image_calls.append((name, url))
@@ -403,6 +417,51 @@ def test_navidrome_append_mode_preserves_playlist_image(patched_db):
                      playlist_image_url='https://img/z.png', deps=deps, sync_mode='append')
 
     assert nd.image_calls == []   # preserved, not clobbered
+
+
+def test_playlist_image_skipped_when_playlist_already_exists(patched_db):
+    """#993: a playlist that already exists on the server keeps its current cover.
+    The source cover is pushed only to a brand-new playlist (first mirror), so a
+    recurring replace-mode sync no longer stomps a hand-set (or prior) cover."""
+    nd = _FakeNavidrome(existing=('PND',))
+    cfg = _FakeConfig(server='navidrome')
+    result = _FakeSyncResult(synced_tracks=4)
+    svc = _FakeSyncService(media_client=_FakeMediaClient(), sync_result=result)
+    deps = _build_deps(sync_service=svc, navidrome=nd, config=cfg)
+
+    ds.run_sync_task('pND', 'PND', [_track()],
+                     playlist_image_url='https://img/z.png', deps=deps)
+
+    assert nd.image_calls == []   # already existed → cover left untouched
+
+
+def test_playlist_image_new_playlist_still_pushes(patched_db):
+    """The complement: a genuinely new playlist (not present pre-sync) still gets
+    the source cover — the guard only suppresses re-pushes, never first fills."""
+    nd = _FakeNavidrome()   # no existing playlists → 'PNew' is brand new
+    cfg = _FakeConfig(server='navidrome')
+    result = _FakeSyncResult(synced_tracks=4)
+    svc = _FakeSyncService(media_client=_FakeMediaClient(), sync_result=result)
+    deps = _build_deps(sync_service=svc, navidrome=nd, config=cfg)
+
+    ds.run_sync_task('pNew', 'PNew', [_track()],
+                     playlist_image_url='https://img/n.png', deps=deps)
+
+    assert nd.image_calls == [('PNew', 'https://img/n.png')]
+
+
+def test_playlist_image_skip_on_existing_applies_to_plex_too(patched_db):
+    """The new-playlist-only rule is uniform across servers, not Navidrome-only."""
+    plex = _FakePlex(existing=('PImg',))
+    cfg = _FakeConfig(server='plex')
+    result = _FakeSyncResult(synced_tracks=5)
+    svc = _FakeSyncService(media_client=_FakeMediaClient(), sync_result=result)
+    deps = _build_deps(sync_service=svc, plex=plex, config=cfg)
+
+    ds.run_sync_task('pImg', 'PImg', [_track()],
+                     playlist_image_url='https://img/x.png', deps=deps)
+
+    assert plex.image_calls == []   # already existed → not re-pushed
 
 
 def test_append_mode_preserves_playlist_image(patched_db):

--- a/tests/metadata/test_metadata_discography.py
+++ b/tests/metadata/test_metadata_discography.py
@@ -754,3 +754,19 @@ def test_get_artist_detail_discography_splits_eps_from_singles(monkeypatch):
     assert [r["id"] for r in result["albums"]] == ["a1"]
     assert [r["id"] for r in result["eps"]] == ["e1"]
     assert [r["id"] for r in result["singles"]] == ["s1"]
+
+
+def test_musicbrainz_secondary_types_reach_artist_detail_cards():
+    # The artist-detail declutter filter classifies Live/Compilation from
+    # secondary_types, so they MUST survive the projection into the card dict.
+    release = types.SimpleNamespace(
+        id='rg-live', name='Unlabelled Concert', artists=['Example Artist'],
+        release_date='2025-01-01', total_tracks=0, album_type='album',
+        image_url=None, external_urls={}, explicit=None, secondary_types=['Live'],
+    )
+    normalized = metadata_discography._build_discography_release_dict(
+        release, artist_id='artist-id', source='musicbrainz')
+    card = metadata_discography._build_artist_detail_release_card(normalized)
+
+    assert normalized['secondary_types'] == ['Live']
+    assert card['secondary_types'] == ['Live']

--- a/tests/metadata/test_musicbrainz_search.py
+++ b/tests/metadata/test_musicbrainz_search.py
@@ -1326,3 +1326,17 @@ def test_get_artist_albums_swallows_browse_errors():
     client._client.browse_artist_release_groups.side_effect = RuntimeError('mb down')
 
     assert client.get_artist_albums('mbid-x') == []
+
+
+def test_release_group_projection_preserves_secondary_types():
+    # _release_group_to_album must stamp the MB secondary-types onto the Album so
+    # the artist-detail page can classify live/compilation releases (declutter).
+    client = MusicBrainzSearchClient.__new__(MusicBrainzSearchClient)
+    client._cached_art = MagicMock(return_value=None)
+    rg = {'id': 'rg-live', 'title': 'Unlabelled Concert', 'primary-type': 'Album',
+          'secondary-types': ['Live', 'Compilation'], 'first-release-date': '2025'}
+
+    album = client._release_group_to_album(rg, 'Example Artist')
+
+    assert album.album_type == 'compilation'          # Compilation secondary → compilation bucket
+    assert album.secondary_types == ['Live', 'Compilation']

--- a/tests/metadata/test_typed_metadata_types.py
+++ b/tests/metadata/test_typed_metadata_types.py
@@ -572,7 +572,7 @@ def test_to_context_dict_shape_is_uniform_across_providers(factory, raw):
     expected_keys = {
         'id', 'name', 'artist', 'artist_name', 'artist_id', 'artists',
         'image_url', 'images', 'release_date', 'album_type',
-        'total_tracks', 'source', 'genres', 'label', 'barcode',
+        'secondary_types', 'total_tracks', 'source', 'genres', 'label', 'barcode',
         'external_ids', 'external_urls',
     }
     assert set(ctx.keys()) == expected_keys

--- a/tests/static/test_auto_sync.mjs
+++ b/tests/static/test_auto_sync.mjs
@@ -1141,3 +1141,106 @@ describe('autoSyncSidebarGroupHtml + toggleAutoSyncKindGroup', () => {
         assert.ok(!html.includes(' on</span>'));
     });
 });
+
+// =========================================================================
+// Enriching already-generated discovery rows so they group with the rest
+// =========================================================================
+
+describe('autoSyncKindLabel', () => {
+    test('strips the {variant} suffix and separator', () => {
+        const sb = makeSandbox();
+        assert.equal(sb.autoSyncKindLabel({ kind: 'time_machine', name_template: 'Time Machine — {variant}' }), 'Time Machine');
+        assert.equal(sb.autoSyncKindLabel({ kind: 'genre_playlist', name_template: 'Genre: {variant}' }), 'Genre');
+    });
+    test('falls back to the kind when no template', () => {
+        const sb = makeSandbox();
+        assert.equal(sb.autoSyncKindLabel({ kind: 'seasonal_mix' }), 'seasonal_mix');
+    });
+});
+
+describe('autoSyncEnrichDiscoveryRows', () => {
+    const KINDS = [
+        { kind: 'hidden_gems', name_template: 'Hidden Gems' },
+        { kind: 'time_machine', requires_variant: true, variants: ['1960s', '1970s'], name_template: 'Time Machine — {variant}' },
+        { kind: 'genre_playlist', requires_variant: true, variants: ['rock'], name_template: 'Genre — {variant}' },
+    ];
+
+    test('tags a generated variant mirror row with kind/variant/kind_label', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: 1397, source: 'soulsync_discovery', source_playlist_id: 'ssd_time_machine_1960s',
+              name: 'Time Machine — 1960s', track_count: 45 },
+        ];
+        const [r] = sb.autoSyncEnrichDiscoveryRows(rows, KINDS);
+        assert.equal(r.kind, 'time_machine');
+        assert.equal(r.variant, '1960s');
+        assert.equal(r.kind_label, 'Time Machine');
+        assert.equal(r.id, 1397);          // unchanged
+        assert.equal(r.track_count, 45);   // unchanged
+        assert.ok(!r._personalized);       // still a real row → schedules via playlist_pipeline
+    });
+
+    test('registered singleton row passes through flat and untouched', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: 939, source: 'soulsync_discovery', source_playlist_id: 'ssd_hidden_gems',
+              name: 'Hidden Gems', track_count: 50 },
+        ];
+        const [r] = sb.autoSyncEnrichDiscoveryRows(rows, KINDS);
+        assert.equal(r.id, 939);
+        assert.ok(!('variant' in r) || !r.variant);  // no variant → stays flat
+        assert.ok(!('kind' in r));                    // not tagged
+    });
+
+    test('drops an orphaned mirror whose kind is no longer registered', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: 1398, source: 'soulsync_discovery', source_playlist_id: 'ssd_year_mix_1970',
+              name: 'Year Mix — 1970', track_count: 32 },
+            { id: 939, source: 'soulsync_discovery', source_playlist_id: 'ssd_hidden_gems', name: 'Hidden Gems' },
+        ];
+        const out = sb.autoSyncEnrichDiscoveryRows(rows, KINDS);
+        assert.equal(out.length, 1);                       // year_mix dropped
+        assert.equal(out[0].source_playlist_id, 'ssd_hidden_gems');
+    });
+
+    test('non-discovery rows pass through unchanged', () => {
+        const sb = makeSandbox();
+        const rows = [{ id: 5, source: 'spotify', name: 'Discover Weekly' }];
+        deepShapeEqual(sb.autoSyncEnrichDiscoveryRows(rows, KINDS), rows);
+    });
+
+    test('fails open with no kinds metadata (keeps every row, orphans included)', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: 1398, source: 'soulsync_discovery', source_playlist_id: 'ssd_year_mix_1970', name: 'Year Mix — 1970' },
+        ];
+        deepShapeEqual(sb.autoSyncEnrichDiscoveryRows(rows, []), rows);
+        deepShapeEqual(sb.autoSyncEnrichDiscoveryRows(rows, null), rows);
+    });
+
+    test('generated + synthetic variants merge into ONE group', () => {
+        const sb = makeSandbox();
+        // Only a variant kind, so no singleton noise: a generated 1960s (real)
+        // plus the not-yet-generated decades (synthetic).
+        const TM_ONLY = [KINDS[1]];  // time_machine with variants 1960s, 1970s
+        const real = [
+            { id: 1397, source: 'soulsync_discovery', source_playlist_id: 'ssd_time_machine_1960s',
+              name: 'Time Machine — 1960s', track_count: 45 },
+        ];
+        const enriched = sb.autoSyncEnrichDiscoveryRows(real, TM_ONLY);
+        const synthetic = sb.autoSyncExpandPersonalizedRows(TM_ONLY, enriched);  // dedups 1960s
+        const { flat, groups } = sb.autoSyncGroupSidebarRows([...enriched, ...synthetic]);
+        assert.equal(flat.length, 0);  // nothing flat
+        assert.equal(groups.length, 1);
+        const tm = groups[0];
+        assert.equal(tm.kind, 'time_machine');
+        // 1960s (generated) + 1970s (synthetic) all under the one Time Machine group
+        deepShapeEqual(tm.rows.map(r => r.variant).sort(), ['1960s', '1970s']);
+        // the generated one kept its real id + track count
+        const gen = tm.rows.find(r => r.variant === '1960s');
+        assert.equal(gen.id, 1397);
+        assert.equal(gen.track_count, 45);
+        assert.ok(!gen._personalized);  // real row → still schedules as a mirrored playlist
+    });
+});

--- a/tests/static/test_auto_sync.mjs
+++ b/tests/static/test_auto_sync.mjs
@@ -684,3 +684,315 @@ describe('autoSyncWeeklyLabel', () => {
         assert.equal(label, 'Daily @ 09:00');
     });
 });
+
+// =========================================================================
+// Personalized (SoulSync Discovery) rows in the Auto-Sync board
+// =========================================================================
+
+describe('autoSyncExpandPersonalizedRows', () => {
+    test('singleton kind → one synthetic row, no variant', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'popular_picks', name_template: 'Popular Picks' }], []);
+        deepShapeEqual(rows, [{
+            id: -1, source: 'soulsync_discovery', name: 'Popular Picks', track_count: 0,
+            kind: 'popular_picks', variant: '', source_playlist_id: 'ssd_popular_picks',
+            _personalized: true,
+        }]);
+    });
+
+    test('variant kind → one synthetic row per variant, ids stay negative', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'time_machine', requires_variant: true,
+            variants: ['1980s', '1990s', '2000s'],
+            name_template: 'Time Machine — {variant}',
+        }], []);
+        assert.equal(rows.length, 3);
+        deepShapeEqual(rows.map(r => r.id), [-1, -2, -3]);
+        deepShapeEqual(rows.map(r => r.variant), ['1980s', '1990s', '2000s']);
+        deepShapeEqual(rows.map(r => r.source_playlist_id),
+            ['ssd_time_machine_1980s', 'ssd_time_machine_1990s', 'ssd_time_machine_2000s']);
+        assert.equal(rows[0].name, 'Time Machine — 1980s');
+        assert.equal(rows[0].kind, 'time_machine');
+        assert.equal(rows[0]._personalized, true);
+    });
+
+    test('skips a variant already present as a real mirrored row', () => {
+        const sb = makeSandbox();
+        const existing = [{
+            id: 42, source: 'soulsync_discovery', source_playlist_id: 'ssd_time_machine_1980s',
+            name: 'Time Machine — 1980s',
+        }];
+        const rows = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'time_machine', requires_variant: true,
+            variants: ['1980s', '1990s'], name_template: 'Time Machine — {variant}',
+        }], existing);
+        // 1980s exists as real → skipped; only 1990s becomes synthetic.
+        assert.equal(rows.length, 1);
+        assert.equal(rows[0].variant, '1990s');
+        assert.equal(rows[0].source_playlist_id, 'ssd_time_machine_1990s');
+    });
+
+    test('skips a singleton already present as a real mirrored row', () => {
+        const sb = makeSandbox();
+        const existing = [{
+            id: 7, source: 'soulsync_discovery', source_playlist_id: 'ssd_hidden_gems',
+        }];
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'hidden_gems', name_template: 'Hidden Gems' }], existing);
+        deepShapeEqual(rows, []);
+    });
+
+    test('variant kind with empty variants list produces nothing', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'genre_playlist', requires_variant: true, variants: [] }], []);
+        deepShapeEqual(rows, []);
+    });
+
+    test('non-array kinds and skips malformed entries', () => {
+        const sb = makeSandbox();
+        deepShapeEqual(sb.autoSyncExpandPersonalizedRows(null, []), []);
+        deepShapeEqual(sb.autoSyncExpandPersonalizedRows(undefined, []), []);
+        // an entry with no `kind` is skipped
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ name_template: 'orphan' }, { kind: 'archives', name_template: 'The Archives' }], []);
+        assert.equal(rows.length, 1);
+        assert.equal(rows[0].kind, 'archives');
+    });
+
+    test('name_template with {variant} placeholder is substituted; falls back without it', () => {
+        const sb = makeSandbox();
+        const withTpl = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'genre_playlist', requires_variant: true, variants: ['rock'],
+               name_template: 'Genre — {variant}' }], []);
+        assert.equal(withTpl[0].name, 'Genre — rock');
+        // no template → "<kind> <variant>" default
+        const noTpl = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'genre_playlist', requires_variant: true, variants: ['rock'] }], []);
+        assert.equal(noTpl[0].name, 'genre_playlist rock');
+    });
+});
+
+describe('autoSyncActionForPlaylist', () => {
+    test('personalized row → personalized_pipeline with single kind entry (with variant)', () => {
+        const sb = makeSandbox();
+        const pl = { id: -2, _personalized: true, kind: 'time_machine', variant: '1990s' };
+        deepShapeEqual(sb.autoSyncActionForPlaylist(pl, -2), {
+            action_type: 'personalized_pipeline',
+            action_config: { kinds: [{ kind: 'time_machine', variant: '1990s' }], refresh_first: true },
+        });
+    });
+
+    test('personalized singleton row → personalized_pipeline, no variant key', () => {
+        const sb = makeSandbox();
+        const pl = { id: -1, _personalized: true, kind: 'hidden_gems', variant: '' };
+        const action = sb.autoSyncActionForPlaylist(pl, -1);
+        deepShapeEqual(action, {
+            action_type: 'personalized_pipeline',
+            action_config: { kinds: [{ kind: 'hidden_gems' }], refresh_first: true },
+        });
+        assert.ok(!('variant' in action.action_config.kinds[0]));
+    });
+
+    test('regression: ordinary mirrored row → playlist_pipeline by numeric id (unchanged)', () => {
+        const sb = makeSandbox();
+        const pl = { id: 5, name: 'Discover Weekly' };
+        deepShapeEqual(sb.autoSyncActionForPlaylist(pl, 5), {
+            action_type: 'playlist_pipeline',
+            action_config: { playlist_id: '5', all: false },
+        });
+    });
+
+    test('regression: null playlist still yields playlist_pipeline (defensive)', () => {
+        const sb = makeSandbox();
+        deepShapeEqual(sb.autoSyncActionForPlaylist(null, 9), {
+            action_type: 'playlist_pipeline',
+            action_config: { playlist_id: '9', all: false },
+        });
+    });
+});
+
+describe('autoSyncIsPersonalizedAutomation / autoSyncPersonalizedEntry', () => {
+    test('recognizes a single-kind personalized_pipeline', () => {
+        const sb = makeSandbox();
+        const auto = { action_type: 'personalized_pipeline',
+                       action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }] } };
+        assert.equal(sb.autoSyncIsPersonalizedAutomation(auto), true);
+        deepShapeEqual(sb.autoSyncPersonalizedEntry(auto), { kind: 'time_machine', variant: '1980s' });
+    });
+
+    test('single-kind without variant → empty-string variant', () => {
+        const sb = makeSandbox();
+        const auto = { action_type: 'personalized_pipeline',
+                       action_config: { kinds: [{ kind: 'popular_picks' }] } };
+        deepShapeEqual(sb.autoSyncPersonalizedEntry(auto), { kind: 'popular_picks', variant: '' });
+    });
+
+    test('multi-kind pipeline (Automations-page built) is NOT a per-row board schedule', () => {
+        const sb = makeSandbox();
+        const auto = { action_type: 'personalized_pipeline',
+                       action_config: { kinds: [{ kind: 'a' }, { kind: 'b' }] } };
+        assert.equal(sb.autoSyncIsPersonalizedAutomation(auto), true);
+        assert.equal(sb.autoSyncPersonalizedEntry(auto), null);
+    });
+
+    test('playlist_pipeline is not personalized', () => {
+        const sb = makeSandbox();
+        const auto = { action_type: 'playlist_pipeline', action_config: { playlist_id: '1' } };
+        assert.equal(sb.autoSyncIsPersonalizedAutomation(auto), false);
+        assert.equal(sb.autoSyncPersonalizedEntry(auto), null);
+    });
+
+    test('missing/empty kinds → null entry', () => {
+        const sb = makeSandbox();
+        assert.equal(sb.autoSyncPersonalizedEntry(
+            { action_type: 'personalized_pipeline', action_config: {} }), null);
+        assert.equal(sb.autoSyncPersonalizedEntry(
+            { action_type: 'personalized_pipeline', action_config: { kinds: [] } }), null);
+        assert.equal(sb.autoSyncPersonalizedEntry(
+            { action_type: 'personalized_pipeline', action_config: { kinds: [{}] } }), null);
+    });
+});
+
+describe('autoSyncRowIdForPersonalized', () => {
+    test('prefers the real mirrored row id when the kind is already generated', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: 88, source: 'soulsync_discovery', source_playlist_id: 'ssd_time_machine_1980s' },
+            { id: -3, _personalized: true, kind: 'time_machine', variant: '1980s' },
+        ];
+        assert.equal(
+            sb.autoSyncRowIdForPersonalized({ kind: 'time_machine', variant: '1980s' }, playlists), 88);
+    });
+
+    test('falls back to the synthetic negative id when not yet generated', () => {
+        const sb = makeSandbox();
+        const playlists = [{ id: -3, _personalized: true, kind: 'time_machine', variant: '1980s' }];
+        assert.equal(
+            sb.autoSyncRowIdForPersonalized({ kind: 'time_machine', variant: '1980s' }, playlists), -3);
+    });
+
+    test('null when neither real nor synthetic row exists', () => {
+        const sb = makeSandbox();
+        assert.equal(sb.autoSyncRowIdForPersonalized({ kind: 'ghost', variant: '' }, []), null);
+        assert.equal(sb.autoSyncRowIdForPersonalized(null, []), null);
+    });
+});
+
+describe('buildAutoSyncScheduleState — personalized integration', () => {
+    test('bucket a personalized schedule onto its synthetic row', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: 1, name: 'Discover Weekly' },
+            { id: -1, _personalized: true, source: 'soulsync_discovery', kind: 'time_machine',
+              variant: '1980s', source_playlist_id: 'ssd_time_machine_1980s', name: 'Time Machine — 1980s' },
+        ];
+        const automations = [
+            { id: 50, action_type: 'personalized_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 1, unit: 'days' },
+              action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }], refresh_first: true },
+              owned_by: 'auto_sync', enabled: 1 },
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        // keyed on the synthetic id -1
+        assert.equal(state.playlistSchedules[-1].automation_id, 50);
+        assert.equal(state.playlistSchedules[-1].hours, 24);
+        assert.equal(state.playlistSchedules[-1].owned, true);
+        // personalized schedules never leak into the "custom pipelines" list
+        deepShapeEqual(state.automationPipelines, []);
+    });
+
+    test('weekly personalized schedule buckets into weeklySchedules', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: -1, _personalized: true, source: 'soulsync_discovery', kind: 'genre_playlist',
+              variant: 'rock', source_playlist_id: 'ssd_genre_playlist_rock', name: 'Genre — rock' },
+        ];
+        const automations = [
+            { id: 51, action_type: 'personalized_pipeline', trigger_type: 'weekly_time',
+              trigger_config: { time: '08:00', days: ['mon', 'thu'], tz: 'UTC' },
+              action_config: { kinds: [{ kind: 'genre_playlist', variant: 'rock' }] },
+              owned_by: 'auto_sync', enabled: 1 },
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        assert.equal(state.weeklySchedules[-1].automation_id, 51);
+        assert.equal(state.weeklySchedules[-1].time, '08:00');
+        deepShapeEqual(state.weeklySchedules[-1].days, ['mon', 'thu']);
+    });
+
+    test('personalized schedule re-keys onto the REAL row once generated', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: 90, source: 'soulsync_discovery', source_playlist_id: 'ssd_time_machine_1980s',
+              name: 'Time Machine — 1980s' },
+        ];
+        const automations = [
+            { id: 52, action_type: 'personalized_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 6, unit: 'hours' },
+              action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }] },
+              owned_by: 'auto_sync', enabled: 1 },
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        assert.equal(state.playlistSchedules[90].automation_id, 52);
+        assert.equal(state.playlistSchedules[90].hours, 6);
+    });
+
+    test('non-owned personalized pipeline is ignored (not a board schedule)', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: -1, _personalized: true, source: 'soulsync_discovery', kind: 'time_machine',
+              variant: '1980s', source_playlist_id: 'ssd_time_machine_1980s' },
+        ];
+        const automations = [
+            { id: 53, action_type: 'personalized_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 1, unit: 'days' },
+              action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }] },
+              enabled: 1 },  // no owned_by
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        deepShapeEqual(state.playlistSchedules, {});
+        deepShapeEqual(state.weeklySchedules, {});
+    });
+
+    test('multi-kind personalized pipeline never binds to a row', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: -1, _personalized: true, source: 'soulsync_discovery', kind: 'time_machine',
+              variant: '1980s', source_playlist_id: 'ssd_time_machine_1980s' },
+        ];
+        const automations = [
+            { id: 54, action_type: 'personalized_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 1, unit: 'days' },
+              action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }, { kind: 'hidden_gems' }] },
+              owned_by: 'auto_sync', enabled: 1 },
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        deepShapeEqual(state.playlistSchedules, {});
+    });
+
+    test('regression: mirrored playlist_pipeline schedules coexist untouched', () => {
+        const sb = makeSandbox();
+        const playlists = [
+            { id: 1, name: 'Discover Weekly' },
+            { id: -1, _personalized: true, source: 'soulsync_discovery', kind: 'time_machine',
+              variant: '1980s', source_playlist_id: 'ssd_time_machine_1980s' },
+        ];
+        const automations = [
+            { id: 10, action_type: 'playlist_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 1, unit: 'hours' },
+              action_config: { playlist_id: '1' }, owned_by: 'auto_sync', enabled: 1 },
+            { id: 50, action_type: 'personalized_pipeline', trigger_type: 'schedule',
+              trigger_config: { interval: 1, unit: 'days' },
+              action_config: { kinds: [{ kind: 'time_machine', variant: '1980s' }] },
+              owned_by: 'auto_sync', enabled: 1 },
+        ];
+        const state = sb.buildAutoSyncScheduleState(playlists, automations);
+        // both bucketed independently
+        assert.equal(state.playlistSchedules[1].automation_id, 10);
+        assert.equal(state.playlistSchedules[1].hours, 1);
+        assert.equal(state.playlistSchedules[-1].automation_id, 50);
+        assert.equal(Object.keys(state.playlistSchedules).length, 2);
+    });
+});

--- a/tests/static/test_auto_sync.mjs
+++ b/tests/static/test_auto_sync.mjs
@@ -701,6 +701,31 @@ describe('autoSyncExpandPersonalizedRows', () => {
         }]);
     });
 
+    test('uses generated counts when provided (refreshed-but-unsynced variant)', () => {
+        const sb = makeSandbox();
+        // time_machine 2000s has been generated (100 tracks) but not synced, so it
+        // has no mirror row; the synthetic row should still show 100, not 0.
+        const genCounts = sb.autoSyncGeneratedCountMap({
+            success: true,
+            playlists: [{ kind: 'time_machine', variant: '2000s', track_count: 100 }],
+        });
+        const rows = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'time_machine', requires_variant: true, variants: ['2000s', '2010s'],
+            name_template: 'Time Machine — {variant}',
+        }], [], genCounts);
+        const r2000 = rows.find(r => r.variant === '2000s');
+        const r2010 = rows.find(r => r.variant === '2010s');
+        assert.equal(r2000.track_count, 100);  // real generated count
+        assert.equal(r2010.track_count, 0);    // never generated
+    });
+
+    test('track_count is 0 when no generated-counts map is passed', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'hidden_gems', name_template: 'Hidden Gems' }], []);
+        assert.equal(rows[0].track_count, 0);
+    });
+
     test('variant kind → one synthetic row per variant, ids stay negative', () => {
         const sb = makeSandbox();
         const rows = sb.autoSyncExpandPersonalizedRows([{
@@ -772,6 +797,26 @@ describe('autoSyncExpandPersonalizedRows', () => {
         const noTpl = sb.autoSyncExpandPersonalizedRows(
             [{ kind: 'genre_playlist', requires_variant: true, variants: ['rock'] }], []);
         assert.equal(noTpl[0].name, 'genre_playlist rock');
+    });
+});
+
+describe('autoSyncGeneratedCountMap', () => {
+    test('keys by kind+variant → track_count', () => {
+        const sb = makeSandbox();
+        const map = sb.autoSyncGeneratedCountMap({ success: true, playlists: [
+            { kind: 'time_machine', variant: '2000s', track_count: 100 },
+            { kind: 'hidden_gems', variant: '', track_count: 50 },
+        ]});
+        assert.equal(map.get('time_machine 2000s'), 100);
+        assert.equal(map.get('hidden_gems '), 50);
+        assert.equal(map.get('genre_playlist rock'), undefined);
+    });
+
+    test('empty / failed response → empty map', () => {
+        const sb = makeSandbox();
+        assert.equal(sb.autoSyncGeneratedCountMap(null).size, 0);
+        assert.equal(sb.autoSyncGeneratedCountMap({ success: false }).size, 0);
+        assert.equal(sb.autoSyncGeneratedCountMap({ success: true, playlists: [] }).size, 0);
     });
 });
 

--- a/tests/static/test_auto_sync.mjs
+++ b/tests/static/test_auto_sync.mjs
@@ -48,7 +48,7 @@ function realAutoParseUTC(ts) {
 function makeSandbox() {
     const sandbox = {
         window: {},
-        document: { getElementById: () => null, body: {} },
+        document: { getElementById: () => null, body: {}, querySelectorAll: () => [] },
         console: { debug: () => {}, error: () => {}, log: () => {} },
         fetch: async () => { throw new Error('fetch not stubbed for this test'); },
         // Globals that auto-sync.js expects to find in the window namespace
@@ -696,7 +696,7 @@ describe('autoSyncExpandPersonalizedRows', () => {
             [{ kind: 'popular_picks', name_template: 'Popular Picks' }], []);
         deepShapeEqual(rows, [{
             id: -1, source: 'soulsync_discovery', name: 'Popular Picks', track_count: 0,
-            kind: 'popular_picks', variant: '', source_playlist_id: 'ssd_popular_picks',
+            kind: 'popular_picks', variant: '', kind_label: '', source_playlist_id: 'ssd_popular_picks',
             _personalized: true,
         }]);
     });
@@ -994,5 +994,150 @@ describe('buildAutoSyncScheduleState — personalized integration', () => {
         assert.equal(state.playlistSchedules[1].hours, 1);
         assert.equal(state.playlistSchedules[-1].automation_id, 50);
         assert.equal(Object.keys(state.playlistSchedules).length, 2);
+    });
+});
+
+// =========================================================================
+// Collapsible variant-kind groups in the sidebar
+// =========================================================================
+
+describe('autoSyncExpandPersonalizedRows — kind_label', () => {
+    test('variant kind gets a group label with the {variant} suffix stripped', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'time_machine', requires_variant: true, variants: ['1980s'],
+            name_template: 'Time Machine — {variant}',
+        }], []);
+        assert.equal(rows[0].kind_label, 'Time Machine');
+    });
+
+    test('colon / dash separators are trimmed too', () => {
+        const sb = makeSandbox();
+        const colon = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'genre_playlist', requires_variant: true, variants: ['rock'],
+            name_template: 'Genre: {variant}',
+        }], []);
+        assert.equal(colon[0].kind_label, 'Genre');
+        const dash = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'genre_playlist', requires_variant: true, variants: ['rock'],
+            name_template: 'Genre - {variant}',
+        }], []);
+        assert.equal(dash[0].kind_label, 'Genre');
+    });
+
+    test('no name_template → kind_label falls back to the kind', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows([{
+            kind: 'seasonal_mix', requires_variant: true, variants: ['halloween'],
+        }], []);
+        assert.equal(rows[0].kind_label, 'seasonal_mix');
+    });
+
+    test('singleton kind has an empty kind_label (never grouped)', () => {
+        const sb = makeSandbox();
+        const rows = sb.autoSyncExpandPersonalizedRows(
+            [{ kind: 'hidden_gems', name_template: 'Hidden Gems' }], []);
+        assert.equal(rows[0].kind_label, '');
+    });
+});
+
+describe('autoSyncGroupSidebarRows', () => {
+    test('variant kinds bucket by kind; singletons and real rows stay flat', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: 5, name: 'Discover Weekly' },                       // real mirrored → flat
+            { id: -1, _personalized: true, kind: 'popular_picks', variant: '' },  // singleton → flat
+            { id: -2, _personalized: true, kind: 'time_machine', variant: '1980s', kind_label: 'Time Machine' },
+            { id: -3, _personalized: true, kind: 'time_machine', variant: '1990s', kind_label: 'Time Machine' },
+            { id: -4, _personalized: true, kind: 'genre_playlist', variant: 'rock', kind_label: 'Genre' },
+        ];
+        const { flat, groups } = sb.autoSyncGroupSidebarRows(rows);
+        deepShapeEqual(flat.map(p => p.id), [5, -1]);
+        assert.equal(groups.length, 2);
+        assert.equal(groups[0].kind, 'time_machine');
+        assert.equal(groups[0].label, 'Time Machine');
+        deepShapeEqual(groups[0].rows.map(p => p.variant), ['1980s', '1990s']);
+        assert.equal(groups[1].kind, 'genre_playlist');
+        assert.equal(groups[1].label, 'Genre');
+        assert.equal(groups[1].rows.length, 1);
+    });
+
+    test('group label falls back to the kind when kind_label is missing', () => {
+        const sb = makeSandbox();
+        const { groups } = sb.autoSyncGroupSidebarRows([
+            { id: -1, _personalized: true, kind: 'time_machine', variant: '1980s' },
+        ]);
+        assert.equal(groups[0].label, 'time_machine');
+    });
+
+    test('empty / null input yields empty flat + groups', () => {
+        const sb = makeSandbox();
+        deepShapeEqual(sb.autoSyncGroupSidebarRows([]), { flat: [], groups: [] });
+        deepShapeEqual(sb.autoSyncGroupSidebarRows(null), { flat: [], groups: [] });
+    });
+});
+
+describe('autoSyncSidebarGroupHtml + toggleAutoSyncKindGroup', () => {
+    // A tiny card renderer that tags id and the display name it was given, so we
+    // can assert flat-vs-grouped placement and the variant-only labels.
+    const renderer = (p, displayName) => `[card:${p.id}:${displayName || p.name}]`;
+
+    test('flat cards render outside groups; variant cards inside, labelled by variant', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: -1, _personalized: true, kind: 'popular_picks', variant: '', name: 'Popular Picks' },
+            { id: -2, _personalized: true, kind: 'time_machine', variant: '1980s', kind_label: 'Time Machine' },
+            { id: -3, _personalized: true, kind: 'time_machine', variant: '1990s', kind_label: 'Time Machine' },
+        ];
+        const html = sb.autoSyncSidebarGroupHtml(rows, renderer);
+        assert.ok(html.includes('[card:-1:Popular Picks]'), 'singleton flat card present');
+        // grouped cards labelled by variant, not full name
+        assert.ok(html.includes('[card:-2:1980s]'), 'grouped card uses variant label');
+        assert.ok(html.includes('[card:-3:1990s]'));
+        // one collapsible header with the kind label + a count of 2
+        assert.ok(html.includes('auto-sync-kind-group'), 'group wrapper present');
+        assert.ok(html.includes('data-kind="time_machine"'));
+        assert.ok(html.includes('Time Machine'), 'group heading present');
+        assert.ok(html.includes('>2</span>'), 'count reflects 2 variants');
+    });
+
+    test('collapsed by default; expanded once its kind is toggled on', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: -2, _personalized: true, kind: 'time_machine', variant: '1980s', kind_label: 'Time Machine' },
+        ];
+        const collapsed = sb.autoSyncSidebarGroupHtml(rows, renderer);
+        assert.ok(!/auto-sync-kind-group expanded|auto-sync-kind-group .*expanded/.test(collapsed),
+            'no expanded class before toggle');
+        sb.toggleAutoSyncKindGroup('time_machine');
+        const expanded = sb.autoSyncSidebarGroupHtml(rows, renderer);
+        assert.ok(expanded.includes('auto-sync-kind-group expanded'),
+            'expanded class present after toggle');
+        // toggling again collapses
+        sb.toggleAutoSyncKindGroup('time_machine');
+        const recollapsed = sb.autoSyncSidebarGroupHtml(rows, renderer);
+        assert.ok(!recollapsed.includes('auto-sync-kind-group expanded'));
+    });
+
+    test('"N on" badge counts scheduled variants via isScheduled predicate', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: -2, _personalized: true, kind: 'time_machine', variant: '1980s', kind_label: 'Time Machine' },
+            { id: -3, _personalized: true, kind: 'time_machine', variant: '1990s', kind_label: 'Time Machine' },
+        ];
+        const isScheduled = (p) => p.id === -2;  // one of the two is scheduled
+        const html = sb.autoSyncSidebarGroupHtml(rows, renderer, isScheduled);
+        assert.ok(html.includes('has-active'), 'group flagged active');
+        assert.ok(html.includes('1 on'), 'active badge shows 1');
+    });
+
+    test('no active badge when nothing in the group is scheduled', () => {
+        const sb = makeSandbox();
+        const rows = [
+            { id: -2, _personalized: true, kind: 'time_machine', variant: '1980s', kind_label: 'Time Machine' },
+        ];
+        const html = sb.autoSyncSidebarGroupHtml(rows, renderer, () => false);
+        assert.ok(!html.includes('has-active'));
+        assert.ok(!html.includes(' on</span>'));
     });
 });

--- a/tests/test_navidrome_playlist_image.py
+++ b/tests/test_navidrome_playlist_image.py
@@ -1,0 +1,102 @@
+"""NavidromeClient.set_playlist_image (#993).
+
+Subsonic (the API this client normally uses) has no playlist-cover field, so the
+mirrored source cover is pushed via Navidrome's NATIVE API: a JWT login with the
+same username/password, then a multipart POST to /api/playlist/{id}/image. These
+tests drive the real method with `requests` stubbed and assert the native path —
+including that the record-blanking PUT /api/playlist/{id} is never used.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from core import navidrome_client as ncmod
+from core.navidrome_client import NavidromeClient
+
+
+class _Resp:
+    def __init__(self, ok=True, json_data=None, content=b"", headers=None, status_code=200):
+        self.ok = ok
+        self._json = json_data or {}
+        self.content = content
+        self.headers = headers or {}
+        self.status_code = status_code
+
+    def json(self):
+        return self._json
+
+
+def _client():
+    c = NavidromeClient.__new__(NavidromeClient)
+    c.ensure_connection = lambda: True
+    c.base_url = "http://nav.local"
+    c.username = "u"
+    c.password = "p"
+    c.get_playlist_by_name = lambda name: SimpleNamespace(id="PL1")
+    return c
+
+
+def test_set_playlist_image_uploads_via_native_api(monkeypatch):
+    calls = []
+
+    def fake_post(url, **kw):
+        calls.append(("POST", url, kw))
+        if url.endswith("/auth/login"):
+            return _Resp(ok=True, json_data={"token": "TKN"})
+        if url.endswith("/api/playlist/PL1/image"):
+            return _Resp(ok=True)
+        return _Resp(ok=False, status_code=404)
+
+    def fake_get(url, **kw):
+        calls.append(("GET", url, kw))
+        return _Resp(ok=True, content=b"IMGDATA", headers={"Content-Type": "image/png"})
+
+    monkeypatch.setattr(ncmod.requests, "post", fake_post)
+    monkeypatch.setattr(ncmod.requests, "get", fake_get)
+
+    assert _client().set_playlist_image("My PL", "http://img/cover.png") is True
+
+    # Native login used the SAME creds already in config.
+    login = [x for x in calls if x[1].endswith("/auth/login")][0]
+    assert login[2]["json"] == {"username": "u", "password": "p"}
+
+    # Image POSTed to the native endpoint with the Bearer token + multipart file.
+    up = [x for x in calls if x[1].endswith("/api/playlist/PL1/image")][0]
+    assert up[0] == "POST"
+    assert up[2]["headers"]["x-nd-authorization"] == "Bearer TKN"
+    assert "image" in up[2]["files"]
+
+    # NEVER the record-blanking PUT /api/playlist/{id}.
+    assert not any(method == "PUT" for (method, _u, _k) in calls)
+
+
+def test_set_playlist_image_returns_false_when_playlist_missing(monkeypatch):
+    posted = []
+    monkeypatch.setattr(ncmod.requests, "post", lambda url, **kw: posted.append(url) or _Resp())
+    monkeypatch.setattr(ncmod.requests, "get", lambda url, **kw: _Resp())
+
+    c = _client()
+    c.get_playlist_by_name = lambda name: None
+    assert c.set_playlist_image("Nope", "http://img/x.png") is False
+    assert posted == []   # no login, no upload attempted
+
+
+def test_set_playlist_image_returns_false_when_login_fails(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ncmod.requests, "post",
+                        lambda url, **kw: calls.append(url) or _Resp(ok=False, status_code=401))
+    monkeypatch.setattr(ncmod.requests, "get",
+                        lambda url, **kw: _Resp(ok=True, content=b"x"))
+
+    assert _client().set_playlist_image("My PL", "http://img/x.png") is False
+    assert calls == ["http://nav.local/auth/login"]   # login only, no upload
+
+
+def test_set_playlist_image_returns_false_without_image_url(monkeypatch):
+    # No cover stored → no-op, and crucially no network calls.
+    called = []
+    monkeypatch.setattr(ncmod.requests, "post", lambda *a, **k: called.append("post") or _Resp())
+    monkeypatch.setattr(ncmod.requests, "get", lambda *a, **k: called.append("get") or _Resp())
+    assert _client().set_playlist_image("My PL", "") is False
+    assert called == []

--- a/tests/test_personalized_manager.py
+++ b/tests/test_personalized_manager.py
@@ -393,6 +393,47 @@ class TestListPlaylists:
         assert len(mgr.list_playlists(1)) == 1
         assert len(mgr.list_playlists(2)) == 1
 
+    @staticmethod
+    def _insert_raw(db, kind, variant='', name='X', profile_id=1, track_count=0):
+        # Insert a row directly (ensure_playlist would reject an unregistered
+        # kind) so we can simulate leftover rows from a removed generator.
+        with db._get_connection() as conn:
+            conn.execute(
+                """INSERT INTO personalized_playlists
+                       (profile_id, kind, variant, name, config_json, track_count,
+                        created_at, updated_at)
+                   VALUES (?, ?, ?, ?, '{}', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)""",
+                (profile_id, kind, variant, name, track_count),
+            )
+            conn.commit()
+
+    def test_drops_rows_whose_kind_is_no_longer_registered(self, db, registry):
+        # A reverted/removed generator (e.g. year_mix) leaves orphan rows.
+        _register_simple_kind(registry, lambda *a, **k: [], kind='hidden_gems')
+        mgr = PersonalizedPlaylistManager(db, deps=None, registry=registry)
+        mgr.ensure_playlist('hidden_gems', '', 1)
+        self._insert_raw(db, 'year_mix', '1970', 'Year Mix — 1970', track_count=32)
+        kinds = {r.kind for r in mgr.list_playlists(1)}
+        assert kinds == {'hidden_gems'}  # year_mix hidden
+
+    def test_fails_open_when_registry_is_empty(self, db, registry):
+        # If generators were never imported the registry is empty; hide nothing
+        # rather than blanking every playlist.
+        self._insert_raw(db, 'hidden_gems', '', 'Hidden Gems', track_count=50)
+        self._insert_raw(db, 'year_mix', '1970', 'Year Mix — 1970', track_count=32)
+        mgr = PersonalizedPlaylistManager(db, deps=None, registry=registry)  # empty
+        kinds = {r.kind for r in mgr.list_playlists(1)}
+        assert kinds == {'hidden_gems', 'year_mix'}  # nothing dropped
+
+    def test_registered_but_empty_kind_still_listed_by_manager(self, db, registry):
+        # The manager only drops UNREGISTERED kinds; empty (0-track) playlists
+        # of a registered kind are the sync SOURCE's concern, not the manager's.
+        _register_simple_kind(registry, lambda *a, **k: [], kind='hidden_gems')
+        mgr = PersonalizedPlaylistManager(db, deps=None, registry=registry)
+        rec = mgr.ensure_playlist('hidden_gems', '', 1)  # created with 0 tracks
+        assert rec.track_count == 0
+        assert {r.kind for r in mgr.list_playlists(1)} == {'hidden_gems'}
+
 
 class TestStalenessFilter:
     """`config.exclude_recent_days > 0` drops tracks served by this

--- a/tests/test_playlist_sources_adapters.py
+++ b/tests/test_playlist_sources_adapters.py
@@ -631,6 +631,29 @@ def test_soulsync_discovery_adapter_refresh_invokes_manager():
     assert manager.refresh_calls == [("hidden_gems", "", 1)]
 
 
+def _discovery_record(id, kind, track_count, name="X", variant=""):
+    return SimpleNamespace(
+        id=id, profile_id=1, kind=kind, variant=variant, name=name, config=None,
+        track_count=track_count, last_generated_at="2026-05-26T00:00:00Z",
+        last_synced_at=None, last_generation_source="discovery_pool",
+        last_generation_error=None, is_stale=False,
+    )
+
+
+def test_soulsync_discovery_adapter_hides_empty_playlists():
+    # A 0-track playlist (e.g. a no-op generator's "Daily Mix 1") can't be
+    # synced — the sync board should not list it, only the ones with tracks.
+    manager = _FakeDiscoveryManager()
+    manager._records = [
+        _discovery_record(42, "hidden_gems", 50, "Hidden Gems"),
+        _discovery_record(9, "daily_mix", 0, "Daily Mix 1", variant="1"),
+    ]
+    src = SoulSyncDiscoveryPlaylistSource(lambda: manager, profile_id_getter=lambda: 1)
+    metas = src.list_playlists()
+    assert [m.source_playlist_id for m in metas] == ["42"]  # empty daily_mix dropped
+    assert all(m.track_count > 0 for m in metas)
+
+
 # ─── Registry ───────────────────────────────────────────────────────────
 
 

--- a/tests/test_settings_redaction.py
+++ b/tests/test_settings_redaction.py
@@ -113,11 +113,29 @@ def test_real_value_overwrites():
     assert cm.config_data['spotify']['client_secret'] == 'NEW'
 
 
-def test_empty_value_clears_secret():
-    # Deliberately clearing a secret must still work (empty != sentinel).
+def test_empty_value_does_not_clear_secret():
+    # A bulk/settings save must NEVER blank a stored secret. The settings
+    # auto-save could fire mid-edit while a masked field was momentarily cleared
+    # to '' on focus, wiping the real value and breaking Spotify auth with
+    # "invalid_client" (#992). Empty means "keep existing"; clearing is done via
+    # the explicit disconnect action.
     cm = _cm({'spotify': {'client_secret': 'REAL'}})
     cm.set('spotify.client_secret', '')
-    assert cm.config_data['spotify']['client_secret'] == ''
+    assert cm.config_data['spotify']['client_secret'] == 'REAL'
+
+
+def test_none_value_does_not_clear_secret():
+    cm = _cm({'spotify': {'client_secret': 'REAL'}})
+    cm.set('spotify.client_secret', None)
+    assert cm.config_data['spotify']['client_secret'] == 'REAL'
+
+
+def test_empty_value_on_non_secret_path_writes_normally():
+    # The empty-guard is scoped to sensitive paths — a normal field can still be
+    # cleared to '' (e.g. clearing a URL).
+    cm = _cm({'plex': {'base_url': 'http://old'}})
+    cm.set('plex.base_url', '')
+    assert cm.config_data['plex']['base_url'] == ''
 
 
 def test_sentinel_on_non_secret_path_writes_normally():

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "2.8.6"
+_SOULSYNC_BASE_VERSION = "2.8.7"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/auto-sync.js
+++ b/webui/static/auto-sync.js
@@ -23,6 +23,7 @@ let _autoSyncScheduleState = {
 };
 let _autoSyncActiveTab = 'schedule';
 let _autoSyncSidebarFilter = '';
+let _autoSyncExpandedKinds = new Set();  // variant-kind groups the user has expanded
 let _autoSyncHistoryFilter = 'all';  // 'all' | 'error' | 'completed' | 'skipped'
 let _autoSyncHistoryLimit = 50;
 // Open weekly-editor popover state. ``null`` when no popover is open.
@@ -271,6 +272,13 @@ function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
             const name = k.requires_variant
                 ? String(k.name_template || `${k.kind} ${variant}`).replace('{variant}', variant)
                 : String(k.name_template || k.kind);
+            // Collapsible-group heading for variant kinds: the name_template with
+            // the "{variant}" placeholder (and any trailing separator) stripped,
+            // e.g. "Time Machine — {variant}" → "Time Machine".
+            const kindLabel = k.requires_variant
+                ? (String(k.name_template || k.kind).split('{variant}')[0]
+                       .replace(/[\s—–:>·.\-]+$/, '').trim() || k.kind)
+                : '';
             rows.push({
                 id: nextId--,
                 source: 'soulsync_discovery',
@@ -278,6 +286,7 @@ function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
                 track_count: 0,
                 kind: k.kind,
                 variant,
+                kind_label: kindLabel,
                 source_playlist_id: ssdId,
                 _personalized: true,
             });
@@ -331,6 +340,71 @@ function autoSyncRowIdForPersonalized(entry, playlists) {
     const synth = (playlists || []).find(
         p => p && p._personalized && p.kind === entry.kind && (p.variant || '') === entry.variant);
     return synth ? synth.id : null;
+}
+
+// Split a sidebar source-group's rows into flat rows and collapsible variant
+// groups. Ungenerated variant kinds (Time Machine decades, Genres, ...) come in
+// as many synthetic rows at once; bucketing them by kind lets the sidebar show a
+// single expandable header per kind instead of every variant inline. Everything
+// else (singletons, already-generated rows) stays flat. Encounter order is
+// preserved; each group keeps its first row's `kind_label` as the heading.
+function autoSyncGroupSidebarRows(rows) {
+    const flat = [];
+    const groups = [];
+    const byKind = new Map();
+    (rows || []).forEach(p => {
+        if (p && p._personalized && p.variant) {
+            let g = byKind.get(p.kind);
+            if (!g) {
+                g = { kind: p.kind, label: p.kind_label || p.kind, rows: [] };
+                byKind.set(p.kind, g);
+                groups.push(g);
+            }
+            g.rows.push(p);
+        } else {
+            flat.push(p);
+        }
+    });
+    return { flat, groups };
+}
+
+// Render a source group's rows: flat cards first, then one collapsible block per
+// variant kind. `cardRenderer(p, displayName)` builds a single draggable card
+// (displayName lets a grouped card show just its variant). `isScheduled(p)`
+// (optional) drives the "N on" badge shown on a collapsed header.
+function autoSyncSidebarGroupHtml(rows, cardRenderer, isScheduled) {
+    const { flat, groups } = autoSyncGroupSidebarRows(rows);
+    const flatHtml = flat.map(p => cardRenderer(p)).join('');
+    const groupsHtml = groups.map(g => {
+        const expanded = _autoSyncExpandedKinds.has(g.kind);
+        const activeCount = typeof isScheduled === 'function'
+            ? g.rows.filter(isScheduled).length : 0;
+        const cards = g.rows.map(p => cardRenderer(p, p.variant)).join('');
+        return `
+            <div class="auto-sync-kind-group ${expanded ? 'expanded' : ''} ${activeCount ? 'has-active' : ''}" data-kind="${_escAttr(g.kind)}">
+                <div class="auto-sync-kind-group-head" onclick="toggleAutoSyncKindGroup('${_escAttr(g.kind)}')">
+                    <span class="auto-sync-kind-group-chevron">&#9654;</span>
+                    <span class="auto-sync-kind-group-label">${_esc(g.label)}</span>
+                    ${activeCount ? `<span class="auto-sync-kind-group-active">${activeCount} on</span>` : ''}
+                    <span class="auto-sync-kind-group-count">${g.rows.length}</span>
+                </div>
+                <div class="auto-sync-kind-group-body">${cards}</div>
+            </div>
+        `;
+    }).join('');
+    return flatHtml + groupsHtml;
+}
+
+// Toggle a variant-kind group open/closed. Flips the class on the live element
+// (both boards can have rendered it) and records the state so a full modal
+// re-render keeps it open.
+function toggleAutoSyncKindGroup(kind) {
+    if (_autoSyncExpandedKinds.has(kind)) _autoSyncExpandedKinds.delete(kind);
+    else _autoSyncExpandedKinds.add(kind);
+    const expanded = _autoSyncExpandedKinds.has(kind);
+    document.querySelectorAll(`.auto-sync-kind-group[data-kind="${kind}"]`).forEach(el => {
+        el.classList.toggle('expanded', expanded);
+    });
 }
 
 function buildAutoSyncScheduleState(playlists, automations, historyData = {}) {
@@ -600,6 +674,17 @@ function renderAutoSyncSchedulePanel(playlists, playlistSchedules) {
     }, {});
     const sourceKeys = Object.keys(grouped).sort((a, b) => autoSyncSourceLabel(a).localeCompare(autoSyncSourceLabel(b)));
 
+    const cardRenderer = (p, displayName) => {
+        const schedule = playlistSchedules[p.id];
+        const assigned = schedule ? autoSyncIntervalLabel(schedule.hours) : 'Unscheduled';
+        return `
+                    <div class="auto-sync-playlist ${schedule ? 'scheduled' : ''}" draggable="true" data-playlist-id="${p.id}" ondragstart="autoSyncDragStart(event)" ondragend="autoSyncDragEnd()">
+                        <div class="auto-sync-playlist-name">${_esc(displayName || p.name)}</div>
+                        <div class="auto-sync-playlist-meta">${p.track_count || 0} tracks &middot; ${_esc(assigned)}</div>
+                    </div>
+                `;
+    };
+    const isScheduled = (p) => !!playlistSchedules[p.id];
     const sidebarHtml = sourceKeys.length ? sourceKeys.map(source => `
         <div class="auto-sync-source-group">
             <div class="auto-sync-source-group-head">
@@ -613,16 +698,7 @@ function renderAutoSyncSchedulePanel(playlists, playlistSchedules) {
                     Bulk
                 </button>
             </div>
-            ${grouped[source].map(p => {
-                const schedule = playlistSchedules[p.id];
-                const assigned = schedule ? autoSyncIntervalLabel(schedule.hours) : 'Unscheduled';
-                return `
-                    <div class="auto-sync-playlist ${schedule ? 'scheduled' : ''}" draggable="true" data-playlist-id="${p.id}" ondragstart="autoSyncDragStart(event)" ondragend="autoSyncDragEnd()">
-                        <div class="auto-sync-playlist-name">${_esc(p.name)}</div>
-                        <div class="auto-sync-playlist-meta">${p.track_count || 0} tracks &middot; ${_esc(assigned)}</div>
-                    </div>
-                `;
-            }).join('')}
+            ${autoSyncSidebarGroupHtml(grouped[source], cardRenderer, isScheduled)}
         </div>
     `).join('') : '<div class="auto-sync-empty">No refreshable mirrored playlists yet.</div>';
 
@@ -719,6 +795,22 @@ function renderAutoSyncWeeklyPanel(playlists, playlistSchedules) {
     }, {});
     const sourceKeys = Object.keys(grouped).sort((a, b) => autoSyncSourceLabel(a).localeCompare(autoSyncSourceLabel(b)));
 
+    const cardRenderer = (p, displayName) => {
+        const weekly = weeklySchedules[p.id];
+        const hourly = playlistSchedules[p.id];
+        let assigned = 'Unscheduled';
+        if (weekly) assigned = autoSyncWeeklyLabel(weekly);
+        else if (hourly) assigned = `Hourly (${autoSyncIntervalLabel(hourly.hours).toLowerCase()})`;
+        return `
+                    <div class="auto-sync-playlist ${weekly ? 'scheduled' : (hourly ? 'scheduled-elsewhere' : '')}"
+                         draggable="true" data-playlist-id="${p.id}"
+                         ondragstart="autoSyncWeeklyDragStart(event)" ondragend="autoSyncWeeklyDragEnd()">
+                        <div class="auto-sync-playlist-name">${_esc(displayName || p.name)}</div>
+                        <div class="auto-sync-playlist-meta">${p.track_count || 0} tracks &middot; ${_esc(assigned)}</div>
+                    </div>
+                `;
+    };
+    const isScheduled = (p) => !!(weeklySchedules[p.id] || playlistSchedules[p.id]);
     const sidebarHtml = sourceKeys.length ? sourceKeys.map(source => `
         <div class="auto-sync-source-group">
             <div class="auto-sync-source-group-head">
@@ -727,21 +819,7 @@ function renderAutoSyncWeeklyPanel(playlists, playlistSchedules) {
                     <span class="auto-sync-source-title-label">${_esc(autoSyncSourceLabel(source))}</span>
                 </span>
             </div>
-            ${grouped[source].map(p => {
-                const weekly = weeklySchedules[p.id];
-                const hourly = playlistSchedules[p.id];
-                let assigned = 'Unscheduled';
-                if (weekly) assigned = autoSyncWeeklyLabel(weekly);
-                else if (hourly) assigned = `Hourly (${autoSyncIntervalLabel(hourly.hours).toLowerCase()})`;
-                return `
-                    <div class="auto-sync-playlist ${weekly ? 'scheduled' : (hourly ? 'scheduled-elsewhere' : '')}"
-                         draggable="true" data-playlist-id="${p.id}"
-                         ondragstart="autoSyncWeeklyDragStart(event)" ondragend="autoSyncWeeklyDragEnd()">
-                        <div class="auto-sync-playlist-name">${_esc(p.name)}</div>
-                        <div class="auto-sync-playlist-meta">${p.track_count || 0} tracks &middot; ${_esc(assigned)}</div>
-                    </div>
-                `;
-            }).join('')}
+            ${autoSyncSidebarGroupHtml(grouped[source], cardRenderer, isScheduled)}
         </div>
     `).join('') : '<div class="auto-sync-empty">No refreshable mirrored playlists yet.</div>';
 

--- a/webui/static/auto-sync.js
+++ b/webui/static/auto-sync.js
@@ -294,7 +294,22 @@ function autoSyncEnrichDiscoveryRows(playlists, kinds) {
     return out;
 }
 
-function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
+// Map (kind, variant) → current generated track count, from
+// /api/personalized/playlists. A playlist that's been GENERATED (refreshed on
+// the Sync page) but not yet SYNCED has a real count here even though it has no
+// mirrored_playlists row yet — this lets the board show that count instead of 0.
+function autoSyncGeneratedCountMap(playlistsData) {
+    const map = new Map();
+    const list = playlistsData && playlistsData.success && Array.isArray(playlistsData.playlists)
+        ? playlistsData.playlists : [];
+    for (const p of list) {
+        if (!p || !p.kind) continue;
+        map.set(`${p.kind} ${p.variant || ''}`, parseInt(p.track_count, 10) || 0);
+    }
+    return map;
+}
+
+function autoSyncExpandPersonalizedRows(kinds, existingPlaylists, generatedCounts) {
     const rows = [];
     if (!Array.isArray(kinds)) return rows;
     // Skip anything already present as a real mirrored soulsync_discovery row
@@ -318,11 +333,14 @@ function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
                 ? String(k.name_template || `${k.kind} ${variant}`).replace('{variant}', variant)
                 : String(k.name_template || k.kind);
             const kindLabel = k.requires_variant ? autoSyncKindLabel(k) : '';
+            // A generated-but-not-yet-synced playlist has no mirror row, so show
+            // its real generated count instead of 0 when we know it.
+            const generated = generatedCounts ? (generatedCounts.get(`${k.kind} ${variant}`) || 0) : 0;
             rows.push({
                 id: nextId--,
                 source: 'soulsync_discovery',
                 name,
-                track_count: 0,
+                track_count: generated,
                 kind: k.kind,
                 variant,
                 kind_label: kindLabel,
@@ -585,11 +603,12 @@ async function refreshAutoSyncScheduleModal() {
     const overlay = document.getElementById('auto-sync-schedule-modal');
     if (!overlay) return;
     try {
-        const [playlistRes, automationRes, historyRes, kindsRes] = await Promise.all([
+        const [playlistRes, automationRes, historyRes, kindsRes, genRes] = await Promise.all([
             fetch('/api/mirrored-playlists'),
             fetch('/api/automations'),
             fetch(`/api/playlist-pipeline/history?limit=${_autoSyncHistoryLimit}`),
-            fetch('/api/personalized/kinds').catch(() => null),   // best-effort; never blocks the board
+            fetch('/api/personalized/kinds').catch(() => null),      // best-effort; never blocks the board
+            fetch('/api/personalized/playlists').catch(() => null),  // generated counts; best-effort
         ]);
         const playlists = await playlistRes.json();
         const automations = await automationRes.json();
@@ -604,10 +623,14 @@ async function refreshAutoSyncScheduleModal() {
         try {
             const kindsData = kindsRes && kindsRes.ok ? await kindsRes.json() : null;
             if (kindsData && kindsData.success && Array.isArray(kindsData.kinds)) {
+                // Generated (but maybe unsynced) counts, so a refreshed-not-synced
+                // variant shows its real track count instead of 0.
+                const genData = genRes && genRes.ok ? await genRes.json() : null;
+                const genCounts = autoSyncGeneratedCountMap(genData);
                 // Tag generated variant rows + drop orphaned mirrors, THEN append
                 // the not-yet-generated variants; both flow into one group per kind.
                 const enriched = autoSyncEnrichDiscoveryRows(playlists, kindsData.kinds);
-                allPlaylists = [...enriched, ...autoSyncExpandPersonalizedRows(kindsData.kinds, enriched)];
+                allPlaylists = [...enriched, ...autoSyncExpandPersonalizedRows(kindsData.kinds, enriched, genCounts)];
             }
         } catch (e) { /* personalized kinds optional */ }
         _autoSyncScheduleState = buildAutoSyncScheduleState(allPlaylists, automations, historyData);

--- a/webui/static/auto-sync.js
+++ b/webui/static/auto-sync.js
@@ -239,6 +239,100 @@ function autoSyncIsScheduleOwned(auto) {
     return group === 'Playlist Auto-Sync' || name.startsWith('Auto-Sync:');
 }
 
+// ── Personalized (SoulSync Discovery) rows in the Auto-Sync board ────────────
+// Variant kinds (Time Machine per-decade, Genre, Seasonal, ...) and not-yet-
+// generated singletons don't exist as mirrored rows until generated. We surface
+// them as synthetic schedulable rows with NEGATIVE numeric ids: negatives never
+// collide with real (positive) mirrored ids AND flow through every parseInt(id)
+// in this board unchanged, so drag/drop/bulk/weekly keep working as-is.
+// Scheduling one creates a single-kind personalized_pipeline automation, which
+// auto-generates on its first run — no manual pre-generation.
+
+function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
+    const rows = [];
+    if (!Array.isArray(kinds)) return rows;
+    // Skip anything already present as a real mirrored soulsync_discovery row
+    // (matched by its synthetic source_playlist_id 'ssd_<kind>_<variant>').
+    const existingSsd = new Set(
+        (existingPlaylists || [])
+            .filter(p => p && p.source === 'soulsync_discovery' && p.source_playlist_id)
+            .map(p => String(p.source_playlist_id))
+    );
+    let nextId = -1;
+    for (const k of kinds) {
+        if (!k || !k.kind) continue;
+        const variants = k.requires_variant
+            ? (Array.isArray(k.variants) ? k.variants : [])
+            : [''];
+        for (const raw of variants) {
+            const variant = k.requires_variant ? String(raw) : '';
+            const ssdId = `ssd_${k.kind}${variant ? `_${variant}` : ''}`;
+            if (existingSsd.has(ssdId)) continue;
+            const name = k.requires_variant
+                ? String(k.name_template || `${k.kind} ${variant}`).replace('{variant}', variant)
+                : String(k.name_template || k.kind);
+            rows.push({
+                id: nextId--,
+                source: 'soulsync_discovery',
+                name,
+                track_count: 0,
+                kind: k.kind,
+                variant,
+                source_playlist_id: ssdId,
+                _personalized: true,
+            });
+        }
+    }
+    return rows;
+}
+
+function autoSyncActionForPlaylist(playlist, playlistId) {
+    // Personalized rows schedule a single-kind personalized_pipeline (auto-generates
+    // on first run); every other row schedules a playlist_pipeline by numeric id
+    // exactly as before.
+    if (playlist && playlist._personalized) {
+        const entry = { kind: playlist.kind };
+        if (playlist.variant) entry.variant = playlist.variant;
+        return {
+            action_type: 'personalized_pipeline',
+            action_config: { kinds: [entry], refresh_first: true },
+        };
+    }
+    return {
+        action_type: 'playlist_pipeline',
+        action_config: { playlist_id: String(playlistId), all: false },
+    };
+}
+
+function autoSyncIsPersonalizedAutomation(auto) {
+    return !!(auto && auto.action_type === 'personalized_pipeline');
+}
+
+function autoSyncPersonalizedEntry(auto) {
+    // The single {kind, variant} a BOARD-created personalized schedule targets.
+    // Multi-kind pipelines (built on the Automations page) return null so they're
+    // never mistaken for a per-row board schedule.
+    if (!autoSyncIsPersonalizedAutomation(auto)) return null;
+    const kinds = (auto.action_config || {}).kinds;
+    if (!Array.isArray(kinds) || kinds.length !== 1) return null;
+    const k = kinds[0] || {};
+    if (!k.kind) return null;
+    return { kind: k.kind, variant: k.variant || '' };
+}
+
+function autoSyncRowIdForPersonalized(entry, playlists) {
+    // Map a personalized {kind, variant} to its board row id: the real mirrored
+    // row if generated, else the synthetic row. Null if neither exists.
+    if (!entry) return null;
+    const ssdId = `ssd_${entry.kind}${entry.variant ? `_${entry.variant}` : ''}`;
+    const real = (playlists || []).find(
+        p => p && p.source === 'soulsync_discovery' && String(p.source_playlist_id) === ssdId);
+    if (real) return real.id;
+    const synth = (playlists || []).find(
+        p => p && p._personalized && p.kind === entry.kind && (p.variant || '') === entry.variant);
+    return synth ? synth.id : null;
+}
+
 function buildAutoSyncScheduleState(playlists, automations, historyData = {}) {
     const playlistSchedules = {};
     const weeklySchedules = {};
@@ -288,6 +382,46 @@ function buildAutoSyncScheduleState(playlists, automations, historyData = {}) {
         }
         automationPipelines.push(auto);
     });
+
+    // Additive: recognize board-owned single-kind personalized_pipeline schedules
+    // and bucket them onto their row (real mirrored row if generated, else the
+    // synthetic row). The playlist_pipeline loop above is untouched.
+    automations.filter(autoSyncIsPersonalizedAutomation).forEach(auto => {
+        const entry = autoSyncPersonalizedEntry(auto);
+        if (!entry || !autoSyncIsScheduleOwned(auto)) return;
+        const key = autoSyncRowIdForPersonalized(entry, playlists);
+        if (key == null) return;
+        if (auto.trigger_type === 'schedule') {
+            const hours = autoSyncHoursFromTrigger(auto.trigger_config || {});
+            if (hours) {
+                playlistSchedules[key] = {
+                    automation_id: auto.id,
+                    automation_name: auto.name,
+                    hours,
+                    enabled: auto.enabled !== false && auto.enabled !== 0,
+                    owned: true,
+                    next_run: auto.next_run,
+                    trigger_config: auto.trigger_config || {},
+                };
+            }
+        } else if (auto.trigger_type === 'weekly_time') {
+            const parsed = autoSyncWeeklyFromTrigger(auto.trigger_config);
+            if (parsed) {
+                weeklySchedules[key] = {
+                    automation_id: auto.id,
+                    automation_name: auto.name,
+                    time: parsed.time,
+                    days: parsed.days,
+                    tz: parsed.tz,
+                    enabled: auto.enabled !== false && auto.enabled !== 0,
+                    owned: true,
+                    next_run: auto.next_run,
+                    trigger_config: auto.trigger_config || {},
+                };
+            }
+        }
+    });
+
     return {
         playlists,
         automations,
@@ -334,10 +468,11 @@ async function refreshAutoSyncScheduleModal() {
     const overlay = document.getElementById('auto-sync-schedule-modal');
     if (!overlay) return;
     try {
-        const [playlistRes, automationRes, historyRes] = await Promise.all([
+        const [playlistRes, automationRes, historyRes, kindsRes] = await Promise.all([
             fetch('/api/mirrored-playlists'),
             fetch('/api/automations'),
             fetch(`/api/playlist-pipeline/history?limit=${_autoSyncHistoryLimit}`),
+            fetch('/api/personalized/kinds').catch(() => null),   // best-effort; never blocks the board
         ]);
         const playlists = await playlistRes.json();
         const automations = await automationRes.json();
@@ -345,7 +480,17 @@ async function refreshAutoSyncScheduleModal() {
         if (!playlistRes.ok || playlists.error) throw new Error(playlists.error || 'Failed to load mirrored playlists');
         if (!automationRes.ok || automations.error) throw new Error(automations.error || 'Failed to load automations');
         if (!historyRes.ok || historyData.error) throw new Error(historyData.error || 'Failed to load pipeline run history');
-        _autoSyncScheduleState = buildAutoSyncScheduleState(playlists, automations, historyData);
+        // Additive: surface not-yet-generated personalized kinds/variants as synthetic
+        // schedulable rows. Best-effort — a kinds failure never breaks the board; real
+        // mirrored soulsync_discovery rows are de-duped inside the expander.
+        let allPlaylists = playlists;
+        try {
+            const kindsData = kindsRes && kindsRes.ok ? await kindsRes.json() : null;
+            if (kindsData && kindsData.success && Array.isArray(kindsData.kinds)) {
+                allPlaylists = [...playlists, ...autoSyncExpandPersonalizedRows(kindsData.kinds, playlists)];
+            }
+        } catch (e) { /* personalized kinds optional */ }
+        _autoSyncScheduleState = buildAutoSyncScheduleState(allPlaylists, automations, historyData);
         renderAutoSyncScheduleModal();
         manageAutoSyncStatusPolling();
     } catch (err) {
@@ -1066,8 +1211,7 @@ async function saveAutoSyncPlaylistScheduleSilent(playlistId, hours) {
         name: `Auto-Sync: ${playlist.name}`,
         trigger_type: 'schedule',
         trigger_config: autoSyncTriggerForHours(hours),
-        action_type: 'playlist_pipeline',
-        action_config: { playlist_id: String(playlistId), all: false },
+        ...autoSyncActionForPlaylist(playlist, playlistId),
         then_actions: [],
         group_name: 'Playlist Auto-Sync',
         owned_by: 'auto_sync',
@@ -1759,8 +1903,7 @@ async function saveAutoSyncPlaylistSchedule(playlistId, hours) {
         name: `Auto-Sync: ${playlist.name}`,
         trigger_type: 'schedule',
         trigger_config: autoSyncTriggerForHours(hours),
-        action_type: 'playlist_pipeline',
-        action_config: { playlist_id: String(playlistId), all: false },
+        ...autoSyncActionForPlaylist(playlist, playlistId),
         then_actions: [],
         group_name: 'Playlist Auto-Sync',
         owned_by: 'auto_sync',
@@ -1956,8 +2099,7 @@ async function saveAutoSyncWeeklySchedule(playlistId, { time, days, tz }) {
         name: `Auto-Sync: ${playlist.name}`,
         trigger_type: 'weekly_time',
         trigger_config: triggerConfig,
-        action_type: 'playlist_pipeline',
-        action_config: { playlist_id: String(playlistId), all: false },
+        ...autoSyncActionForPlaylist(playlist, playlistId),
         then_actions: [],
         group_name: 'Playlist Auto-Sync',
         owned_by: 'auto_sync',
@@ -1998,6 +2140,25 @@ async function unscheduleAutoSyncWeekly(playlistId) {
 async function runAutoSyncScheduledPlaylist(playlistId) {
     const playlist = _autoSyncScheduleState.playlists.find(p => parseInt(p.id, 10) === parseInt(playlistId, 10));
     if (!playlist) return;
+    if (playlist._personalized) {
+        // A synthetic personalized row has no mirrored pipeline to run; run its
+        // scheduled personalized_pipeline automation immediately instead.
+        const sched = _autoSyncScheduleState.playlistSchedules?.[playlistId]
+                   || _autoSyncScheduleState.weeklySchedules?.[playlistId];
+        if (!sched || !sched.automation_id) {
+            if (typeof showToast === 'function') showToast('Schedule it first, then Run now.', 'info');
+            return;
+        }
+        try {
+            const res = await fetch(`/api/automations/${sched.automation_id}/run`, { method: 'POST' });
+            const data = await res.json();
+            if (!res.ok || data.error) throw new Error(data.error || 'Failed to run');
+            if (typeof showToast === 'function') showToast(`Running ${playlist.name}…`, 'success');
+        } catch (err) {
+            if (typeof showToast === 'function') showToast(`Error: ${err.message}`, 'error');
+        }
+        return;
+    }
     await runMirroredPlaylistPipeline(playlistId, playlist.name || `Playlist #${playlistId}`);
     await refreshAutoSyncScheduleModal();
 }

--- a/webui/static/auto-sync.js
+++ b/webui/static/auto-sync.js
@@ -249,6 +249,51 @@ function autoSyncIsScheduleOwned(auto) {
 // Scheduling one creates a single-kind personalized_pipeline automation, which
 // auto-generates on its first run — no manual pre-generation.
 
+// Collapsible-group heading for a variant kind: the name_template with the
+// "{variant}" placeholder (and any trailing separator) stripped, e.g.
+// "Time Machine — {variant}" → "Time Machine". Falls back to the kind id.
+function autoSyncKindLabel(k) {
+    return String((k && k.name_template) || (k && k.kind) || '')
+        .split('{variant}')[0]
+        .replace(/[\s—–:>·.\-]+$/, '')
+        .trim() || (k && k.kind) || '';
+}
+
+// Tag already-generated SoulSync Discovery rows (real mirrored playlists) with
+// the kind/variant parsed from their 'ssd_<kind>_<variant>' source id, so a
+// generated Time Machine decade groups under the same collapsible header as the
+// not-yet-generated ones. Rows whose kind is no longer registered (e.g. a
+// reverted 'year_mix' left in mirrored_playlists) are DROPPED — they can't be
+// regenerated and shouldn't clutter the board. Fails open: with no kinds
+// metadata, every row passes through untouched.
+function autoSyncEnrichDiscoveryRows(playlists, kinds) {
+    if (!Array.isArray(playlists)) return [];
+    if (!Array.isArray(kinds) || !kinds.length) return playlists;
+    const singletons = new Map();   // 'ssd_<kind>' → true
+    const variantKinds = [];        // [{ prefix, k }]
+    for (const k of kinds) {
+        if (!k || !k.kind) continue;
+        if (k.requires_variant) variantKinds.push({ prefix: `ssd_${k.kind}_`, k });
+        else singletons.set(`ssd_${k.kind}`, true);
+    }
+    // Longest prefix first so a shorter kind can't shadow a longer one.
+    variantKinds.sort((a, b) => b.prefix.length - a.prefix.length);
+    const out = [];
+    for (const p of playlists) {
+        if (!p || p.source !== 'soulsync_discovery' || !p.source_playlist_id) { out.push(p); continue; }
+        const sid = String(p.source_playlist_id);
+        if (singletons.has(sid)) { out.push(p); continue; }  // registered singleton → flat, as-is
+        const vk = variantKinds.find(v => sid.startsWith(v.prefix));
+        if (vk) {
+            out.push({ ...p, kind: vk.k.kind, variant: sid.slice(vk.prefix.length),
+                       kind_label: autoSyncKindLabel(vk.k) });
+            continue;
+        }
+        // Unregistered kind (orphaned mirror row) → drop.
+    }
+    return out;
+}
+
 function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
     const rows = [];
     if (!Array.isArray(kinds)) return rows;
@@ -272,13 +317,7 @@ function autoSyncExpandPersonalizedRows(kinds, existingPlaylists) {
             const name = k.requires_variant
                 ? String(k.name_template || `${k.kind} ${variant}`).replace('{variant}', variant)
                 : String(k.name_template || k.kind);
-            // Collapsible-group heading for variant kinds: the name_template with
-            // the "{variant}" placeholder (and any trailing separator) stripped,
-            // e.g. "Time Machine — {variant}" → "Time Machine".
-            const kindLabel = k.requires_variant
-                ? (String(k.name_template || k.kind).split('{variant}')[0]
-                       .replace(/[\s—–:>·.\-]+$/, '').trim() || k.kind)
-                : '';
+            const kindLabel = k.requires_variant ? autoSyncKindLabel(k) : '';
             rows.push({
                 id: nextId--,
                 source: 'soulsync_discovery',
@@ -353,7 +392,11 @@ function autoSyncGroupSidebarRows(rows) {
     const groups = [];
     const byKind = new Map();
     (rows || []).forEach(p => {
-        if (p && p._personalized && p.variant) {
+        // Group any variant-kind row — synthetic (not-yet-generated) OR an
+        // already-generated mirrored row enriched with kind/variant — so both
+        // land under one collapsible header. Singletons (no variant) and other
+        // sources (no kind) stay flat.
+        if (p && p.variant && p.kind) {
             let g = byKind.get(p.kind);
             if (!g) {
                 g = { kind: p.kind, label: p.kind_label || p.kind, rows: [] };
@@ -561,7 +604,10 @@ async function refreshAutoSyncScheduleModal() {
         try {
             const kindsData = kindsRes && kindsRes.ok ? await kindsRes.json() : null;
             if (kindsData && kindsData.success && Array.isArray(kindsData.kinds)) {
-                allPlaylists = [...playlists, ...autoSyncExpandPersonalizedRows(kindsData.kinds, playlists)];
+                // Tag generated variant rows + drop orphaned mirrors, THEN append
+                // the not-yet-generated variants; both flow into one group per kind.
+                const enriched = autoSyncEnrichDiscoveryRows(playlists, kindsData.kinds);
+                allPlaylists = [...enriched, ...autoSyncExpandPersonalizedRows(kindsData.kinds, enriched)];
             }
         } catch (e) { /* personalized kinds optional */ }
         _autoSyncScheduleState = buildAutoSyncScheduleState(allPlaylists, automations, historyData);

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,15 +3404,13 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '2.8.6': [
-        { date: 'July 2026 — 2.8.6' },
-        { title: 'Spotify search works without a connected account', desc: 'picking "Spotify" as your search source now returns results even if you haven\'t connected an account — it uses the no-auth Spotify Free source. and if you are connected but the official search comes back empty, it falls back to Free instead of a blank page.', page: 'search' },
-        { title: 'Import & Stats black screen on Docker (#986)', desc: 'a follow-up to the 2.8.5 fix — some Docker setups still got a blank Import/Stats page because the JS module bundle was served with a non-JS content type. we now force the correct type at the HTTP layer, so the module scripts always run.', page: 'import' },
-        { title: 'Mirrored playlists can\'t be silently wiped anymore (#990)', desc: 'a wrong-shaped refresh could overwrite a mirror with thousands of empty rows and still report success. it now accepts the Spotify track shape directly and validates before deleting — a malformed payload is rejected and your existing mirror is left intact.', page: 'playlists' },
-        { title: 'Browsing an artist no longer shows a different artist\'s tracks (#988)', desc: 'a Deezer name-search was accepting the first result even on a poor name match, so e.g. The Outfield could show Beatles tracks. it now requires a real name match before using a result.', page: 'artists' },
-        { title: 'iTunes singles no longer land in "Unknown Artist" (#989)', desc: 'when a single\'s album-artist came back empty, the track could file and tag under "Unknown Artist"; it now falls back to the real track artist.', page: 'import' },
-        { title: 'Library Reorganize cleans up the folders it empties (#985)', desc: 'after moving files it left the old, now-empty disc/album folders behind; it prunes them now — safely, never climbing up to the artist or library root.', page: 'library' },
-        { title: 'Earlier versions', desc: '2.8.51 was a one-fix hotfix (#983 fresh-install watchlist settings). 2.8.5 was a fix batch: Import & Stats black screen (#979), iTunes singles landing in Unknown Artist (#980), a stray "01-" on single-disc albums (#981), cleanup deleting a configured root (#976), repair Fix All outside the transfer path (#978), and backfill overreaching past owned artists (#977). 2.8.4 added Artist Web + named Quality Profiles (#974); 2.8.3 rebuilt Discover with a real recommendation engine; 2.8.2 fixed the Spotify Docker boot hang (#949); 2.7.0 made multi-user real.' },
+    '2.8.7': [
+        { date: 'July 2026 — 2.8.7' },
+        { title: 'Schedule SoulSync Discovery playlists straight from Auto-Sync', desc: 'every soulsync-made discovery playlist (Time Machine decades, Genre, Seasonal, Daily Mix, plus Popular Picks / Hidden Gems / The Archives / Fresh Tape / Discovery Shuffle) now shows up in the auto-sync schedule modal. flip one on and it generates itself on the first run and keeps syncing on your interval, no manual "generate" step. the many-variant kinds collapse into one expandable row so the list stays tidy, and track counts show even before a playlist has synced.', page: 'playlists' },
+        { title: 'Artist discography hides non-studio releases by default', desc: 'a browsed artist now shows just the studio catalog by default, hiding live albums, compilations, and singles. it reads strictly from MusicBrainz, so the main view stays clean.', page: 'artists' },
+        { title: 'Navidrome playlist cover art (#993)', desc: 'mirrored playlists now push their cover art to Navidrome when they sync, so synced playlists show the right artwork instead of a blank tile. the art goes up on the first mirror, not re-pushed on every sync.', page: 'playlists' },
+        { title: 'Saving settings can\'t wipe a stored API secret anymore (#992)', desc: 'a saved secret could get blanked by the settings page auto-save if it fired while a masked field was mid-edit. that showed up as Spotify failing to authenticate with "invalid_client" even after re-entering the secret, and it could quietly clear other API keys (Last.fm, Genius, Discogs, and so on) too. a settings save can no longer empty a saved secret.', page: 'settings' },
+        { title: 'Earlier versions', desc: '2.8.6 was a fix batch: Spotify search without a connected account, the Import/Stats black screen on Docker (#986), mirrored playlists no longer wiped by a bad refresh (#990), artist browse showing another artist\'s tracks (#988), iTunes singles landing in Unknown Artist (#989), and Reorganize pruning the folders it empties (#985). 2.8.51 fixed fresh-install watchlist settings (#983). 2.8.4 added Artist Web + named Quality Profiles (#974); 2.8.3 rebuilt Discover with a real recommendation engine; 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3443,7 +3441,18 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "2.8.6 — fix batch",
+        title: "2.8.7 — schedule your discovery playlists + a credential-wipe fix",
+        description: "the soulsync-made discovery playlists become first-class Auto-Sync items, plus a fix for the settings page quietly wiping saved API secrets.",
+        features: [
+            "Schedule SoulSync Discovery playlists from Auto-Sync — every discovery playlist (Time Machine decades, Genre, Seasonal, Daily Mix, plus Popular Picks / Hidden Gems / The Archives / Fresh Tape / Discovery Shuffle) now shows in the schedule modal; turn one on and it generates itself on the first run and keeps syncing on your interval, no manual \"generate\" step",
+            "the many-variant kinds (Time Machine, Genre, Seasonal) collapse into one expandable row per kind so the list stays tidy, and track counts show even for a playlist you've generated but not yet synced to the server",
+            "#992 — a saved API secret could be wiped by the settings auto-save firing while a masked field was mid-edit; it surfaced as Spotify failing with \"invalid_client\" even after re-entering the secret, and could silently clear other keys (Last.fm, Genius, Discogs, and the rest). a settings save can no longer blank a saved secret",
+            "#993 — mirrored playlists now push their cover art to Navidrome on sync (on the first mirror, not every sync), so synced playlists show the right artwork",
+            "artist discography hides non-studio releases (live, compilations, singles) by default, strictly from MusicBrainz, so you see the studio catalog cleanly",
+        ],
+    },
+    {
+        title: "Earlier in 2.8.6",
         description: "a focused fix release across search, import, library, and playlists.",
         features: [
             "Spotify search without a connected account — picking \"Spotify\" as your search source now works even if you haven't authenticated, using the no-auth Spotify Free source; and a connected account whose official search returns empty falls back to Free instead of a blank page",

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -736,9 +736,19 @@ if (typeof window !== 'undefined') {
 // Discography filter state
 let discographyFilterState = {
     categories: { albums: true, eps: true, singles: true },
+    // Content defaults to show-all. The declutter (hide non-studio by default)
+    // is applied ONLY for MusicBrainz discographies, in populateDiscographySections
+    // once the discography's true source is known. Other sources are already clean
+    // commercial catalogues, so their default is unchanged.
     content: { live: true, compilations: true, featured: true },
     ownership: 'all'  // 'all', 'owned', 'missing'
 };
+
+// Non-studio MusicBrainz release-group secondary types (EXCLUDING Compilation,
+// which has its own toggle). Mirrors core/musicbrainz_search _NON_STUDIO_SECONDARY_TYPES
+// so backend + UI agree. Only used to declutter MusicBrainz artist pages by default.
+const _NON_STUDIO_SECONDARY = new Set(['live', 'soundtrack', 'remix', 'demo',
+    'mixtape/street', 'interview', 'audiobook', 'audio drama']);
 
 // Maximum visible characters of an artist name in the sidebar Library
 // breadcrumb. Names longer than this get truncated with an ellipsis so the
@@ -1828,6 +1838,42 @@ function populateDiscographySections(discography) {
     // Populate singles
     populateReleaseSection('singles', discography.singles);
 
+    // MusicBrainz lists an artist's WHOLE catalogue (live, soundtracks, remixes,
+    // etc.), which buries the studio albums. ONLY for a MusicBrainz discography,
+    // hide non-studio content by default (compilations stay shown; owned releases
+    // are never hidden; the user can toggle it back on). Other sources are already
+    // clean commercial catalogues, so this leaves their default untouched. Gated
+    // on the discography's real source, which is known now that data has loaded.
+    if ((discography && String(discography.source || '').toLowerCase()) === 'musicbrainz') {
+        discographyFilterState.content.live = false;
+        discographyFilterState._mbDeclutter = true;
+
+        // MusicBrainz tags live/non-studio authoritatively, so recompute each
+        // card's data-is-live from its secondary_types instead of the title guess.
+        // This fixes the false positive where a studio album titled "Live Through
+        // This" would be hidden, and covers soundtrack/remix/demo too. MB cards only.
+        ['albums', 'eps', 'singles'].forEach(cat => {
+            const grid = document.getElementById(`${cat}-grid`);
+            if (!grid) return;
+            grid.querySelectorAll('.release-card').forEach(card => {
+                const rd = card._releaseData;
+                const secs = (rd && Array.isArray(rd.secondary_types))
+                    ? rd.secondary_types.map(s => String(s).trim().toLowerCase()) : [];
+                const nonStudio = secs.some(s => _NON_STUDIO_SECONDARY.has(s));
+                card.setAttribute('data-is-live', nonStudio ? 'true' : 'false');
+            });
+        });
+
+        // The toggle governs the broader non-studio set on MB, so label it honestly.
+        const container = document.getElementById('discography-filters');
+        const liveBtn = container && container.querySelector(
+            '.discography-filter-btn[data-filter="content"][data-value="live"]');
+        if (liveBtn) {
+            liveBtn.classList.remove('active');
+            liveBtn.textContent = 'Non-Studio';
+        }
+    }
+
     // Apply any active filters after populating
     applyDiscographyFilters();
 }
@@ -2391,8 +2437,11 @@ function initializeDiscographyFilters() {
 
 function resetDiscographyFilters() {
     discographyFilterState.categories = { albums: true, eps: true, singles: true };
+    // Neutral show-all. The MusicBrainz-only declutter is applied later, in
+    // populateDiscographySections, once the discography's real source is known.
     discographyFilterState.content = { live: true, compilations: true, featured: true };
     discographyFilterState.ownership = 'all';
+    discographyFilterState._mbDeclutter = false;
 
     // Reset button visual states
     const container = document.getElementById('discography-filters');
@@ -2406,6 +2455,9 @@ function resetDiscographyFilters() {
             btn.classList.add('active');
         }
     });
+    // Restore the default "Live" label; the MB path relabels it to "Non-Studio".
+    const liveBtn = container.querySelector('.discography-filter-btn[data-filter="content"][data-value="live"]');
+    if (liveBtn) liveBtn.textContent = 'Live';
 }
 
 function applyDiscographyFilters() {
@@ -2433,15 +2485,24 @@ function applyDiscographyFilters() {
         grid.querySelectorAll('.release-card').forEach(card => {
             let hidden = false;
 
-            // Content filters
-            if (!discographyFilterState.content.live && card.getAttribute('data-is-live') === 'true') {
-                hidden = true;
-            }
-            if (!discographyFilterState.content.compilations && card.getAttribute('data-is-compilation') === 'true') {
-                hidden = true;
-            }
-            if (!discographyFilterState.content.featured && card.getAttribute('data-is-featured') === 'true') {
-                hidden = true;
+            // Content filters. On MusicBrainz pages (where non-studio is hidden by
+            // an automatic default the user didn't set) never hide something the
+            // user OWNS. Elsewhere the toggles are entirely user-driven, so they are
+            // respected as-is (no owned exemption) — keeps non-MB behaviour identical
+            // to before. (owned is null while its completion check is pending; the
+            // filter re-runs once checks resolve, so an owned card reappears then.)
+            const _ownedExempt = discographyFilterState._mbDeclutter
+                && card._releaseData && card._releaseData.owned === true;
+            if (!_ownedExempt) {
+                if (!discographyFilterState.content.live && card.getAttribute('data-is-live') === 'true') {
+                    hidden = true;
+                }
+                if (!discographyFilterState.content.compilations && card.getAttribute('data-is-compilation') === 'true') {
+                    hidden = true;
+                }
+                if (!discographyFilterState.content.featured && card.getAttribute('data-is-featured') === 'true') {
+                    hidden = true;
+                }
             }
 
             // Ownership filter (only apply if card is not still checking)
@@ -2609,6 +2670,10 @@ function _esc(s) { const d = document.createElement('div'); d.textContent = s; r
 // Artist Detail cards and the Download Discography modal so they can't drift.
 function _classifyReleaseContent(release) {
     const t = (release && (release.title || release.name)) || '';
+    // Title-based classification, shared by all sources and the download modal.
+    // On MusicBrainz artist pages the data-is-live attribute is recomputed
+    // authoritatively from secondary_types in populateDiscographySections (MB tags
+    // live/non-studio reliably), so this title heuristic only governs non-MB here.
     const livePattern = /\b(live)\b|\(live[^)]*\)|\[live[^\]]*\]/i;
     const compilationPattern = /\b(greatest hits|best of|collection|anthology|essential)\b/i;
     const featuredPattern = /\(?\bfeat\.?\s|\bft\.?\s|\bfeaturing\b/i;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -12669,6 +12669,85 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     color: rgb(var(--accent-light-rgb));
 }
 
+/* Collapsible variant-kind group (Time Machine decades, Genres, ...) in the
+   sidebar — one expandable header instead of every variant listed inline. */
+.auto-sync-kind-group {
+    margin-bottom: 8px;
+}
+
+.auto-sync-kind-group-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 11px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 10px;
+    background: rgba(22, 22, 22, 0.95);
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.auto-sync-kind-group-head:hover {
+    border-color: rgba(var(--accent-rgb), 0.25);
+    background: rgba(28, 28, 28, 0.98);
+}
+
+.auto-sync-kind-group.has-active .auto-sync-kind-group-head {
+    border-color: rgba(var(--accent-rgb), 0.22);
+}
+
+.auto-sync-kind-group-chevron {
+    flex-shrink: 0;
+    font-size: 9px;
+    color: rgba(255, 255, 255, 0.4);
+    transition: transform 0.2s ease;
+}
+
+.auto-sync-kind-group.expanded .auto-sync-kind-group-chevron {
+    transform: rotate(90deg);
+}
+
+.auto-sync-kind-group-label {
+    flex: 1;
+    min-width: 0;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 13px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.auto-sync-kind-group-active {
+    flex-shrink: 0;
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: rgba(var(--accent-rgb), 0.16);
+    color: rgb(var(--accent-light-rgb));
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+.auto-sync-kind-group-count {
+    flex-shrink: 0;
+    min-width: 18px;
+    text-align: center;
+    color: rgba(255, 255, 255, 0.4);
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.auto-sync-kind-group-body {
+    display: none;
+    padding: 8px 0 2px 12px;
+}
+
+.auto-sync-kind-group.expanded .auto-sync-kind-group-body {
+    display: block;
+}
+
 /* Bulk-schedule popover for a source group */
 .auto-sync-bulk-menu {
     position: fixed;


### PR DESCRIPTION
# soulsync 2.8.7: `dev` → `main`

the soulsync-made discovery playlists become first-class auto-sync items, plus a fix for the settings page quietly wiping saved API secrets.

---

## schedule SoulSync Discovery playlists straight from Auto-Sync

every discovery playlist soulsync makes now shows up in the auto-sync schedule modal: Time Machine (per decade), Genre, Seasonal, Daily Mix, plus the singletons (Popular Picks, Hidden Gems, The Archives, Fresh Tape, Discovery Shuffle).

- flip a schedule on and it generates itself on the first run and keeps syncing on your interval. no more going to the discover page to "generate" it first.
- the many-variant kinds (Time Machine, Genre, Seasonal) collapse into one expandable row per kind, so the list isn't a wall of decades and genres.
- track counts show even for a playlist you've generated but not yet synced, instead of a misleading "0 tracks".
- orphaned or empty discovery playlists (leftovers from a removed generator) no longer clutter the board.

built additively: the synthetic rows ride the board's existing numeric-id machinery with negative ids, so scheduling / drag-drop / run-now all work unchanged. covered by JS unit tests + backend tests.

## saving settings can't wipe a stored API secret anymore (#992)

reported as Spotify failing to authenticate with `invalid_client` even after rotating and re-entering the client secret. the credentials were fine (the reporter proved the same id/secret get a token straight from Spotify). the bug was on our side.

root cause: the settings page auto-saves ~2s after any input. a masked secret field is cleared to `''` on focus so you can type fresh, and a timer landing in that window posted the empty string. `ConfigManager.set()` only refused to overwrite the redaction sentinel, not `''`, so it persisted the empty value and wiped the real secret. an empty secret is sent as-is and Spotify rejects the token exchange with `invalid_client`. it explains why re-entering never stuck (the "clear the box first" step maximizes the empty-save window) and why a standalone script with the same creds worked.

this wasn't Spotify-only. every masked credential (Tidal, Deezer, Discogs, Last.fm, Genius, AcoustID, ListenBrainz, Qobuz, Plex, Jellyfin, and the rest) shared the exact code path. Spotify just fails loudly enough to get reported. the set-once API keys rarely hit the timing window; an interactive re-auth dance does.

fix: `set()` now treats `''` / `None` for a sensitive path the same as the sentinel: keep the existing value. clearing a credential is done via its explicit disconnect action, never by saving an empty form. one guard at the single chokepoint, so it covers every secret at once. disconnect flows clear token blobs via `{}`, which is unaffected. updated the test that had encoded the footgun.

## navidrome playlist cover art (#993)

mirrored playlists now push their cover art to Navidrome when they sync, so a synced playlist shows the right artwork instead of a blank tile. the art goes up on the first mirror, not re-pushed on every sync.

## artist discography declutter

a browsed artist now shows just the studio catalog by default, hiding live albums, compilations, and singles. reads strictly from MusicBrainz so the main view stays clean.
