### PR TITLE
fix(webui): stop floating chrome from covering album modal's mobile actions

### DIFF
--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -6400,6 +6400,20 @@ body.np-modal-open #helper-float-btn {
     display: none !important;
 }
 
+/* Same problem for the full-screen "download missing / add to wishlist"
+   modal (z-index 9000): the floating bottom-right chrome (z-index 999999)
+   would otherwise sit on top of the modal's footer actions — on a phone
+   the notification bell and helper FAB cover the "Add to Wishlist" / "Close"
+   buttons and make them untappable. That modal is created/removed from the
+   DOM and toggled via inline display, so key off the *visible* instance
+   (base CSS is display:none; it is revealed with style.display='flex'). */
+body:has(.download-missing-modal[style*="display: flex"]) #gsearch-bar,
+body:has(.download-missing-modal[style*="display: flex"]) #gsearch-aura,
+body:has(.download-missing-modal[style*="display: flex"]) #notif-bell-btn,
+body:has(.download-missing-modal[style*="display: flex"]) #helper-float-btn {
+    display: none !important;
+}
+
 .gsearch-bar {
     position: fixed;
     bottom: 24px;


### PR DESCRIPTION
## Before / After (mobile, 375×667)

![Before/after — floating chrome no longer covers the album modal footer](https://raw.githubusercontent.com/bluejorts/SoulSync/pr-assets/.github/pr-shots/1007-compare-v2.png)

*Left (before): the notification bell + helper FAB sit on top of the **Close** button — and on a taller footer, **Add to Wishlist** — making them untappable. Right (after): the chrome is hidden while the modal is open, so the whole footer is reachable.*

---

## Problem

On mobile, searching an album → tapping a result opens the full-screen album modal (`.download-missing-modal`, `z-index: 9000`). The floating bottom-right chrome — the notification bell and helper FAB (`#notif-bell-btn` / `#helper-float-btn`, `z-index: 999999`), plus `#gsearch-bar` — renders **on top of** that modal, sitting directly over its footer. On a phone this covers the **"Add to Wishlist"** / **"Close"** buttons and makes them untappable.

Hit-testing at 375×667 confirmed those footer buttons resolved to the floating chrome, not the buttons themselves.

## Fix

Mirror the existing `body.np-modal-open` rule (which already hides this same chrome for the Now-Playing modal), but key off the **visible** `.download-missing-modal` via `:has()`:

```css
body:has(.download-missing-modal[style*="display: flex"]) #notif-bell-btn,
/* + #helper-float-btn, #gsearch-bar, #gsearch-aura */
{ display: none !important; }
```

Using `:has()` avoids threading a body class through the many open/close call sites (`downloads.js`, `shared-helpers.js`, `sync-*.js`). The modal's base CSS is `display:none` and it's revealed via inline `style.display='flex'`, so the selector matches **only the shown instance** — it self-clears on close, including the close-while-running path that hides via `display:none` (which won't match `display: flex`).

## Verification

At 375×667: all four footer buttons ("Begin Analysis" / "Add to Wishlist" / "Export as M3U" / "Close") report nothing overlapping them, and the bell + FAB return (`display: flex`) once the modal closes. Desktop unaffected (chrome briefly hides while this modal is open, same as the Now-Playing modal already does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

