### PR TITLE
fix(paths): select compilation_path template for compilation albums

### DIFF
--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -584,7 +584,9 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
         # so $cdnum can decide between "CDxx" and an empty string.
         template_context["total_discs"] = total_discs
 
-        album_template = _get_config_manager().get("file_organization.templates", {}).get("album_path", "") or ""
+        _template_key = "compilation_path" if raw_album_type in ("compilation", "compile") else "album_path"
+
+        album_template = _get_config_manager().get("file_organization.templates", {}).get(_template_key, "") or ""
         # Suppress the auto-injected disc folder when the user already
         # encodes the disc in the filename via $disc, $discnum, or $cdnum.
         user_controls_disc = (
@@ -596,7 +598,7 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
         )
         disc_label = _get_config_manager().get("file_organization.disc_label", "Disc")
 
-        folder_path, filename_base = get_file_path_from_template(template_context, "album_path")
+        folder_path, filename_base = get_file_path_from_template(template_context, _template_key)
 
         # #829: if this album already lives in a single folder on disk, drop the
         # new track there instead of a freshly-templated folder — this is what
@@ -604,8 +606,10 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
         # batches (wishlist, Album Completeness, a missed track later). Strict
         # match + transfer-dir-only + single-folder-only inside the resolver;
         # any miss falls through to the template path below. Best-effort.
+        # Compilations skip reuse — their namespace moved from artist-based to
+        # Compilations/, so matching an old artist folder would scatter tracks.
         reuse_folder = None
-        if filename_base:
+        if filename_base and raw_album_type not in ("compilation", "compile"):
             try:
                 from core.library.existing_album_folder import resolve_existing_album_folder
                 from database.music_database import get_database
@@ -646,11 +650,14 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
                 _ensure_dir(os.path.join(transfer_dir, folder_path), exist_ok=True)
             return final_path, True
 
-        artist_name_sanitized = sanitize_filename(template_context["albumartist"])
         album_name_sanitized = sanitize_filename(album_info["album_name"])
-        artist_dir = os.path.join(transfer_dir, artist_name_sanitized)
-        album_folder_name = f"{artist_name_sanitized} - {album_name_sanitized}"
-        album_dir = os.path.join(artist_dir, album_folder_name)
+        if raw_album_type in ("compilation", "compile"):
+            album_dir = os.path.join(transfer_dir, "Compilations", album_name_sanitized)
+        else:
+            artist_name_sanitized = sanitize_filename(template_context["albumartist"])
+            artist_dir = os.path.join(transfer_dir, artist_name_sanitized)
+            album_folder_name = f"{artist_name_sanitized} - {album_name_sanitized}"
+            album_dir = os.path.join(artist_dir, album_folder_name)
         if total_discs > 1:
             album_dir = os.path.join(album_dir, f"{disc_label} {disc_number}")
         _ensure_dir(album_dir, exist_ok=True)

--- a/tests/imports/test_import_paths.py
+++ b/tests/imports/test_import_paths.py
@@ -87,9 +87,9 @@ def test_itunes_single_albumartist_falls_back_to_track_artist(monkeypatch, tmp_p
     assert "Unknown Artist" not in final_path
 
 
-def test_real_album_artist_still_wins_over_track_artist(monkeypatch, tmp_path):
-    """The #989 guard must not clobber a genuine, different album artist (compilations,
-    'various artists' style releases keep their real collection artist)."""
+def test_compilation_uses_compilation_path_template(monkeypatch, tmp_path):
+    """Compilation albums route through the compilation_path template so all tracks
+    land in a single Compilations/<album>/ folder instead of being split by artist."""
     monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _album_path_config(tmp_path))
     monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
     ctx = {
@@ -105,7 +105,11 @@ def test_real_album_artist_still_wins_over_track_artist(monkeypatch, tmp_path):
     info = {"is_album": True, "album_name": "Big Comp", "track_number": 3, "disc_number": 1}
     final_path, _ = import_paths.build_final_path_for_track(
         ctx, {"name": "Guest Singer"}, info, ".flac", create_dirs=False)
-    assert "Various Artists" in final_path        # real album artist preserved
+    # compilation_path default: Compilations/$album/$track - $artist - $title
+    assert "Compilations" in final_path
+    assert "Big Comp" in final_path
+    assert "Guest Singer" in final_path
+    assert "Various Artists" not in final_path
 
 
 def test_create_dirs_true_still_creates_folders(monkeypatch, tmp_path):


### PR DESCRIPTION
## Problem

Compilation albums (various-artists compilations like "Absolute Music 10" or "Now That's What I Call Music") were being routed through the **album_path** template, which organizes by `$albumartist`. Since each track on a compilation has a different artist, this scattered tracks across individual artist folders instead of keeping them together.

The **compilation_path** template already existed in the config defaults — it was defined as dead code but never selected by any code path.

## Solution

In `build_final_path_for_track()`, when `raw_album_type` is `"compilation"` or `"compile"`, select the **compilation_path** template instead of **album_path**. The default template puts everything under `Compilations/$album/$track - $artist - $title`.

Three supporting changes in the same function:

1. **Template-aware disc-folder check** — hoist the template key selection before the `user_controls_disc` check so it reads from the correct template (previously always read `album_path` even for compilations).

2. **Skip folder reuse for compilations** — the #829 existing-album-folder reuse logic would redirect new compilation tracks back into old artist-based folders from before this fix, defeating the purpose. Compilations now skip this reuse since their namespace changed from artist-based to `Compilations/`.

3. **Compilation-aware fallback path** — when the template returns empty, the hardcoded fallback now routes compilations to `Compilations/<album>/` instead of `$albumartist/$albumartist - $album/`.

## Testing

- All 658 existing tests pass
- Updated `test_real_album_artist_still_wins_over_track_artist` → `test_compilation_uses_compilation_path_template` to reflect new expected behavior (compilations go to `Compilations/`, not `Various Artists/`)
- Ruff lint clean (only pre-existing lint in `album_consistency.py` is unrelated)

## Backward Compatibility

- Non-compilation albums are completely unaffected — they continue to use `album_path`
- Compilations with no `album_type` metadata (empty string, e.g. Soulseek downloads with no enrichment) fall through to `album_path` — safe default
- Users can customize the `compilation_path` template in Settings → File Organization, just like all other templates
