### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 3.0.0)'
+        description: 'Version tag (e.g. 3.0.1)'
         required: true
-        default: '3.0.0'
+        default: '3.0.1'
 
 jobs:
   build-and-push:

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -55,22 +55,28 @@ _SLSKD_KEYS = {
 
 
 def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None, want_year=None,
-                   want_title=None) -> list:
+                   want_title=None, blocked_users=None) -> list:
     """Parse → evaluate → rank a list of raw indexer hits against the quality profile.
     Shared by the mock search and the live slskd start/poll endpoints.
 
-    ``blocked`` = the release blocklist as {(username, filename)} (None = look it
-    up). Blocked releases stay VISIBLE in manual search (greyed, with the reason —
-    the Sonarr behaviour) but are never `accepted`, so every auto-picker skips
-    them; a manual grab of one is a deliberate user override."""
+    ``blocked`` = the per-release blocklist as {(username, filename)}; ``blocked_users``
+    = uploaders blocked source-wide (every release from them skipped). Both None = look
+    them up. Blocked hits stay VISIBLE in manual search (greyed, with the reason — the
+    Sonarr behaviour) but are never `accepted`, so every auto-picker skips them; a manual
+    grab of one is a deliberate user override."""
     from core.video.quality_eval import evaluate_release
     from core.video.release_parse import parse_release
-    if blocked is None:
+    if blocked is None or blocked_users is None:
         try:
             from . import get_video_db
-            blocked = get_video_db().video_blocklist_pairs()
+            db = get_video_db()
+            if blocked is None:
+                blocked = db.video_blocklist_pairs()
+            if blocked_users is None:
+                blocked_users = db.blocked_usernames()
         except Exception:   # noqa: BLE001 - filtering is an assist, never a 500
-            blocked = frozenset()
+            blocked = blocked or frozenset()
+            blocked_users = blocked_users or frozenset()
     results = []
     for hit in raw:
         parsed = parse_release(hit.get("title"))
@@ -78,8 +84,12 @@ def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None,
         verdict = evaluate_release(parsed, profile, scope=scope, want_season=want_season,
                                    want_episode=want_episode, size_gb=size_gb, want_year=want_year,
                                    want_title=want_title)
-        is_blocked = (hit.get("username"), hit.get("filename")) in blocked
-        if is_blocked:
+        user = hit.get("username")
+        is_blocked = bool(user and user in blocked_users) or (user, hit.get("filename")) in blocked
+        if user and user in blocked_users:
+            verdict = {**verdict, "accepted": False,
+                       "rejected": (verdict.get("rejected") or []) + ["Uploader blocklisted"]}
+        elif (user, hit.get("filename")) in blocked:
             verdict = {**verdict, "accepted": False,
                        "rejected": (verdict.get("rejected") or []) + ["Blocklisted release"]}
         # Availability = how downloadable the source is (slskd: free slot/queue/speed score
@@ -225,6 +235,14 @@ def register_routes(bp):
                                             "season_number", "episode_number", "username",
                                             "filename", "release_title", "reason")}
             row.setdefault("reason", "Blocked by user")
+        # scope='source' → block the whole UPLOADER (peer), so every future search skips
+        # them, not just this one file (Boulder: 'blacklist a source on a completed download').
+        if str(body.get("scope") or "").lower() == "source":
+            username = (row or {}).get("username") or body.get("username")
+            if not username:
+                return jsonify({"success": False, "error": "That row has no uploader to block."}), 400
+            rid = db.block_video_source(username, reason=body.get("reason") or "Uploader blocked")
+            return jsonify({"success": bool(rid), "id": rid, "scope": "source", "username": username})
         if not row or not row.get("username") or not row.get("filename"):
             return jsonify({"success": False,
                             "error": "That row has no release to block."}), 400

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -54,7 +54,8 @@ _SLSKD_KEYS = {
 }
 
 
-def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None, want_year=None) -> list:
+def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None, want_year=None,
+                   want_title=None) -> list:
     """Parse → evaluate → rank a list of raw indexer hits against the quality profile.
     Shared by the mock search and the live slskd start/poll endpoints.
 
@@ -75,7 +76,8 @@ def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None,
         parsed = parse_release(hit.get("title"))
         size_gb = round((hit.get("size_bytes") or 0) / (1024 ** 3), 1)
         verdict = evaluate_release(parsed, profile, scope=scope, want_season=want_season,
-                                   want_episode=want_episode, size_gb=size_gb, want_year=want_year)
+                                   want_episode=want_episode, size_gb=size_gb, want_year=want_year,
+                                   want_title=want_title)
         is_blocked = (hit.get("username"), hit.get("filename")) in blocked
         if is_blocked:
             verdict = {**verdict, "accepted": False,
@@ -418,7 +420,7 @@ def register_routes(bp):
             raw = mock_search(scope, title, year=body.get("year"), season=want_season,
                               episode=want_episode, season_end=season_end, source=source)
         return jsonify({"scope": scope, "live": live,
-                        "results": _evaluate_hits(raw, profile, scope, want_season, want_episode, want_year=body.get("year"))})
+                        "results": _evaluate_hits(raw, profile, scope, want_season, want_episode, want_year=body.get("year"), want_title=body.get("title"))})
 
     @bp.route("/downloads/search/start", methods=["POST"])
     def video_downloads_search_start():
@@ -457,12 +459,12 @@ def register_routes(bp):
             if pres.get("error"):
                 return jsonify({"error": "Prowlarr: " + str(pres["error"])})
             return jsonify({"id": None, "live": True, "complete": True,
-                            "results": _evaluate_hits(pres["hits"], profile, scope, want_season, want_episode, want_year=body.get("year"))})
+                            "results": _evaluate_hits(pres["hits"], profile, scope, want_season, want_episode, want_year=body.get("year"), want_title=body.get("title"))})
         # remaining mock sources (e.g. youtube placeholder) resolve in one shot
         raw = mock_search(scope, title, year=body.get("year"), season=want_season,
                           episode=want_episode, season_end=season_end, source=source)
         return jsonify({"id": None, "live": False, "complete": True,
-                        "results": _evaluate_hits(raw, profile, scope, want_season, want_episode, want_year=body.get("year"))})
+                        "results": _evaluate_hits(raw, profile, scope, want_season, want_episode, want_year=body.get("year"), want_title=body.get("title"))})
 
     @bp.route("/downloads/search/poll", methods=["GET"])
     def video_downloads_search_poll():
@@ -479,7 +481,7 @@ def register_routes(bp):
         profile = load_profile(get_video_db())
         polled = poll_search(sid)
         return jsonify({"live": True, "total_files": polled["total_files"],
-                        "results": _evaluate_hits(polled["hits"], profile, scope, want_season, want_episode, want_year=request.args.get("year"))})
+                        "results": _evaluate_hits(polled["hits"], profile, scope, want_season, want_episode, want_year=request.args.get("year"), want_title=request.args.get("title"))})
 
     @bp.route("/downloads/grab", methods=["POST"])
     def video_downloads_grab():

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -243,14 +243,14 @@ def register_routes(bp):
 
     @bp.route("/downloads/history", methods=["GET"])
     def video_downloads_history():
-        """Paged permanent history of grabs (movies + episodes). ?kind=movie|show,
-        ?search=, ?outcome=, ?page=, ?limit=. Always returns counts for the tabs."""
+        """Paged permanent history of grabs (movies + episodes + YouTube). ?kind=
+        movie|show|youtube, ?search=, ?outcome=, ?page=, ?limit=. Always returns counts."""
         from . import get_video_db
         try:
             db = get_video_db()
             kind = request.args.get("kind")
             res = db.query_download_history(
-                kind=kind if kind in ("movie", "show") else None,
+                kind=kind if kind in ("movie", "show", "youtube") else None,
                 search=request.args.get("search", ""),
                 outcome=request.args.get("outcome") or None,
                 page=request.args.get("page", 1), limit=request.args.get("limit", 40))

--- a/core/automation/handlers/video_process_wishlist.py
+++ b/core/automation/handlers/video_process_wishlist.py
@@ -121,13 +121,42 @@ def active_download_keys(active: Iterable[Dict[str, Any]]) -> set:
     return keys
 
 
+def _acceptable_titles(primary: Any, kind: str, tmdb_id: Any) -> List[str]:
+    """[primary title, *TMDB alternative titles] — deduped, primary first. The alias
+    set the release-title gate matches against (so a release named by a known aka still
+    matches). Best-effort: just the primary when TMDB is unavailable."""
+    aliases: List[str] = []
+    if tmdb_id:
+        try:
+            from core.video.enrichment.engine import get_video_enrichment_engine
+            aliases = get_video_enrichment_engine().alt_titles_for(kind, tmdb_id) or []
+        except Exception:   # noqa: BLE001 - a matching assist must never break a grab
+            aliases = []
+    out, seen = [], set()
+    for t in [primary, *aliases]:
+        t = str(t or "").strip()
+        if t and t.lower() not in seen:
+            seen.add(t.lower())
+            out.append(t)
+    return out
+
+
 def search_context(item: Dict[str, Any], media_type: str) -> Dict[str, Any]:
-    """The ``search_ctx`` the download row carries (drives the monitor's requery)."""
+    """The ``search_ctx`` the download row carries (drives the monitor's requery).
+    Carries ``titles`` — the primary title plus TMDB aliases — so both the initial pick
+    and every retry gate releases against the full alias set."""
     if media_type == "movie":
