### PR TITLE
Frontend: mobile-responsive + UI-consistency pass

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -2452,7 +2452,7 @@
                         </div>
                         <div class="automations-stats" id="automations-stats"></div>
                         <div class="auto-filter-bar" id="auto-filter-bar" style="display:none;">
-                            <input type="text" class="auto-filter-search" id="auto-filter-search" placeholder="Search automations...">
+                            <input type="text" class="auto-filter-search" id="auto-filter-search" placeholder="Filter automations…">
                             <select class="auto-filter-select" id="auto-filter-trigger"><option value="">All Triggers</option></select>
                             <select class="auto-filter-select" id="auto-filter-action"><option value="">All Actions</option></select>
                             <span class="auto-filter-count" id="auto-filter-count"></span>
@@ -2571,7 +2571,7 @@
                     <div class="library-controls">
                         <div class="library-search-container">
                             <input type="text" id="library-search-input" class="library-search-input"
-                                placeholder="Search artists...">
+                                placeholder="Filter your library…">
                             <div class="library-search-icon">🔍</div>
                         </div>
 
@@ -3450,7 +3450,7 @@
                         </div>
                         <div class="spotify-library-filters" id="your-albums-filters" style="display: none;">
                             <input type="text" class="spotify-library-search" id="your-albums-search"
-                                placeholder="Search by artist or album..." oninput="debouncedYourAlbumsSearch()">
+                                placeholder="Filter your albums…" oninput="debouncedYourAlbumsSearch()">
                             <select id="your-albums-status-filter" class="spotify-library-select" onchange="loadYourAlbumsGrid()">
                                 <option value="all">All Albums</option>
                                 <option value="missing">Missing</option>
@@ -7080,7 +7080,7 @@
                                 </div>
                             </div>
                             <div class="log-viewer-actions">
-                                <input type="text" id="log-viewer-search" class="log-viewer-search" placeholder="Search logs..." oninput="_logViewerOnSearch(this)">
+                                <input type="text" id="log-viewer-search" class="log-viewer-search" placeholder="Filter logs…" oninput="_logViewerOnSearch(this)">
                                 <button class="log-action-btn" onclick="_logViewerCopy()" title="Copy visible logs">Copy</button>
                                 <button class="log-action-btn" onclick="_logViewerClear()" title="Clear display">Clear</button>
                                 <label class="log-autoscroll-label">
@@ -7208,7 +7208,7 @@
                     <nav class="docs-sidebar" id="docs-sidebar">
                         <div class="docs-sidebar-header">
                             <h3>Documentation</h3>
-                            <input type="text" class="docs-search" id="docs-search-input" placeholder="Search docs..." autocomplete="off">
+                            <input type="text" class="docs-search" id="docs-search-input" placeholder="Filter docs…" autocomplete="off">
                         </div>
                         <div class="docs-nav" id="docs-nav">
                             <!-- Populated by JS -->
@@ -7747,7 +7747,7 @@
                     <div class="watchlist-toolbar">
                         <div class="watchlist-search-container">
                             <svg class="watchlist-search-icon" width="16" height="16" viewBox="0 0 24 24" fill="rgba(255,255,255,0.35)"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0016 9.5 6.5 6.5 0 109.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
-                            <input type="text" id="watchlist-search-input" class="watchlist-search-input" placeholder="Search watchlist..." oninput="filterWatchlistArtists()">
+                            <input type="text" id="watchlist-search-input" class="watchlist-search-input" placeholder="Filter watchlist…" oninput="filterWatchlistArtists()">
                         </div>
                         <select class="watchlist-sort-select" id="watchlist-sort-select" onchange="sortWatchlistArtists(this.value)">
                             <option value="name-asc">Name A-Z</option>
@@ -7842,7 +7842,7 @@
                     <div class="wl-nebula" id="wishlist-nebula">
                         <!-- Action bar -->
                         <div class="wl-nebula-bar">
-                            <input type="text" class="wl-nebula-search" id="wl-nebula-search" placeholder="Search artists, albums..." oninput="_filterNebula()">
+                            <input type="text" class="wl-nebula-search" id="wl-nebula-search" placeholder="Filter wishlist…" oninput="_filterNebula()">
                             <button class="btn btn--primary" onclick="_nebulaDownload()">
                                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                                 Download Wishlist
@@ -8805,7 +8805,7 @@
                 <button class="mcache-tab" data-tab="track" onclick="switchMetadataCacheTab('track')">Tracks</button>
             </div>
             <div class="mcache-filters">
-                <input type="text" class="mcache-search-input" id="mcache-search" placeholder="Search cached metadata..." oninput="debouncedMetadataCacheSearch()">
+                <input type="text" class="mcache-search-input" id="mcache-search" placeholder="Filter cached metadata…" oninput="debouncedMetadataCacheSearch()">
                 <select class="mcache-source-filter" id="mcache-source-filter" onchange="loadMetadataCacheBrowse()">
                     <option value="">All Sources</option>
                     <option value="spotify">Spotify</option>
