### PR TITLE
test(webui): route invariants sweep at desktop+mobile — and the /status race it caught

### DIFF
--- a/tests/test_status_windowed_calls.py
+++ b/tests/test_status_windowed_calls.py
@@ -1,0 +1,46 @@
+"""Regression test: /status must survive concurrent polling.
+
+_get_windowed_calls() appends to and scans a shared per-service deque. Every
+/status request walks it for each enrichment service, so two overlapping
+requests (e.g. several browser tabs, or the webui E2E sweep) used to race:
+one thread appended while another iterated, raising
+"RuntimeError: deque mutated during iteration" and turning /status into a 500.
+"""
+
+import collections
+import threading
+import time
+
+import web_server
+
+
+def test_windowed_calls_survive_concurrent_status_polls():
+    key = "_test_windowed_calls_concurrency"
+    now = time.time()
+
+    # Entries older than 1h but inside 24h force the scan to walk the whole
+    # deque (the 1h cutoff is only reached at the freshly-appended tail),
+    # which is what makes the iterate-while-append race likely in practice.
+    web_server._enrichment_activity_log[key] = collections.deque(
+        ((now - 7200 + i * 0.01, i) for i in range(17000)), maxlen=17300
+    )
+
+    errors = []
+
+    def hammer(offset):
+        try:
+            for i in range(300):
+                web_server._get_windowed_calls(key, 20000 + offset + i)
+        except RuntimeError as exc:  # noqa: PERF203 - the assertion target
+            errors.append(exc)
+
+    threads = [threading.Thread(target=hammer, args=(t * 1000,)) for t in range(8)]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    finally:
+        web_server._enrichment_activity_log.pop(key, None)
+
+    assert not errors, f"concurrent /status polls raced on the activity deque: {errors[0]}"

--- a/web_server.py
+++ b/web_server.py
@@ -1213,6 +1213,10 @@ from core.runtime_state import batch_locks
 _orphaned_download_keys = set()
 
 _enrichment_activity_log = {}
+# Guards _enrichment_activity_log's deques: every /status request appends to
+# and scans them via _get_windowed_calls, so concurrent polls (multiple tabs)
+# race into "deque mutated during iteration" without it.
+_enrichment_activity_lock = threading.Lock()
 _idle_since = {}
 _IDLE_GRACE_SECONDS = 5
 