-        return {"scope": "movie", "title": item.get("title"), "year": item.get("year")}
-    return {"scope": "episode", "title": item.get("show_title"),
-            "season": item.get("season_number"), "episode": item.get("episode_number"),
-            "year": (str(item.get("air_date") or "")[:4] or None)}
+        ctx = {"scope": "movie", "title": item.get("title"), "year": item.get("year")}
+        tmdb_id, kind = item.get("tmdb_id"), "movie"
+    else:
+        ctx = {"scope": "episode", "title": item.get("show_title"),
+               "season": item.get("season_number"), "episode": item.get("episode_number"),
+               "year": (str(item.get("air_date") or "")[:4] or None)}
+        tmdb_id, kind = item.get("show_tmdb_id"), "show"
+    titles = _acceptable_titles(ctx["title"], kind, tmdb_id)
+    if len(titles) > 1:
+        ctx["titles"] = titles
+    return ctx
 
 
 def build_download_record(item: Dict[str, Any], best: Dict[str, Any], candidates: List[Dict[str, Any]],
@@ -241,7 +270,8 @@ def _search_one_source(source: str, item: Dict[str, Any], media_type: str):
     else:
         return None, "unsupported source %r" % source
     cands = _evaluate_hits(hits, profile, ctx["scope"], ctx.get("season"), ctx.get("episode"),
-                           want_year=ctx.get("year"))
+                           want_year=ctx.get("year"),
+                           want_title=ctx.get("titles") or ctx.get("title"))
     for c in cands:
         c["source"] = source
     return cands, None

--- a/core/automation/handlers/video_refresh_airing_schedules.py
+++ b/core/automation/handlers/video_refresh_airing_schedules.py
@@ -33,10 +33,16 @@ def _default_fetch_shows() -> List[Dict[str, Any]]:
 def _default_refresh_show(library_id: Any) -> Dict[str, Any]:
     """Re-pull a library show's TMDB season/episode schedule (the lazy on-view backfill,
     invoked deliberately). Re-matches + cascades episodes, so air dates/stills refresh.
+
     ``with_ratings=False`` — we only need schedules, and the per-show OMDb ratings call
-    would burn the daily quota across a whole watchlist."""
+    would burn the daily quota across a whole watchlist. ``recent_seasons_only=True`` —
+    new episodes only land in the current season, so this pulls just the latest season(s)
+    instead of every season of every airing show every night (one API call per season, per
+    show, on settled history that never changes) — the difference between ~1 and ~5+ calls
+    per show, which matters a lot at hundreds of airing shows."""
     from core.video.enrichment.engine import get_video_enrichment_engine
-    return get_video_enrichment_engine().refresh_show_art(library_id, with_ratings=False) or {}
+    return get_video_enrichment_engine().refresh_show_art(
+        library_id, with_ratings=False, recent_seasons_only=True) or {}
 
 
 def auto_video_refresh_airing_schedules(

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -1029,11 +1029,50 @@ class RepairWorker:
             'library_retag': self._fix_library_retag,
             'short_preview_track': self._fix_short_preview_track,
             'corrupt_audio': self._fix_corrupt_audio,
+            'canonical_version': self._fix_canonical_version,
         }
         handler = handlers.get(finding_type)
         if not handler:
             return {'success': False, 'error': f'No fix available for finding type: {finding_type}'}
         return handler(entity_type, entity_id, file_path, details)
+
+    def _fix_canonical_version(self, entity_type, entity_id, file_path, details):
+        """Apply a canonical-version finding — pin the release the resolver chose
+        (source, release id and score, straight from the finding) onto the album
+        so the Reorganizer and Track Number Repair resolve the same edition (#765).
+
+        Writes an AUTO pin (``locked=False``), like the resolve job's dry-run-OFF
+        path and the Reorganizer — a later resolve can still self-heal it. A
+        LOCKED manual pin is a deliberate album-view edition choice (#758), so
+        accepting the resolver's suggestion here stays unlocked.
+        """
+        source = details.get('source')
+        canonical_album_id = details.get('album_id')
+        if not source or not canonical_album_id:
+            return {'success': False,
+                    'error': 'Finding is missing the canonical source/release id'}
+        try:
+            score = float(details.get('score') or 0.0)
+        except (TypeError, ValueError):
+            score = 0.0
+        try:
+            updated = self.db.set_album_canonical(
+                entity_id, source, str(canonical_album_id), score,
+            )
+        except Exception as e:
+            return {'success': False, 'error': f'Failed to store canonical pin: {e}'}
+        if not updated:
+            return {
+                'success': False,
+                'error': ('Album not updated — it may be manually locked to a '
+                          'different edition, or the album row is missing'),
+            }
+        label = details.get('album_title') or details.get('artist_name') or entity_id
+        return {
+            'success': True,
+            'action': 'pinned_canonical',
+            'message': f'Pinned {source} release {canonical_album_id} as canonical for "{label}"',
+        }
 
     def _fix_discography_backfill(self, entity_type, entity_id, file_path, details):
         """Add missing discography track to wishlist."""

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -433,12 +433,22 @@ def _blocked_pairs(db):
         return frozenset()
 
 
+def _blocked_users(db):
+    """Source-wide blocked uploaders — never pick any release from them, even a
+    candidate stored before the block. Best-effort (a read failure = no filter)."""
+    try:
+        return db.blocked_usernames()
+    except Exception:   # noqa: BLE001
+        logger.exception("video blocked-usernames read failed")
+        return frozenset()
+
+
 def _fail_or_retry(db, dl, error_msg) -> None:
     """A download just failed/disappeared. Try the next candidate inline; if none,
     hand off to a requery thread; if nothing left, mark it failed for real — and
     put it back on the wishlist so it isn't silently lost."""
     from core.video.retry import plan_retry
-    plan = plan_retry(dl, blocked=_blocked_pairs(db))
+    plan = plan_retry(dl, blocked=_blocked_pairs(db), blocked_users=_blocked_users(db))
     if plan["action"] == "candidate" and _apply_candidate(db, dl["id"], dl, plan["candidate"], plan["rest"]):
         return
     if plan["action"] in ("candidate", "requery"):
@@ -511,7 +521,7 @@ def _requery_worker(dl_id) -> None:
             row = db.get_video_download(dl_id)
             if not row or row.get("status") != "searching":
                 return
-            plan = plan_retry(row, blocked=_blocked_pairs(db))
+            plan = plan_retry(row, blocked=_blocked_pairs(db), blocked_users=_blocked_users(db))
             if plan["action"] == "candidate":
                 if _apply_candidate(db, dl_id, row, plan["candidate"], plan["rest"]):
                     return
@@ -549,7 +559,7 @@ def _requery_worker(dl_id) -> None:
                 tried_files = json.loads(row2.get("tried_files") or "[]")
             except (ValueError, TypeError):
                 tried_files = []
-            fresh = merge_candidates(accepted, tried_files, blocked=_blocked_pairs(db))
+            fresh = merge_candidates(accepted, tried_files, blocked=_blocked_pairs(db), blocked_users=_blocked_users(db))
             if fresh and _apply_candidate(db, dl_id, row2, fresh[0], fresh[1:]):
                 return
             # this query gave nothing usable → loop tries the next query (or fails)

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -534,7 +534,7 @@ def _requery_worker(dl_id) -> None:
                 v = evaluate_release(parse_release(hit.get("title")), profile,
                                      scope=ctx.get("scope") or "movie",
                                      want_season=ctx.get("season"), want_episode=ctx.get("episode"),
-                                     want_year=ctx.get("year"))
+                                     want_year=ctx.get("year"), want_title=ctx.get("title"))
                 if v["accepted"]:
                     accepted.append(hit)
             row2 = db.get_video_download(dl_id)

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -534,7 +534,8 @@ def _requery_worker(dl_id) -> None:
                 v = evaluate_release(parse_release(hit.get("title")), profile,
                                      scope=ctx.get("scope") or "movie",
                                      want_season=ctx.get("season"), want_episode=ctx.get("episode"),
-                                     want_year=ctx.get("year"), want_title=ctx.get("title"))
+                                     want_year=ctx.get("year"),
+                                     want_title=ctx.get("titles") or ctx.get("title"))
                 if v["accepted"]:
                     accepted.append(hit)
             row2 = db.get_video_download(dl_id)

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -530,7 +530,10 @@ def _requery_worker(dl_id) -> None:
                                      attempts=int(row.get("attempts") or 0) + 1)
             polled = _search_for_retry(query)
             accepted = []
+            blocked_users = db.blocked_usernames()
             for hit in (polled.get("hits") or []):
