### PR TITLE
ci: gate the webui (lint, build, vitest) alongside the python checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,3 +34,34 @@ jobs:
         env:
           PYTHONPATH: ${{ github.workspace }}
         run: python -m pytest
+
+  webui:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: webui
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          # Matches the Dockerfile's node:24-slim webui-builder stage
+          node-version: 24
+          cache: npm
+          cache-dependency-path: webui/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint and format check
+        run: npm run check
+
+      - name: Build webui
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/webui/src/app/router.test.tsx
+++ b/webui/src/app/router.test.tsx
@@ -8,9 +8,9 @@ import {
   type ShellPageId,
 } from '@/platform/shell/bridge';
 import { HttpResponse, http, server } from '@/test/msw';
+import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
-import { createAppQueryClient } from './query-client';
 import { AppRouterProvider, createAppRouter } from './router';
 
 describe('createAppRouter', () => {
@@ -51,7 +51,7 @@ describe('createAppRouter', () => {
   });
 
   it('creates one shared query client and applies router defaults', () => {
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const router = createAppRouter({ queryClient });
 
     expect(router.options.context?.queryClient).toBe(queryClient);
@@ -65,7 +65,7 @@ describe('createAppRouter', () => {
   it('renders migrated React routes directly and updates shell chrome', async () => {
     window.SoulSyncWebShellBridge = createShellBridge();
 
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const history = createMemoryHistory({ initialEntries: ['/issues'] });
     const router = createAppRouter({ history, queryClient });
 
@@ -83,7 +83,7 @@ describe('createAppRouter', () => {
   it('routes non-migrated paths through the legacy fallback handler', async () => {
     window.SoulSyncWebShellBridge = createShellBridge();
 
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const history = createMemoryHistory({ initialEntries: ['/search'] });
     const router = createAppRouter({ history, queryClient });
 
@@ -99,7 +99,7 @@ describe('createAppRouter', () => {
       isPageAllowed: vi.fn((pageId) => pageId !== 'issues'),
     });
 
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const history = createMemoryHistory({ initialEntries: ['/issues'] });
     const router = createAppRouter({ history, queryClient });
 
@@ -116,7 +116,7 @@ describe('createAppRouter', () => {
       getCurrentProfileContext,
     });
 
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const history = createMemoryHistory({ initialEntries: ['/issues'] });
     const router = createAppRouter({ history, queryClient });
 
@@ -137,7 +137,7 @@ describe('createAppRouter', () => {
       getProfileHomePage: vi.fn<() => ShellPageId>(() => 'search'),
     });
 
-    const queryClient = createAppQueryClient();
+    const queryClient = createTestQueryClient();
     const history = createMemoryHistory({ initialEntries: ['/'] });
     const router = createAppRouter({ history, queryClient });
 

--- a/webui/src/routes/artist-detail/-route.test.tsx
+++ b/webui/src/routes/artist-detail/-route.test.tsx
@@ -2,12 +2,12 @@ import { createMemoryHistory } from '@tanstack/react-router';
 import { render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAppQueryClient } from '@/app/query-client';
 import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 function renderArtistDetailRoute(initialEntries = ['/artist-detail/library/42']) {
-  const queryClient = createAppQueryClient();
+  const queryClient = createTestQueryClient();
   const history = createMemoryHistory({ initialEntries });
   const router = createAppRouter({ history, queryClient });
 

--- a/webui/src/routes/import/-route.test.tsx
+++ b/webui/src/routes/import/-route.test.tsx
@@ -2,9 +2,9 @@ import { createMemoryHistory } from '@tanstack/react-router';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAppQueryClient } from '@/app/query-client';
 import { AppRouterProvider, createAppRouter } from '@/app/router';
 import { HttpResponse, http, server } from '@/test/msw';
+import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 import type { ImportStagingFile } from './-import.types';
@@ -13,7 +13,7 @@ import { autoImportResultsQueryOptions, autoImportStatusQueryOptions } from './-
 import { resetImportWorkflowStore } from './-import.store';
 
 function renderImportRoute(initialEntries = ['/import']) {
-  const queryClient = createAppQueryClient();
+  const queryClient = createTestQueryClient();
   const history = createMemoryHistory({ initialEntries });
   const router = createAppRouter({ history, queryClient });
 

--- a/webui/src/routes/import/-route.test.tsx
+++ b/webui/src/routes/import/-route.test.tsx
@@ -369,7 +369,8 @@ describe('import route', () => {
         return HttpResponse.json(
           {
             success: false,
-            error: "Plex isn't connected, so importing now would copy files into place without adding them to your Library. Connect Plex in Settings, or switch to Standalone mode, then try again.",
+            error:
+              "Plex isn't connected, so importing now would copy files into place without adding them to your Library. Connect Plex in Settings, or switch to Standalone mode, then try again.",
             error_code: 'media_server_not_connected',
           },
           { status: 503 },

--- a/webui/src/routes/import/-ui/auto-import-tab.tsx
+++ b/webui/src/routes/import/-ui/auto-import-tab.tsx
@@ -228,7 +228,10 @@ export function AutoImportPanel({
                 <option value="300">5m</option>
               </Select>
             </div>
-            <div className={styles.autoImportSetting} title="Which quality profile Auto-Import checks new files against. Leave on the app-wide default unless you specifically want different rules (e.g. AcoustID, quality targets) for Auto-Import than for normal downloads.">
+            <div
+              className={styles.autoImportSetting}
+              title="Which quality profile Auto-Import checks new files against. Leave on the app-wide default unless you specifically want different rules (e.g. AcoustID, quality targets) for Auto-Import than for normal downloads."
+            >
               <span>Quality profile:</span>
               <Select
                 id="auto-import-quality-profile"

--- a/webui/src/routes/import/-ui/import-page.tsx
+++ b/webui/src/routes/import/-ui/import-page.tsx
@@ -61,7 +61,6 @@ function formatShortTime(timestamp: number) {
   });
 }
 
-
 function ImportHeader({
   error,
   fileCountText,

--- a/webui/src/routes/issues/-route.test.tsx
+++ b/webui/src/routes/issues/-route.test.tsx
@@ -2,8 +2,8 @@ import { createMemoryHistory } from '@tanstack/react-router';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAppQueryClient } from '@/app/query-client';
 import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 function createResponse(body: unknown, ok = true, status = 200) {
@@ -14,7 +14,7 @@ function createResponse(body: unknown, ok = true, status = 200) {
 }
 
 function renderIssuesRoute(initialEntries = ['/issues']) {
-  const queryClient = createAppQueryClient();
+  const queryClient = createTestQueryClient();
   const history = createMemoryHistory({ initialEntries });
   const router = createAppRouter({ history, queryClient });
 

--- a/webui/src/routes/issues/-ui/issues-page.tsx
+++ b/webui/src/routes/issues/-ui/issues-page.tsx
@@ -271,11 +271,7 @@ function IssueBoardList({
     }
 
     return issues.map((issue) => (
-      <IssueBoardCard
-        key={issue.id}
-        issue={issue}
-        showReporterName={showReporterName}
-      />
+      <IssueBoardCard key={issue.id} issue={issue} showReporterName={showReporterName} />
     ));
   }
 }

--- a/webui/src/routes/stats/-route.test.tsx
+++ b/webui/src/routes/stats/-route.test.tsx
@@ -2,13 +2,13 @@ import { createMemoryHistory } from '@tanstack/react-router';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createAppQueryClient } from '@/app/query-client';
 import { AppRouterProvider, createAppRouter } from '@/app/router';
 import { HttpResponse, http, server } from '@/test/msw';
+import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 function renderStatsRoute(initialEntries = ['/stats']) {
-  const queryClient = createAppQueryClient();
+  const queryClient = createTestQueryClient();
   const history = createMemoryHistory({ initialEntries });
   const router = createAppRouter({ history, queryClient });
 

--- a/webui/src/routes/stats/-stats.helpers.ts
+++ b/webui/src/routes/stats/-stats.helpers.ts
@@ -70,10 +70,7 @@ export const STATS_ENRICHMENT_SERVICES = [
   { key: 'bandcamp', label: 'Bandcamp', color: '#1da0c3' },
 ] as const;
 
-export function visibleStatsEnrichmentServices(
-  jiosaavnEnabled: boolean,
-  bandcampEnabled: boolean,
-) {
+export function visibleStatsEnrichmentServices(jiosaavnEnabled: boolean, bandcampEnabled: boolean) {
   return STATS_ENRICHMENT_SERVICES.filter((service) => {
     if (service.key === 'jiosaavn') return jiosaavnEnabled;
     if (service.key === 'bandcamp') return bandcampEnabled;

--- a/webui/src/test/query-client.ts
+++ b/webui/src/test/query-client.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+import { createAppQueryClient } from '@/app/query-client';
+
+// The app client retries failed queries once with a ~1s backoff, so in tests a
+// query's error state lands right at Testing Library's 1s findBy* timeout —
+// error-path assertions become a coin flip on slow runners. Tests exercise
+// failures deterministically through MSW, so retries only add latency here.
+export function createTestQueryClient(): QueryClient {
+  const queryClient = createAppQueryClient();
+  const defaults = queryClient.getDefaultOptions();
+
+  queryClient.setDefaultOptions({
+    ...defaults,
+    queries: { ...defaults.queries, retry: false },
+    mutations: { ...defaults.mutations, retry: false },
+  });
+
+  return queryClient;
+}


### PR DESCRIPTION
## What

CI was python-only (ruff / compileall / pytest): nothing ran the React app's lint, type-check, build, or its 96 vitest tests — the only thing exercising `webui/src` was the Docker image's `vite build`. With three pages now on React (`/issues`, `/stats`, `/import`) and more porting planned, regressions there can land silently.

This adds a `webui` job to `build-and-test.yml`, mirroring the existing job's shape: setup-node 24 (matching the Dockerfile's `node:24-slim` webui-builder stage) with npm caching, then `npm ci` → `npm run check` → `npm run build` → `npm test`. It runs in ~33s.

Two small preparatory commits make the gate start green:

1. **`style(webui)`** — five files had oxfmt drift (long-line wrapping only, no code changes), which fails `npm run check`. Reformatted with `oxfmt src`.
2. **`test(webui)`** — fixed a real flake before gating on it: the app query client retries failed queries once with a ~1s backoff, so a test that 500s an endpoint and awaits the error UI sees it settle right at Testing Library's 1s `findBy*` deadline. `import route › keeps the import page rendering when staging files fail to load` was a coin flip under load (~3/6 locally). Route tests now render through a shared `createTestQueryClient()` (the app client with query/mutation retries off — MSW already makes failures deterministic, so retries only added latency). Side effect: the import route test file drops from 4.1s to 1.1s of test time.

## Verification

- Full workflow (both jobs) green on the fork: https://github.com/bluejorts/SoulSync/actions/runs/29151387961
- `npm run check`, `npm run build`, and 8 consecutive full vitest runs (96/96) green locally on node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqXAbbbbzN1vCCQBYuQK6q