@@ -2394,23 +2398,24 @@ def _get_windowed_calls(key, current_total):
     Deque stores (timestamp, cumulative_total) in chronological order.
     To get calls in a window: current_total minus the oldest total within that window."""
     now = time.time()
-    history = _enrichment_activity_log.setdefault(key, collections.deque(maxlen=17300))
-    history.append((now, current_total))
-
     cutoff_1h = now - 3600
     cutoff_24h = now - 86400
 
-    # Forward scan: first entry with ts >= cutoff is the oldest in that window
-    oldest_1h_total = current_total
-    oldest_24h_total = current_total
-    found_24h = False
-    for ts, total in history:
-        if not found_24h and ts >= cutoff_24h:
-            oldest_24h_total = total
-            found_24h = True
-        if ts >= cutoff_1h:
-            oldest_1h_total = total
-            break
+    with _enrichment_activity_lock:
+        history = _enrichment_activity_log.setdefault(key, collections.deque(maxlen=17300))
+        history.append((now, current_total))
+
+        # Forward scan: first entry with ts >= cutoff is the oldest in that window
+        oldest_1h_total = current_total
+        oldest_24h_total = current_total
+        found_24h = False
+        for ts, total in history:
+            if not found_24h and ts >= cutoff_24h:
+                oldest_24h_total = total
+                found_24h = True
+            if ts >= cutoff_1h:
+                oldest_1h_total = total
+                break
 
     return max(0, current_total - oldest_1h_total), max(0, current_total - oldest_24h_total)
 

--- a/webui/tests/shell-routes.smoke.spec.ts
+++ b/webui/tests/shell-routes.smoke.spec.ts
@@ -94,6 +94,114 @@ test('direct load activates all known shell routes', async ({ page, baseURL }) =
   }
 });
 
+const invariantViewports = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 375, height: 667 },
+] as const;
+
+// Known-noisy failures that predate this suite and don't indicate a broken
+// page. Keep each entry narrow and commented; an empty list is the goal.
+const allowedConsoleErrors: RegExp[] = [];
+const allowedFailedRequests: RegExp[] = [];
+
+interface RouteProblems {
+  consoleErrors: string[];
+  pageErrors: string[];
+  failedRequests: string[];
+}
+
+// Network assertions are same-origin only: third-party fetches (brand icons,
+// cover art) depend on outside network state and ORB policy, so they'd make
+// the suite flaky without saying anything about the app. Console assertions
+// skip "Failed to load resource" reports for the same reason — JS-emitted
+// errors are what that channel is for, and same-origin request failures are
+// already caught by the network listeners.
+function watchForProblems(page: Page, baseURL: string): RouteProblems {
+  const problems: RouteProblems = { consoleErrors: [], pageErrors: [], failedRequests: [] };
+  const origin = new URL(baseURL).origin;
+  const sameOrigin = (url: string) => URL.parse(url)?.origin === origin;
+
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const text = message.text();
+    if (text.startsWith('Failed to load resource')) return;
+    if (allowedConsoleErrors.some((pattern) => pattern.test(text))) return;
+    const location = message.location();
+    problems.consoleErrors.push(`${text} (${location.url}:${location.lineNumber})`);
+  });
+
+  page.on('pageerror', (error) => {
+    problems.pageErrors.push(error.message);
+  });
+
+  page.on('response', async (response) => {
+    if (response.status() < 500 || !sameOrigin(response.url())) return;
+    const body = await response.text().catch(() => '<body unavailable>');
+    const label = `${response.status()} ${response.request().method()} ${response.url()} — ${body.slice(0, 300)}`;
+    if (allowedFailedRequests.some((pattern) => pattern.test(label))) return;
+    problems.failedRequests.push(label);
+  });
+
+  page.on('requestfailed', (request) => {
+    if (!sameOrigin(request.url())) return;
+    const label = `FAILED ${request.method()} ${request.url()} (${request.failure()?.errorText})`;
+    if (allowedFailedRequests.some((pattern) => pattern.test(label))) return;
+    problems.failedRequests.push(label);
+  });
+
+  return problems;
+}
+
+for (const viewport of invariantViewports) {
+  test(`every shell route loads clean at ${viewport.name} (${viewport.width}px)`, async ({
+    page,
+    baseURL,
+  }) => {
+    if (!baseURL) {
+      test.skip();
+      return;
+    }
+
+    await selectProfile(page, baseURL);
+
+    for (const route of shellRouteManifest) {
+      const routePage = await page.context().newPage();
+      await routePage.setViewportSize({ width: viewport.width, height: viewport.height });
+      const problems = watchForProblems(routePage, baseURL);
+
+      try {
+        await routePage.goto(new URL(route.path, baseURL).toString(), {
+          waitUntil: 'domcontentloaded',
+        });
+        await waitForShellRoute(routePage, route.pageId);
+        // Continuous status polling keeps some pages from ever reaching
+        // networkidle, so give async content a bounded window and move on.
+        await routePage.waitForLoadState('networkidle', { timeout: 4000 }).catch(() => {});
+
+        const overflow = await routePage.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+        }));
+        expect
+          .soft(overflow.scrollWidth, `${route.path} overflows horizontally at ${viewport.name}`)
+          .toBeLessThanOrEqual(overflow.clientWidth + 1);
+
+        expect
+          .soft(problems.pageErrors, `${route.path} threw at ${viewport.name}`)
+          .toEqual([]);
+        expect
+          .soft(problems.consoleErrors, `${route.path} logged errors at ${viewport.name}`)
+          .toEqual([]);
+        expect
+          .soft(problems.failedRequests, `${route.path} had failed requests at ${viewport.name}`)
+          .toEqual([]);
+      } finally {
+        await routePage.close();
+      }
+    }
+  });
+}
+
 test('browser history restores shell routes', async ({ page, baseURL }) => {
   if (!baseURL) {
     test.skip();


### PR DESCRIPTION
## What

Extends `webui/tests/shell-routes.smoke.spec.ts` with a load-clean invariant for **every manifest route at 1440px and 375px**: no uncaught exceptions, no JS-emitted console errors, no same-origin 5xx/failed requests, and no horizontal page overflow (locking in the mobile-responsive pass from #997). As pages flip from `legacy` to `react` in the manifest, the sweep applies unchanged — it's meant as a standing parity net for the React migration.

Scoping decisions (so the suite stays trustworthy rather than noisy):
- **Network assertions are same-origin only.** Third-party fetches (brand icons, cover art CDNs) depend on outside network state and Chromium's ORB policy — they flake without saying anything about the app.
- **Console assertions skip `Failed to load resource` reports** — same-origin request failures are already caught by the network listeners, and the rest is the third-party noise above. The console channel asserts on real JS `console.error` output, with source location attached.
- 5xx response bodies are captured into the failure message, so a red run tells you *what* broke, not just that something did.
- Allowlists for known-noisy patterns exist in the spec but **ship empty**.

## The bug it caught

First full runs failed intermittently (~1 per 36-page sweep) with `500 GET /status — {"error":"deque mutated during iteration"}`, striking a random route each run. Root cause: `_get_windowed_calls()` in `web_server.py` appends to and forward-scans a shared per-service deque with no synchronization, and every `/status` request walks it for each enrichment service — so two overlapping polls (several open tabs, or this sweep) can interleave append with iteration, which raises `RuntimeError`. The first commit serializes the append+scan behind a module lock, with a threaded regression test that reliably reproduced the RuntimeError before the fix.

## Verification

- Regression test: fails on unfixed `web_server.py`, passes after the lock.
- Full python suite: 7602 passed, 3 skipped.
- E2E: 3/3 consecutive clean sweeps (36 page loads each, both viewports, all 18 routes) against a live local server after the fix; the 500 appeared roughly once per sweep before it. Full 5-test spec green in 1.1m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqXAbbbbzN1vCCQBYuQK6q