+                if hit.get("username") in blocked_users:
+                    continue                                  # source-wide blocked uploader
                 v = evaluate_release(parse_release(hit.get("title")), profile,
                                      scope=ctx.get("scope") or "movie",
                                      want_season=ctx.get("season"), want_episode=ctx.get("episode"),

--- a/core/video/enrichment/clients.py
+++ b/core/video/enrichment/clients.py
@@ -431,6 +431,33 @@ class TMDBClient:
         out.sort(key=lambda x: x["date"] or "zzzz")
         return out
 
+    def alternative_titles(self, kind, tmdb_id):
+        """AKA / alternative-release titles for a movie or show — the alias set the
+        downloader matches releases against (Radarr/Sonarr parity: a release named
+        'God Particle' still matches 'The Cloverfield Paradox'). Returns a deduped
+        list of title strings; best-effort ([] on any error / no key)."""
+        if not self.api_key or tmdb_id is None:
+            return []
+        import requests
+        path = "/movie/" if kind == "movie" else "/tv/"
+        try:
+            r = requests.get(self.BASE + path + str(tmdb_id) + "/alternative_titles",
+                             params={"api_key": self.api_key}, timeout=12)
+            r.raise_for_status()
+            d = r.json() or {}
+        except Exception:
+            logger.debug("alt-titles fetch failed for %s %s", kind, tmdb_id, exc_info=True)
+            return []
+        rows = d.get("titles") if kind == "movie" else d.get("results")
+        seen, out = set(), []
+        for a in (rows or []):
+            t = str(a.get("title") or "").strip()
+            k = t.lower()
+            if t and k not in seen:
+                seen.add(k)
+                out.append(t)
+        return out[:30]
+
     def season_episodes(self, tv_id, season_number):
         """Episode-level data for one season (still/overview/rating) — the show
         worker cascades over a show's seasons to backfill episodes the media

--- a/core/video/enrichment/engine.py
+++ b/core/video/enrichment/engine.py
@@ -26,6 +26,16 @@ _DISPLAY = {"tmdb": "TMDB", "tvdb": "TVDB", "omdb": "OMDb"}
 _OMDB_RETRY_SECONDS = 6 * 3600
 
 
+def _latest_seasons(season_nums, keep: int = 2):
+    """The most recent ``keep`` regular seasons (highest season numbers, specials /
+    season 0 excluded) — the only seasons where a still-airing show gains new episodes.
+    The nightly airing refresh scopes to these so it stops re-pulling long-finished
+    seasons every night. Falls back to the full list when there are no regular seasons
+    (a specials-only show)."""
+    regular = sorted({n for n in (season_nums or []) if isinstance(n, int) and n > 0}, reverse=True)
+    return regular[:keep] if regular else list(season_nums or [])
+
+
 class VideoEnrichmentEngine:
     def __init__(self, db, clients: dict, ratings_client=None):
         self.db = db
@@ -199,7 +209,8 @@ class VideoEnrichmentEngine:
                         ", ".join(sorted(self._scan_paused)))
         self._scan_paused = set()
 
-    def refresh_show_art(self, show_id, *, with_ratings: bool = True) -> dict:
+    def refresh_show_art(self, show_id, *, with_ratings: bool = True,
+                         recent_seasons_only: bool = False) -> dict:
         """On-demand (lazy) backfill of a show's season posters + episode art from
         TMDB, used when the detail page is opened and art is missing. Works
         regardless of the show's match status (sidesteps 'already matched, never
@@ -207,7 +218,15 @@ class VideoEnrichmentEngine:
 
         ``with_ratings=False`` skips the OMDb ratings backfill — used by the bulk
         'Refresh Airing TV Schedules' automation, which only needs episode schedules and
-        would otherwise burn the daily OMDb quota one call per show."""
+        would otherwise burn the daily OMDb quota one call per show.
+
+        ``recent_seasons_only=True`` cascades ONLY the latest 1–2 regular seasons instead
+        of every season — also for the nightly airing refresh, where new episodes only ever
+        land in the current season and re-pulling long-finished seasons every night (one API
+        call per season, per show) is pure waste since backfill is gap-fill and settled
+        seasons write nothing. It also leaves the episodes-synced flag untouched, so a show
+        that hasn't had its FULL history pulled yet still gets its older seasons filled by
+        the background episode-sync pass rather than being falsely marked complete."""
         w = self.workers.get("tmdb")
         if not w or not w.enabled:
             return {"ok": False, "reason": "tmdb_not_configured"}
@@ -228,7 +247,12 @@ class VideoEnrichmentEngine:
         nums = []
         try:
             nums = [s["season_number"] for s in (result.get("metadata") or {}).get("seasons") or []]
-            w._cascade_episodes(show_id, result["id"], nums)    # full list: owned + missing
+            if recent_seasons_only:
+                nums = _latest_seasons(nums)    # only the current season(s) gain new episodes
+            # mark_synced only when we pulled the FULL season list — a scoped refresh must
+            # not claim the show is fully synced (the background pass finishes the rest).
+            w._cascade_episodes(show_id, result["id"], nums,
+                                mark_synced=not recent_seasons_only)
         except Exception:
             logger.exception("refresh_show_art: episode cascade failed for show %s", show_id)
         # TVDB episode GAP-FILL — TMDB is often slow on just-aired / reality-TV episode

--- a/core/video/enrichment/engine.py
+++ b/core/video/enrichment/engine.py
@@ -74,6 +74,26 @@ class VideoEnrichmentEngine:
     def _cache_put(self, key, data, ttl=1800):
         self._cache.put(key, data, ttl=ttl)
 
+    def alt_titles_for(self, kind, tmdb_id) -> list:
+        """Cached AKA titles for a movie/show — the alias set the downloader matches
+        releases against. Cached hard (aliases barely change) so the search path adds
+        no per-grab TMDB latency. Best-effort: [] when TMDB isn't configured."""
+        if not tmdb_id:
+            return []
+        key = ("alt_titles", kind, str(tmdb_id))
+        hit = self._cache_get(key)
+        if hit is not None:
+            return hit
+        out = []
+        w = self.workers.get("tmdb")
+        if w and getattr(w, "enabled", False) and hasattr(w.client, "alternative_titles"):
+            try:
+                out = w.client.alternative_titles(kind, tmdb_id) or []
+            except Exception:   # noqa: BLE001 - a matching assist must never break a grab
+                logger.debug("alt_titles_for failed for %s %s", kind, tmdb_id, exc_info=True)
+        self._cache_put(key, out, ttl=86400)
+        return out
+
     def _omdb_blocked_now(self) -> bool:
         """The OMDb over-quota / bad-key latch — True while ratings should be skipped.
         Self-healing: once tripped it stays set (no per-item re-probe within a run), but

--- a/core/video/enrichment/worker.py
+++ b/core/video/enrichment/worker.py
@@ -274,10 +274,14 @@ class VideoEnrichmentWorker:
             self.stats["errors"] += 1
         return True
 
-    def _cascade_episodes(self, show_id, tv_id, season_numbers=None) -> None:
-        """Backfill a show's FULL episode list from the provider (one call per
-        season) — owned + missing. Best-effort: a season failure never aborts the
-        show's enrichment. Falls back to the known seasons if none are passed."""
+    def _cascade_episodes(self, show_id, tv_id, season_numbers=None, mark_synced=True) -> None:
+        """Backfill a show's episode list from the provider (one call per season) —
+        owned + missing. Best-effort: a season failure never aborts the show's
+        enrichment. Falls back to the known seasons if none are passed.
+
+        ``mark_synced=False`` skips flagging the show episodes-synced — for a scoped
+        refresh (e.g. the nightly airing job pulling only the current season), which
+        must not claim the FULL history was pulled."""
         seasons = season_numbers
         if not seasons:
             try:
@@ -293,10 +297,11 @@ class VideoEnrichmentWorker:
                                               data.get("overview"), data.get("poster_url"))
             except Exception:
                 logger.exception("episode backfill failed: show %s season %s", show_id, snum)
-        try:
-            self.db.mark_episodes_synced(show_id)
-        except Exception:
-            logger.exception("episode backfill: could not mark synced for show %s", show_id)
+        if mark_synced:
+            try:
+                self.db.mark_episodes_synced(show_id)
+            except Exception:
+                logger.exception("episode backfill: could not mark synced for show %s", show_id)
 
     # ── status (same shape the music enrichment API returns) ──────────────────
     def get_stats(self) -> dict:

--- a/core/video/quality_eval.py
+++ b/core/video/quality_eval.py
@@ -130,12 +130,20 @@ def tier_key(source, resolution) -> str:
     return (pre + "-" + resolution) if resolution else ""
 
 
-def _scope_ok(parsed, scope, want_season, want_episode, want_year=None):
-    """Validate a hit actually matches what was searched (Sonarr-style): an episode
-    search wants SxxExx, a season search wants the whole season PACK, a show search
-    wants a complete-series pack. For a movie, the release YEAR must match the wanted
-    year (±1 for production-vs-release slop) — otherwise a text search for 'The Odyssey
-    (2026)' happily matches 'Troy The Odyssey 2017', a different film."""
+def _scope_ok(parsed, scope, want_season, want_episode, want_year=None, want_title=None):
+    """Validate a hit actually matches what was searched (Sonarr/Radarr-style): the
+    TITLE must match the wanted film/show (not just be a substring — 'The Cloverfield
+    Paradox 2018' must NOT satisfy a search for 'Paradox (2017)'), an episode search
+    wants SxxExx, a season search wants the whole season PACK, a show search wants a
+    complete-series pack, and a movie's release YEAR must match the wanted year (±1 for
+    production-vs-release slop)."""
+    # Title gate first — applies to every scope. Rejects a confident title mismatch;
+    # an unknown/unisolable title passes through to the scope/year checks below.
+    if want_title:
+        from core.video.release_parse import extract_title, titles_match
+        if not titles_match(parsed.get("title"), want_title):
+            return None, "Wrong title (%s — wanted %s)" % (
+                extract_title(parsed.get("title")) or "?", want_title)
     season, episode = parsed.get("season"), parsed.get("episode")
     if scope == "movie":
         if season is not None:
@@ -167,7 +175,7 @@ def _scope_ok(parsed, scope, want_season, want_episode, want_year=None):
 
 
 def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
