### PR TITLE
fix(repair): apply canonical_version findings (add _fix_canonical_version)

### DIFF
--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -1029,11 +1029,50 @@ class RepairWorker:
             'library_retag': self._fix_library_retag,
             'short_preview_track': self._fix_short_preview_track,
             'corrupt_audio': self._fix_corrupt_audio,
+            'canonical_version': self._fix_canonical_version,
         }
         handler = handlers.get(finding_type)
         if not handler:
             return {'success': False, 'error': f'No fix available for finding type: {finding_type}'}
         return handler(entity_type, entity_id, file_path, details)
+
+    def _fix_canonical_version(self, entity_type, entity_id, file_path, details):
+        """Apply a canonical-version finding — pin the release the resolver chose
+        (source, release id and score, straight from the finding) onto the album
+        so the Reorganizer and Track Number Repair resolve the same edition (#765).
+
+        Writes an AUTO pin (``locked=False``), like the resolve job's dry-run-OFF
+        path and the Reorganizer — a later resolve can still self-heal it. A
+        LOCKED manual pin is a deliberate album-view edition choice (#758), so
+        accepting the resolver's suggestion here stays unlocked.
+        """
+        source = details.get('source')
+        canonical_album_id = details.get('album_id')
+        if not source or not canonical_album_id:
+            return {'success': False,
+                    'error': 'Finding is missing the canonical source/release id'}
+        try:
+            score = float(details.get('score') or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        try:
+            updated = self.db.set_album_canonical(
+                entity_id, source, str(canonical_album_id), score,
+            )
+        except Exception as e:
+            return {'success': False, 'error': f'Failed to store canonical pin: {e}'}
+        if not updated:
+            return {
+                'success': False,
+                'error': ('Album not updated — it may be manually locked to a '
+                          'different edition, or the album row is missing'),
+            }
+        label = details.get('album_title') or details.get('artist_name') or entity_id
+        return {
+            'success': True,
+            'action': 'pinned_canonical',
+            'message': f'Pinned {source} release {canonical_album_id} as canonical for "{label}"',
+        }
 
     def _fix_discography_backfill(self, entity_type, entity_id, file_path, details):
         """Add missing discography track to wishlist."""

--- a/tests/test_repair_worker_canonical_version.py
+++ b/tests/test_repair_worker_canonical_version.py
@@ -1,0 +1,90 @@
+"""Regression: applying a ``canonical_version`` finding did nothing.
+
+The Resolve Canonical Album Versions job (#765) creates ``canonical_version``
+findings in its dry run, but ``RepairWorker._execute_fix`` had no handler for
+that finding type, so single-fix / Fix All returned
+"No fix available for finding type: canonical_version" and pinned nothing.
+
+``_fix_canonical_version`` applies the pin straight from the finding — the
+per-finding equivalent of running the job with dry-run OFF. It writes an AUTO
+pin (``locked=False``), matching ``resolve_and_store_canonical_for_album`` and
+the Reorganizer, and must NOT clobber a manual/locked pin (#758).
+"""
+
+from database.music_database import MusicDatabase
+from core.repair_worker import RepairWorker
+
+
+def _worker(tmp_path):
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES (1, 'A', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) "
+                     "VALUES (1, 'Beggars Banquet', 1, 'test')")
+        conn.commit()
+    w = RepairWorker(database=db)
+    w._config_manager = None
+    return db, w
+
+
+def _finding_details(source='musicbrainz', release_id='mb-release-123', score=0.97):
+    """Mirror the details a real canonical_version finding carries: note the
+    resolver's release id lands on the ``album_id`` key (``{'album_id': local,
+    **resolved}`` — the resolved release id wins)."""
+    return {
+        'album_id': release_id,
+        'source': source,
+        'score': score,
+        'album_title': 'Beggars Banquet',
+        'artist_name': 'The Rolling Stones',
+    }
+
+
+def test_apply_pins_canonical_as_auto(tmp_path):
+    """Applying the finding pins the resolver's release, unlocked, so a later
+    resolve can still self-heal it."""
+    db, w = _worker(tmp_path)
+    res = w._fix_canonical_version('album', '1', None, _finding_details())
+    assert res['success'] is True, res
+
+    pin = db.get_album_canonical(1)
+    assert pin is not None
+    assert pin['source'] == 'musicbrainz'
+    assert pin['album_id'] == 'mb-release-123'
+    assert round(pin['score'], 2) == 0.97
+    assert pin['locked'] is False
+
+
+def test_dispatch_no_longer_reports_no_fix(tmp_path):
+    """The reported bug: _execute_fix used to fall through to 'No fix available
+    for finding type: canonical_version'. It now routes to the handler."""
+    db, w = _worker(tmp_path)
+    res = w._execute_fix('canonical_version', 'album', '1', None, _finding_details())
+    assert res['success'] is True, res
+    assert 'No fix available' not in (res.get('error') or '')
+
+
+def test_missing_source_or_release_is_rejected(tmp_path):
+    """A malformed finding (no source/release id) is refused, not silently
+    written as a null pin."""
+    _db, w = _worker(tmp_path)
+    res = w._fix_canonical_version('album', '1', None, {'album_title': 'x'})
+    assert res['success'] is False
+    assert 'canonical source/release id' in res['error']
+
+
+def test_auto_apply_does_not_clobber_manual_lock(tmp_path):
+    """A user's manual edition lock (#758) survives applying an auto finding —
+    the finding reports failure instead of overwriting the locked pin."""
+    db, w = _worker(tmp_path)
+    # User manually pinned+locked the Deezer edition (as /api/library/manual-match does).
+    db.set_album_canonical('1', 'deezer', 'dz-999', 1.0, locked=True)
+
+    res = w._fix_canonical_version('album', '1', None, _finding_details())
+    assert res['success'] is False
+    assert 'locked' in res['error']
+
+    pin = db.get_album_canonical(1)
+    assert pin['source'] == 'deezer'
+    assert pin['album_id'] == 'dz-999'
+    assert pin['locked'] is True


### PR DESCRIPTION
## Summary

Canonical-version findings could not be applied. Clicking Fix (or Fix All) always returned `No fix available for finding type: canonical_version` and pinned nothing.

## Problem

The **Resolve Canonical Album Versions** job (#765) creates `canonical_version` findings during its dry run, and the UI offers a Fix action on them, but applying one is a no-op error.

## Root cause

`RepairWorker._execute_fix` has no handler entry for `canonical_version`, so it falls through to the generic `No fix available for finding type: ...` branch. The scan side exists; the apply side was never wired up.

## Solution

Add `_fix_canonical_version`. It pins the resolver's chosen release (`source`, release id and `score`, taken straight from the finding) via `db.set_album_canonical` as an AUTO pin (`locked=False`). This is the per-finding equivalent of running the job with dry-run OFF, matching `resolve_and_store_canonical_for_album` and the Reorganizer, so a later resolve can still self-heal it.

It deliberately does not create a manual/locked pin (that is the album-view edition override, #758) and will not clobber an existing locked pin. Malformed findings are rejected rather than written as a null pin.

## Testing

New `tests/test_repair_worker_canonical_version.py` covers the apply path, the dispatch fix (no more "No fix available"), the malformed-finding guard, and the manual-lock guard.

Locally: `ruff check .` clean, `py_compile` clean, and the 172 existing canonical/repair-worker tests plus the 4 new ones pass.