@@ -8989,7 +8989,7 @@
         <div class="gsearch-icon">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
         </div>
-        <input type="text" class="gsearch-input" id="gsearch-input" placeholder="Search artists, albums, tracks..." autocomplete="off" spellcheck="false">
+        <input type="text" class="gsearch-input" id="gsearch-input" placeholder="Search everything…" autocomplete="off" spellcheck="false">
         <button class="gsearch-clear" id="gsearch-clear" style="display:none" title="Clear">&times;</button>
         <span class="gsearch-shortcut" id="gsearch-shortcut">/</span>
     </div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -7709,7 +7709,7 @@
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
                             Cancel Scan
                         </button>
-                        <button class="wl-chip wl-chip--blue" id="update-similar-artists-btn" onclick="updateSimilarArtists()">
+                        <button class="wl-chip wl-chip--slate" id="update-similar-artists-btn" onclick="updateSimilarArtists()">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
                             Update Similar Artists
                         </button>
@@ -7717,11 +7717,11 @@
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
                             Global Settings
                         </button>
-                        <button class="wl-chip wl-chip--green" id="watchlist-page-origins-btn" onclick="openDownloadOriginsModal('watchlist')" title="See every track your watchlist downloaded">
+                        <button class="wl-chip wl-chip--slate" id="watchlist-page-origins-btn" onclick="openDownloadOriginsModal('watchlist')" title="See every track your watchlist downloaded">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                             Download Origins
                         </button>
-                        <button class="wl-chip wl-chip--amber" id="watchlist-page-history-btn" onclick="openWatchlistHistoryModal()" title="Every past scan and the tracks it added to the wishlist">
+                        <button class="wl-chip wl-chip--slate" id="watchlist-page-history-btn" onclick="openWatchlistHistoryModal()" title="Every past scan and the tracks it added to the wishlist">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v5h5"/><path d="M3.05 13A9 9 0 1 0 6 5.3L3 8"/><polyline points="12 7 12 12 15 15"/></svg>
                             History
                         </button>

--- a/webui/index.html
+++ b/webui/index.html
@@ -7804,20 +7804,21 @@
                                 <span class="wishlist-page-timer" id="wishlist-next-auto-timer">Next Auto: --</span>
                             </div>
                         </div>
-                        <div class="wishlist-page-header-right">
-                            <button class="btn btn--secondary" onclick="openWishlistIgnoreModal()" title="Tracks you removed or cancelled — auto-skipped until they expire. Un-ignore to allow auto-download again.">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
-                                Ignored
-                            </button>
-                            <button class="btn btn--secondary" onclick="cleanupWishlistOverview()">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/></svg>
-                                Cleanup
-                            </button>
-                            <button class="btn btn--danger" onclick="clearEntireWishlist()">
-                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
-                                Clear All
-                            </button>
-                        </div>
+                    </div>
+
+                    <div class="wishlist-page-actions">
+                        <button class="btn btn--secondary" onclick="openWishlistIgnoreModal()" title="Tracks you removed or cancelled — auto-skipped until they expire. Un-ignore to allow auto-download again.">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>
+                            Ignored
+                        </button>
+                        <button class="btn btn--secondary" onclick="cleanupWishlistOverview()">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/></svg>
+                            Cleanup
+                        </button>
+                        <button class="btn btn--danger" onclick="clearEntireWishlist()">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+                            Clear All
+                        </button>
                     </div>
 
                     <!-- Stats strip -->

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -509,7 +509,7 @@ function _renderWatchAllModalContent(overlay, eligible, ineligible, sourceName) 
 
     // Search filter
     if (eligible.length > 10) {
-        html += '<div class="watch-all-search-wrap"><input type="text" class="watch-all-search" id="watch-all-search" placeholder="Search artists..." oninput="_filterWatchAllList(this.value)"></div>';
+        html += '<div class="watch-all-search-wrap"><input type="text" class="watch-all-search" id="watch-all-search" placeholder="Filter artists…" oninput="_filterWatchAllList(this.value)"></div>';
     }
 
     // Eligible grid