-                     want_episode=None, size_gb=None, want_year=None) -> dict:
+                     want_episode=None, size_gb=None, want_year=None, want_title=None) -> dict:
     """Judge a parsed search hit against the quality profile + the search scope.
 
     Returns ``{accepted, score, rejected, tier, quality_label}`` — ``accepted`` False
@@ -202,7 +210,7 @@ def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
 
     # 4) scope validation (episode vs season pack vs series pack; movie year match)
     if not rejected:
-        _, scope_reason = _scope_ok(parsed, scope, want_season, want_episode, want_year)
+        _, scope_reason = _scope_ok(parsed, scope, want_season, want_episode, want_year, want_title)
         if scope_reason:
             rejected = scope_reason
 

--- a/core/video/release_parse.py
+++ b/core/video/release_parse.py
@@ -14,6 +14,7 @@ imports only re/typing; the music side never imports it.
 from __future__ import annotations
 
 import re
+import unicodedata
 from typing import Any
 
 # Resolution — first match wins (most specific first).
@@ -123,4 +124,78 @@ def parse_release(title: Any) -> dict:
     return out
 
 
-__all__ = ["parse_release"]
+# ── Title extraction + matching (Radarr/Sonarr-parity title gate) ──────────────
+# The download engine must confirm a hit's TITLE matches the wanted film/show, not
+# just the year — otherwise a text search for "Paradox (2017)" happily accepts
+# "The Cloverfield Paradox 2018" (title is a substring, year is one off). We isolate
+# the title portion of the release name, normalize it, and require a real match.
+
+_YEAR_TOKEN = re.compile(r"\b(?:19|20)\d{2}\b")
+# First "release metadata" token — where the title ends when there's no usable year.
+_META_BOUNDARY = re.compile(
+    r"\b(?:2160p|1080[pi]|720[pi]|480[pi]|576[pi]|4k|uhd"
+    r"|blu-?ray|bdrip|brrip|web-?dl|web-?rip|web|hdtv|dvdrip|dvd|remux|hdcam|cam|telesync|hdts"
+    r"|x264|x265|h\.?264|h\.?265|hevc|avc|av1"
+    r"|s\d{1,2}(?:e\d{1,3})?|season)\b", re.I)
+_ARTICLE = re.compile(r"^(?:the|a|an)\s+")
+# Trailing words that are an edition of the SAME film, not a different title.
+_EDITION_TOKENS = frozenset({
+    "extended", "remastered", "remaster", "unrated", "uncut", "directors", "director",
+    "cut", "edition", "theatrical", "special", "imax", "final", "ultimate", "definitive",
+})
+
+
+def _spaces(s: Any) -> str:
+    """Separators (dots/underscores/dashes) → spaces, whitespace collapsed."""
+    return re.sub(r"\s+", " ", re.sub(r"[._\-]+", " ", str(s or ""))).strip()
+
+
+def extract_title(release_name: Any) -> str:
+    """The title portion of a release name — everything before the release year (the
+    LAST year token, so 'Blade Runner 2049 2017 1080p' keeps '2049'), or before the
+    first quality/scope token when there's no trailing year. Returns '' when the title
+    can't be isolated (e.g. a numeric-only title like '2012' with no release year)."""
+    t = str(release_name or "").strip()
+    if not t:
+        return ""
+    cut = None
+    years = list(_YEAR_TOKEN.finditer(t))
+    if years and _spaces(t[:years[-1].start()]):
+        cut = years[-1].start()          # cut at the release year (keeps years IN the title)
+    if cut is None:
+        m = _META_BOUNDARY.search(t)     # no usable year → cut at the first quality/scope token
+        cut = m.start() if m else len(t)
+    return _spaces(t[:cut])
+
+
+def normalize_title(s: Any) -> str:
+    """Fold a title to a comparable key: strip accents, lowercase, '&'→'and',
+    punctuation → space, drop a single leading article. 'The Dark Knight' and
+    'dark.knight' both fold to 'dark knight'."""
+    s = unicodedata.normalize("NFKD", str(s or "")).encode("ascii", "ignore").decode("ascii")
+    s = s.lower().replace("&", " and ")
+    s = re.sub(r"[^a-z0-9]+", " ", s)
+    s = re.sub(r"\s+", " ", s).strip()
+    return _ARTICLE.sub("", s, count=1)
+
+
+def titles_match(release_name: Any, want_title: Any) -> bool:
+    """True when a release's parsed title matches the wanted film/show. Exact after
+    normalization, tolerating only trailing edition words ('Paradox Extended' for
+    'Paradox'). An unknown/unisolable title passes (the year gate still applies) so a
+    numeric title like '2012' is never falsely rejected — we only ever REJECT on a
+    confident mismatch, never guess a match."""
+    want = normalize_title(want_title)
+    if not want:
+        return True
+    got = normalize_title(extract_title(release_name))
+    if not got or got == want:
+        return True
+    if got.startswith(want + " "):
+        rest = got[len(want):].split()
+        if rest and all(tok in _EDITION_TOKENS for tok in rest):
+            return True
+    return False
+
+
+__all__ = ["parse_release", "extract_title", "normalize_title", "titles_match"]

--- a/core/video/release_parse.py
+++ b/core/video/release_parse.py
@@ -179,23 +179,40 @@ def normalize_title(s: Any) -> str:
     return _ARTICLE.sub("", s, count=1)
 
 
+def acceptable_titles(want_title: Any) -> set:
+    """The set of normalized titles a release may legitimately carry. ``want_title`` is
+    a single title OR an iterable of them (the film/show's primary title + its TMDB
+    alternative / original-language titles) — this is how we beat Radarr/Sonarr on
+    FALSE NEGATIVES: a release named by any known alias ('God Particle' for 'The
+    Cloverfield Paradox', a foreign film under its original title) still matches."""
+    if want_title is None:
+        return set()
+    items = [want_title] if isinstance(want_title, str) else list(want_title)
+    return {n for n in (normalize_title(x) for x in items) if n}
+
+
 def titles_match(release_name: Any, want_title: Any) -> bool:
-    """True when a release's parsed title matches the wanted film/show. Exact after
-    normalization, tolerating only trailing edition words ('Paradox Extended' for
-    'Paradox'). An unknown/unisolable title passes (the year gate still applies) so a
-    numeric title like '2012' is never falsely rejected — we only ever REJECT on a
-    confident mismatch, never guess a match."""
-    want = normalize_title(want_title)
-    if not want:
+    """True when a release's parsed title matches ANY acceptable title (primary +
+    aliases). Exact after normalization, tolerating only trailing edition words
+    ('Paradox Extended' for 'Paradox'). An unknown/unisolable title passes (the year
+    gate still applies) so a numeric title like '2012' is never falsely rejected — we
+    only ever REJECT on a confident mismatch against every acceptable title, never
+    guess a match."""
+    wants = acceptable_titles(want_title)
+    if not wants:
         return True
     got = normalize_title(extract_title(release_name))
-    if not got or got == want:
+    if not got:
         return True
-    if got.startswith(want + " "):
-        rest = got[len(want):].split()
-        if rest and all(tok in _EDITION_TOKENS for tok in rest):
+    for want in wants:
+        if got == want:
             return True
+        if got.startswith(want + " "):
+            rest = got[len(want):].split()
+            if rest and all(tok in _EDITION_TOKENS for tok in rest):
+                return True
     return False
 
 
-__all__ = ["parse_release", "extract_title", "normalize_title", "titles_match"]
+__all__ = ["parse_release", "extract_title", "normalize_title",
+           "acceptable_titles", "titles_match"]

--- a/core/video/retry.py
+++ b/core/video/retry.py
@@ -54,21 +54,24 @@ def _loads(s, default):
         return default
 
 
-def plan_retry(row: dict, max_attempts: int = MAX_ATTEMPTS, blocked=frozenset()) -> dict:
+def plan_retry(row: dict, max_attempts: int = MAX_ATTEMPTS, blocked=frozenset(),
+               blocked_users=frozenset()) -> dict:
     """Decide what to do for a failed download row. Returns one of:
       {action: 'candidate', candidate: {...}, rest: [...]}  — try the next stored hit
       {action: 'requery', query: str, ctx: {...}}           — re-search a new query
       {action: 'fail', reason: str}                         — genuinely out of options
     Pure: reads the row's JSON columns (candidates / tried_files / search_ctx / tried_queries).
 
-    ``blocked`` = {(username, filename)} from the release blocklist. Composes with
-    tried_files, not folded into it: tried is per-row ("this attempt sequence"),
-    blocked is global + permanent ("never pick this release for anything")."""
+    ``blocked`` = {(username, filename)} (per-release) and ``blocked_users`` = usernames
+    blocked source-wide. Both compose with tried_files, not folded into it: tried is
+    per-row ("this attempt sequence"), the blocklists are global + permanent — so a
+    candidate STORED before the block still gets dropped here on retry."""
     if int(row.get("attempts") or 0) >= max_attempts:
         return {"action": "fail", "reason": "retry budget reached"}
     tried_files = set(_loads(row.get("tried_files"), []))
     fresh = [c for c in _loads(row.get("candidates"), [])
              if c.get("filename") not in tried_files
+             and c.get("username") not in blocked_users
              and (c.get("username"), c.get("filename")) not in blocked]
     if fresh:
         return {"action": "candidate", "candidate": fresh[0], "rest": fresh[1:]}
@@ -79,15 +82,17 @@ def plan_retry(row: dict, max_attempts: int = MAX_ATTEMPTS, blocked=frozenset())
     return {"action": "fail", "reason": "no candidates or queries left"}
 
 
-def merge_candidates(new_accepted: Any, tried_files: Any, blocked=frozenset()) -> list:
+def merge_candidates(new_accepted: Any, tried_files: Any, blocked=frozenset(),
+                     blocked_users=frozenset()) -> list:
     """Turn fresh accepted search results into candidate dicts, dropping anything
     already attempted (so a requery never re-tries the same failing release) and
-    anything on the release blocklist."""
+    anything on the release blocklist (a specific file OR a source-wide uploader)."""
     seen = set(tried_files or [])
     out = []
     for r in (new_accepted or []):
         fn = r.get("filename")
-        if not fn or fn in seen or (r.get("username"), fn) in blocked:
+        if not fn or fn in seen or r.get("username") in blocked_users \
+                or (r.get("username"), fn) in blocked:
             continue
         seen.add(fn)
         out.append({"username": r.get("username"), "filename": fn, "size_bytes": r.get("size_bytes"),

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -2038,12 +2038,48 @@ class VideoDatabase:
             conn.close()
 
     def video_blocklist_pairs(self) -> set:
-        """{(username, filename)} for candidate filtering — cheap enough to read
-        per search/retry pass (the table stays small)."""
+        """{(username, filename)} for per-release candidate filtering — cheap enough to
+        read per search/retry pass (the table stays small). Excludes the source-wide
+        ('' filename) sentinels — those are matched by ``blocked_usernames`` instead."""
         conn = self._get_connection()
         try:
             return {(r["username"], r["filename"]) for r in conn.execute(
-                "SELECT username, filename FROM video_blocklist")}
+                "SELECT username, filename FROM video_blocklist WHERE COALESCE(filename,'') <> ''")}
+        finally:
+            conn.close()
+
+    def block_video_source(self, username, reason=None) -> int:
+        """Block a whole uploader/peer: every release from this username is skipped by
+        future searches (a SOURCE-wide block, stored with the '' filename sentinel so it
+        dedupes on (username,'')). Returns the row id, 0 on an empty username."""
+        username = (username or "").strip()
+        if not username:
+            return 0
+        conn = self._get_connection()
+        try:
+            conn.execute(
+                "INSERT INTO video_blocklist (username, filename, reason) VALUES (?, '', ?) "
+                "ON CONFLICT(username, filename) DO UPDATE SET "
+                "reason=COALESCE(excluded.reason, video_blocklist.reason)",
+                (username, reason or "Uploader blocked"))
+            conn.commit()
+            r = conn.execute("SELECT id FROM video_blocklist WHERE username=? AND filename=''",
+                             (username,)).fetchone()
+            return r["id"] if r else 0
+        except sqlite3.Error:
+            logger.exception("block_video_source failed")
+            return 0
+        finally:
+            conn.close()
+
+    def blocked_usernames(self) -> set:
+        """Uploaders blocked source-wide (the '' filename sentinel) — every release from
+        them is filtered out of search, on top of the per-release (username,filename)
+        blocks. Read per search pass alongside ``video_blocklist_pairs``."""
+        conn = self._get_connection()
+        try:
+            return {r["username"] for r in conn.execute(
+                "SELECT username FROM video_blocklist WHERE COALESCE(filename,'') = '' AND username IS NOT NULL")}
         finally:
             conn.close()
 

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -1948,8 +1948,16 @@ class VideoDatabase:
             page, limit = 1, 40
         # Cleared ledger rows are hidden from the modal (the facts live on).
         where, args = ["cleared_at IS NULL"], []
