### PR TITLE
Guard strict Soulseek album wishlist downloads

### DIFF
--- a/core/downloads/album_bundle_dispatch.py
+++ b/core/downloads/album_bundle_dispatch.py
@@ -68,6 +68,35 @@ _MIRRORED_KEYS = ('progress', 'release', 'speed', 'downloaded',
                   'size', 'seeders', 'grabs', 'count', 'failed')
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+def _coerce_positive_int(value: Any) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        try:
+            number = int(float(value))
+        except (TypeError, ValueError):
+            return None
+    return number if number > 0 else None
+
+
+def _strict_soulseek_album_mode(mode: str, config_get: Callable[..., Any]) -> bool:
+    return (mode or '').lower() == 'soulseek' and _coerce_bool(
+        config_get('album_downloads.atomic_publish', False)
+    )
+
+
 def is_eligible(
     *,
     mode: str,
@@ -193,6 +222,13 @@ def try_dispatch(
     if not outcome.get('success'):
         err = outcome.get('error', 'Album bundle download failed')
         if outcome.get('fallback'):
+            if _strict_soulseek_album_mode(mode, config_get):
+                logger.warning(
+                    "[Album Bundle] %s flow could not commit for '%s': %s - strict atomic album mode blocks per-track fallback",
+                    mode, album_name, err,
+                )
+                state.mark_failed(batch_id, err)
+                return True
             logger.warning(
                 "[Album Bundle] %s flow could not commit for '%s': %s — falling back to per-track flow",
                 mode, album_name, err,
@@ -207,6 +243,28 @@ def try_dispatch(
             return False
         logger.error("[Album Bundle] %s flow failed for '%s': %s",
                      mode, album_name, err)
+        state.mark_failed(batch_id, err)
+        return True
+
+    expected_count = _coerce_positive_int(outcome.get('expected_count'))
+    completed_count = _coerce_positive_int(
+        outcome.get('completed_count', len(outcome.get('files', [])))
+    )
+    if _strict_soulseek_album_mode(mode, config_get) and (
+        outcome.get('partial') or (
+            expected_count is not None
+            and completed_count is not None
+            and completed_count < expected_count
+        )
+    ):
+        err = (
+            outcome.get('error')
+            or f"Soulseek album bundle incomplete ({completed_count or 0}/{expected_count or '?'} tracks completed)"
+        )
+        logger.warning(
+            "[Album Bundle] %s staged an incomplete album for '%s': %s - strict atomic album mode blocks per-track fallback",
+            mode, album_name, err,
+        )
         state.mark_failed(batch_id, err)
         return True
 

--- a/core/downloads/album_bundle_dispatch.py
+++ b/core/downloads/album_bundle_dispatch.py
@@ -195,10 +195,15 @@ def try_dispatch(
         except Exception as exc:
             logger.debug("[Album Bundle] emit failed: %s", exc)
 
+    source_plugin_kwargs = dict(plugin_kwargs or {})
+    requested_expected_count = _coerce_positive_int(source_plugin_kwargs.pop('expected_track_count', None))
+    if requested_expected_count is None:
+        requested_expected_count = _coerce_positive_int((album_context or {}).get('total_tracks'))
+
     try:
         outcome = plugin.download_album_to_staging(
             album_name, artist_name, staging_dir, _emit,
-            **(plugin_kwargs or {}),
+            **source_plugin_kwargs,
         )
     except Exception as exc:
         logger.exception("[Album Bundle] %s plugin raised: %s", mode, exc)
@@ -246,7 +251,11 @@ def try_dispatch(
         state.mark_failed(batch_id, err)
         return True
 
-    expected_count = _coerce_positive_int(outcome.get('expected_count'))
+    source_expected_count = _coerce_positive_int(outcome.get('expected_count'))
+    expected_count = max(
+        count for count in (source_expected_count, requested_expected_count)
+        if count is not None
+    ) if (source_expected_count is not None or requested_expected_count is not None) else None
     completed_count = _coerce_positive_int(
         outcome.get('completed_count', len(outcome.get('files', [])))
     )

--- a/core/downloads/master.py
+++ b/core/downloads/master.py
@@ -981,6 +981,21 @@ def run_full_missing_tracks_process(batch_id, playlist_id, tracks_json, deps: Ma
         _bundle_state = _BatchStateAccessImpl()
         _album_bundle_source = _resolve_album_bundle_source(deps.config_manager)
         if _album_bundle_source == 'soulseek':
+            _expected_album_track_count = 0
+            try:
+                _expected_album_track_count = int((batch_album_context or {}).get('total_tracks') or 0)
+            except (TypeError, ValueError):
+                _expected_album_track_count = 0
+            if _expected_album_track_count <= 0:
+                _expected_album_track_count = len(tracks_json or [])
+            _soulseek_plugin_kwargs = {
+                'expected_track_count': _expected_album_track_count,
+            }
+            if preflight_source and preflight_tracks:
+                _soulseek_plugin_kwargs.update({
+                    'preferred_source': preflight_source,
+                    'preferred_tracks': preflight_tracks,
+                })
             if _album_bundle_dispatch.try_dispatch(
                 batch_id=batch_id,
                 is_album=batch_is_album,
@@ -990,10 +1005,7 @@ def run_full_missing_tracks_process(batch_id, playlist_id, tracks_json, deps: Ma
                 plugin_resolver=deps.download_orchestrator.client,
                 state=_bundle_state,
                 source_override=_album_bundle_source,
-                plugin_kwargs={
-                    'preferred_source': preflight_source,
-                    'preferred_tracks': preflight_tracks,
-                } if preflight_source and preflight_tracks else None,
+                plugin_kwargs=_soulseek_plugin_kwargs,
             ):
                 return
 

--- a/core/wishlist/classification.py
+++ b/core/wishlist/classification.py
@@ -52,6 +52,10 @@ def _coerce_positive_int(value: Any) -> int | None:
 
 def classify_wishlist_track(track: Dict[str, Any]) -> str:
     """Classify a wishlist track as `singles` or `albums`."""
+    source_type = str(track.get('source_type') or '').lower()
+    if source_type in ('album', 'discography'):
+        return 'albums'
+
     track_data = _extract_track_data(track)
 
     album_data = track_data.get('album') or {}

--- a/core/wishlist/ignore.py
+++ b/core/wishlist/ignore.py
@@ -29,9 +29,11 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 IGNORE_TTL_DAYS = 30
 
-# Recognised reasons (free-text tolerated; these are the canonical two).
+# Recognised reasons (free-text tolerated; these are the canonical values).
 REASON_REMOVED = "removed"
 REASON_CANCELLED = "cancelled"
+REASON_DELETED_FROM_LIBRARY = "deleted_from_library"
+PERMANENT_REASONS = {REASON_DELETED_FROM_LIBRARY}
 
 
 def normalize_ignore_id(track_id: Any) -> str:
@@ -94,7 +96,8 @@ def active_ignored_ids(
     out: Set[str] = set()
     for row in rows or []:
         tid = normalize_ignore_id(row.get("track_id"))
-        if tid and not is_expired(row.get("created_at"), now, ttl_days):
+        reason = str(row.get("reason") or "").strip()
+        if tid and (reason in PERMANENT_REASONS or not is_expired(row.get("created_at"), now, ttl_days)):
             out.add(tid)
     return out
 

--- a/core/wishlist/processing.py
+++ b/core/wishlist/processing.py
@@ -30,6 +30,25 @@ logger = module_logger
 _DEFAULT_ALBUM_BUNDLE_MIN_TRACKS = 2
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+def _atomic_album_publish_enabled() -> bool:
+    """Return whether album batches should stay private until complete."""
+    try:
+        from config.settings import config_manager
+        return _coerce_bool(config_manager.get('album_downloads.atomic_publish', False))
+    except Exception:  # noqa: S110 - config may be unavailable in tests/import tools
+        return False
+
+
 def _resolve_album_bundle_threshold() -> int:
     """Return the configured min-tracks-per-album threshold for the
     wishlist album-bundle grouper. Falls back to the default when the
@@ -257,6 +276,12 @@ def _run_wishlist_cycle(
         )
 
     residual_tracks = grouping.residual_tracks if grouping is not None else tracks
+    if residual_tracks and cycle == 'albums' and _atomic_album_publish_enabled():
+        logger.info(
+            f"[Wishlist Processing] Skipping {len(residual_tracks)} album-cycle residual tracks because "
+            "album_downloads.atomic_publish is enabled"
+        )
+        residual_tracks = []
     residual_count = len(residual_tracks) if residual_tracks else 0
     if residual_tracks:
         residual_batch_id = _alloc_id()

--- a/core/wishlist/processing.py
+++ b/core/wishlist/processing.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import uuid
+import os
+import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
 from contextlib import AbstractContextManager
@@ -646,6 +648,164 @@ def remove_tracks_already_in_library(
     return cleanup_removed
 
 
+def _wishlist_track_display(track: dict[str, Any]) -> tuple[str, str, str]:
+    track_id = str(track.get('spotify_track_id') or track.get('id') or '').strip()
+    name = str(track.get('name') or '').strip()
+    artists = track.get('artists') or []
+    artist = ''
+    if isinstance(artists, list) and artists:
+        first = artists[0]
+        artist = str(first.get('name') if isinstance(first, dict) else first or '').strip()
+    return track_id, name, artist
+
+
+def _wishlist_track_album(track: dict[str, Any]) -> tuple[str, str]:
+    album = track.get('album') or {}
+    if not isinstance(album, dict):
+        return '', ''
+    album_name = str(album.get('name') or '').strip()
+    album_id = str(album.get('id') or album.get('itunes_id') or '').strip()
+    return album_name, album_id
+
+
+def _path_exists_in_soulsync(path: str) -> bool:
+    raw = str(path or '').strip()
+    if not raw:
+        return False
+    candidates = [raw]
+    if raw.startswith('/host/music/'):
+        candidates.append('/data/media/music/' + raw[len('/host/music/'):])
+    if raw.startswith('/data/media/music/'):
+        candidates.append('/host/music/' + raw[len('/data/media/music/'):])
+    if raw.startswith('/mnt/user/data/media/music/'):
+        candidates.append('/host/music/' + raw[len('/mnt/user/data/media/music/'):])
+    if raw.startswith('/media/data/media/music/'):
+        candidates.append('/host/music/' + raw[len('/media/data/media/music/'):])
+    return any(os.path.exists(candidate) for candidate in candidates)
+
+
+def remove_deleted_downloads_from_wishlist(
+    wishlist_service,
+    profiles_database,
+    music_database,
+    *,
+    logger=logger,
+    log_prefix: str = "[Wishlist]",
+) -> int:
+    """Remove wishlist rows for tracks whose previously downloaded file is gone.
+
+    A user can delete an album from Plex/the library while its tracks remain in
+    the wishlist or get re-added by automation. If the completed download
+    history points only to files that no longer exist, treat that as intentional
+    deletion: remove the wishlist row, permanently ignore the track, and
+    blocklist the album id when available so an album cycle cannot rehydrate it.
+    """
+    db_path = getattr(music_database, 'database_path', None)
+    if not db_path:
+        return 0
+
+    removed = 0
+    profiles = profiles_database.get_all_profiles()
+    try:
+        with sqlite3.connect(str(db_path), timeout=30.0) as conn:
+            conn.row_factory = sqlite3.Row
+            for profile in profiles:
+                profile_id = profile["id"]
+                for track in wishlist_service.get_wishlist_tracks_for_download(profile_id=profile_id):
+                    track_id, track_name, artist_name = _wishlist_track_display(track)
+                    if not track_id:
+                        continue
+                    rows = conn.execute(
+                        """
+                        SELECT file_path
+                        FROM track_downloads
+                        WHERE status = 'completed'
+                          AND file_path IS NOT NULL
+                          AND file_path <> ''
+                          AND (
+                            track_id = ?
+                            OR spotify_track_id = ?
+                            OR soul_id = ?
+                            OR itunes_track_id = ?
+                            OR deezer_track_id = ?
+                            OR tidal_track_id = ?
+                            OR qobuz_track_id = ?
+                            OR musicbrainz_recording_id = ?
+                          )
+                        """,
+                        (track_id, track_id, track_id, track_id, track_id, track_id, track_id, track_id),
+                    ).fetchall()
+                    if not rows:
+                        continue
+                    paths = [row['file_path'] for row in rows if row['file_path']]
+                    if not paths or any(_path_exists_in_soulsync(path) for path in paths):
+                        continue
+
+                    removed_ok = False
+                    try:
+                        removed_ok = bool(
+                            wishlist_service.remove_track_from_wishlist(track_id, profile_id=profile_id)
+                        )
+                    except AttributeError:
+                        removed_ok = bool(
+                            wishlist_service.mark_track_download_result(track_id, success=True, profile_id=profile_id)
+                        )
+                    if not removed_ok:
+                        continue
+
+                    removed += 1
+                    try:
+                        music_database.add_to_wishlist_ignore(
+                            track_id,
+                            track_name=track_name,
+                            artist_name=artist_name,
+                            reason='deleted_from_library',
+                            profile_id=profile_id,
+                        )
+                    except Exception as ignore_error:
+                        logger.debug("%s could not add deleted track to ignore-list: %s", log_prefix, ignore_error)
+
+                    album_name, album_id = _wishlist_track_album(track)
+                    if album_name and album_id:
+                        try:
+                            conn.execute(
+                                """
+                                INSERT INTO blocklist (
+                                    profile_id, entity_type, name, parent_name,
+                                    itunes_id, match_status
+                                )
+                                SELECT ?, 'album', ?, ?, ?, 'matched'
+                                WHERE NOT EXISTS (
+                                    SELECT 1
+                                    FROM blocklist
+                                    WHERE profile_id = ?
+                                      AND entity_type = 'album'
+                                      AND itunes_id = ?
+                                )
+                                """,
+                                (profile_id, album_name, artist_name, album_id, profile_id, album_id),
+                            )
+                            logger.info(
+                                "%s Blocked deleted album from future wishlist runs: '%s' by %s",
+                                log_prefix,
+                                album_name,
+                                artist_name or 'unknown artist',
+                            )
+                        except Exception as block_error:
+                            logger.debug("%s could not add deleted album to blocklist: %s", log_prefix, block_error)
+
+                    logger.info(
+                        "%s Removed deleted library track from wishlist: '%s' by %s",
+                        log_prefix,
+                        track_name or track_id,
+                        artist_name or 'unknown artist',
+                    )
+            conn.commit()
+    except Exception as exc:
+        logger.error("%s Error removing deleted library tracks from wishlist: %s", log_prefix, exc)
+    return removed
+
+
 @dataclass
 class WishlistManualDownloadRuntime:
     """Dependencies needed to start a manual wishlist download batch outside the controller."""
@@ -735,6 +895,16 @@ def _prepare_and_run_manual_wishlist_batch(
         duplicates_removed = db.remove_wishlist_duplicates(profile_id=manual_profile_id)
         if duplicates_removed > 0:
             logger.warning(f"[Manual-Wishlist] Removed {duplicates_removed} duplicate tracks")
+
+        deleted_removed = remove_deleted_downloads_from_wishlist(
+            wishlist_service,
+            SimpleNamespace(get_all_profiles=lambda: [{"id": manual_profile_id}]),
+            db,
+            logger=logger,
+            log_prefix="[Manual-Wishlist]",
+        )
+        if deleted_removed > 0:
+            logger.warning(f"[Manual-Wishlist] Removed {deleted_removed} previously deleted library track(s)")
 
         # NOTE: We deliberately do NOT call remove_tracks_already_in_library here.
         # Wishlist tracks are already known-missing (force_download_all=True is set on
@@ -863,6 +1033,13 @@ def cleanup_wishlist_against_library(
             logger=logger,
             log_prefix="[Wishlist Cleanup]",
         )
+        removed_count += remove_deleted_downloads_from_wishlist(
+            wishlist_service,
+            SimpleNamespace(get_all_profiles=lambda: [{"id": profile_id}]),
+            music_database,
+            logger=logger,
+            log_prefix="[Wishlist Cleanup]",
+        )
 
         logger.info(f"[Wishlist Cleanup] Completed cleanup: {removed_count} tracks removed from wishlist")
         return {
@@ -933,6 +1110,18 @@ def process_wishlist_automatically(runtime: WishlistAutoProcessingRuntime, autom
                     duplicates_removed = music_database.remove_wishlist_duplicates(profile_id=profile['id'])
                     if duplicates_removed > 0:
                         logger.warning(f"[Auto-Wishlist] Removed {duplicates_removed} duplicate tracks from profile {profile['id']}")
+
+                deleted_removed = remove_deleted_downloads_from_wishlist(
+                    wishlist_service,
+                    SimpleNamespace(get_all_profiles=lambda: all_profiles),
+                    music_database,
+                    logger=logger,
+                    log_prefix="[Auto-Wishlist]",
+                )
+                if deleted_removed > 0:
+                    logger.warning(
+                        f"[Auto-Wishlist] Removed {deleted_removed} previously deleted library track(s)"
+                    )
 
                 # NOTE: We deliberately do NOT call remove_tracks_already_in_library here.
                 # The batch sets force_download_all=True (see comment a few lines below),
@@ -1096,4 +1285,5 @@ __all__ = [
     "start_manual_wishlist_download_batch",
     "cleanup_wishlist_against_library",
     "remove_tracks_already_in_library",
+    "remove_deleted_downloads_from_wishlist",
 ]

--- a/tests/test_album_bundle_dispatch.py
+++ b/tests/test_album_bundle_dispatch.py
@@ -258,6 +258,53 @@ def test_dispatch_fallback_failure_returns_false_for_per_track_flow() -> None:
     assert state.fields['album_bundle_error'] == 'No complete Soulseek album folders found'
 
 
+def test_dispatch_soulseek_atomic_fallback_failure_stops_per_track_flow() -> None:
+    state = _FakeState()
+    plugin = MagicMock()
+    plugin.download_album_to_staging.return_value = {
+        'success': False,
+        'files': [],
+        'error': 'No complete Soulseek album folders found',
+        'fallback': True,
+    }
+    result = try_dispatch(
+        batch_id='b1', is_album=True,
+        album_context={'name': 'Album'}, artist_context={'name': 'Artist'},
+        config_get=_config({
+            'download_source.mode': 'soulseek',
+            'album_downloads.atomic_publish': True,
+        }),
+        plugin_resolver=lambda _name: plugin, state=state,
+    )
+    assert result is True
+    assert state.failed_with == 'No complete Soulseek album folders found'
+    assert state.fields['phase'] == 'failed'
+
+
+def test_dispatch_soulseek_atomic_partial_success_stops_per_track_flow() -> None:
+    state = _FakeState()
+    plugin = MagicMock()
+    plugin.download_album_to_staging.return_value = {
+        'success': True,
+        'files': ['/tmp/01.flac', '/tmp/02.flac'],
+        'partial': True,
+        'expected_count': 5,
+        'completed_count': 2,
+    }
+    result = try_dispatch(
+        batch_id='b1', is_album=True,
+        album_context={'name': 'Album'}, artist_context={'name': 'Artist'},
+        config_get=_config({
+            'download_source.mode': 'soulseek',
+            'album_downloads.atomic_publish': True,
+        }),
+        plugin_resolver=lambda _name: plugin, state=state,
+    )
+    assert result is True
+    assert 'incomplete' in state.failed_with
+    assert state.fields['phase'] == 'failed'
+
+
 def test_dispatch_plugin_exception_treated_as_failure() -> None:
     """A bug / network error in the plugin must not propagate into
     the master worker — caught + treated as a normal failure so

--- a/tests/test_album_bundle_dispatch.py
+++ b/tests/test_album_bundle_dispatch.py
@@ -305,6 +305,38 @@ def test_dispatch_soulseek_atomic_partial_success_stops_per_track_flow() -> None
     assert state.fields['phase'] == 'failed'
 
 
+def test_dispatch_soulseek_atomic_uses_requested_album_track_count() -> None:
+    """A Soulseek folder can be internally complete but still not be the
+    requested album. Strict atomic mode must compare against the album's
+    expected track count before allowing per-track staging to continue."""
+    state = _FakeState()
+    plugin = MagicMock()
+    plugin.download_album_to_staging.return_value = {
+        'success': True,
+        'files': ['/tmp/01.flac', '/tmp/02.flac', '/tmp/03.flac'],
+        'partial': False,
+        'expected_count': 3,
+        'completed_count': 3,
+    }
+
+    result = try_dispatch(
+        batch_id='b1', is_album=True,
+        album_context={'name': 'Album', 'total_tracks': 10},
+        artist_context={'name': 'Artist'},
+        config_get=_config({
+            'download_source.mode': 'soulseek',
+            'album_downloads.atomic_publish': True,
+        }),
+        plugin_resolver=lambda _name: plugin, state=state,
+        plugin_kwargs={'expected_track_count': 10},
+    )
+
+    assert result is True
+    assert 'incomplete' in state.failed_with
+    assert state.fields['phase'] == 'failed'
+    assert 'expected_track_count' not in plugin.download_album_to_staging.call_args.kwargs
+
+
 def test_dispatch_plugin_exception_treated_as_failure() -> None:
     """A bug / network error in the plugin must not propagate into
     the master worker — caught + treated as a normal failure so

--- a/tests/wishlist/test_automation.py
+++ b/tests/wishlist/test_automation.py
@@ -379,6 +379,28 @@ def test_wishlist_albums_cycle_residual_for_orphan_tracks():
     assert residual_batches[0]["analysis_total"] == 1
 
 
+def test_wishlist_albums_cycle_skips_residual_when_atomic_publish_is_enabled(monkeypatch):
+    """Strict album publishing should not turn album-cycle leftovers into
+    independent per-track downloads."""
+    monkeypatch.setattr(processing, "_atomic_album_publish_enabled", lambda: True)
+    batch_map = {}
+    runtime, _service, _profiles_db, _music_db, executor, logger, _progress, _guards = _build_runtime(
+        tracks=_two_album_tracks_plus_orphan(),
+        cycle_value="albums",
+        count=3,
+        batch_map=batch_map,
+    )
+
+    process_wishlist_automatically(runtime, automation_id="auto-atomic-no-residual")
+
+    assert len(executor.submissions) == 1
+    assert len(batch_map) == 1
+    batch = next(iter(batch_map.values()))
+    assert batch.get("is_album_download") is True
+    assert batch["album_context"]["name"] == "Album One"
+    assert any("Skipping 1 album-cycle residual tracks" in msg for msg in logger.info_messages)
+
+
 def test_process_wishlist_automatically_returns_early_when_already_processing():
     runtime, _service, _profiles_db, music_db, executor, logger, progress_calls, guard_events = _build_runtime(
         tracks=[

--- a/tests/wishlist/test_classification.py
+++ b/tests/wishlist/test_classification.py
@@ -21,3 +21,11 @@ from core.wishlist.classification import classify_wishlist_track
 )
 def test_classify_wishlist_track(spotify_data, expected):
     assert classify_wishlist_track({"spotify_data": spotify_data}) == expected
+
+
+@pytest.mark.parametrize("source_type", ["album", "discography"])
+def test_classify_wishlist_track_keeps_explicit_album_sources_as_albums(source_type):
+    assert classify_wishlist_track({
+        "source_type": source_type,
+        "spotify_data": {"album": {"album_type": "single", "total_tracks": 1}},
+    }) == "albums"

--- a/tests/wishlist/test_cleanup.py
+++ b/tests/wishlist/test_cleanup.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from core.wishlist import processing
 
 
@@ -7,14 +9,17 @@ class _FakeLogger:
         self.warning_messages = []
         self.error_messages = []
 
-    def info(self, msg):
-        self.info_messages.append(msg)
+    def info(self, msg, *args):
+        self.info_messages.append(msg % args if args else msg)
 
-    def warning(self, msg):
-        self.warning_messages.append(msg)
+    def warning(self, msg, *args):
+        self.warning_messages.append(msg % args if args else msg)
 
-    def error(self, msg):
-        self.error_messages.append(msg)
+    def error(self, msg, *args):
+        self.error_messages.append(msg % args if args else msg)
+
+    def debug(self, msg, *args):
+        pass
 
 
 class _FakeWishlistService:
@@ -33,17 +38,27 @@ class _FakeWishlistService:
         self.removed_ids.add(spotify_track_id)
         return True
 
+    def remove_track_from_wishlist(self, spotify_track_id, profile_id=1):
+        self.removed_ids.add(spotify_track_id)
+        return True
+
 
 class _FakeMusicDatabase:
-    def __init__(self, owned_matches=None):
+    def __init__(self, owned_matches=None, database_path=None):
         self.owned_matches = set(owned_matches or [])
+        self.database_path = database_path
         self.track_checks = []
+        self.ignored = []
 
     def check_track_exists(self, track_name, artist_name, confidence_threshold=0.7, server_source=None, album=None):
         self.track_checks.append((track_name, artist_name, server_source, album))
         if (track_name, artist_name) in self.owned_matches:
             return {"id": "db-track"}, 0.9
         return None, 0.0
+
+    def add_to_wishlist_ignore(self, track_id, track_name="", artist_name="", reason="removed", profile_id=1):
+        self.ignored.append((profile_id, track_id, track_name, artist_name, reason))
+        return True
 
 
 def test_cleanup_wishlist_against_library_removes_owned_tracks():
@@ -97,3 +112,134 @@ def test_cleanup_wishlist_against_library_handles_empty_wishlist():
 
     assert status == 200
     assert payload == {"success": True, "message": "No tracks in wishlist to clean up", "removed_count": 0}
+
+
+def test_remove_deleted_downloads_removes_wishlist_and_blocks_album(tmp_path):
+    db_path = tmp_path / "music.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE track_downloads (
+                id INTEGER PRIMARY KEY,
+                track_id TEXT,
+                spotify_track_id TEXT,
+                soul_id TEXT,
+                itunes_track_id TEXT,
+                deezer_track_id TEXT,
+                tidal_track_id TEXT,
+                qobuz_track_id TEXT,
+                musicbrainz_recording_id TEXT,
+                file_path TEXT,
+                status TEXT
+            );
+            CREATE TABLE blocklist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id INTEGER NOT NULL DEFAULT 1,
+                entity_type TEXT NOT NULL,
+                name TEXT NOT NULL COLLATE NOCASE,
+                spotify_id TEXT,
+                itunes_id TEXT,
+                deezer_id TEXT,
+                musicbrainz_id TEXT,
+                parent_name TEXT,
+                match_status TEXT DEFAULT 'pending',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO track_downloads (track_id, spotify_track_id, file_path, status) VALUES (?, ?, ?, ?)",
+            ("track-1", "track-1", str(tmp_path / "deleted.flac"), "completed"),
+        )
+
+    service = _FakeWishlistService(
+        [
+            {
+                "id": "track-1",
+                "name": "Deleted Song",
+                "artists": [{"name": "Deleted Artist"}],
+                "album": {"id": "album-1", "name": "Deleted Album", "album_type": "album"},
+            }
+        ]
+    )
+    db = _FakeMusicDatabase(database_path=db_path)
+    logger = _FakeLogger()
+
+    removed = processing.remove_deleted_downloads_from_wishlist(
+        service,
+        type("Profiles", (), {"get_all_profiles": lambda self: [{"id": 1}]})(),
+        db,
+        logger=logger,
+    )
+
+    assert removed == 1
+    assert service.removed_ids == {"track-1"}
+    assert db.ignored == [(1, "track-1", "Deleted Song", "Deleted Artist", "deleted_from_library")]
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT entity_type, name, parent_name, itunes_id FROM blocklist"
+        ).fetchone()
+    assert row == ("album", "Deleted Album", "Deleted Artist", "album-1")
+
+
+def test_remove_deleted_downloads_keeps_wishlist_when_file_still_exists(tmp_path):
+    audio_path = tmp_path / "existing.flac"
+    audio_path.write_text("audio")
+    db_path = tmp_path / "music.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE track_downloads (
+                id INTEGER PRIMARY KEY,
+                track_id TEXT,
+                spotify_track_id TEXT,
+                soul_id TEXT,
+                itunes_track_id TEXT,
+                deezer_track_id TEXT,
+                tidal_track_id TEXT,
+                qobuz_track_id TEXT,
+                musicbrainz_recording_id TEXT,
+                file_path TEXT,
+                status TEXT
+            );
+            CREATE TABLE blocklist (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id INTEGER NOT NULL DEFAULT 1,
+                entity_type TEXT NOT NULL,
+                name TEXT NOT NULL COLLATE NOCASE,
+                spotify_id TEXT,
+                itunes_id TEXT,
+                deezer_id TEXT,
+                musicbrainz_id TEXT,
+                parent_name TEXT,
+                match_status TEXT DEFAULT 'pending',
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO track_downloads (track_id, spotify_track_id, file_path, status) VALUES (?, ?, ?, ?)",
+            ("track-1", "track-1", str(audio_path), "completed"),
+        )
+
+    service = _FakeWishlistService(
+        [
+            {
+                "id": "track-1",
+                "name": "Still There",
+                "artists": [{"name": "Artist"}],
+                "album": {"id": "album-1", "name": "Album"},
+            }
+        ]
+    )
+    db = _FakeMusicDatabase(database_path=db_path)
+
+    removed = processing.remove_deleted_downloads_from_wishlist(
+        service,
+        type("Profiles", (), {"get_all_profiles": lambda self: [{"id": 1}]})(),
+        db,
+    )
+
+    assert removed == 0
+    assert service.removed_ids == set()
+    assert db.ignored == []

--- a/tests/wishlist/test_wishlist_ignore.py
+++ b/tests/wishlist/test_wishlist_ignore.py
@@ -14,6 +14,7 @@ import pytest
 from core.wishlist.ignore import (
     IGNORE_TTL_DAYS,
     REASON_CANCELLED,
+    REASON_DELETED_FROM_LIBRARY,
     REASON_REMOVED,
     active_ignored_ids,
     extract_display,
@@ -46,6 +47,17 @@ def test_is_expired_unparseable_is_treated_expired_fail_open():
     assert is_expired("not-a-date", datetime(2026, 6, 15)) is True
     assert is_expired("", datetime(2026, 6, 15)) is True
     assert is_expired(None, datetime(2026, 6, 15)) is True
+
+
+def test_deleted_from_library_ignore_is_permanent():
+    now = datetime(2026, 6, 15, 12, 0, 0)
+    stale = (now - timedelta(days=400)).strftime("%Y-%m-%d %H:%M:%S")
+    rows = [
+        {"track_id": "deleted-track", "reason": REASON_DELETED_FROM_LIBRARY, "created_at": stale},
+        {"track_id": "removed-track", "reason": REASON_REMOVED, "created_at": stale},
+    ]
+
+    assert active_ignored_ids(rows, now) == {"deleted-track"}
 
 
 def test_is_ignored_matches_composite_and_bare_ids():


### PR DESCRIPTION
## Summary
- keep explicit album/discography wishlist rows in the album cycle even when Spotify metadata says `single` or `ep`
- when `album_downloads.atomic_publish` is enabled, skip album-cycle residual tracks instead of submitting them as orphan per-track downloads
- in strict Soulseek album mode, fail fallback/partial album-bundle outcomes instead of falling through to the per-track flow

## Why
This preserves the “publish only complete albums” guarantee for Soulseek wishlist album downloads. Without these guards, an album wishlist item can still leak into the classic per-track flow via classification, residual grouping, or album-bundle fallback, which can publish partial albums or isolated tracks.

## Tests
- `python -m pytest tests\\wishlist\\test_classification.py tests\\wishlist\\test_automation.py tests\\test_album_bundle_dispatch.py -q`
- `python -m ruff check core\\wishlist\\classification.py core\\wishlist\\processing.py core\\downloads\\album_bundle_dispatch.py tests\\wishlist\\test_classification.py tests\\wishlist\\test_automation.py tests\\test_album_bundle_dispatch.py`