--- a/webui/static/media-player.js
+++ b/webui/static/media-player.js
@@ -1593,6 +1593,9 @@ function openNowPlayingModal() {
     npModalOpen = true;
     overlay.classList.remove('hidden');
     document.body.style.overflow = 'hidden';
+    // Suppress the floating bottom chrome (global search bar, FAB buttons)
+    // so it can't sit over the immersive player's transport controls.
+    document.body.classList.add('np-modal-open');
     syncExpandedPlayerUI();
     // Bind lyrics toggle (idempotent — only attaches once). Lyrics
     // fetch fires from setTrackInfo so by the time the modal opens
@@ -1608,6 +1611,7 @@ function closeNowPlayingModal() {
     npModalOpen = false;
     overlay.classList.add('hidden');
     document.body.style.overflow = '';
+    document.body.classList.remove('np-modal-open');
     npStopVisualizerLoop();
 }
 

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -1849,8 +1849,10 @@
 
     /* --- Phase 9: Touch & Hover Adaptations --- */
 
-    /* Global touch targets - only standalone/action buttons, not inline */
-    button:not(.watchlist-card-remove):not(.wishlist-delete-btn):not(.wishlist-delete-album-btn):not(.wishlist-delete-btn-small):not(.wishlist-back-btn):not(.alphabet-btn):not(.filter-btn):not(.playlist-modal-close):not([data-import-page-result-row]):not([data-import-page-inline-action]) {
+    /* Global touch targets - only standalone/action buttons, not inline.
+       Round icon buttons (fixed-size circles) are excluded so the min-height
+       can't stretch them into vertical ellipses. */
+    button:not(.watchlist-card-remove):not(.wishlist-delete-btn):not(.wishlist-delete-album-btn):not(.wishlist-delete-btn-small):not(.wishlist-back-btn):not(.alphabet-btn):not(.filter-btn):not(.playlist-modal-close):not(.notif-bell-btn):not(.helper-float-btn):not(.hero-indicator):not(.discover-blacklist-btn):not(.tool-help-button):not([data-import-page-result-row]):not([data-import-page-inline-action]) {
         min-height: 38px;
     }
 

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -599,10 +599,11 @@
         flex-wrap: wrap;
     }
 
+    /* Keep the icon-chip shape on mobile too (was a 50%-width pill for the
+       old labeled-tab design) so the strip stays uniform and reflow-free. */
     .sync-tab-button {
-        min-width: calc(50% - 2px);
-        font-size: 13px;
-        padding: 10px 8px;
+        min-width: 0;
+        padding: 0;
     }
 
     /* Spotify playlist cards - stack vertically on mobile */
@@ -2059,7 +2060,7 @@
     }
 
     .sync-tab-button {
-        min-width: 100%;
+        min-width: 0;
     }
 
     .matching-modal-actions {

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -178,7 +178,9 @@
     }
 
     .page {
-        padding: 70px 20px 20px 20px;
+        /* Bottom padding clears the fixed floating search bar / FAB buttons
+           (~50px band) so the last row of content stays visible & tappable. */
+        padding: 70px 20px 72px 20px;
         height: auto;
         min-height: 0;
         overflow: visible;
@@ -1887,7 +1889,7 @@
 
     /* Spacing reductions */
     .page {
-        padding: 70px 16px 16px 16px;
+        padding: 70px 16px 72px 16px;
     }
 
     .activity-section {
@@ -1979,7 +1981,7 @@
 @media (max-width: 480px) {
 
     .page {
-        padding: 70px 12px 12px 12px;
+        padding: 70px 12px 72px 12px;
     }
 
     .stats-grid-dashboard {

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -1919,6 +1919,25 @@
         padding: 70px 16px 72px 16px;
     }
 
+    /* Nested wrappers each add horizontal padding, which compounds on a phone
+       into more chrome than content (~136px of a 375px screen). Trim the
+       biggest offender — the global .page-shell card (margin 20 + padding 24 =
+       44px/side) — and drop the settings content wrappers' inner gutters so
+       controls get the width back. Global, so all 8 .page-shell pages benefit
+       (X4). */
+    .page-shell {
+        margin: 10px;
+        padding: 24px 16px 26px;
+    }
+    #settings-page .settings-content {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    #settings-page .settings-columns {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
     .activity-section {
         padding: 16px;
     }
@@ -2009,6 +2028,12 @@
 
     .page {
         padding: 70px 12px 72px 12px;
+    }
+
+    /* Even tighter card gutters on the smallest phones (X4). */
+    .page-shell {
+        margin: 6px;
+        padding: 20px 12px 22px;
     }
 
     .stats-grid-dashboard {

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -191,6 +191,24 @@
         display: block;
     }
 
+    /* ── Minor tap-target enlargements for touch ── */
+    #watchlist-select-all-cb {
+        width: 18px;
+        height: 18px;
+    }
+    .watchlist-select-all-label {
+        min-height: 32px;
+    }
+    .td-close {
+        width: 36px;
+        height: 36px;
+    }
+    .bp-info-toggle {
+        width: 28px;
+        height: 28px;
+        font-size: 14px;
+    }
+
     .nav-button {
         width: 100%;
     }

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -1150,6 +1150,13 @@
         gap: 6px;
     }
 
+    /* On a narrow hero the centered carousel indicators and the bottom-right
+       action buttons both pin to the bottom edge and collide — lift the
+       indicators above the action row so the dots stay usable. */
+    .discover-hero-indicators {
+        bottom: 62px;
+    }
+
     .discover-hero-watch-all,
     .discover-hero-view-all {
         padding: 6px 12px;

--- a/webui/static/shared-helpers.js
+++ b/webui/static/shared-helpers.js
@@ -3762,7 +3762,8 @@ function getMetadataSourcePresentation(metadataStatus, spotifyStatus) {
     if (source) {
         return {
             statusClass: connected ? 'connected' : 'disconnected',
-            statusText: connected ? (spotifyFamily ? `Connected (${metadataStatus?.response_time}ms)` : sourceLabel) : 'Disconnected',
+            // Uniform state word; the ms lives in the card's Response row (D4).
+            statusText: connected ? 'Connected' : 'Disconnected',
             dotClass: connected ? 'connected' : 'disconnected',
             dotTitle: connected ? sourceLabel : 'Disconnected',
             sessionActive
@@ -3796,7 +3797,7 @@ function updateServiceStatus(service, statusData, spotifyStatus = null) {
         } else {
             if (statusData.connected) {
                 indicator.className = 'service-card-indicator connected';
-                statusText.textContent = `Connected (${statusData.response_time}ms)`;
+                statusText.textContent = 'Connected';
                 statusText.className = 'service-card-status-text connected';
             } else {
                 indicator.className = 'service-card-indicator disconnected';
@@ -3804,6 +3805,16 @@ function updateServiceStatus(service, statusData, spotifyStatus = null) {
                 statusText.className = 'service-card-status-text disconnected';
             }
         }
+    }
+
+    // Response time row — populated uniformly for every service card so all
+    // three read the same way (D4).
+    const responseRow = document.getElementById(`${service}-response-time`);
+    if (responseRow) {
+        const rt = statusData?.response_time;
+        responseRow.textContent = (rt !== undefined && rt !== null)
+            ? `Response: ${rt}ms`
+            : 'Response: --';
     }
 
     // Update music source title based on active source
@@ -3827,14 +3838,6 @@ function updateServiceStatus(service, statusData, spotifyStatus = null) {
         }
 
         syncPrimaryMetadataSourceAvailability(spotifyStatus);
-
-        const responseTimeElement = document.getElementById('metadata-source-response-time');
-        if (responseTimeElement) {
-            const responseTime = statusData.response_time;
-            responseTimeElement.textContent = responseTime !== undefined && responseTime !== null
-                ? `Response: ${responseTime}ms`
-                : 'Response: --';
-        }
 
         const testButton = document.querySelector('#metadata-source-service-card .service-card-button');
         if (testButton) {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -46811,9 +46811,9 @@ body.downloads-disabled [onclick*="DownloadMissing"]:not([onclick*="close"]) {
 }
 .auto-new-btn {
     position: relative;
-    background: linear-gradient(135deg, rgba(255,255,255,0.10) 0%, rgba(255,255,255,0.04) 100%);
+    background: linear-gradient(135deg, rgb(var(--accent-rgb)), rgb(var(--accent-light-rgb)));
     color: #fff;
-    border: 1.5px solid rgba(255,255,255,0.15);
+    border: 1.5px solid rgba(var(--accent-light-rgb), 0.6);
     padding: 10px 22px;
     border-radius: 12px;
     font-size: 14px;
@@ -46821,13 +46821,13 @@ body.downloads-disabled [onclick*="DownloadMissing"]:not([onclick*="close"]) {
     cursor: pointer;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     letter-spacing: 0.3px;
-    animation: btn-rainbow-glow 6s linear infinite;
+    box-shadow: 0 4px 18px rgba(var(--accent-rgb), 0.35);
     backdrop-filter: blur(12px);
 }
 .auto-new-btn:hover {
     transform: translateY(-2px);
-    background: linear-gradient(135deg, rgba(255,255,255,0.16) 0%, rgba(255,255,255,0.08) 100%);
-    animation: btn-rainbow-glow-hover 4s linear infinite;
+    background: linear-gradient(135deg, rgb(var(--accent-rgb)), rgb(var(--accent-light-rgb)));
+    box-shadow: 0 6px 24px rgba(var(--accent-rgb), 0.5);
 }
 .auto-new-btn:active {
     transform: translateY(0) scale(0.97);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -65374,8 +65374,11 @@ body.max-performance .dash-card::after {
 
 .qa-tile--hero .qa-tile__cta {
     grid-row: 4;
-    padding-top: clamp(10px, 1cqw + 4px, 16px);
-    border-top: 1px solid rgba(255, 255, 255, 0.07);
+    /* Same clean inline CTA rhythm as the minor tiles — drop the divider
+       "footer" treatment so all three read as one family (D2). The hero
+       keeps its signature (status dot, big title, own icon row). */
+    align-self: start;
+    margin-top: clamp(4px, 0.4cqw, 6px);
 }
 
 .qa-tile__cta-label {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -15203,9 +15203,14 @@ body.np-modal-open #helper-float-btn {
 }
 
 .sync-tab-button[data-tab="mirrored"].active {
-    background: #a78bfa;
-    color: #fff;
-    box-shadow: 0 4px 15px rgba(167, 139, 250, 0.3);
+    /* Mirrored is not a real brand — use the app green like the other
+       brandless source (Server Playlists) instead of an arbitrary
+       lavender (SR2). */
+    background: linear-gradient(135deg,
+        rgba(var(--accent-rgb), 0.95),
+        rgba(var(--accent-rgb), 0.75));
+    color: #000;
+    box-shadow: 0 4px 15px rgba(var(--accent-rgb), 0.3);
 }
 
 .sync-tab-button.active .mirrored-icon {
@@ -60981,7 +60986,7 @@ tr.tag-diff-same {
     .server-search-result-art { width: 36px; height: 36px; }
     .server-search-result-details { gap: 3px; }
 
-    .sync-tab-server { flex: 1 !important; }
+    .sync-tab-server { flex: 0 0 auto !important; }
     .sync-tab-divider { display: none; }
 }
 
@@ -67040,11 +67045,11 @@ body.max-performance .dash-card::after {
     box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
 }
 
-/* Active state — swell into a pill that shows the label inline. */
+/* Active state — stay the same 40px circle as the inactive chips (no
+   swell) so the row never reflows when you switch source (SY1). The active
+   chip reads by its brand-color fill; the source name shows in the panel
+   header below the strip. */
 .sync-tab-button.active {
-    width: auto;
-    padding: 0 14px 0 10px;
-    gap: 8px;
     background: linear-gradient(135deg,
         color-mix(in srgb, var(--sync-tab-accent, rgb(var(--accent-rgb))) 92%, white 8%),
         color-mix(in srgb, var(--sync-tab-accent, rgb(var(--accent-rgb))) 78%, black 22%));
@@ -67104,10 +67109,8 @@ body.max-performance .dash-card::after {
                 opacity 0.22s ease;
 }
 
-.sync-tab-button.active .sync-tab-label {
-    max-width: 200px;
-    opacity: 1;
-}
+/* Labels stay collapsed for every chip (icon-only strip); the active
+   source is named by the panel header, so the chip needn't swell (SY1). */
 
 /* Chain-link badge for the ``Link`` variants (Spotify Link, Deezer
  * Link, iTunes Link). Bottom-right corner of the chip, accent-tinted

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -6556,7 +6556,7 @@ body.np-modal-open #helper-float-btn {
     cursor: pointer;
     transition: all 0.15s;
 }
-.gsearch-tab.active { background: rgba(var(--accent-rgb), 0.12); color: var(--accent); border-color: rgba(var(--accent-rgb), 0.2); }
+.gsearch-tab.active { background: rgba(var(--accent-rgb), 0.12); color: rgb(var(--accent-light-rgb)); border-color: rgba(var(--accent-rgb), 0.2); }
 .gsearch-tab:hover:not(.active) { background: rgba(255,255,255,0.06); }
 
 /* Source icon row in the global widget. The popover itself is already a
@@ -36623,7 +36623,7 @@ div.artist-hero-badge {
     color: rgba(255,255,255,0.4); cursor: pointer; transition: all 0.2s;
 }
 .ya-filter-btn:hover { background: rgba(255,255,255,0.07); color: rgba(255,255,255,0.7); }
-.ya-filter-btn.active { background: rgba(var(--accent-rgb),0.15); border-color: rgba(var(--accent-rgb),0.3); color: var(--accent); }
+.ya-filter-btn.active { background: rgba(var(--accent-rgb),0.15); border-color: rgba(var(--accent-rgb),0.3); color: rgb(var(--accent-light-rgb)); }
 .ya-modal-sort {
     padding: 6px 10px; border-radius: 8px; font-size: 11px;
     background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.07);
@@ -38574,7 +38574,7 @@ div.artist-hero-badge {
 .decade-tab.active,
 .genre-tab.active {
     color: #fff;
-    border-bottom-color: #667eea;
+    border-bottom-color: rgb(var(--accent-light-rgb));
 }
 
 .decade-tab-content,
@@ -38758,11 +38758,11 @@ div.artist-hero-badge {
     left: 4px;
     width: calc(50% - 4px);
     height: calc(100% - 8px);
-    background: linear-gradient(135deg, rgba(138, 43, 226, 0.9), rgba(123, 31, 162, 0.9));
+    background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.9), rgba(24, 156, 71, 0.9));
     border-radius: 8px;
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
     z-index: 1;
-    box-shadow: 0 2px 8px rgba(138, 43, 226, 0.4);
+    box-shadow: 0 2px 8px rgba(var(--accent-rgb), 0.4);
 }
 
 .search-mode-toggle[data-active="basic"] .toggle-slider {
@@ -53812,8 +53812,8 @@ tr.tag-diff-same {
 }
 
 .mcache-tab.active {
-    color: var(--accent, #6d5dfc);
-    border-bottom-color: var(--accent, #6d5dfc);
+    color: rgb(var(--accent-light-rgb));
+    border-bottom-color: rgb(var(--accent-light-rgb));
 }
 
 /* Filters */
@@ -54539,8 +54539,8 @@ tr.tag-diff-same {
 }
 
 .repair-tab.active {
-    color: var(--accent-color, #6366f1);
-    border-bottom-color: var(--accent-color, #6366f1);
+    color: rgb(var(--accent-light-rgb));
+    border-bottom-color: rgb(var(--accent-light-rgb));
 }
 
 .repair-tab-badge {
@@ -70026,7 +70026,7 @@ body.em-scroll-lock { overflow: hidden; }
     font: 600 11.5px/1 'JetBrains Mono', ui-monospace, monospace;
     color: #8b93b0; transition: all .15s ease;
 }
-.arec-tab.active { background: rgba(122,162,247,0.22); color: #cdd6f4; }
+.arec-tab.active { background: rgba(var(--accent-rgb),0.22); color: rgb(var(--accent-light-rgb)); }
 .arec-tab:not(.active):hover { color: #cdd6f4; }
 .arec-filter {
     flex: 1; min-width: 120px;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -6390,6 +6390,16 @@ body.helper-mode-active #dashboard-activity-feed:hover {
             transparent 85%);
 }
 
+/* While the immersive Now Playing modal is open, suppress the floating
+   bottom chrome — its very high z-index would otherwise render the global
+   search bar and FAB buttons on top of the player's transport controls. */
+body.np-modal-open #gsearch-bar,
+body.np-modal-open #gsearch-aura,
+body.np-modal-open #notif-bell-btn,
+body.np-modal-open #helper-float-btn {
+    display: none !important;
+}
+
 .gsearch-bar {
     position: fixed;
     bottom: 24px;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -56807,17 +56807,28 @@ tr.tag-diff-same {
 /* The growing label pushes the control to a consistent right edge; the ⓘ rides
    immediately after the control as a pair so it can never shove it around. The
    help callout (flex-basis:100%) wraps to its own line below. */
+/* Shared control column — every control type sizes to one width so labels
+   sit left and controls line up in a tidy right-hand column (S1). */
 #settings-page .form-group > select,
-#settings-page .form-group > .form-select {
-    flex: 0 0 auto;
+#settings-page .form-group > .form-select,
+#settings-page .form-group > input[type="text"],
+#settings-page .form-group > input[type="password"],
+#settings-page .form-group > input[type="number"],
+#settings-page .form-group > input[type="url"] {
+    /* flex:none (not a fixed flex-basis) so the 260px comes from `width` on
+       the desktop row layout, while the mobile column layout — which flips
+       flex-direction and would otherwise read 260px as a *height* — falls
+       back to content height. */
+    flex: none;
+    width: 260px;
+    max-width: 260px;
+    box-sizing: border-box;
 }
 
 #settings-page .form-group > input[type="text"],
 #settings-page .form-group > input[type="password"],
 #settings-page .form-group > input[type="number"],
 #settings-page .form-group > input[type="url"] {
-    flex: 1;
-    max-width: 340px;
     padding: 9px 14px;
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid rgba(255, 255, 255, 0.06);
@@ -56871,7 +56882,7 @@ tr.tag-diff-same {
     font-size: 0.88em;
     font-family: inherit;
     cursor: pointer;
-    min-width: 180px;
+    min-width: 0;
     margin: 0;
     transition: border-color 0.25s, background-color 0.25s, box-shadow 0.25s;
 }
@@ -57143,6 +57154,15 @@ tr.tag-diff-same {
 #settings-page .form-group > input[type="text"][id^="template-"] {
     flex: 1;
     max-width: 420px;
+}
+
+/* Inline hints (<small>/.settings-hint) wrap below the control instead of
+   stealing horizontal space and squeezing the input narrower (S1). */
+#settings-page .form-group > small,
+#settings-page .form-group > .settings-hint {
+    flex-basis: 100%;
+    width: 100%;
+    margin: 4px 0 0;
 }
 
 /* ── Setting help text — always wraps to its own line ── */

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -52567,6 +52567,9 @@ tr.tag-diff-same {
     font-size: 14px;
     line-height: 1.6;
     color: rgba(255, 255, 255, 0.72);
+    /* Long paths/URLs must break so the flex item can shrink instead of clipping */
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .docs-steps li::before {
@@ -52595,6 +52598,13 @@ tr.tag-diff-same {
     display: flex;
     gap: 12px;
     align-items: flex-start;
+    min-width: 0;
+}
+
+/* Callout body must be able to shrink and wrap long paths/URLs */
+.docs-callout > * {
+    min-width: 0;
+    overflow-wrap: anywhere;
 }
 
 .docs-callout-icon {
@@ -52651,6 +52661,23 @@ tr.tag-diff-same {
 
 .docs-table tr:hover td {
     background: rgba(255, 255, 255, 0.02);
+}
+
+/* Long inline tokens (URLs, docker paths) in prose must wrap, not clip */
+.docs-content p,
+.docs-content li,
+.docs-content strong,
+.docs-content a,
+.docs-table th,
+.docs-table td {
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 768px) {
+    /* Keep data tables inside the viewport by wrapping cell text */
+    .docs-table {
+        table-layout: fixed;
+    }
 }
 
 /* Keyboard shortcut badges */
@@ -53461,6 +53488,44 @@ tr.tag-diff-same {
 
     .docs-section-title {
         font-size: 22px;
+    }
+
+    /* Step rows carry rich inline content (code, badges); let it wrap
+       instead of forcing the flex row wider than the viewport */
+    .docs-steps li {
+        flex-wrap: wrap;
+    }
+
+    /* API param tables pin their first two columns nowrap — release that
+       on small screens and let the fixed layout keep them in-bounds */
+    .api-params-table {
+        table-layout: fixed;
+    }
+    .api-params-table td:first-child,
+    .api-params-table td:nth-child(2),
+    .api-params-table th,
+    .api-params-table td {
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
+    /* API tester: key bar + endpoint headers are nowrap flex rows with a
+       non-shrinking path — let them wrap and shrink on small screens */
+    .api-key-bar {
+        flex-wrap: wrap;
+    }
+    .api-endpoint-header {
+        flex-wrap: wrap;
+    }
+    .api-endpoint-path {
+        flex-shrink: 1;
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+    .api-endpoint-desc {
+        max-width: 100%;
+        text-align: left;
+        white-space: normal;
     }
 }
 

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -63668,10 +63668,16 @@ body.max-performance #page-particles-canvas {
     gap: 6px;
 }
 
-.wishlist-page-header-right {
+/* Wishlist actions live in a left-aligned row below the header, matching
+   its sibling Watchlist page (.watchlist-page-actions) instead of sitting
+   inside the header top-right (WL1). */
+.wishlist-page-actions {
     display: flex;
     gap: 8px;
     align-items: center;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+    padding: 0 4px;
 }
 
 .wishlist-page-title {
@@ -64361,9 +64367,9 @@ body.max-performance #page-particles-canvas {
         width: 100%;
     }
 
-    .wishlist-page-header-right {
-        width: 100%;
-        justify-content: flex-end;
+    .wishlist-page-actions {
+        flex-direction: column;
+        align-items: stretch;
     }
 
     .wishlist-stat-item {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -47048,6 +47048,16 @@ body.downloads-disabled [onclick*="DownloadMissing"]:not([onclick*="close"]) {
     margin-bottom: 16px;
     overflow-x: auto;
 }
+@media (max-width: 768px) {
+    /* Fade the right edge to signal the tab row scrolls */
+    .auto-hub-tabs {
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+        -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
+        mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
+    }
+    .auto-hub-tabs::-webkit-scrollbar { display: none; }
+}
 .auto-hub-tab {
     padding: 8px 16px;
     border: none;
@@ -57716,13 +57726,19 @@ tr.tag-diff-same {
     #settings-page .settings-nav-row .header-actions {
         margin-left: auto;
     }
-    /* Tab bar scrolls horizontally */
+    /* Tab bar scrolls horizontally; fade the right edge to signal more tabs */
     #settings-page .stg-tabbar {
         width: 100%;
         flex: 1 1 100%;
         border-radius: 0;
         justify-content: flex-start;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none;
+        -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
+        mask-image: linear-gradient(to right, #000 calc(100% - 22px), transparent);
     }
+    #settings-page .stg-tabbar::-webkit-scrollbar { display: none; }
     .stg-tab { padding: 8px 14px; font-size: 0.8em; }
     /* Content fills screen */
     #settings-page .settings-columns { max-width: 100% !important; padding: 0 8px; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -64885,7 +64885,11 @@ body.max-performance .dash-card::after {
     grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
     grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
     gap: clamp(8px, 0.8cqw + 4px, 14px);
-    height: clamp(280px, 18cqw + 200px, 340px);
+    /* Size to content (rows are minmax(0,1fr) so the row-spanning hero
+       auto-equalizes to the two stacked minor tiles); keep a floor for
+       visual mass. Forcing a fixed height taller than content is what
+       left the dead gap above the Auto-Sync title (D1). */
+    min-height: clamp(220px, 14cqw + 160px, 280px);
 }
 
 .qa-tile {
@@ -64951,7 +64955,7 @@ body.max-performance .dash-card::after {
 .qa-tile--hero {
     grid-row: span 2;
     padding: clamp(20px, 1.6cqw + 14px, 32px);
-    grid-template-rows: auto auto 1fr auto;
+    grid-template-rows: auto auto auto 1fr;
     gap: clamp(10px, 1cqw + 4px, 18px);
 }
 
@@ -65315,7 +65319,7 @@ body.max-performance .dash-card::after {
 
 .qa-tile--hero .qa-tile__heading {
     grid-row: 3;
-    align-self: end;
+    align-self: start;
 }
 
 .qa-tile__title {
@@ -65409,7 +65413,9 @@ body.max-performance .dash-card::after {
         grid-template-rows: auto auto auto;
         height: auto;
     }
-    .qa-tile--hero { grid-row: auto; aspect-ratio: 4 / 3; }
+    /* Size to content in the single-column layout — a fixed 4:3 box left a
+       big dead gap below the CTA on the narrow dashboard column (D1). */
+    .qa-tile--hero { grid-row: auto; aspect-ratio: auto; }
     .qa-tile--minor { min-height: 90px; }
 }
 

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -9144,14 +9144,21 @@ body.np-modal-open #helper-float-btn {
     gap: 5px;
 }
 
-/* Page header icon — shown beside all page titles */
+/* Page header icon — compact by default (unified header bar); the Dashboard
+   keeps the full-size hero illustration (see #dashboard-page override below). */
 .page-header-icon {
-    width: 176px;
-    height: 176px;
+    width: 48px;
+    height: 48px;
     object-fit: contain;
     flex-shrink: 0;
     filter: drop-shadow(0 2px 8px rgba(var(--accent-rgb), 0.3));
     transition: transform 0.3s ease, filter 0.3s ease;
+}
+
+/* Dashboard is the one page that keeps the large hero illustration. */
+#dashboard-page .page-header-icon {
+    width: 176px;
+    height: 176px;
 }
 
 .page-header-icon:hover {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -62952,6 +62952,9 @@ body.max-performance #page-particles-canvas {
     letter-spacing: -0.5px;
     line-height: 1.1;
     font-family: 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+    /* Keep values like "1.8 MB" on one line so this tile's baseline matches
+       the single-line sibling tiles (2 / 12 / ...) (D5). */
+    white-space: nowrap;
 }
 
 .library-status-stat-label {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -27761,13 +27761,13 @@ body.np-modal-open #helper-float-btn {
 .watchlist-filter {
     display: flex;
     gap: 8px;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 8px 0;
 }
 
 .library-source-filter {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     padding: 0 0 4px;
 }
 .library-source-filter-select {
@@ -28076,7 +28076,7 @@ body.np-modal-open #helper-float-btn {
     gap: 12px;
     padding: 16px;
     min-width: max-content;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
 }
 


### PR DESCRIPTION
A two-part frontend pass: **mobile-responsive fixes** (overflow, tap targets, hidden/overlapping controls) followed by a **UI-consistency pass** (headers, tabs, buttons, alignment). All changes are frontend-only (`webui/`), scoped to the legacy vanilla-JS pages, and verified in-browser at 375 / 1440 / 2560 px. `mobile.css`/component-breakpoint-scoped changes leave desktop untouched.

## Responsive / overflow
- Scroll-fade affordance on overflowing mobile tab rows (settings, automations)
- Docs/help content no longer overflows the viewport on mobile (tables, `<pre>`, api-tester)
- Floating bottom chrome (search bar, bell, help) stays clear of the Now-Playing modal and of page content
- Enlarged undersized mobile tap targets (select-all checkbox, close/toggle buttons)
- Round icon buttons no longer stretch into ellipses under the global mobile min-height rule
- Discover carousel indicators lifted clear of the hero action buttons

## UI consistency — cross-cuts
- **Headers** de-hero'd into a unified compact bar (large hero kept only on the Dashboard)
- **Tabs**: active/selected accent unified to the app green (several tab systems were falling back to hardcoded blue/purple via undefined `--accent-color`/`--accent` vars)
- **Buttons** normalized to a primary (green) / secondary (grey) / destructive (red) scheme (retires the watchlist "rainbow" toolbar and the purple New-Automation button)
- **Search fields**: scoped filters now read "Filter…" vs the global "Search everything…"

## UI consistency — per page
- **Dashboard**: removed the dead vertical gap in the Auto-Sync tile; harmonized its CTA with the sibling tiles; uniform service-status cards (`Connected` + `Response: Xms` on every card); Library "N MB" stat no longer wraps to two lines
- **Settings**: every form-row control shares one 260px column with a common right edge; inline hints wrap below the control
- **Sync**: source-tab row no longer reflows when you switch source (chips stay a uniform size; active reads by its brand-color fill); brandless "Mirrored" source uses the app green (real per-source brand colors kept by design)
- **Library**: filter/alphabet clusters left-align with the search bar and grid
- **Wishlist**: action buttons moved to a below-header row, matching its sibling Watchlist page

## Mobile layout
- Trimmed the compounding horizontal padding of nested layout wrappers (`.page-shell` margin/padding) that was eating ~136px of a 375px screen — recovers real content width across all 8 page-shell pages

## Notes
- No JS/CSS build step touched; the React routes (`/issues`, `/stats`, `/import`) are unaffected (their prebuilt bundle isn't modified).
- A handful of catalogued items were verified to be **not** bugs and intentionally left alone: dashboard column balance (grid already equalizes rows), library card badges (data-driven), settings status tints and help-icon/Auto-detect affordances (functional/status-driven).
- Header standardization and a few consistency items on the React pages are deferred to a follow-up (they require `src/*.tsx` + a bundle rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