-        if kind in ("movie", "show"):
-            where.append("kind = ?"); args.append(kind)
+        # Tabs classify by kind+source, not raw kind: episodes store kind='episode'
+        # (not 'show'), and YouTube grabs carry source='youtube'. So 'TV' = anything
+        # that isn't a movie or a YouTube grab; 'youtube' = source/kind youtube.
+        _yt = "(COALESCE(source,'') = 'youtube' OR kind = 'youtube')"
+        if kind == "movie":
+            where.append("kind = 'movie' AND NOT " + _yt)
+        elif kind in ("show", "tv"):
+            where.append("kind <> 'movie' AND NOT " + _yt)
+        elif kind == "youtube":
+            where.append(_yt)
         if outcome:
             where.append("outcome = ?"); args.append(outcome)
         s = (search or "").strip()
@@ -1981,15 +1989,22 @@ class VideoDatabase:
             conn.close()
 
     def download_history_counts(self) -> dict:
-        """{movie, show, total} of completed grabs (for the modal tabs/badge)."""
+        """{movie, show(=TV: episodes + show/season packs), youtube, total} of completed
+        grabs (for the modal tabs/badge). Classifies by kind+source so episodes (kind=
+        'episode') land under TV and YouTube (source='youtube') gets its own bucket —
+        the old version counted only kind='movie'/'show', so TV + YouTube vanished."""
         conn = self._get_connection()
         try:
-            rows = conn.execute(
-                "SELECT kind, COUNT(*) c FROM video_download_history "
-                "WHERE outcome='completed' AND cleared_at IS NULL GROUP BY kind").fetchall()
-            by = {r["kind"]: r["c"] for r in rows}
-            movie, show = by.get("movie", 0), by.get("show", 0)
-            return {"movie": movie, "show": show, "total": movie + show}
+            _yt = "(COALESCE(source,'') = 'youtube' OR kind = 'youtube')"
+            row = conn.execute(
+                "SELECT "
+                "SUM(CASE WHEN " + _yt + " THEN 1 ELSE 0 END) AS yt, "
+                "SUM(CASE WHEN kind = 'movie' AND NOT " + _yt + " THEN 1 ELSE 0 END) AS mv, "
+                "SUM(CASE WHEN kind <> 'movie' AND NOT " + _yt + " THEN 1 ELSE 0 END) AS tv, "
+                "COUNT(*) AS total FROM video_download_history "
+                "WHERE outcome='completed' AND cleared_at IS NULL").fetchone()
+            return {"movie": row["mv"] or 0, "show": row["tv"] or 0,
+                    "youtube": row["yt"] or 0, "total": row["total"] or 0}
         finally:
             conn.close()
 

--- a/tests/test_repair_worker_canonical_version.py
+++ b/tests/test_repair_worker_canonical_version.py
@@ -1,0 +1,90 @@
+"""Regression: applying a ``canonical_version`` finding did nothing.
+
+The Resolve Canonical Album Versions job (#765) creates ``canonical_version``
+findings in its dry run, but ``RepairWorker._execute_fix`` had no handler for
+that finding type, so single-fix / Fix All returned
+"No fix available for finding type: canonical_version" and pinned nothing.
+
+``_fix_canonical_version`` applies the pin straight from the finding — the
+per-finding equivalent of running the job with dry-run OFF. It writes an AUTO
+pin (``locked=False``), matching ``resolve_and_store_canonical_for_album`` and
+the Reorganizer, and must NOT clobber a manual/locked pin (#758).
+"""
+
+from database.music_database import MusicDatabase
+from core.repair_worker import RepairWorker
+
+
+def _worker(tmp_path):
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES (1, 'A', 'test')")
+        conn.execute("INSERT INTO albums (id, title, artist_id, server_source) "
+                     "VALUES (1, 'Beggars Banquet', 1, 'test')")
+        conn.commit()
+    w = RepairWorker(database=db)
+    w._config_manager = None
+    return db, w
+
+
+def _finding_details(source='musicbrainz', release_id='mb-release-123', score=0.97):
+    """Mirror the details a real canonical_version finding carries: note the
+    resolver's release id lands on the ``album_id`` key (``{'album_id': local,
+    **resolved}`` — the resolved release id wins)."""
+    return {
+        'album_id': release_id,
+        'source': source,
+        'score': score,
+        'album_title': 'Beggars Banquet',
+        'artist_name': 'The Rolling Stones',
+    }
+
+
+def test_apply_pins_canonical_as_auto(tmp_path):
+    """Applying the finding pins the resolver's release, unlocked, so a later
+    resolve can still self-heal it."""
+    db, w = _worker(tmp_path)
+    res = w._fix_canonical_version('album', '1', None, _finding_details())
+    assert res['success'] is True, res
+
+    pin = db.get_album_canonical(1)
+    assert pin is not None
+    assert pin['source'] == 'musicbrainz'
+    assert pin['album_id'] == 'mb-release-123'
+    assert round(pin['score'], 2) == 0.97
+    assert pin['locked'] is False
+
+
+def test_dispatch_no_longer_reports_no_fix(tmp_path):
+    """The reported bug: _execute_fix used to fall through to 'No fix available
+    for finding type: canonical_version'. It now routes to the handler."""
+    db, w = _worker(tmp_path)
+    res = w._execute_fix('canonical_version', 'album', '1', None, _finding_details())
+    assert res['success'] is True, res
+    assert 'No fix available' not in (res.get('error') or '')
+
+
+def test_missing_source_or_release_is_rejected(tmp_path):
+    """A malformed finding (no source/release id) is refused, not silently
+    written as a null pin."""
+    _db, w = _worker(tmp_path)
+    res = w._fix_canonical_version('album', '1', None, {'album_title': 'x'})
+    assert res['success'] is False
+    assert 'canonical source/release id' in res['error']
+
+
+def test_auto_apply_does_not_clobber_manual_lock(tmp_path):
+    """A user's manual edition lock (#758) survives applying an auto finding —
+    the finding reports failure instead of overwriting the locked pin."""
+    db, w = _worker(tmp_path)
+    # User manually pinned+locked the Deezer edition (as /api/library/manual-match does).
+    db.set_album_canonical('1', 'deezer', 'dz-999', 1.0, locked=True)
+
+    res = w._fix_canonical_version('album', '1', None, _finding_details())
+    assert res['success'] is False
+    assert 'locked' in res['error']
+
+    pin = db.get_album_canonical(1)
+    assert pin['source'] == 'deezer'
+    assert pin['album_id'] == 'dz-999'
+    assert pin['locked'] is True

--- a/tests/test_video_download_history.py
+++ b/tests/test_video_download_history.py
@@ -38,6 +38,32 @@ def _episode(**over):
     return row
 
 
+def _youtube(**over):
+    row = {"id": 3, "kind": "youtube", "title": "Some Video", "status": "completed",
+           "source": "youtube", "media_source": "youtube", "username": None,
+           "release_title": "Some Video", "completed_at": "2026-06-22 00:00:00"}
+    row.update(over)
+    return row
+
+
+def test_history_tabs_classify_real_episode_and_youtube_kinds(db):
+    # Production stores TV grabs as kind='episode' (not 'show') and YouTube as
+    # source/kind='youtube'. The tabs must classify BOTH — the bug was the TV tab
+    # filtering kind='show' and the counts summing only movie+show (TV + YT vanished).
+    db.record_download_history(_movie(id=1))
+    db.record_download_history(_episode(id=2, kind="episode"))
+    db.record_download_history(_youtube(id=3))
+
+    assert db.download_history_counts() == {"movie": 1, "show": 1, "youtube": 1, "total": 3}
+
+    def kinds(tab):
+        return sorted(r["kind"] for r in db.query_download_history(kind=tab)["items"])
+    assert kinds("movie") == ["movie"]
+    assert kinds("show") == ["episode"]      # TV tab now catches kind='episode'
+    assert kinds("youtube") == ["youtube"]   # YouTube gets its own tab
+    assert len(db.query_download_history(kind=None)["items"]) == 3   # 'All'
+
+
 def test_records_a_completed_movie_with_parsed_quality(db):
     hid = db.record_download_history(_movie())
     assert hid > 0
@@ -76,7 +102,7 @@ def test_counts_only_count_completed(db):
     db.record_download_history(_movie(id=3, status="failed", dest_path=None,
                                       error="no release found"))
     c = db.download_history_counts()
-    assert c == {"movie": 1, "show": 0, "total": 1}   # the failed one isn't counted
+    assert c == {"movie": 1, "show": 0, "youtube": 0, "total": 1}   # the failed one isn't counted
 
 
 def test_latest_completed_download_is_the_probe_target(db):

