### PR TITLE
fix(metadata): honor canonical album pins in completion cards

### DIFF
--- a/core/metadata/completion.py
+++ b/core/metadata/completion.py
@@ -98,6 +98,54 @@ def _resolve_completion_track_total(release: Dict[str, Any], source_chain: List[
     return 0
 
 
+def _resolve_canonical_album_completion(db, db_album: Any) -> Optional[Dict[str, Any]]:
+    """Recalculate completion from a local album's exact pinned release.
+
+    A canonical pin is authoritative: when its source is temporarily unavailable,
+    fall back only to the local album's stored count, never to a different release
+    supplied by the discography response.
+    """
+    local_album_id = _extract_lookup_value(db_album, 'id')
+    get_canonical = getattr(db, 'get_album_canonical', None)
+    check_completeness = getattr(db, 'check_album_completeness', None)
+    if not local_album_id or not callable(get_canonical) or not callable(check_completeness):
+        return None
+
+    canonical = get_canonical(local_album_id)
+    if not canonical:
+        return None
+
+    canonical_source = _extract_lookup_value(canonical, 'source', 'canonical_source', default='')
+    canonical_album_id = _extract_lookup_value(canonical, 'album_id', 'canonical_album_id', default='')
+    canonical_total = 0
+
+    if canonical_source and canonical_album_id:
+        api_tracks = get_album_tracks_for_source(str(canonical_source), str(canonical_album_id))
+        canonical_total = len(_extract_track_items(api_tracks))
+
+    if canonical_total == 0:
+        logger.warning(
+            "Could not load canonical release %s:%s for local album %s; "
+            "using only the local stored track count",
+            canonical_source,
+            canonical_album_id,
+            local_album_id,
+        )
+
+    owned_tracks, expected_tracks, is_complete, formats = check_completeness(
+        local_album_id,
+        canonical_total or None,
+    )
+
+    return {
+        'owned_tracks': owned_tracks,
+        'expected_tracks': expected_tracks,
+        'is_complete': is_complete,
+        'formats': formats,
+        'canonical_track_count': canonical_total,
+    }
+
+
 def check_album_completion(
     db,
     album_data: Dict[str, Any],
@@ -134,6 +182,18 @@ def check_album_completion(
                 candidate_albums=candidate_albums,
                 strict_discography_match=True,
             )
+
+            canonical_completion = _resolve_canonical_album_completion(db, db_album)
+            if canonical_completion is not None:
+                owned_tracks = canonical_completion['owned_tracks']
+                expected_tracks = canonical_completion['expected_tracks']
+                is_complete = canonical_completion['is_complete']
+                formats = canonical_completion['formats']
+                total_tracks = (
+                    canonical_completion['canonical_track_count']
+                    or expected_tracks
+                    or 0
+                )
         except Exception as db_error:
             logger.error(f"Database error for album '{album_name}': {db_error}")
             return {

--- a/tests/metadata/test_metadata_completion_canonical.py
+++ b/tests/metadata/test_metadata_completion_canonical.py
@@ -1,0 +1,160 @@
+import sys
+import types
+
+
+if "spotipy" not in sys.modules:
+    spotipy = types.ModuleType("spotipy")
+
+    class _DummySpotify:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    oauth2 = types.ModuleType("spotipy.oauth2")
+
+    class _DummyOAuth:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    spotipy.Spotify = _DummySpotify
+    oauth2.SpotifyOAuth = _DummyOAuth
+    oauth2.SpotifyClientCredentials = _DummyOAuth
+    spotipy.oauth2 = oauth2
+    sys.modules["spotipy"] = spotipy
+    sys.modules["spotipy.oauth2"] = oauth2
+
+if "config.settings" not in sys.modules:
+    config_pkg = types.ModuleType("config")
+    settings_mod = types.ModuleType("config.settings")
+
+    class _DummyConfigManager:
+        def get_active_media_server(self):
+            return "plex"
+
+    settings_mod.config_manager = _DummyConfigManager()
+    config_pkg.settings = settings_mod
+    sys.modules["config"] = config_pkg
+    sys.modules["config.settings"] = settings_mod
+
+from core.metadata import completion as metadata_completion
+
+
+class _CanonicalCompletionDB:
+    def __init__(self, canonical, local_expected=28):
+        self.canonical = canonical
+        self.local_album = types.SimpleNamespace(id="local-album")
+        self.local_expected = local_expected
+        self.match_calls = []
+        self.completeness_calls = []
+
+    def check_album_exists_with_completeness(self, **kwargs):
+        self.match_calls.append(dict(kwargs))
+        return self.local_album, 0.95, 28, kwargs["expected_track_count"], False, ["FLAC"]
+
+    def get_album_canonical(self, album_id):
+        assert album_id == "local-album"
+        return self.canonical
+
+    def check_album_completeness(self, album_id, expected_track_count=None):
+        self.completeness_calls.append((album_id, expected_track_count))
+        expected = expected_track_count or self.local_expected
+        return 28, expected, 28 >= expected, ["FLAC"]
+
+
+def test_album_completion_uses_exact_canonical_release_count(monkeypatch):
+    db = _CanonicalCompletionDB({
+        "source": "musicbrainz",
+        "album_id": "canonical-28",
+    })
+    source_calls = []
+
+    def get_tracks(source, album_id):
+        source_calls.append((source, album_id))
+        return {
+            "items": [
+                {"id": f"track-{number}"}
+                for number in range(1, 29)
+            ],
+        }
+
+    monkeypatch.setattr(
+        metadata_completion,
+        "get_album_tracks_for_source",
+        get_tracks,
+    )
+
+    result = metadata_completion.check_album_completion(
+        db,
+        {
+            "id": "remote-deluxe-93",
+            "name": "Mellon Collie and the Infinite Sadness",
+            "total_tracks": 93,
+        },
+        "The Smashing Pumpkins",
+    )
+
+    assert db.match_calls[0]["expected_track_count"] == 93
+    assert source_calls == [("musicbrainz", "canonical-28")]
+    assert db.completeness_calls == [("local-album", 28)]
+    assert result["owned_tracks"] == 28
+    assert result["expected_tracks"] == 28
+    assert result["completion_percentage"] == 100.0
+    assert result["status"] == "completed"
+
+
+def test_album_completion_never_falls_back_to_remote_edition_when_canonical_unavailable(monkeypatch):
+    db = _CanonicalCompletionDB({
+        "source": "musicbrainz",
+        "album_id": "canonical-unavailable",
+    })
+    source_calls = []
+
+    def get_tracks(source, album_id):
+        source_calls.append((source, album_id))
+        return None
+
+    monkeypatch.setattr(
+        metadata_completion,
+        "get_album_tracks_for_source",
+        get_tracks,
+    )
+
+    result = metadata_completion.check_album_completion(
+        db,
+        {
+            "id": "remote-deluxe-93",
+            "name": "Mellon Collie and the Infinite Sadness",
+            "total_tracks": 93,
+        },
+        "The Smashing Pumpkins",
+    )
+
+    assert source_calls == [("musicbrainz", "canonical-unavailable")]
+    assert db.completeness_calls == [("local-album", None)]
+    assert result["owned_tracks"] == 28
+    assert result["expected_tracks"] == 28
+    assert result["completion_percentage"] == 100.0
+    assert result["status"] == "completed"
+
+
+def test_album_completion_keeps_existing_behavior_without_canonical_pin(monkeypatch):
+    db = _CanonicalCompletionDB(None)
+    monkeypatch.setattr(
+        metadata_completion,
+        "get_album_tracks_for_source",
+        lambda source, album_id: None,
+    )
+
+    result = metadata_completion.check_album_completion(
+        db,
+        {
+            "id": "remote-edition",
+            "name": "Album",
+            "total_tracks": 12,
+        },
+        "Artist",
+    )
+
+    assert db.completeness_calls == []
+    assert result["owned_tracks"] == 28
+    assert result["expected_tracks"] == 12
+    assert result["status"] == "completed"


### PR DESCRIPTION
## Problem

Artist/library completion cards kept using the track total from the discography release currently being rendered, even after the local album had been pinned to a canonical release.

This caused standard editions to remain incorrectly marked as incomplete, for example:

- **Adore**: `16/90`
- **Mellon Collie and the Infinite Sadness**: `28/93`

The canonical resolver had already stored the correct MusicBrainz releases, but `check_album_completion()` never consulted those pins.

## Solution

After matching the discography item to its local album, completion now:

- reads the local album's canonical source and release ID;
- loads the exact pinned release tracklist;
- recalculates owned/expected counts using that canonical track total;
- treats the canonical identity as authoritative;
- falls back only to the local stored track count if the canonical source is temporarily unavailable, never to a different remote edition.

Albums without a canonical pin keep the existing behavior.

## Tests

Added regression coverage for:

- a remote 93-track deluxe card mapped to a canonical 28-track local release;
- an unavailable canonical source not falling back to the remote deluxe count;
- preserving existing behavior when no canonical pin exists.

Local focused test result:

```text
3 passed in 0.12s
```