--- a/tests/test_video_refresh_airing_schedules.py
+++ b/tests/test_video_refresh_airing_schedules.py
@@ -87,20 +87,73 @@ def test_watchlist_continuing_shows_skips_ended_tmdbonly_and_dupes(tmp_path, mon
     assert [s["library_id"] for s in out] == [1, 4]
 
 
-# ── OMDb quota safety ─────────────────────────────────────────────────────────
-def test_refresh_skips_omdb_ratings(monkeypatch):
-    # the bulk refresh must NOT do the per-show OMDb ratings call (it'd burn the daily quota)
+# ── OMDb quota safety + season scoping ────────────────────────────────────────
+def test_refresh_skips_omdb_and_scopes_to_recent_seasons(monkeypatch):
+    # the nightly refresh must NOT do the per-show OMDb ratings call (burns the daily quota)
+    # AND must scope to the current season(s) only, not re-pull every season every night.
     import core.automation.handlers.video_refresh_airing_schedules as mod
     seen = {}
 
     class _Eng:
-        def refresh_show_art(self, lib, *, with_ratings=True):
-            seen["lib"], seen["with_ratings"] = lib, with_ratings
+        def refresh_show_art(self, lib, *, with_ratings=True, recent_seasons_only=False):
+            seen["lib"] = lib
+            seen["with_ratings"] = with_ratings
+            seen["recent_seasons_only"] = recent_seasons_only
             return {"ok": True}
 
     monkeypatch.setattr("core.video.enrichment.engine.get_video_enrichment_engine", lambda: _Eng())
     assert mod._default_refresh_show(7) == {"ok": True}
-    assert seen == {"lib": 7, "with_ratings": False}
+    assert seen == {"lib": 7, "with_ratings": False, "recent_seasons_only": True}
+
+
+def test_latest_seasons_picks_top_two_regular_seasons():
+    from core.video.enrichment.engine import _latest_seasons
+    assert _latest_seasons([0, 1, 2, 3, 4]) == [4, 3]      # top 2, specials (0) excluded
+    assert _latest_seasons([5, 1, 3, 2, 4]) == [5, 4]      # unsorted input → sorted desc
+    assert _latest_seasons([0, 1]) == [1]                  # only one regular season
+    assert _latest_seasons([0]) == [0]                     # specials-only → fall back to full
+    assert _latest_seasons([]) == []
+    assert _latest_seasons([1, 2, 3], keep=1) == [3]
+
+
+def test_refresh_show_art_recent_only_scopes_seasons_and_leaves_synced_flag():
+    """The nightly airing path cascades ONLY the latest regular seasons and does not
+    mark the show fully synced; the default (on-view / re-match) still pulls every
+    season and marks it synced."""
+    from core.video.enrichment.engine import VideoEnrichmentEngine
+    cap = {}
+
+    class _Client:
+        def match(self, kind, title, year, known_id=None):
+            return {"id": 999, "metadata": {"seasons": [
+                {"season_number": 0}, {"season_number": 1},
+                {"season_number": 2}, {"season_number": 3}]}}
+
+    class _Worker:
+        enabled = True
+        client = _Client()
+
+        def _cascade_episodes(self, show_id, tv_id, season_numbers=None, mark_synced=True):
+            cap["nums"], cap["mark_synced"] = season_numbers, mark_synced
+
+    class _DB:
+        def show_match_info(self, i):
+            return {"title": "S", "year": 2020, "tmdb_id": 999, "tvdb_id": None}
+
+        def enrichment_apply(self, *a, **k):
+            pass
+
+    eng = VideoEnrichmentEngine.__new__(VideoEnrichmentEngine)
+    eng.db, eng.ratings_client = _DB(), None
+    eng.workers = {"tmdb": _Worker()}
+
+    # nightly airing mode: latest 2 regular seasons only, synced flag untouched
+    assert eng.refresh_show_art(7, with_ratings=False, recent_seasons_only=True) == {"ok": True}
+    assert cap["nums"] == [3, 2] and cap["mark_synced"] is False
+
+    # default mode: every season, marks synced (unchanged behavior)
+    assert eng.refresh_show_art(7) == {"ok": True}
+    assert cap["nums"] == [0, 1, 2, 3] and cap["mark_synced"] is True
 
 
 def test_omdb_limit_latches_off_and_stops_hammering():

--- a/tests/test_video_title_gate.py
+++ b/tests/test_video_title_gate.py
@@ -1,0 +1,104 @@
+"""Radarr/Sonarr-parity title gate for the video downloader.
+
+A text search for "Paradox (2017)" was accepting "The.Cloverfield.Paradox.2018..." —
+the release title is only a SUBSTRING and the year is one off, yet nothing checked
+the title (movies passed on year alone). These lock in a real title match: the
+release's parsed title must equal the wanted film/show (tolerating only trailing
+edition words), so a different film is rejected, while legit releases still pass.
+"""
+
+from __future__ import annotations
+
+from core.video.release_parse import (
+    extract_title, normalize_title, titles_match, parse_release)
+from core.video.quality_eval import evaluate_release
+
+# A permissive profile so ONLY the title/year gate decides accept vs reject.
+_PROFILE = {"tiers": [{"key": t, "enabled": True} for t in
+                      ("webdl-1080p", "bluray-1080p", "webrip-1080p", "bluray-2160p")]}
+
+
+# ── extraction ────────────────────────────────────────────────────────────────
+def test_extract_title_cuts_at_release_year():
+    assert extract_title("The.Cloverfield.Paradox.2018.1080p.WEBRip.x265-PS") == "The Cloverfield Paradox"
+    assert extract_title("Paradox.2017.1080p.BluRay.x264-GROUP") == "Paradox"
+    assert extract_title("Spider-Man.No.Way.Home.2021.2160p.UHD.BluRay") == "Spider Man No Way Home"
+
+
+def test_extract_title_keeps_a_year_that_is_part_of_the_title():
+    # the LAST year is the release year; 2049 stays in the title
+    assert extract_title("Blade.Runner.2049.2017.1080p.BluRay.x264") == "Blade Runner 2049"
+
+
+def test_extract_title_falls_back_to_quality_token_when_no_release_year():
+    assert extract_title("Paradox.1080p.WEB-DL.x264") == "Paradox"
+    assert extract_title("The.Wire.S02.1080p.BluRay.x265") == "The Wire"
+
+
+def test_extract_title_recovers_a_numeric_title_via_the_quality_boundary():
+    # '2012' has no separate release year, but cutting at the quality token still isolates it
+    assert extract_title("2012.1080p.BluRay") == "2012"
+    assert extract_title("") == ""
+
+
+# ── normalization ─────────────────────────────────────────────────────────────
+def test_normalize_folds_articles_punctuation_accents_and_ampersand():
+    assert normalize_title("The Dark Knight") == "dark knight"
+    assert normalize_title("dark.knight") == "dark knight"
+    assert normalize_title("Fast & Furious") == "fast and furious"
+    assert normalize_title("Amélie") == "amelie"
+    assert normalize_title("Mission: Impossible") == "mission impossible"
+
+
+# ── the match ─────────────────────────────────────────────────────────────────
+def test_the_reported_bug_cloverfield_paradox_is_rejected_for_paradox():
+    assert titles_match("The.Cloverfield.Paradox.2018.1080p.WEBRip.x265-PS", "Paradox") is False
+
+
+def test_exact_and_separator_variants_match():
+    assert titles_match("Paradox.2017.1080p.BluRay.x264", "Paradox") is True
+    assert titles_match("The.Dark.Knight.2008.1080p.BluRay", "The Dark Knight") is True
+    assert titles_match("Spider-Man.No.Way.Home.2021.2160p", "Spider-Man: No Way Home") is True
+
+
+def test_trailing_edition_words_are_tolerated_but_extra_real_words_are_not():
+    assert titles_match("Paradox.Extended.2017.1080p", "Paradox") is True     # edition of same film
+    assert titles_match("The.Paradox.Effect.2023.1080p", "Paradox") is False  # a different film
+
+
+def test_sequels_and_numbers_do_not_collapse():
+    assert titles_match("Moana.2.2024.1080p.WEBRip", "Moana 2") is True
+    assert titles_match("Moana.2016.1080p.BluRay", "Moana 2") is False   # the original, not the sequel
+
+
+def test_numeric_or_unknown_title_passes_so_it_is_never_falsely_rejected():
+    # can't isolate a numeric title → don't block; the YEAR gate still guards it
+    assert titles_match("2012.1080p.BluRay.x264", "2012") is True
+    assert titles_match("anything", None) is True
+    assert titles_match("anything", "") is True
+
+
+def test_episode_release_matches_on_the_show_name():
+    assert titles_match("The.Wire.S02E03.1080p.BluRay.x265", "The Wire") is True
+    assert titles_match("Some.Other.Show.S02E03.1080p", "The Wire") is False
+
+
+# ── evaluate_release integration (the actual gate the downloader uses) ─────────
+def test_evaluate_release_rejects_the_wrong_film_end_to_end():
+    parsed = parse_release("The.Cloverfield.Paradox.2018.1080p.WEBRip.x265-PS")
+    v = evaluate_release(parsed, _PROFILE, scope="movie", want_year=2017, want_title="Paradox")
+    assert v["accepted"] is False
+    assert "Wrong title" in (v.get("rejected") or "")
+
+
+def test_evaluate_release_accepts_the_right_film():
+    parsed = parse_release("Paradox.2017.1080p.BluRay.x264-GROUP")
+    v = evaluate_release(parsed, _PROFILE, scope="movie", want_year=2017, want_title="Paradox")
+    assert v["accepted"] is True
+
+
+def test_evaluate_release_without_want_title_keeps_old_behavior():
+    # back-compat: no wanted title supplied → the title gate is skipped (year still applies)
+    parsed = parse_release("The.Cloverfield.Paradox.2018.1080p.WEBRip.x265-PS")
+    v = evaluate_release(parsed, _PROFILE, scope="movie", want_year=2017)
+    assert v["accepted"] is True     # only the year gate ran (2018 within 2017..2018)

--- a/tests/test_video_title_gate.py
+++ b/tests/test_video_title_gate.py
@@ -83,6 +83,61 @@ def test_episode_release_matches_on_the_show_name():
     assert titles_match("Some.Other.Show.S02E03.1080p", "The Wire") is False
 
 
+def test_alias_set_beats_false_negatives():
+    # the 'beat Radarr' win: a release named by a KNOWN alias still matches
+    # ('God Particle' is TMDB's alternative title for 'The Cloverfield Paradox').
+    aliases = ["The Cloverfield Paradox", "God Particle"]
+    assert titles_match("God.Particle.2018.1080p.WEBRip.x264", aliases) is True
+    assert titles_match("The.Cloverfield.Paradox.2018.1080p", aliases) is True
+    # an unrelated film is still rejected against the WHOLE alias set
+    assert titles_match("Paradox.2017.1080p.BluRay", aliases) is False
+    # a single string still works (back-compat)
+    assert titles_match("Paradox.2017.1080p", "Paradox") is True
+
+
+def test_evaluate_release_accepts_a_matching_alias_end_to_end():
+    parsed = parse_release("God.Particle.2018.1080p.WEBRip.x264")
+    v = evaluate_release(parsed, _PROFILE, scope="movie", want_year=2018,
+                         want_title=["The Cloverfield Paradox", "God Particle"])
+    assert v["accepted"] is True
+
+
+# ── alias plumbing (fetch → cache → search context) ───────────────────────────
+def test_engine_alt_titles_for_caches_and_is_best_effort():
+    from core.video.enrichment.engine import VideoEnrichmentEngine
+    from core.video.enrichment.cache import TTLCache
+    calls = {"n": 0}
+
+    class _Client:
+        def alternative_titles(self, kind, tmdb_id):
+            calls["n"] += 1
+            return ["God Particle"]
+
+    eng = VideoEnrichmentEngine.__new__(VideoEnrichmentEngine)
+    eng._cache = TTLCache(maxsize=16, ttl=60)
+    eng.workers = {"tmdb": type("W", (), {"enabled": True, "client": _Client()})()}
+    assert eng.alt_titles_for("movie", 42) == ["God Particle"]
+    assert eng.alt_titles_for("movie", 42) == ["God Particle"]   # served from cache
+    assert calls["n"] == 1                                        # only one TMDB hit
+    assert eng.alt_titles_for("movie", None) == []               # no id → no call
+
+
+def test_search_context_carries_the_alias_set(monkeypatch):
+    import core.automation.handlers.video_process_wishlist as mod
+
+    class _Eng:
+        def alt_titles_for(self, kind, tmdb_id):
+            return ["God Particle"] if str(tmdb_id) == "42" else []
+
+    monkeypatch.setattr(
+        "core.video.enrichment.engine.get_video_enrichment_engine", lambda: _Eng())
+    ctx = mod.search_context({"title": "The Cloverfield Paradox", "year": 2018, "tmdb_id": 42}, "movie")
+    assert ctx["title"] == "The Cloverfield Paradox"
+    assert ctx["titles"] == ["The Cloverfield Paradox", "God Particle"]
+    # no aliases → ctx keeps its old shape (no 'titles' key)
+    assert "titles" not in mod.search_context({"title": "Paradox", "year": 2017, "tmdb_id": 99}, "movie")
+
+
 # ── evaluate_release integration (the actual gate the downloader uses) ─────────
 def test_evaluate_release_rejects_the_wrong_film_end_to_end():
     parsed = parse_release("The.Cloverfield.Paradox.2018.1080p.WEBRip.x265-PS")

--- a/tests/video/test_video_blocklist.py
+++ b/tests/video/test_video_blocklist.py
@@ -84,7 +84,7 @@ def test_ranker_unaccepts_blocked_releases(db):
     profile = load_profile(db)
     blocked = {("peer1", "bad.mkv")}
     out = _evaluate_hits([_hit("peer1", "bad.mkv"), _hit("peer2", "good.mkv")],
-                         profile, "movie", None, None, blocked=blocked)
+                         profile, "movie", None, None, blocked=blocked, blocked_users=set())
     by_fn = {r["filename"]: r for r in out}
     assert by_fn["bad.mkv"]["blocked"] is True
     assert by_fn["bad.mkv"]["accepted"] is False
@@ -93,6 +93,38 @@ def test_ranker_unaccepts_blocked_releases(db):
     # pick_best (first accepted) therefore skips the blocked one
     from core.automation.handlers.video_process_wishlist import pick_best
     assert pick_best(out)["filename"] == "good.mkv"
+
+
+# ── source (uploader) blocklist — block a whole peer, skip all their releases ──
+def test_block_source_roundtrip_and_excluded_from_release_pairs(db):
+    rid = db.block_video_source("baduser", reason="always fake")
+    assert rid > 0
+    assert db.blocked_usernames() == {"baduser"}
+    assert db.block_video_source("baduser") == rid          # idempotent on the username
+    assert db.block_video_source("") == 0                   # empty never writes
+    # a source-wide block is NOT a per-release pair (the '' sentinel is excluded)
+    _block(db, user="peer1")
+    assert db.video_blocklist_pairs() == {("peer1", "@@x\\Movies\\Heat.1995.mkv")}
+    assert db.blocked_usernames() == {"baduser"}
+
+
+def test_ranker_unaccepts_every_release_from_a_blocked_uploader(db):
+    from api.video.downloads import _evaluate_hits
+    from core.video.quality_profile import load as load_profile
+    profile = load_profile(db)
+    out = _evaluate_hits([_hit("baduser", "a.mkv"), _hit("goodpeer", "b.mkv")],
+                         profile, "movie", None, None, blocked=set(), blocked_users={"baduser"})
+    by_user = {r["username"]: r for r in out}
+    assert by_user["baduser"]["accepted"] is False and by_user["baduser"]["blocked"] is True
+    assert "Uploader blocklisted" in by_user["baduser"]["rejected"]
+    assert by_user["goodpeer"]["accepted"] is True          # a different peer still passes
+
+
+def test_block_source_api_via_scope(client):
+    c, db = client
+    r = c.post("/api/video/downloads/blocklist", json={"username": "baduser", "scope": "source"})
+    assert r.status_code == 200 and r.get_json()["success"] is True
+    assert db.blocked_usernames() == {"baduser"}
 
 
 # ── retry paths ──────────────────────────────────────────────────────────────

--- a/tests/video/test_video_blocklist.py
+++ b/tests/video/test_video_blocklist.py
@@ -147,6 +147,22 @@ def test_merge_candidates_drops_blocked_requery_hits():
     assert [c["filename"] for c in out] == ["good.mkv"]
 
 
+def test_stored_candidate_from_a_blocked_uploader_is_dropped_on_retry():
+    # a candidate stored BEFORE the uploader was blocked must still be skipped
+    from core.video.retry import plan_retry, merge_candidates
+    row = {"attempts": 1,
+           "candidates": json.dumps([{"username": "baduser", "filename": "a.mkv"},
+                                     {"username": "goodpeer", "filename": "b.mkv"}]),
+           "tried_files": "[]", "search_ctx": "{}", "tried_queries": "[]"}
+    plan = plan_retry(row, blocked=set(), blocked_users={"baduser"})
+    assert plan["action"] == "candidate" and plan["candidate"]["filename"] == "b.mkv"
+    # and merging fresh requery hits drops the blocked uploader too
+    hits = [{"username": "baduser", "filename": "a.mkv", "title": "x"},
+            {"username": "goodpeer", "filename": "b.mkv", "title": "y"}]
+    assert [c["filename"] for c in merge_candidates(hits, [], blocked=set(),
+                                                    blocked_users={"baduser"})] == ["b.mkv"]
+
+
 # ── importer tagging: file-is-junk vs fine-release-wrong-context ─────────────
 def test_importer_tags_only_proven_bad_files():
     from core.video.importer import plan_import

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.0.0"
+_SOULSYNC_BASE_VERSION = "3.0.1"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,11 +3404,13 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.0.0': [
-        { date: 'July 2026 — 3.0.0' },
+    '3.0.1': [
+        { date: 'July 2026 — 3.0.1' },
         { title: 'New: the entire video side (movies, tv & youtube)', desc: 'soulsync isn\'t just music anymore. a whole isolated video app: library scanning for plex/jellyfin, tmdb/tvdb/omdb enrichment plus 10 background backfill workers, a tv calendar, and a follow-to-wishlist-to-download pipeline for shows, actors, directors, studios, and youtube channels. its own database and dashboard, never touches the music side.' },
         { title: 'Video: overlays & collections (kometa-style)', desc: 'an overlay studio that paints template overlays onto your plex/jellyfin posters, and a collection manager that builds plex collections / jellyfin boxsets from smart filters and ranked lists (imdb, tmdb, trakt, mdblist) in true rank order. both with nightly automations.' },
         { title: 'New: Server Activity (tautulli-style)', desc: 'a live now-playing view for plex + jellyfin in a slide-out drawer: live streams over websocket, click one to open it inside soulsync, a history tab, a stats tab, and terminate-a-stream-with-a-message.', page: 'dashboard' },
+        { title: 'Smarter video downloads (Radarr/Sonarr-parity matching)', desc: 'the download search now checks the release TITLE, not just the year — so a search for "Paradox (2017)" can no longer grab "The Cloverfield Paradox (2018)". and it matches TMDB alternate/original-language titles too, so a release named by a known aka still gets found. wrong grabs out, missed grabs out.' },
+        { title: 'Faster nightly TV refresh', desc: 'the airing-schedule refresh only re-pulls the current season now instead of every season of every airing show every night — a big drop in api calls if you follow a lot of shows.' },
         { title: 'Mobile docs nav fixed', desc: 'the help/docs sidebar was untappable on phones (a sticky header ate the tap area, and the scroll target was a no-op on the stacked mobile layout). fixed in both spots. thanks @bluejorts for the characterization tests that caught it.', page: 'help' },
         { title: 'Earlier versions', desc: '2.8.9 fixed multi-disc downloads (#1009), sped up the Server Playlists page (#1005), and added a prefer-explicit-versions setting (#923). 2.8.8 stopped a tag write from corrupting FLAC audio (#1000) and added the Corrupt File Detector. 2.8.7 made discovery playlists first-class Auto-Sync items. 2.8.4 added Artist Web + Quality Profiles; 2.7.0 made multi-user real.' },
     ],
@@ -3441,14 +3443,15 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.0.0 — soulsync does video now",
-        description: "the big one: a whole video side (movies, tv, youtube) plus a tautulli-style live server activity view, on top of the usual pile of fixes.",
+        title: "3.0.1 — soulsync does video now",
+        description: "the big one: a whole video side (movies, tv, youtube) plus a tautulli-style live server activity view, with Radarr/Sonarr-parity download matching.",
         features: [
             "the video side is a fully isolated app (its own database, dashboard, search, calendar and download pipeline) for plex and jellyfin that never touches the music side. library scanning, tmdb/tvdb/omdb enrichment plus 10 backfill workers, source-agnostic movie/show/person/studio detail pages, and a progressive netflix-feel search",
             "follow shows, actors, directors, studios (with family presets like disney = pixar + marvel + lucasfilm) and youtube channels/playlists, then let the wishlist-to-download pipeline grab them: soulseek + prowlarr + yt-dlp, with radarr/sonarr-class quality profiles, a download history, a recycle bin and a release blocklist",
+            "smarter download matching: the search now gates on the release TITLE (not just the year), so 'Paradox (2017)' can't grab 'The Cloverfield Paradox (2018)' anymore — and it matches TMDB alternate/original-language titles too, so an aka-named release still gets found. wrong grabs out, missed grabs out",
             "kometa-style overlay studio (paint template overlays onto your posters) and collection manager (build plex collections / jellyfin boxsets from imdb/tmdb/trakt/mdblist ranked lists in true rank order), both with nightly automations",
             "Server Activity: a tautulli-style live now-playing drawer for plex + jellyfin, with websocket streams, click-to-open-inside-soulsync, a history tab, a stats tab, and terminate-a-stream-with-a-message",
-            "music-side: the help/docs sidebar nav works on mobile again (thanks @bluejorts for the characterization tests that caught it), the dashboard header reads 'music dashboard', and there's a github sponsor button now",
+            "the nightly TV refresh only re-pulls the current season now (not every season of every airing show, every night), the help/docs mobile nav works again (thanks @bluejorts), the dashboard header reads 'music dashboard', and there's a github sponsor button",
         ],
     },
     {

--- a/webui/static/video/video-download-history.js
+++ b/webui/static/video/video-download-history.js
@@ -11,7 +11,7 @@
 
     var LIMIT = 40;
     var state = { open: false, tab: 'all', search: '', page: 1, loading: false,
-                  counts: { movie: 0, show: 0, total: 0 }, items: [], pages: 1 };
+                  counts: { movie: 0, show: 0, youtube: 0, total: 0 }, items: [], pages: 1 };
     var el = null, searchTimer = null;
 
     function esc(s) {
@@ -68,6 +68,7 @@
                         '<button class="vdh-tab vdh-tab--on" type="button" data-vdh-tab="all">All <span class="vdh-tab-n" data-vdh-c-all>0</span></button>' +
                         '<button class="vdh-tab" type="button" data-vdh-tab="movie">Movies <span class="vdh-tab-n" data-vdh-c-movie>0</span></button>' +
                         '<button class="vdh-tab" type="button" data-vdh-tab="show">TV <span class="vdh-tab-n" data-vdh-c-show>0</span></button>' +
+                        '<button class="vdh-tab" type="button" data-vdh-tab="youtube">YouTube <span class="vdh-tab-n" data-vdh-c-youtube>0</span></button>' +
                     '</div>' +
                     '<div class="vdh-search">' +
                         '<svg class="vdh-search-ic" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>' +
@@ -241,9 +242,12 @@
         q('[data-vdh-c-all]').textContent = state.counts.total || 0;
         q('[data-vdh-c-movie]').textContent = state.counts.movie || 0;
         q('[data-vdh-c-show]').textContent = state.counts.show || 0;
+        var yc = q('[data-vdh-c-youtube]');
+        if (yc) yc.textContent = state.counts.youtube || 0;
         var sub = q('[data-vdh-sub]');
         sub.textContent = (state.counts.total || 0) + ' grab' + (state.counts.total === 1 ? '' : 's') +
-            ' · ' + (state.counts.movie || 0) + ' movies · ' + (state.counts.show || 0) + ' episodes';
+            ' · ' + (state.counts.movie || 0) + ' movies · ' + (state.counts.show || 0) + ' episodes · '
+            + (state.counts.youtube || 0) + ' youtube';
         updateBadge(state.counts.total || 0);
     }
 

--- a/webui/static/video/video-download-history.js
+++ b/webui/static/video/video-download-history.js
@@ -124,6 +124,26 @@
                     }).catch(function () { blk.disabled = false; });
                 return;
             }
+            // Block uploader (source-wide): never grab from this peer again.
+            var blks = e.target.closest('[data-vdh-block-src]');
+            if (blks) {
+                e.stopPropagation();
+                blks.disabled = true;
+                fetch('/api/video/downloads/blocklist',
+                    { method: 'POST', headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+                      body: JSON.stringify({ history_id: +blks.getAttribute('data-vdh-block-src'), scope: 'source' }) })
+                    .then(function (r) { return r.json(); })
+                    .then(function (d) {
+                        if (d && d.success) {
+                            if (typeof showToast === 'function') showToast('Uploader blocked — future searches will skip them', 'success');
+                            blks.textContent = 'Uploader blocked';
+                        } else {
+                            blks.disabled = false;
+                            if (typeof showToast === 'function') showToast((d && d.error) || 'Could not block that uploader', 'error');
+                        }
+                    }).catch(function () { blks.disabled = false; });
+                return;
+            }
             // Clear all history (guarded — it's permanent).
             if (e.target.closest('[data-vdh-clear]')) {
                 var go = function () {
@@ -193,6 +213,10 @@
                     ((it.outcome === 'failed' || it.outcome === 'import_failed') && it.username && it.filename && it.source !== 'youtube'
                         ? '<button class="vdh-redl vdh-block" type="button" data-vdh-block="' + esc(it.id) +
                           '" title="Never pick this exact release again">&#8856; Block release</button>'
+                        : '') +
+                    (it.username && it.source !== 'youtube'
+                        ? '<button class="vdh-redl vdh-block" type="button" data-vdh-block-src="' + esc(it.id) +
+                          '" title="Never grab from this uploader (' + esc(it.username) + ') again">&#8856; Block uploader</button>'
                         : '') +
                 '</div>' +
             '</div>';


### PR DESCRIPTION
# soulsync 3.0.1: `dev` → `main`

the big one. soulsync isn't just music anymore. this release adds a whole video side (movies, tv, youtube) plus a tautulli-style live server activity view, with Radarr/Sonarr-parity download matching, on top of the usual pile of fixes. that's the 3.0.

---

## the video side (movies, tv & youtube)

a fully isolated video app: its own database, dashboard, search, calendar, and download pipeline. shares the automation engine but never touches the music side. works with plex and jellyfin.

- **library & scanning**: three scan modes (incremental modified-since delta, deep re-read + prune, full reset), movies and tv tracked as independent libraries, plus a smart post-download scan that skips the crawl when it already has the newest grab
- **enrichment**: tmdb (movies+shows), tvdb (shows + an episode-metadata fallback), omdb (imdb/rt/metacritic ratings), plus 10 background backfill workers (fanart.tv, opensubtitles, return youtube dislike, sponsorblock, trakt, tvmaze, anilist, wikidata, streaming providers, mediastinger). gap-fill by design so it never clobbers server data, per-field locking, and a rolling re-enrichment automation so ratings, overviews, art and air-dates never go stale
- **detail pages & search**: source-agnostic movie/show/person/studio pages, and a progressive netflix-feel search that streams results in per group as they arrive
- **tv calendar**: a real week grid with air times, a watchlist vs all-library scope toggle, and wishlist an episode straight from the modal
- **follow, wishlist, download**: follow shows, actors/directors, studios (with family presets like disney = pixar + marvel + lucasfilm), youtube channels and playlists. a 1-year look-ahead horizon keeps the wishlist current without flooding it, and a sonarr-style airing job wishlists today's episodes for the shows you follow
- **downloads**: soulseek (slskd), prowlarr indexers, youtube (yt-dlp), radarr/sonarr-class quality profiles (ladder, cutoff, upgrade-until-cutoff, reject rules, preferred words), a permanent download history, a recycle bin, and a release blocklist
- **overlay studio** (kometa-style): a visual overlay-template editor applied via pillow onto plex/jellyfin posters, per-scope assignments (movie/show/season/episode), logo badges, and a nightly re-apply that skips unchanged items
- **collection manager** (kometa-style): build plex collections / jellyfin boxsets from smart filters and ranked lists (imdb, tmdb, trakt, mdblist) in true rank order
- **youtube**: follow channels and playlists as shows (yt-dlp, no api key), per-channel keep windows, and true downloaded-state tracking
- plus library-maintenance repair jobs, bulk metadata edit + per-field lock, re-identify a title, an issues system, and a dedicated video automations page on the shared engine

## smarter video downloads (radarr/sonarr-parity matching)

the download search used to accept a release on the YEAR alone, so a search for "paradox (2017)" could grab "the cloverfield paradox (2018)" (title's a substring, year's one off). now it gates on the release TITLE too:

- a confident title mismatch is rejected, at BOTH the initial auto-pick and every retry (the initial pick had no title check at all before this)
- it matches TMDB alternate + original-language titles, so a release named by a known aka (or a foreign film under its original title) still gets found. this is where we beat radarr/sonarr on missed grabs, not just wrong ones
- manual search greys out mismatches with the reason, sonarr-style

## faster nightly TV refresh

the airing-schedule refresh only re-pulls the current season now, instead of every season of every still-airing show every night. at hundreds of airing shows that's thousands of api calls a night dropped to a fraction, with no loss (new episodes only ever land in the current season).

## server activity (tautulli-style)

a live now-playing view for plex and jellyfin, in an app-wide slide-out drawer:

- live streams merged across plex + jellyfin, pushed over websocket
- click a stream to open it inside soulsync (tmdb fallback so anything playing is clickable)
- a history tab, a stats tab, and terminate-a-stream-with-a-message
- gated to plex/jellyfin, hidden when the active server can't provide it

## music-side fixes & polish

- **mobile docs nav works now**: sidebar taps on the help/docs page were dead on phones (a sticky header ate the tap area, and the scroll target was a no-op on the stacked mobile layout). both fixed, in two places
- the music dashboard header now reads "music dashboard" instead of "system dashboard"

## testing & infra

- new playwright characterization tests for the shell chrome, search, help and artist-detail pages, at desktop + mobile (#1015, #1016, thanks @bluejorts). they lock in real ui contracts, including the #1007 modal-button regression, right ahead of the react migration
- a github sponsor button (funding.yml)
