### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 3.0.1)'
+        description: 'Version tag (e.g. 3.0.2)'
         required: true
-        default: '3.0.1'
+        default: '3.0.2'
 
 jobs:
   build-and-push:

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -55,7 +55,7 @@ _SLSKD_KEYS = {
 
 
 def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None, want_year=None,
-                   want_title=None, blocked_users=None) -> list:
+                   want_title=None, blocked_users=None, want_date=None) -> list:
     """Parse → evaluate → rank a list of raw indexer hits against the quality profile.
     Shared by the mock search and the live slskd start/poll endpoints.
 
@@ -83,7 +83,7 @@ def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None,
         size_gb = round((hit.get("size_bytes") or 0) / (1024 ** 3), 1)
         verdict = evaluate_release(parsed, profile, scope=scope, want_season=want_season,
                                    want_episode=want_episode, size_gb=size_gb, want_year=want_year,
-                                   want_title=want_title)
+                                   want_title=want_title, want_date=want_date)
         user = hit.get("username")
         is_blocked = bool(user and user in blocked_users) or (user, hit.get("filename")) in blocked
         if user and user in blocked_users:

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -54,6 +54,21 @@ _SLSKD_KEYS = {
 }
 
 
+def _parse_text(hit) -> str:
+    """What the release parser should read for a hit. Soulseek hits are grouped by
+    FOLDER — the folder title carries the show/release name, but on library-style
+    shares the episode number, date and quality live in the FILENAME. Join both so
+    one parse sees everything ('90 Day Fiancé/Season 12' + '90.Day.Fiance.S12E09.
+    1080p.mkv'). Prowlarr/torrent hits have no meaningful filename beyond the title,
+    and the join is a no-op when the basename is already the title."""
+    title = str((hit or {}).get("title") or "")
+    fn = str((hit or {}).get("filename") or "").replace("\\", "/").rstrip("/")
+    base = fn.rsplit("/", 1)[-1]
+    if base and base.lower() not in title.lower():
+        return (title + "/" + base) if title else base
+    return title
+
+
 def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None, want_year=None,
                    want_title=None, blocked_users=None, want_date=None) -> list:
     """Parse → evaluate → rank a list of raw indexer hits against the quality profile.
@@ -79,7 +94,7 @@ def _evaluate_hits(raw, profile, scope, want_season, want_episode, blocked=None,
             blocked_users = blocked_users or frozenset()
     results = []
     for hit in raw:
-        parsed = parse_release(hit.get("title"))
+        parsed = parse_release(_parse_text(hit))
         size_gb = round((hit.get("size_bytes") or 0) / (1024 ** 3), 1)
         verdict = evaluate_release(parsed, profile, scope=scope, want_season=want_season,
                                    want_episode=want_episode, size_gb=size_gb, want_year=want_year,

--- a/core/automation/handlers/video_process_wishlist.py
+++ b/core/automation/handlers/video_process_wishlist.py
@@ -285,28 +285,34 @@ def _default_search(item: Dict[str, Any], media_type: str):
     """Ranked candidates for a wished item, honoring the download mode/order. In hybrid mode the
     sources are tried IN ORDER — the first that yields an ACCEPTED release wins (mirrors the
     music per-item quality-fallback). Returns [] for a real empty result across all sources, or
-    **None** (with the error) if no source's search could even run."""
+    **None** (with the error) if no source's search could even run.
+
+    When SOME source in the chain couldn't run (e.g. torrent is first but Prowlarr
+    isn't configured), that skip rides back in the error slot alongside the surviving
+    results — silent degradation to a weaker source misled a whole run once ('why
+    can't it find what's plainly on TPB?'), so the run log must say it every time."""
     from core.video import download_config
     from api.video import get_video_db
     cfg = download_config.load(get_video_db())
     mode = str(cfg.get("download_mode") or "soulseek")
     chain = (cfg.get("hybrid_order") or ["soulseek"]) if mode == "hybrid" else [mode]
-    last_err = None
+    skips: List[str] = []
     fallback = None      # hits that didn't pass the profile — kept so the caller can say 'rejected'
     for src in chain:
         cands, err = _search_one_source(src, item, media_type)
         if cands is None:
-            last_err = err
+            skips.append("%s skipped — %s" % (src, err or "search didn't run"))
             continue
         if any(c.get("accepted") for c in cands):
             return cands, None                       # first source with a usable release wins
         if cands:
             fallback = cands
+    note = "; ".join(skips) or None
     if fallback is not None:
-        return fallback, None                        # → 'rejected' (hits, none accepted)
-    if last_err is not None:
-        return None, last_err                        # → 'search didn't run'
-    return [], None                                  # → 'source empty'
+        return fallback, note                        # → 'rejected' (hits, none accepted)
+    if len(skips) == len(chain):
+        return None, note                            # → 'search didn't run' (nothing ran at all)
+    return [], note                                  # → 'source empty' (+ any skip note)
 
 
 def _default_enqueue(item: Dict[str, Any], best: Dict[str, Any], candidates: List[Dict[str, Any]],
@@ -432,14 +438,19 @@ def auto_video_process_wishlist(
                 name = "%s S%02dE%02d" % (name, int(it.get('season_number') or 0),
                                           int(it.get('episode_number') or 0))
             # tell apart: grabbed / search-didn't-run / source-empty / hits-but-all-rejected.
+            # `err` alongside RESULTS is a non-fatal note (a chain source was skipped,
+            # e.g. 'torrent skipped — Prowlarr not configured') — always show it, or a
+            # mis-configured first source silently degrades every search.
             if ok:
                 msg, lt = "Grabbed '%s'" % name, 'success'
             elif didnt_run:
-                msg = ("Search didn't run for '%s' — slskd error: %s" % (name, err)) if err \
+                msg = ("Search didn't run for '%s' — %s" % (name, err)) if err \
                     else ("Search didn't run for '%s' — slskd not responding?" % name)
                 lt = 'warning'
             elif not cands:
                 msg, lt = "No search results for '%s'" % name, 'info'
+                if err:
+                    msg, lt = msg + " · " + str(err), 'warning'
             elif it.get('_min_rank'):
                 msg = ("%d result(s) for '%s', none better than your current copy — "
                        "still watching for an upgrade" % (len(cands), name))
@@ -447,6 +458,8 @@ def auto_video_process_wishlist(
             else:
                 why = (cands[0].get('rejected') or 'none met your quality profile')
                 msg, lt = "%d result(s) for '%s', none accepted — %s" % (len(cands), name, why), 'info'
+                if err:
+                    msg, lt = msg + " · " + str(err), 'warning'
             with lock:
                 searched[0] += 1
                 if ok:

--- a/core/automation/handlers/video_process_wishlist.py
+++ b/core/automation/handlers/video_process_wishlist.py
@@ -151,7 +151,10 @@ def search_context(item: Dict[str, Any], media_type: str) -> Dict[str, Any]:
     else:
         ctx = {"scope": "episode", "title": item.get("show_title"),
                "season": item.get("season_number"), "episode": item.get("episode_number"),
-               "year": (str(item.get("air_date") or "")[:4] or None)}
+               "year": (str(item.get("air_date") or "")[:4] or None),
+               # full air date — daily series (Daily Show / Kimmel / soaps) release by
+               # DATE, not SxxExx; the ranker + retry queries key off this.
+               "air_date": (str(item.get("air_date") or "")[:10] or None)}
         tmdb_id, kind = item.get("show_tmdb_id"), "show"
     titles = _acceptable_titles(ctx["title"], kind, tmdb_id)
     if len(titles) > 1:
@@ -271,7 +274,8 @@ def _search_one_source(source: str, item: Dict[str, Any], media_type: str):
         return None, "unsupported source %r" % source
     cands = _evaluate_hits(hits, profile, ctx["scope"], ctx.get("season"), ctx.get("episode"),
                            want_year=ctx.get("year"),
-                           want_title=ctx.get("titles") or ctx.get("title"))
+                           want_title=ctx.get("titles") or ctx.get("title"),
+                           want_date=ctx.get("air_date"))
     for c in cands:
         c["source"] = source
     return cands, None

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -615,9 +615,16 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
         # that one folder is whichever disc landed first, so every later track
         # of a box set would be funneled into it — collapsing all discs into a
         # single disc folder and colliding same-numbered filenames.
+        # Reorganize disables reuse outright (`_no_album_folder_reuse`): its whole
+        # job is to move albums OUT of the folder they currently sit in, and the
+        # resolver would answer with exactly that folder — making every reorganize
+        # compute "destination == current location" and no-op (the template-change
+        # complaint from TheHomeGuy).
         reuse_folder = None
         _multi_disc_album = total_discs > 1 or disc_number > 1
-        if filename_base and not _multi_disc_album and raw_album_type not in ("compilation", "compile"):
+        if (filename_base and not _multi_disc_album
+                and raw_album_type not in ("compilation", "compile")
+                and not context.get("_no_album_folder_reuse")):
             try:
                 from core.library.existing_album_folder import resolve_existing_album_folder
                 from database.music_database import get_database

--- a/core/imports/routes.py
+++ b/core/imports/routes.py
@@ -537,6 +537,10 @@ def album_process(runtime: ImportRouteRuntime, data: Dict[str, Any]) -> tuple[Di
             )
             if isinstance(context, dict):
                 context['is_local_import'] = True  # user's own file, not an slskd transfer (#804)
+                # Manual import = the user explicitly matched this exact file to this
+                # track, so the quality profile has no veto here (#1017). AcoustID,
+                # integrity and silence guards still run.
+                context['_skip_quarantine_check'] = ['quality', 'bit_depth']
 
             try:
                 runtime.post_process_matched_download(context_key, context, file_path)
@@ -640,6 +644,10 @@ def process_single_import_file(runtime: ImportRouteRuntime, file_info: Dict[str,
         )
         context = runtime.normalize_import_context(resolved["context"])
         context['is_local_import'] = True  # user's own file, not an slskd transfer (#804)
+        # Manual import = the user explicitly matched this exact file to this
+        # track, so the quality profile has no veto here (#1017). AcoustID,
+        # integrity and silence guards still run.
+        context['_skip_quarantine_check'] = ['quality', 'bit_depth']
         artist_data = runtime.get_import_context_artist(context)
         track_data = runtime.get_import_track_info(context)
         final_title = track_data.get("name", title)

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -987,6 +987,13 @@ def _build_post_process_context(
         'is_album_download': True,
         'has_clean_spotify_data': True,
         'has_full_spotify_metadata': True,
+        # Reorganize destinations must come from the CURRENT template alone.
+        # The #829 existing-folder reuse would resolve to the folder the album
+        # already lives in — the very folder reorganize is trying to move it
+        # out of — so preview computed "unchanged" for every already-together
+        # album and both the Tools job and Reorganize All silently no-opped
+        # after a template change.
+        '_no_album_folder_reuse': True,
     }
 
 

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -548,7 +548,9 @@ def _requery_worker(dl_id) -> None:
                                      scope=ctx.get("scope") or "movie",
                                      want_season=ctx.get("season"), want_episode=ctx.get("episode"),
                                      want_year=ctx.get("year"),
-                                     want_title=ctx.get("titles") or ctx.get("title"))
+                                     want_title=ctx.get("titles") or ctx.get("title"),
+                                     want_date=ctx.get("air_date"),
+                                     size_gb=round((hit.get("size_bytes") or 0) / (1024 ** 3), 1))
                 if v["accepted"]:
                     accepted.append(hit)
             row2 = db.get_video_download(dl_id)

--- a/core/video/download_monitor.py
+++ b/core/video/download_monitor.py
@@ -541,10 +541,11 @@ def _requery_worker(dl_id) -> None:
             polled = _search_for_retry(query)
             accepted = []
             blocked_users = db.blocked_usernames()
+            from api.video.downloads import _parse_text
             for hit in (polled.get("hits") or []):
                 if hit.get("username") in blocked_users:
                     continue                                  # source-wide blocked uploader
-                v = evaluate_release(parse_release(hit.get("title")), profile,
+                v = evaluate_release(parse_release(_parse_text(hit)), profile,
                                      scope=ctx.get("scope") or "movie",
                                      want_season=ctx.get("season"), want_episode=ctx.get("episode"),
                                      want_year=ctx.get("year"),

--- a/core/video/quality_eval.py
+++ b/core/video/quality_eval.py
@@ -130,7 +130,8 @@ def tier_key(source, resolution) -> str:
     return (pre + "-" + resolution) if resolution else ""
 
 
-def _scope_ok(parsed, scope, want_season, want_episode, want_year=None, want_title=None):
+def _scope_ok(parsed, scope, want_season, want_episode, want_year=None, want_title=None,
+              want_date=None):
     """Validate a hit actually matches what was searched (Sonarr/Radarr-style): the
     TITLE must match the wanted film/show (not just be a substring — 'The Cloverfield
     Paradox 2018' must NOT satisfy a search for 'Paradox (2017)'), an episode search
@@ -157,10 +158,20 @@ def _scope_ok(parsed, scope, want_season, want_episode, want_year=None, want_tit
         return None, None
     if scope == "episode":
         if episode is None:
+            # Daily series (Sonarr-style): releases are named by AIR DATE, not SxxExx
+            # ('The.Daily.Show.2026.07.08...'). A date match IS the episode identity.
+            if want_date and parsed.get("air_date") == want_date:
+                return None, None
             return None, "Not a single episode"
         if want_season is not None and season != want_season:
+            # A date match trumps a numbering mismatch — scene season numbering for
+            # dailies rarely agrees with TMDB's, but the air date is unambiguous.
+            if want_date and parsed.get("air_date") == want_date:
+                return None, None
             return None, "Wrong season"
         if want_episode is not None and episode != want_episode:
+            if want_date and parsed.get("air_date") == want_date:
+                return None, None
             return None, "Wrong episode"
         return None, None
     if scope == "season":
@@ -175,7 +186,8 @@ def _scope_ok(parsed, scope, want_season, want_episode, want_year=None, want_tit
 
 
 def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
-                     want_episode=None, size_gb=None, want_year=None, want_title=None) -> dict:
+                     want_episode=None, size_gb=None, want_year=None, want_title=None,
+                     want_date=None) -> dict:
     """Judge a parsed search hit against the quality profile + the search scope.
 
     Returns ``{accepted, score, rejected, tier, quality_label}`` — ``accepted`` False
@@ -185,6 +197,19 @@ def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
     res, source = parsed.get("resolution"), parsed.get("source")
     rejects = profile.get("rejects") or []
     rejected = None
+
+    # Resolution inference — Soulseek files (and plenty of loose torrents) often
+    # carry NO resolution token at all ('90.Day.Fiance.S12E09.HEVC.mkv'), which used
+    # to dead-end as 'Unknown / unsupported quality' even when the file was clearly a
+    # real episode. Sonarr rejects those too — but unlike an indexer we always know
+    # the FILE SIZE, so infer a conservative resolution from it (movie/episode only;
+    # packs are cumulative so sizes mean nothing there). ffprobe verifies the true
+    # quality after download (the existing invariant for sourceless names), and the
+    # import rejects fakes — so a wrong guess self-corrects instead of losing a grab.
+    inferred = False
+    if not res and size_gb and scope in ("movie", "episode"):
+        res = _infer_resolution(scope, size_gb)
+        inferred = res is not None
 
     # 1) hard rejects — junk source / 3D / rejected codec
     if source in ("cam", "screener", "workprint") and source in rejects:
@@ -210,7 +235,8 @@ def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
 
     # 4) scope validation (episode vs season pack vs series pack; movie year match)
     if not rejected:
-        _, scope_reason = _scope_ok(parsed, scope, want_season, want_episode, want_year, want_title)
+        _, scope_reason = _scope_ok(parsed, scope, want_season, want_episode, want_year, want_title,
+                                    want_date)
         if scope_reason:
             rejected = scope_reason
 
@@ -231,10 +257,42 @@ def evaluate_release(parsed, profile, *, scope="movie", want_season=None,
     if profile.get("prefer_repack") and (parsed.get("repack") or parsed.get("proper")):
         score += 10
 
-    label = " · ".join([x for x in [resolution_label(res),
+    res_lab = resolution_label(res)
+    if inferred and res_lab:
+        res_lab += "~"          # size-inferred, not from the name — ffprobe confirms on import
+    label = " · ".join([x for x in [res_lab,
                         (source or "").upper() if source else "", fam.upper() if fam else ""] if x])
     return {"accepted": rejected is None, "score": score, "rejected": rejected,
             "tier": tier, "quality_label": label}
+
+
+def _infer_resolution(scope, size_gb):
+    """Conservative size→resolution guess for a release whose NAME carries no
+    resolution token. Thresholds sit at the low edge of each tier's typical size so
+    we under-promise (a 1.4GB episode reads as 1080p web, an 800MB one as 720p) —
+    the post-download ffprobe measures the truth."""
+    try:
+        gb = float(size_gb)
+    except (TypeError, ValueError):
+        return None
+    if gb <= 0:
+        return None
+    if scope == "episode":
+        if gb < 0.25:
+            return "480p"
+        if gb < 0.85:
+            return "720p"
+        if gb < 4.0:
+            return "1080p"
+        return "2160p"
+    # movie
+    if gb < 0.95:
+        return "480p"
+    if gb < 2.5:
+        return "720p"
+    if gb < 12.0:
+        return "1080p"
+    return "2160p"
 
 
 __all__ = ["resolution_rank", "resolution_label", "meets_cutoff", "evaluate_owned",

--- a/core/video/release_parse.py
+++ b/core/video/release_parse.py
@@ -207,24 +207,38 @@ def acceptable_titles(want_title: Any) -> set:
 def titles_match(release_name: Any, want_title: Any) -> bool:
     """True when a release's parsed title matches ANY acceptable title (primary +
     aliases). Exact after normalization, tolerating only trailing edition words
-    ('Paradox Extended' for 'Paradox'). An unknown/unisolable title passes (the year
-    gate still applies) so a numeric title like '2012' is never falsely rejected — we
-    only ever REJECT on a confident mismatch against every acceptable title, never
-    guess a match."""
+    ('Paradox Extended' for 'Paradox') and squeezed spacing ('90DayFiance').
+
+    Soulseek results are share PATHS, not scene one-liners — the show name often
+    lives in a parent folder ('TV/90 Day Fiancé/Season 12/ep.mkv'), so every path
+    SEGMENT is tried as a title candidate, not just the whole string. An
+    unknown/unisolable title passes (the year gate still applies) so a numeric
+    title like '2012' is never falsely rejected — we only ever REJECT on a
+    confident mismatch against every acceptable title, never guess a match."""
     wants = acceptable_titles(want_title)
     if not wants:
         return True
-    got = normalize_title(extract_title(release_name))
-    if not got:
-        return True
-    for want in wants:
-        if got == want:
-            return True
-        if got.startswith(want + " "):
-            rest = got[len(want):].split()
-            if rest and all(tok in _EDITION_TOKENS for tok in rest):
+    raw = str(release_name or "")
+    cands = [raw]
+    segs = [s for s in re.split(r"[\\/]+", raw) if s.strip()]
+    if len(segs) > 1:
+        cands += segs
+    saw_any = False
+    for cand in cands:
+        got = normalize_title(extract_title(cand))
+        if not got:
+            continue
+        saw_any = True
+        for want in wants:
+            if got == want:
                 return True
-    return False
+            if got.replace(" ", "") == want.replace(" ", ""):
+                return True                              # '90DayFiance' == '90 day fiance'
+            if got.startswith(want + " "):
+                rest = got[len(want):].split()
+                if rest and all(tok in _EDITION_TOKENS for tok in rest):
+                    return True
+    return not saw_any
 
 
 __all__ = ["parse_release", "extract_title", "normalize_title",

--- a/core/video/release_parse.py
+++ b/core/video/release_parse.py
@@ -59,11 +59,15 @@ _AUDIO = [
 ]
 
 _RANGE = re.compile(r"\bS(\d{1,2})\s*[-–]\s*S?(\d{1,2})\b", re.I)   # S01-S05
-_SXXEXX = re.compile(r"\bS(\d{1,2})[\s.]?E(\d{1,3})\b", re.I)        # S02E03
-_SXX = re.compile(r"\bS(\d{1,2})\b", re.I)                          # S02 (pack)
+# Season allows 3 digits — long-running dailies really do reach S277 (House Hunters).
+_SXXEXX = re.compile(r"\bS(\d{1,3})[\s.]?E(\d{1,3})\b", re.I)        # S02E03 / S277E05
+_SXX = re.compile(r"\bS(\d{1,3})\b", re.I)                          # S02 (pack)
 _SEASON_WORD = re.compile(r"\bseason[\s.]?(\d{1,2})\b", re.I)        # Season 2
 _COMPLETE = re.compile(r"\b(complete|collection|all\s?seasons)\b", re.I)
 _GROUP = re.compile(r"-([A-Za-z0-9]{2,})\s*$")
+# Daily/date-named releases — 'The.Daily.Show.2026.07.08.Guest.1080p...' (Sonarr's
+# daily-series naming). Dots/spaces/dashes between the parts; month/day validated.
+_AIR_DATE = re.compile(r"\b((?:19|20)\d{2})[ ._-](0[1-9]|1[0-2])[ ._-](0[1-9]|[12]\d|3[01])\b")
 
 
 def _first(table, text) -> Any:
@@ -97,12 +101,16 @@ def parse_release(title: Any) -> dict:
         "season": None,
         "season_end": None,
         "episode": None,
+        "air_date": None,
         "is_season_pack": False,
         "is_series_pack": False,
     }
     g = _GROUP.search(t)
     if g:
         out["group"] = g.group(1)
+    ad = _AIR_DATE.search(t)
+    if ad:
+        out["air_date"] = ad.group(1) + "-" + ad.group(2) + "-" + ad.group(3)
 
     rng = _RANGE.search(t)
     m = _SXXEXX.search(t)
@@ -136,7 +144,7 @@ _META_BOUNDARY = re.compile(
     r"\b(?:2160p|1080[pi]|720[pi]|480[pi]|576[pi]|4k|uhd"
     r"|blu-?ray|bdrip|brrip|web-?dl|web-?rip|web|hdtv|dvdrip|dvd|remux|hdcam|cam|telesync|hdts"
     r"|x264|x265|h\.?264|h\.?265|hevc|avc|av1"
-    r"|s\d{1,2}(?:e\d{1,3})?|season)\b", re.I)
+    r"|s\d{1,3}(?:e\d{1,3})?|season)\b", re.I)
 _ARTICLE = re.compile(r"^(?:the|a|an)\s+")
 # Trailing words that are an edition of the SAME film, not a different title.
 _EDITION_TOKENS = frozenset({
@@ -152,9 +160,12 @@ def _spaces(s: Any) -> str:
 
 def extract_title(release_name: Any) -> str:
     """The title portion of a release name — everything before the release year (the
-    LAST year token, so 'Blade Runner 2049 2017 1080p' keeps '2049'), or before the
-    first quality/scope token when there's no trailing year. Returns '' when the title
-    can't be isolated (e.g. a numeric-only title like '2012' with no release year)."""
+    LAST year token, so 'Blade Runner 2049 2017 1080p' keeps '2049') or before the
+    first quality/scope token, whichever comes FIRST. The scope token matters for
+    date-named daily releases ('Show.S277E05.2026.07.08...'): the date's year sits
+    AFTER the SxxExx, and cutting only at the year would leave numbering junk in the
+    title. Returns '' when the title can't be isolated (e.g. a numeric-only title
+    like '2012' with no release year)."""
     t = str(release_name or "").strip()
     if not t:
         return ""
@@ -162,9 +173,11 @@ def extract_title(release_name: Any) -> str:
     years = list(_YEAR_TOKEN.finditer(t))
     if years and _spaces(t[:years[-1].start()]):
         cut = years[-1].start()          # cut at the release year (keeps years IN the title)
+    m = _META_BOUNDARY.search(t)         # first quality/scope token wins if it comes earlier
+    if m and _spaces(t[:m.start()]) and (cut is None or m.start() < cut):
+        cut = m.start()
     if cut is None:
-        m = _META_BOUNDARY.search(t)     # no usable year → cut at the first quality/scope token
-        cut = m.start() if m else len(t)
+        cut = len(t)
     return _spaces(t[:cut])
 
 

--- a/core/video/retry.py
+++ b/core/video/retry.py
@@ -20,7 +20,10 @@ MAX_ATTEMPTS = 6   # total tries (candidate hops + requeries) before giving up
 def next_query(ctx: dict, tried: Any) -> str | None:
     """The next alternate slskd query to try for a search context, or None when
     exhausted. Movie: 'Title Year' then 'Title'. TV keeps the SxxExx/Sxx identity but
-    offers a couple of numbering variants."""
+    offers a couple of numbering variants, then — when the episode has an air date —
+    DATE-form queries (Sonarr's daily-series naming: 'Title 2026 07 08'), since daily
+    shows (late night / soaps / House Hunters) release by date, not SxxExx. The ranker
+    accepts a date match as the episode identity, so these are safe to try last."""
     ctx = ctx or {}
     triedset = set(tried or [])
     scope = str(ctx.get("scope") or "movie").lower()
@@ -34,6 +37,10 @@ def next_query(ctx: dict, tried: Any) -> str | None:
         s, e = int(ctx["season"]), int(ctx["episode"])
         cands.append("%s S%02dE%02d" % (title, s, e))
         cands.append("%s %dx%02d" % (title, s, e))
+        ad = str(ctx.get("air_date") or "")[:10]
+        if len(ad) == 10:
+            cands.append("%s %s" % (title, ad.replace("-", " ")))   # Title 2026 07 08
+            cands.append("%s %s" % (title, ad.replace("-", ".")))   # Title 2026.07.08
     elif scope == "season" and ctx.get("season") is not None:
         s = int(ctx["season"])
         cands.append("%s S%02d" % (title, s))

--- a/core/video/slskd_search.py
+++ b/core/video/slskd_search.py
@@ -13,6 +13,7 @@ the HTTP poll is thin I/O glue.
 
 from __future__ import annotations
 
+import re
 import threading
 import time
 from typing import Any
@@ -109,13 +110,31 @@ def _is_video(filename: str) -> bool:
     return ext in VIDEO_EXTS
 
 
+# A parent folder that is just a CONTAINER, not a release name — library-style
+# Soulseek shares nest 'Show Name/Season 12/episode.mkv', and keying the hit on
+# 'Season 12' alone loses the show (the title gate then rejects every candidate)
+# and collides different shows' same-named season folders into one hit.
+_GENERIC_DIR = re.compile(
+    r"^(?:season[ ._-]?\d{1,4}|s\d{1,3}|series[ ._-]?\d{1,3}|specials?|extras?"
+    r"|disc[ ._-]?\d+|disk[ ._-]?\d+|cd[ ._-]?\d+|subs?|subtitles|samples?|\d{1,4})$", re.I)
+
+
 def _release_name(filename: str) -> str:
     """The release a file belongs to — its parent folder (where scene/p2p put the
-    quality), falling back to the bare filename (sans extension)."""
+    quality). When the parent is a generic container ('Season 12', 'Specials'),
+    the grandparent (the show folder) is prepended so the hit keeps its identity:
+    'TV/90 Day Fiancé/Season 12/ep.mkv' → '90 Day Fiancé/Season 12'. Falls back
+    to the bare filename (sans extension) for root-level files."""
     fn = str(filename or "").replace("\\", "/").strip("/")
     parts = [p for p in fn.split("/") if p]
     if len(parts) >= 2:
-        return parts[-2]
+        parent = parts[-2]
+        if len(parts) >= 3 and _GENERIC_DIR.match(parent.strip()):
+            gp = parts[-3]
+            # slskd share roots look like '@@abcdef' — never a show name.
+            if gp and not gp.startswith("@@"):
+                return gp + "/" + parent
+        return parent
     base = parts[-1] if parts else ""
     return base.rsplit(".", 1)[0] if "." in base else base
 

--- a/tests/imports/test_import_paths.py
+++ b/tests/imports/test_import_paths.py
@@ -762,6 +762,42 @@ def test_multi_disc_album_skips_folder_reuse(monkeypatch, tmp_path):
         tmp_path / "Transfer" / "Artist One" / "Album One" / "CD02" / "13 - Song One.flac")
 
 
+def test_reorganize_flag_disables_folder_reuse(monkeypatch, tmp_path):
+    """A reorganize context carries `_no_album_folder_reuse` — its destination
+    must come from the CURRENT template, never the folder the album already
+    sits in. Otherwise a template change computes "destination == current
+    location" for every already-together album and reorganize silently no-ops
+    (TheHomeGuy's report: old `$albumartist - $album` folders never moved)."""
+    config = _reuse_test_config(tmp_path, "$albumartist/$album/$track - $title")
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: config)
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+
+    # The album's current home under the OLD template — the resolver would
+    # happily return it, and the resulting path must NOT use it.
+    old_home = tmp_path / "Transfer" / "Artist One" / "Artist One - Album One"
+    old_home.mkdir(parents=True)
+    import core.library.existing_album_folder as eaf
+    import database.music_database as mdb
+    monkeypatch.setattr(mdb, "get_database", lambda: object(), raising=False)
+    resolver_calls = []
+    monkeypatch.setattr(eaf, "resolve_existing_album_folder",
+                        lambda **kw: resolver_calls.append(kw) or str(old_home))
+
+    context = _reuse_context(disc_number=1, total_discs_from_api=1)
+    context["_no_album_folder_reuse"] = True
+    final_path, created = import_paths.build_final_path_for_track(
+        context,
+        {"name": "Artist One"},
+        {"is_album": True, "album_name": "Album One", "track_number": 13, "disc_number": 1},
+        ".flac",
+        create_dirs=False,
+    )
+    assert created is True
+    assert resolver_calls == []  # reuse lookup skipped entirely
+    assert final_path == str(
+        tmp_path / "Transfer" / "Artist One" / "Album One" / "13 - Song One.flac")
+
+
 def test_single_disc_album_still_reuses_existing_folder(monkeypatch, tmp_path):
     """The #829 behavior the gate must NOT break: single-disc albums keep
     joining their existing folder so $albumtype/$year drift can't split them."""

--- a/tests/imports/test_import_routes.py
+++ b/tests/imports/test_import_routes.py
@@ -482,6 +482,9 @@ def test_album_process_posts_valid_files_and_records_side_effects(tmp_path):
     assert context["artist_context"] == {"name": "Artist"}
     assert context["total_discs"] == 2
     assert context["source"] == "deezer"
+    assert context["is_local_import"] is True
+    # explicit user match — quality profile has no veto (#1017)
+    assert context["_skip_quarantine_check"] == ["quality", "bit_depth"]
     assert path == str(good_file)
     assert activity == [("", "Album Imported", "Album by Artist (1/2 tracks)", "Now")]
     assert refresh_calls == ["refresh"]
@@ -581,7 +584,9 @@ def test_process_single_import_file_resolves_and_posts_context(tmp_path):
     assert len(post_calls) == 1
     assert post_calls[0][0].startswith("import_single_")
     assert post_calls[0][1] == {"track": {"name": "Song"}, "artist": {"name": "Artist"},
-                                "is_local_import": True}
+                                "is_local_import": True,
+                                # explicit user match — quality profile has no veto (#1017)
+                                "_skip_quarantine_check": ["quality", "bit_depth"]}
     assert post_calls[0][2] == str(audio_file)
 
 

--- a/tests/imports/test_quality_guard.py
+++ b/tests/imports/test_quality_guard.py
@@ -106,6 +106,18 @@ def test_acoustid_bypass_does_not_skip_quality():
     assert _should_skip_quarantine_check(ctx, 'quality') is False
 
 
+def test_manual_import_bypass_list_skips_quality_but_not_acoustid():
+    # The Import page's explicit-match flows set this exact list (#1017):
+    # the quality profile has no veto on a file the user hand-matched, but
+    # AcoustID/integrity/silence still guard against a mislabeled file.
+    ctx = {'_skip_quarantine_check': ['quality', 'bit_depth']}
+    assert _should_skip_quarantine_check(ctx, 'quality') is True
+    assert _should_skip_quarantine_check(ctx, 'bit_depth') is True
+    assert _should_skip_quarantine_check(ctx, 'acoustid') is False
+    assert _should_skip_quarantine_check(ctx, 'integrity') is False
+    assert _should_skip_quarantine_check(ctx, 'silence') is False
+
+
 def test_quality_quarantine_persists_quality_trigger(monkeypatch, tmp_path):
     # A quality reject writes trigger='quality' (not 'acoustid') into the
     # sidecar, so Approve never routes it through the force_import path.

--- a/tests/test_library_reorganize_orchestrator.py
+++ b/tests/test_library_reorganize_orchestrator.py
@@ -1341,6 +1341,101 @@ def test_preview_marks_unmatched_tracks(monkeypatch, tmpdirs):
     assert by_title['Completely Unrelated Side Quest']['new_path'] == ''
 
 
+def test_preview_plans_move_out_of_old_template_folder(monkeypatch, tmpdirs):
+    """TheHomeGuy's report: after changing the album template (dropping the
+    '$albumartist - ' prefix from the album folder), both the Tools-page job
+    and Reorganize All did nothing — every track came back `unchanged`.
+
+    Root cause: the preview computes destinations through the REAL
+    `build_final_path_for_track`, whose #829 existing-folder reuse resolves
+    the folder the album ALREADY lives in — the old-template folder it's
+    supposed to move out of — so destination == current location. This wires
+    the real builder with a poisoned resolver and pins that a reorganize
+    context never consults it."""
+    import core.imports.paths as import_paths
+    import core.library.existing_album_folder as eaf
+    import database.music_database as mdb
+
+    library, _staging, transfer = tmpdirs
+
+    class _Cfg:
+        def __init__(self, values):
+            self._values = values
+
+        def get(self, key, default=None):
+            return self._values.get(key, default)
+
+        def get_active_media_server(self):
+            return None
+
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: _Cfg({
+        "soulseek.transfer_path": str(transfer),
+        "file_organization.enabled": True,
+        "file_organization.templates": {
+            # The NEW template — no artist prefix on the album folder.
+            "album_path": "$albumartist/$album/$track - $title",
+            "single_path": "$artist/$title",
+        },
+        "file_organization.collab_artist_mode": "first",
+        "file_organization.disc_label": "Disc",
+    }))
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+
+    # The file sits where the OLD template put it: Artist/Artist - Album/.
+    old_home = transfer / "Aerosmith" / "Aerosmith - Rocks"
+    old_home.mkdir(parents=True)
+    current = old_home / "01 - Back in the Saddle.flac"
+    current.write_bytes(b"fakeflacdata")
+
+    # Poisoned resolver: if the builder consults folder reuse at all, it gets
+    # the old folder back and the preview would report `unchanged` (the bug).
+    monkeypatch.setattr(mdb, "get_database", lambda: object(), raising=False)
+    resolver_calls = []
+    monkeypatch.setattr(eaf, "resolve_existing_album_folder",
+                        lambda **kw: resolver_calls.append(kw) or str(old_home))
+
+    db = _FakeDB()
+    _setup_album(db, deezer_id='dz-1', tracks=[
+        ('t1', 1, 'Back in the Saddle', str(current)),
+    ])
+    monkeypatch.setattr(library_reorganize, 'get_primary_source', lambda: 'deezer')
+    monkeypatch.setattr(library_reorganize, 'get_source_priority', lambda p: [p])
+    monkeypatch.setattr(library_reorganize, 'get_album_for_source',
+                        lambda *a: {'id': 'dz-1', 'name': 'Rocks'})
+    monkeypatch.setattr(
+        library_reorganize, 'get_album_tracks_for_source',
+        lambda *a: {'items': [
+            {'id': 'a1', 'name': 'Back in the Saddle', 'track_number': 1, 'disc_number': 1},
+        ]},
+    )
+
+    result = library_reorganize.preview_album_reorganize(
+        album_id='alb-1', db=db, transfer_dir=str(transfer),
+        resolve_file_path_fn=lambda p: p,
+        build_final_path_fn=import_paths.build_final_path_for_track,
+    )
+
+    assert result['success'] is True
+    (track,) = result['tracks']
+    assert track['matched'] is True
+    assert resolver_calls == []          # reuse never consulted for reorganize
+    assert track['unchanged'] is False   # the bug reported True here
+    assert track['new_path_abs'] == str(
+        transfer / "Aerosmith" / "Rocks" / "01 - Back in the Saddle.flac")
+
+
+def test_reorganize_context_disables_folder_reuse():
+    """The contract the preview test above relies on: every reorganize
+    pipeline context (preview, rename-only apply, full apply — all built by
+    `_build_post_process_context`) carries the no-reuse flag."""
+    context = library_reorganize._build_post_process_context(
+        {'id': 'dz-1', 'name': 'Rocks'},
+        {'id': 'a1', 'name': 'Back in the Saddle', 'track_number': 1},
+        'Aerosmith', 'Rocks', 1,
+    )
+    assert context['_no_album_folder_reuse'] is True
+
+
 def test_preview_uses_same_logic_as_apply(monkeypatch, tmpdirs):
     """Sanity check: a multi-disc album previewed and then applied
     should show the same destinations. If preview drift creeps in

--- a/tests/test_video_daily_and_sizeinfer.py
+++ b/tests/test_video_daily_and_sizeinfer.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from core.video.quality_eval import evaluate_release, _infer_resolution
 from core.video.release_parse import parse_release
 from core.video.retry import next_query
+from core.video.release_parse import titles_match
 
 _PROFILE = {"tiers": [{"key": k, "enabled": True} for k in
                       ("web-2160p", "web-1080p", "webrip-1080p", "hdtv-1080p",
@@ -131,3 +132,65 @@ def test_named_resolution_still_wins_over_size():
     v = evaluate_release(parsed, _PROFILE, scope="episode", size_gb=3.0)
     assert v["tier"] == "web-720p"                             # size does not override
     assert "~" not in v["quality_label"]
+
+
+# ── Soulseek path-aware matching (the 'Wrong title (Season 12)' log lines) ────
+def test_release_name_promotes_show_folder_over_generic_season_dir():
+    from core.video.slskd_search import _release_name
+    assert _release_name(r"@@x\TV\90 Day Fiancé\Season 12\90.Day.Fiance.S12E09.1080p.mkv") \
+        == "90 Day Fiancé/Season 12"
+    # scene-style folders keep their name (the existing behavior)
+    assert _release_name(r"@@x\The.Wire.S02.1080p.BluRay.x265-GRP\the.wire.s02e01.mkv") \
+        == "The.Wire.S02.1080p.BluRay.x265-GRP"
+    # a share-root grandparent ('@@…') is never a show name
+    assert _release_name(r"@@x\Season 12\ep.mkv") == "Season 12"
+
+
+def test_different_shows_season_folders_no_longer_collide():
+    from core.video.slskd_search import group_video_files
+    hits = group_video_files([
+        {"username": "a", "uploadSpeed": 1, "freeUploadSlots": 1, "files": [
+            {"filename": r"@@x\90 Day Fiance\Season 12\ep.mkv", "size": 1}]},
+        {"username": "b", "uploadSpeed": 1, "freeUploadSlots": 1, "files": [
+            {"filename": r"@@y\Love Island\Season 12\ep.mkv", "size": 1}]},
+    ])
+    assert len(hits) == 2                     # used to merge into one 'Season 12' hit
+
+
+def test_parse_text_joins_folder_title_and_filename():
+    from api.video.downloads import _parse_text
+    slskd_hit = {"title": "90 Day Fiancé/Season 12",
+                 "filename": r"@@x\TV\90 Day Fiancé\Season 12\90.Day.Fiance.S12E09.1080p.HEVC.mkv"}
+    assert _parse_text(slskd_hit) == "90 Day Fiancé/Season 12/90.Day.Fiance.S12E09.1080p.HEVC.mkv"
+    torrent_hit = {"title": "90 Day Fiance S12E09 1080p HEVC x265-MeGusta", "filename": None}
+    assert _parse_text(torrent_hit) == "90 Day Fiance S12E09 1080p HEVC x265-MeGusta"
+
+
+def test_the_reported_library_share_now_matches_end_to_end():
+    # the literal failing log line: 1 result for '90 Day Fiancé S12E09' rejected
+    # 'Wrong title (Season 12 — wanted [aliases])'
+    from api.video.downloads import _evaluate_hits
+    hit = {"title": "90 Day Fiancé/Season 12",
+           "filename": r"@@x\TV\90 Day Fiancé\Season 12\90.Day.Fiance.S12E09.1080p.HEVC.mkv",
+           "size_bytes": 1_073_741_824, "username": "peer1"}
+    out = _evaluate_hits([hit], _PROFILE, "episode", 12, 9,
+                         blocked=set(), blocked_users=set(),
+                         want_title=["90 Day Fiancé", "90 Day Fiance"])
+    assert out[0]["accepted"] is True, out[0]["rejected"]
+
+
+def test_wrong_show_library_share_still_rejected():
+    from api.video.downloads import _evaluate_hits
+    hit = {"title": "Little House On The Prairie/Season 3",
+           "filename": r"@@x\TV\Little House On The Prairie\Season 3\LHOTP.S03E05.1080p.mkv",
+           "size_bytes": 1_000_000_000, "username": "peer1"}
+    out = _evaluate_hits([hit], _PROFILE, "episode", 277, 5,
+                         blocked=set(), blocked_users=set(),
+                         want_title=["House Hunters"])
+    assert out[0]["accepted"] is False and "Wrong" in out[0]["rejected"]
+
+
+def test_titles_match_squeezed_spacing_and_segments():
+    assert titles_match("90DayFiance.S12E09.1080p.mkv", "90 Day Fiancé") is True
+    assert titles_match(r"TV/90 Day Fiancé/Season 12/ep.mkv", ["90 Day Fiancé"]) is True
+    assert titles_match(r"TV/Little House/Season 12/ep.mkv", ["House Hunters"]) is False

--- a/tests/test_video_daily_and_sizeinfer.py
+++ b/tests/test_video_daily_and_sizeinfer.py
@@ -1,0 +1,133 @@
+"""Sonarr-parity fixes from the '59 searched, 0 grabbed' wishlist run.
+
+Two structural gaps that threw away real episodes:
+
+1. DAILY SERIES — late night / soaps / House Hunters release by AIR DATE
+   ('The.Daily.Show.2026.07.08...'), not SxxExx. Those parsed with no episode
+   marker and died as 'Not a single episode'. Now: the parser extracts the date,
+   a date match IS the episode identity (even over a numbering mismatch), and
+   the retry ladder tries date-form queries after the SxxExx forms.
+
+2. SIZE-INFERRED QUALITY — Soulseek files often carry no resolution token
+   ('90.Day.Fiance.S12E09.HEVC.mkv') and died as 'Unknown / unsupported
+   quality'. We always know the file size, so infer a conservative resolution
+   from it (episode/movie only); ffprobe verifies the truth after download.
+"""
+
+from __future__ import annotations
+
+from core.video.quality_eval import evaluate_release, _infer_resolution
+from core.video.release_parse import parse_release
+from core.video.retry import next_query
+
+_PROFILE = {"tiers": [{"key": k, "enabled": True} for k in
+                      ("web-2160p", "web-1080p", "webrip-1080p", "hdtv-1080p",
+                       "web-720p", "hdtv-720p", "dvd")]}
+
+
+# ── date parsing ──────────────────────────────────────────────────────────────
+def test_parse_release_extracts_air_dates():
+    assert parse_release("The.Daily.Show.2026.07.08.Some.Guest.1080p.WEB.h264")["air_date"] == "2026-07-08"
+    assert parse_release("Jimmy Kimmel Live 2026-07-08 720p")["air_date"] == "2026-07-08"
+    assert parse_release("Beyond the Gates 2026 07 08 HDTV")["air_date"] == "2026-07-08"
+
+
+def test_parse_release_no_false_date_positives():
+    assert parse_release("Blade.Runner.2049.2017.1080p.BluRay")["air_date"] is None
+    assert parse_release("Show.S02E03.1080p.WEB")["air_date"] is None
+    assert parse_release("Movie.2026.13.40.fake")["air_date"] is None    # month 13 invalid
+
+
+# ── the daily-series gate ─────────────────────────────────────────────────────
+def test_date_named_release_accepted_when_air_date_matches():
+    parsed = parse_release("The.Daily.Show.2026.07.08.Guest.1080p.WEB.h264-GRP")
+    v = evaluate_release(parsed, _PROFILE, scope="episode", want_season=31, want_episode=85,
+                         want_title="The Daily Show", want_date="2026-07-08")
+    assert v["accepted"] is True
+
+
+def test_date_named_release_rejected_on_wrong_date_or_no_wanted_date():
+    parsed = parse_release("The.Daily.Show.2026.07.09.Guest.1080p.WEB.h264")
+    v = evaluate_release(parsed, _PROFILE, scope="episode", want_season=31, want_episode=85,
+                         want_title="The Daily Show", want_date="2026-07-08")
+    assert v["accepted"] is False and "Not a single episode" in v["rejected"]
+    # without a wanted date the old behavior stands (no SxxExx -> not an episode)
+    v2 = evaluate_release(parsed, _PROFILE, scope="episode", want_season=31, want_episode=85,
+                          want_title="The Daily Show")
+    assert v2["accepted"] is False
+
+
+def test_date_match_trumps_scene_numbering_mismatch():
+    # scene numbering for dailies rarely agrees with TMDB's — the date is authoritative.
+    # Also proves 3-digit seasons parse (House Hunters is genuinely on S277) and that
+    # the title extractor cuts at the SxxExx, not at the date's year.
+    parsed = parse_release("House.Hunters.S278E01.2026.07.08.1080p.WEB")
+    assert parsed["season"] == 278 and parsed["air_date"] == "2026-07-08"
+    v = evaluate_release(parsed, _PROFILE, scope="episode", want_season=277, want_episode=5,
+                         want_title="House Hunters", want_date="2026-07-08")
+    assert v["accepted"] is True
+
+
+def test_retry_ladder_adds_date_queries_after_sxxexx():
+    ctx = {"scope": "episode", "title": "The Daily Show", "season": 31, "episode": 85,
+           "air_date": "2026-07-08"}
+    q1 = next_query(ctx, [])
+    q2 = next_query(ctx, [q1])
+    q3 = next_query(ctx, [q1, q2])
+    q4 = next_query(ctx, [q1, q2, q3])
+    assert q1 == "The Daily Show S31E85"
+    assert q2 == "The Daily Show 31x85"
+    assert q3 == "The Daily Show 2026 07 08"
+    assert q4 == "The Daily Show 2026.07.08"
+    assert next_query(ctx, [q1, q2, q3, q4]) is None
+    # no air date -> ladder unchanged (numbering forms only)
+    assert next_query({"scope": "episode", "title": "X", "season": 1, "episode": 2},
+                      ["X S01E02"]) == "X 1x02"
+
+
+def test_search_context_carries_the_air_date(monkeypatch):
+    import core.automation.handlers.video_process_wishlist as mod
+    monkeypatch.setattr(mod, "_acceptable_titles", lambda p, k, t: [p])
+    ctx = mod.search_context({"show_title": "The Daily Show", "season_number": 31,
+                              "episode_number": 85, "air_date": "2026-07-08",
+                              "show_tmdb_id": 2224}, "episode")
+    assert ctx["air_date"] == "2026-07-08" and ctx["year"] == "2026"
+
+
+# ── size-inferred quality ─────────────────────────────────────────────────────
+def test_resolutionless_episode_is_inferred_from_size_and_accepted():
+    # the reported case: '90 Day Fiance S12E09 ... HEVC' with no resolution token
+    parsed = parse_release("90.Day.Fiance.S12E09.HEVC.x265-MeGusta")
+    assert parsed["resolution"] is None
+    v = evaluate_release(parsed, _PROFILE, scope="episode", want_season=12, want_episode=9,
+                         want_title="90 Day Fiancé", size_gb=1.0)
+    assert v["accepted"] is True
+    assert v["tier"] == "web-1080p"          # 1.0 GB episode ≈ 1080p, sourceless -> web
+    assert "1080p~" in v["quality_label"]    # honest 'inferred' marker
+
+
+def test_size_inference_tiers():
+    assert _infer_resolution("episode", 0.15) == "480p"
+    assert _infer_resolution("episode", 0.6) == "720p"
+    assert _infer_resolution("episode", 2.0) == "1080p"
+    assert _infer_resolution("episode", 6.0) == "2160p"
+    assert _infer_resolution("movie", 1.5) == "720p"
+    assert _infer_resolution("movie", 5.0) == "1080p"
+    assert _infer_resolution("movie", 20.0) == "2160p"
+    assert _infer_resolution("movie", 0) is None
+
+
+def test_no_inference_without_size_or_for_packs():
+    parsed = parse_release("Some.Show.S01.Complete.HEVC")     # series pack, no res
+    v = evaluate_release(parsed, _PROFILE, scope="series", size_gb=40.0)
+    assert v["accepted"] is False and "Unknown" in v["rejected"]
+    parsed2 = parse_release("Some.Movie.HEVC.mkv")
+    v2 = evaluate_release(parsed2, _PROFILE, scope="movie")   # no size known
+    assert v2["accepted"] is False and "Unknown" in v2["rejected"]
+
+
+def test_named_resolution_still_wins_over_size():
+    parsed = parse_release("Show.S01E01.720p.WEB.x264")       # explicit 720p
+    v = evaluate_release(parsed, _PROFILE, scope="episode", size_gb=3.0)
+    assert v["tier"] == "web-720p"                             # size does not override
+    assert "~" not in v["quality_label"]

--- a/tests/test_video_daily_and_sizeinfer.py
+++ b/tests/test_video_daily_and_sizeinfer.py
@@ -194,3 +194,46 @@ def test_titles_match_squeezed_spacing_and_segments():
     assert titles_match("90DayFiance.S12E09.1080p.mkv", "90 Day Fiancé") is True
     assert titles_match(r"TV/90 Day Fiancé/Season 12/ep.mkv", ["90 Day Fiancé"]) is True
     assert titles_match(r"TV/Little House/Season 12/ep.mkv", ["House Hunters"]) is False
+
+
+# ── silent source degradation (torrent skipped: Prowlarr not configured) ──────
+def test_default_search_reports_skipped_chain_sources(monkeypatch):
+    """Boulder's run: hybrid [torrent, soulseek] with Prowlarr unconfigured — every
+    search silently degraded to Soulseek-only and the run log never said so. The
+    skip must ride back with the results so the log shows it every time."""
+    import core.automation.handlers.video_process_wishlist as mod
+
+    monkeypatch.setattr("core.video.download_config.load",
+                        lambda db: {"download_mode": "hybrid",
+                                    "hybrid_order": ["torrent", "soulseek"]})
+    monkeypatch.setattr("api.video.get_video_db", lambda: object())
+
+    def fake_source(src, item, media_type):
+        if src == "torrent":
+            return None, "Prowlarr not configured"
+        return [{"accepted": False, "rejected": "Wrong title", "filename": "x.mkv"}], None
+
+    monkeypatch.setattr(mod, "_search_one_source", fake_source)
+    cands, note = mod._default_search({"title": "X"}, "episode")
+    assert len(cands) == 1
+    assert "torrent skipped — Prowlarr not configured" in note
+
+    # empty soulseek result still carries the note
+    monkeypatch.setattr(mod, "_search_one_source",
+                        lambda src, item, mt: (None, "Prowlarr not configured")
+                        if src == "torrent" else ([], None))
+    cands2, note2 = mod._default_search({"title": "X"}, "episode")
+    assert cands2 == [] and "torrent skipped" in note2
+
+    # every source down -> didn't run at all
+    monkeypatch.setattr(mod, "_search_one_source",
+                        lambda src, item, mt: (None, "down"))
+    cands3, note3 = mod._default_search({"title": "X"}, "episode")
+    assert cands3 is None and "torrent skipped" in note3 and "soulseek skipped" in note3
+
+    # an accepted release means no note needed (the grab happened)
+    monkeypatch.setattr(mod, "_search_one_source",
+                        lambda src, item, mt: (None, "Prowlarr not configured")
+                        if src == "torrent" else ([{"accepted": True, "filename": "y.mkv"}], None))
+    cands4, note4 = mod._default_search({"title": "X"}, "episode")
+    assert cands4[0]["accepted"] and note4 is None

--- a/tests/test_video_process_wishlist.py
+++ b/tests/test_video_process_wishlist.py
@@ -86,7 +86,8 @@ def test_build_record_episode_shape():
     rec = build_download_record(item, best, [best], media_type="episode", target_dir="/tv", query="q")
     assert rec["kind"] == "episode" and rec["media_id"] == "9" and rec["year"] == "2008"
     assert json.loads(rec["search_ctx"]) == {"scope": "episode", "title": "Breaking Bad",
-                                             "season": 1, "episode": 3, "year": "2008"}
+                                             "season": 1, "episode": 3, "year": "2008",
+                                             "air_date": "2008-02-10"}
 
 
 # ── handler ───────────────────────────────────────────────────────────────────

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.0.1"
+_SOULSYNC_BASE_VERSION = "3.0.2"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/static/basic-search-v2.css
+++ b/webui/static/basic-search-v2.css
@@ -287,10 +287,15 @@
 }
 
 
-/* — Results area: glass surface for cards. */
+/* — Results area: glass surface for cards.
+ *   min-height matters: everything above (source tabs, search bar, status,
+ *   filters) is rigid, and the page is height-bound — on a short viewport
+ *   flex:1 collapsed this to a few px and the results were invisible until
+ *   the user zoomed OUT (#1024). The floor keeps results usable and lets the
+ *   page scroll instead when vertical space runs out. */
 .bs-results-wrap {
     flex: 1;
-    min-height: 0;
+    min-height: 280px;
     overflow-y: auto;
     padding: 4px 2px;
     display: flex;

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,15 +3404,16 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.0.1': [
-        { date: 'July 2026 — 3.0.1' },
-        { title: 'New: the entire video side (movies, tv & youtube)', desc: 'soulsync isn\'t just music anymore. a whole isolated video app: library scanning for plex/jellyfin, tmdb/tvdb/omdb enrichment plus 10 background backfill workers, a tv calendar, and a follow-to-wishlist-to-download pipeline for shows, actors, directors, studios, and youtube channels. its own database and dashboard, never touches the music side.' },
-        { title: 'Video: overlays & collections (kometa-style)', desc: 'an overlay studio that paints template overlays onto your plex/jellyfin posters, and a collection manager that builds plex collections / jellyfin boxsets from smart filters and ranked lists (imdb, tmdb, trakt, mdblist) in true rank order. both with nightly automations.' },
-        { title: 'New: Server Activity (tautulli-style)', desc: 'a live now-playing view for plex + jellyfin in a slide-out drawer: live streams over websocket, click one to open it inside soulsync, a history tab, a stats tab, and terminate-a-stream-with-a-message.', page: 'dashboard' },
-        { title: 'Smarter video downloads (Radarr/Sonarr-parity matching)', desc: 'the download search now checks the release TITLE, not just the year — so a search for "Paradox (2017)" can no longer grab "The Cloverfield Paradox (2018)". and it matches TMDB alternate/original-language titles too, so a release named by a known aka still gets found. wrong grabs out, missed grabs out.' },
-        { title: 'Faster nightly TV refresh', desc: 'the airing-schedule refresh only re-pulls the current season now instead of every season of every airing show every night — a big drop in api calls if you follow a lot of shows.' },
-        { title: 'Mobile docs nav fixed', desc: 'the help/docs sidebar was untappable on phones (a sticky header ate the tap area, and the scroll target was a no-op on the stacked mobile layout). fixed in both spots. thanks @bluejorts for the characterization tests that caught it.', page: 'help' },
-        { title: 'Earlier versions', desc: '2.8.9 fixed multi-disc downloads (#1009), sped up the Server Playlists page (#1005), and added a prefer-explicit-versions setting (#923). 2.8.8 stopped a tag write from corrupting FLAC audio (#1000) and added the Corrupt File Detector. 2.8.7 made discovery playlists first-class Auto-Sync items. 2.8.4 added Artist Web + Quality Profiles; 2.7.0 made multi-user real.' },
+    '3.0.2': [
+        { date: 'July 2026 — 3.0.2' },
+        { title: 'Video downloads: daily shows + smarter searching', desc: 'daily series match by air date now ("The Daily Show 2026.07.08" style releases), soulseek results parse their share paths the way the music matcher does, releases with no quality token get size-inferred quality, and the wishlist run log names any source that was skipped (like prowlarr not being configured) instead of silently degrading.' },
+        { title: 'Download history: TV + YouTube, and uploader blacklisting', desc: 'tv episode and youtube grabs now show in the download history modal (youtube gets its own tab), and you can blacklist an uploader straight from a completed download — searches, retries and requeries all skip them from then on.' },
+        { title: 'The whole video side works on your phone', desc: 'full mobile/tablet pass: dashboard, search, discover, library, watchlist, wishlist, downloads, calendar, detail pages, and both studios (overlay + collection). desktop unchanged.' },
+        { title: 'Library Reorganize actually moves files', desc: 'after a template change, reorganize reported every album as "already organized" and moved nothing — the keep-albums-together folder reuse was answering with the very folder you were moving out of. destinations now come from your current template alone. thanks TheHomeGuy for the report.' },
+        { title: 'Manual imports skip the quality profile (#1017)', desc: 'a file you hand-match on the import page is your call — the quality profile no longer vetoes it. acoustid, integrity and silence checks still run.' },
+        { title: 'Basic search results no longer vanish (#1024)', desc: 'the results area could get starved to zero height on short or zoomed-out windows. it has a real minimum height now.' },
+        { title: 'Canonical version findings apply now (#1022)', desc: 'the album version repair job could flag canonical-version mismatches but the apply button did nothing (the fix handler was missing). thanks @sam-coodu.' },
+        { title: 'Earlier versions', desc: '3.0.1 shipped the entire video side (movies, tv & youtube): library scanning, enrichment, a tv calendar, kometa-style overlays & collections, Server Activity (tautulli-style), and radarr/sonarr-parity download matching. before that: 2.8.9 fixed multi-disc downloads (#1009), 2.8.8 stopped a tag write from corrupting FLAC audio (#1000), 2.8.4 added Artist Web + Quality Profiles, and 2.7.0 made multi-user real.' },
     ],
 };
 
@@ -3443,7 +3444,19 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.0.1 — soulsync does video now",
+        title: "3.0.2 — the follow-up polish release",
+        description: "video downloading gets sonarr-parity round 2, the entire video side goes mobile, and three music-side bugs are dead (library reorganize works again).",
+        features: [
+            "smarter video searching: daily shows match by air date ('The Daily Show 2026.07.08' style releases), soulseek results parse their share paths the way the music matcher does, releases with no quality token get size-inferred quality, and the wishlist run log now names any source that was skipped (like prowlarr not being configured) instead of silently degrading",
+            "download history now tracks tv episodes and youtube grabs (youtube gets its own tab), and you can blacklist an uploader straight from a completed download — searches, retries and requeries all skip them from then on",
+            "the entire video side is responsive: dashboard, search, discover, library, watchlist, wishlist, downloads, calendar, detail pages, and both studios (overlay + collection) work on phones and tablets. desktop unchanged",
+            "library reorganize actually reorganizes: after a template change it reported every album as 'already organized' — the keep-albums-together folder reuse was answering with the very folder you were moving out of. destinations now come from your current template alone. thanks TheHomeGuy for the report",
+            "manual imports skip the quality profile (#1017): a hand-matched file is your call — acoustid, integrity and silence checks still run, but the profile no longer vetoes it",
+            "basic search results no longer vanish on short or zoomed-out windows (#1024), and canonical-version repair findings can actually be applied now (#1022, thanks @sam-coodu)",
+        ],
+    },
+    {
+        title: "Earlier in 3.0.1 — soulsync does video now",
         description: "the big one: a whole video side (movies, tv, youtube) plus a tautulli-style live server activity view, with Radarr/Sonarr-parity download matching.",
         features: [
             "the video side is a fully isolated app (its own database, dashboard, search, calendar and download pipeline) for plex and jellyfin that never touches the music side. library scanning, tmdb/tvdb/omdb enrichment plus 10 backfill workers, source-agnostic movie/show/person/studio detail pages, and a progressive netflix-feel search",

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -3178,6 +3178,22 @@
         font-size: 16px;
     }
 
+    /* Server Activity button — match the bell/helper row (it kept its desktop
+       44px @ bottom 24 / right 136, so it floated bigger and higher than the
+       other two on phones). Same size, same baseline, next slot leftward. */
+    .activity-float-btn {
+        bottom: 16px;
+        right: 108px;
+        width: 38px;
+        height: 38px;
+    }
+
+    .activity-float-badge {
+        font-size: 9px;
+        min-width: 14px;
+        height: 14px;
+    }
+
     /* Global search bar */
     .gsearch-bar {
         width: calc(100vw - 160px);
@@ -3231,6 +3247,13 @@
     .helper-float-btn {
         bottom: 12px;
         right: 10px;
+        width: 34px;
+        height: 34px;
+    }
+
+    .activity-float-btn {
+        bottom: 12px;
+        right: 96px;
         width: 34px;
         height: 34px;
     }

--- a/webui/static/mobile.css
+++ b/webui/static/mobile.css
@@ -1859,8 +1859,11 @@
 
     /* Global touch targets - only standalone/action buttons, not inline.
        Round icon buttons (fixed-size circles) are excluded so the min-height
-       can't stretch them into vertical ellipses. */
-    button:not(.watchlist-card-remove):not(.wishlist-delete-btn):not(.wishlist-delete-album-btn):not(.wishlist-delete-btn-small):not(.wishlist-back-btn):not(.alphabet-btn):not(.filter-btn):not(.playlist-modal-close):not(.notif-bell-btn):not(.helper-float-btn):not(.hero-indicator):not(.discover-blacklist-btn):not(.tool-help-button):not([data-import-page-result-row]):not([data-import-page-inline-action]) {
+       can't stretch them into vertical ellipses. The video dashboard's Studios
+       halves (.vst-half) are excluded because this chain's specificity beats
+       their own min-height: 208px — their content is absolutely positioned, so
+       "winning" here collapses each half to a 38px sliver on phones. */
+    button:not(.watchlist-card-remove):not(.wishlist-delete-btn):not(.wishlist-delete-album-btn):not(.wishlist-delete-btn-small):not(.wishlist-back-btn):not(.alphabet-btn):not(.filter-btn):not(.playlist-modal-close):not(.notif-bell-btn):not(.helper-float-btn):not(.hero-indicator):not(.discover-blacklist-btn):not(.tool-help-button):not(.vst-half):not([data-import-page-result-row]):not([data-import-page-inline-action]) {
         min-height: 38px;
     }
 

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -71106,7 +71106,7 @@ body.app-locked > *:not(#launch-pin-overlay):not(#login-overlay):not(script):not
 .sact-empty-ic { font-size: 40px; margin-bottom: 12px; }
 .sact-empty-t { font-size: 15px; font-weight: 700; color: rgba(255,255,255,0.8); }
 .sact-empty-s { font-size: 12.5px; margin-top: 6px; color: rgba(255,255,255,0.45); line-height: 1.5; }
-@media (max-width: 560px) { .sact-drawer { width: 100vw; } .activity-float-btn { right: 136px; } }
+@media (max-width: 560px) { .sact-drawer { width: 100vw; } }
 @media (prefers-reduced-motion: reduce) { .activity-float-btn.activity-live, .sact-live-dot, .sact-st-buffering .sact-prog-fill { animation: none; } }
 
 /* Server Activity — tabs + history rows (Phase 2) */

--- a/webui/static/video/video-collection-editor.css
+++ b/webui/static/video/video-collection-editor.css
@@ -646,3 +646,26 @@ textarea.vce-input { resize: vertical; min-height: 58px; }
 
 /* Admin-only launcher (parity with the overlay studio card). */
 body:not(.video-admin) [data-video-collection-studio] { display: none !important; }
+
+/* ── Mobile / tablet (<=768px): make the Studio usable on phones ───────────
+   The fixed 60px topbar couldn't hold brand + section nav + actions + close
+   on a phone — the pieces overlapped and the action cluster (Sync all / New
+   collection / close) was pushed clean off-screen. Wrap it into rows: brand +
+   actions/close first, the section nav on its own full-width scrollable row.
+   The page body (stats, gallery, editor panels) already stacked fine.
+   Desktop (>768px) untouched. */
+@media (max-width: 768px) {
+    .vce-topbar { flex-wrap: wrap; height: auto; padding: 8px 12px 0; row-gap: 0; gap: 10px; }
+    .vce-brand { order: 1; }
+    .vce-top-spacer { order: 2; }
+    .vce-top-actions { order: 3; }
+    .vce-x { order: 4; }
+    .vce-nav {
+        order: 5; flex: 1 1 100%; margin-left: 0; align-self: auto;
+        overflow-x: auto; scrollbar-width: none; height: 44px;
+    }
+    .vce-nav::-webkit-scrollbar { display: none; }
+    .vce-page { padding: 18px 14px 70px; }
+    .vce-stat { padding: 12px 16px; }
+    .vce-gallery { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 12px; }
+}

--- a/webui/static/video/video-overlay-editor.css
+++ b/webui/static/video/video-overlay-editor.css
@@ -697,3 +697,34 @@ select.voe-input option { background: #17171d; }
 .voe-grid-grouphead i { font-style: normal; font-weight: 600; text-transform: none;
     letter-spacing: 0; color: rgba(255,255,255,.35); font-size: 11.5px; }
 .voe-card--wide .voe-card-canvas { aspect-ratio: 16 / 9; }
+
+/* ── Mobile / tablet (<=768px): the editor was desktop-only ────────────────
+   The 3-pane editor row (236px palette | canvas | 268px inspector) left ~15px
+   of canvas on a phone, and the stage sized itself from HEIGHT (min(80vh) at
+   2:3 = ~400px wide on a 375px screen). Stack the panes into one scrolling
+   column — canvas first, tools next, layers/inspector last — and size the
+   stage from the viewport WIDTH instead. Desktop (>768px) untouched. */
+@media (max-width: 768px) {
+    .voe-topbar { flex-wrap: wrap; height: auto; padding: 10px 12px; gap: 8px; row-gap: 6px; }
+    .voe-name-input { min-width: 120px; flex: 1 1 140px; max-width: none; }
+
+    .voe-editor { flex-direction: column; overflow-y: auto; }
+    .voe-canvas-wrap { order: 1; flex: 0 0 auto; overflow: visible; padding: 16px 10px 22px; }
+    .voe-canvas-bar { flex-wrap: wrap; justify-content: center; }
+    .voe-stage { height: auto; width: min(86vw, 340px); }
+    .voe-stage--wide { width: 96%; }
+
+    .voe-palette {
+        order: 2; flex: 0 0 auto; overflow-y: visible;
+        border-right: 0; border-top: 1px solid rgba(255,255,255,.07);
+    }
+    .voe-pal-label { display: inline; }            /* room for labels again */
+
+    .voe-side {
+        order: 3; flex: 0 0 auto;
+        border-left: 0; border-top: 1px solid rgba(255,255,255,.07);
+    }
+
+    .voe-gallery-inner { padding: 30px 16px 48px; }
+    .voe-gallery-title { font-size: 24px; }
+}

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -1485,16 +1485,27 @@ a.vd-prov:hover img, a.vd-prov:hover .vd-prov-ph { border-color: rgba(var(--vd-a
 .vst-more-spinner { display: flex; justify-content: center; padding: 26px 0; }
 .vst-more-spinner[hidden] { display: none; }
 
-@media (max-width: 720px) {
-    .vsr-page, .vp-page, .vst-page { margin-left: -20px; margin-right: -20px; }
-    .vsr-hero { padding: 34px 22px 22px; }
-    .vsr-body, .vp-body, .vst-body { padding-left: 22px; padding-right: 22px; }
-    .vp-hero { flex-direction: column; align-items: center; text-align: center; padding: 104px 22px 24px; }
-    .vst-hero { flex-direction: column; align-items: center; text-align: center; padding: 104px 22px 24px; }
+@media (max-width: 768px) {
+    /* Bleed must MATCH mobile.css's .page side padding (16px at <=768, 12px at
+       <=480) — mobile.css flips at 768, so this block must too (at 721-768 the
+       base -40px bleed was overshooting the 16px padding by 24px per side). */
+    .vsr-page, .vp-page, .vst-page { margin-left: -16px; margin-right: -16px; }
+    .vsr-hero { padding: 34px 18px 22px; }
+    .vsr-body, .vp-body, .vst-body { padding-left: 18px; padding-right: 18px; }
+    .vp-hero { flex-direction: column; align-items: center; text-align: center; padding: 104px 18px 24px; }
+    .vst-hero { flex-direction: column; align-items: center; text-align: center; padding: 104px 18px 24px; }
     .vst-meta { justify-content: center; }
     .vp-meta { justify-content: center; }
     .vsr-grid { grid-template-columns: repeat(auto-fill, minmax(128px, 1fr)); gap: 16px 14px; }
     .vp-photo-wrap { width: 150px; height: 150px; }
+}
+@media (max-width: 480px) {
+    .vsr-page, .vp-page, .vst-page { margin-left: -12px; margin-right: -12px; }
+    .vsr-body, .vp-body, .vst-body { padding-left: 14px; padding-right: 14px; }
+    .vsr-hero { padding: 28px 14px 20px; }
+    .vsr-hero-title { font-size: 26px; }
+    .vsr-searchbar { height: 50px; border-radius: 13px; }
+    .vsr-grid { grid-template-columns: repeat(auto-fill, minmax(108px, 1fr)); gap: 14px 10px; }
 }
 
 /* ── billboard: Play CTA, crew line, next-episode, season overview ────────── */

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -817,10 +817,25 @@ body[data-side="video"] .dashboard-header-sweep {
 .vd-ep--missing .vd-ep-index, .vd-ep--missing .vd-ep-title { opacity: 0.7; }
 
 @media (max-width: 820px) {
-    .vd-bb-content { padding-left: 24px; }
+    .vd-bb-content { padding-left: 24px; padding-right: 24px; }
     .vd-body { padding: 24px 22px 60px; }
     .vd-ep { grid-template-columns: 36px 1fr auto; }
     .vd-ep-thumb { display: none; }
+}
+/* The detail page full-bleeds with -40px margins over the .page padding — but
+   mobile.css shrinks that padding to 16px (<=768) / 12px (<=480), so the fixed
+   -40 overhung the viewport by up to 28px per side (billboard, title, actions
+   all clipped at the right edge). Match the bleed to the real padding. */
+@media (max-width: 768px) {
+    .vd-page { margin-left: -16px; margin-right: -16px; }
+}
+@media (max-width: 480px) {
+    .vd-page { margin-left: -12px; margin-right: -12px; }
+    .vd-bb-content { padding-left: 16px; padding-right: 16px; padding-bottom: 34px; }
+    .vd-billboard { min-height: 62vh; }
+    /* Episode rows: the nowrap runtime chip beside the title squeezed titles
+       into one-word-per-line columns — let the top line wrap instead. */
+    .vd-ep-top { flex-wrap: wrap; row-gap: 2px; }
 }
 
 .video-card--clickable { cursor: pointer; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -2418,6 +2418,13 @@ body:not(.video-admin) .vst-combo-panels { grid-template-columns: 1fr; }
     .vwlp-head, .vwlp-body { padding-left: 18px; padding-right: 18px; }
     .vwlp-grid { grid-template-columns: repeat(auto-fill, minmax(128px, 1fr)); gap: 18px 14px; }
 }
+@media (max-width: 640px) {
+    /* Four tabs (Shows/People/Studios/Channels + counts) don't fit one row on a
+       phone — the no-wrap row ran the Channels tab clean off-screen. */
+    .vwlp-tabs { flex-wrap: wrap; }
+    .vwlp-tab { padding: 8px 14px; font-size: 13px; }
+    .vwlp-title { font-size: 28px; }
+}
 
 /* Ensure the show poster box is a positioning context for its .vwl-btn
    (scoped to VIDEO cards so the shared music .library-artist-image is untouched). */

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -3113,6 +3113,11 @@ body:not(.video-admin) .vst-combo-panels { grid-template-columns: 1fr; }
 
 /* ── small screens ────────────────────────────────────────────────────────── */
 @media (max-width: 640px) {
+    /* The Ignore-List pill floats top-right over the page on desktop, where the
+       hero body hugs the bottom-left. On a phone the (shorter) hero's text can
+       reach the top row, so the pill sat ON the hero title — flow it above the
+       hero instead, still right-aligned. */
+    .vdsc-ignore-btn { position: static; display: flex; width: max-content; margin: 4px 0 10px auto; }
     .vdsc-browse { padding: 13px 13px 15px; margin-bottom: 22px; }
     .vdsc-browse-top { gap: 10px; }
     .vdsc-shelf { margin-bottom: 24px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -98,6 +98,56 @@ body:not(.video-admin) [data-video-overlay-studio] { display: none !important; }
 .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="upcoming"] { order: 5; grid-column: span 2; }
 .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="stats"] { order: 6; }
 
+/* ── Dashboard responsive (tablet + phone) ──────────────────────────────────
+   The shared .dash-grid (style.css) collapses 3→2 cols at 1499px and →1 col at
+   699px, but its mobile reset only covers the music helper classes
+   (.dash-card--wide/--full) — NOT the raw span-2 rules above. Without the reset
+   below, the three spanning cards force an IMPLICIT second column into the
+   1-col phone grid (double-width cards, sideways page scroll). */
+@media (max-width: 1499px) and (min-width: 700px) {
+    /* 2-col tablet range: Stats is the last card and sat alone at half width —
+       let it finish the grid full-width (its six stat tiles flow 3-up there). */
+    .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="stats"] { grid-column: span 2; }
+}
+@media (max-width: 699px) {
+    .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="recent"],
+    .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="studios"],
+    .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="upcoming"],
+    .video-subpage[data-video-subpage="video-dashboard"] .dash-card[data-card="stats"] { grid-column: auto; }
+    /* The studios "Metadata ready" rings wrap under the title on phones —
+       left-align the wrapped row so it reads cleanly. */
+    .vcov { align-items: flex-start; }
+}
+
+/* Phone enrichment strip — worker orbs are disabled ≤768px (video-worker-orbs.js)
+   so the 13 accent buttons + the Manage Workers pill render as real elements.
+   Mirror music's treatment (style.css scopes it to #dashboard-page, which never
+   reaches this subpage): an even auto-fit grid of the 46px buttons, with the
+   pill on its own full-width row instead of dangling inline. */
+@media (max-width: 768px) {
+    .video-subpage[data-video-subpage="video-dashboard"] .header-actions {
+        width: 100%;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(46px, 1fr));
+        justify-items: center;
+        align-items: center;
+        gap: 12px 10px;
+    }
+    .video-subpage[data-video-subpage="video-dashboard"] .header-actions .em-manage-btn {
+        grid-column: 1 / -1;
+        width: 100%;
+        margin-left: 0;
+        justify-content: center;
+    }
+}
+
+/* Touch devices get no hover — an enrichment tooltip would pop on tap and sit
+   stuck over the buttons. Music hides its worker tooltips at this width
+   (style.css @900px); same for the video workers. */
+@media (max-width: 900px) {
+    .video-enrich-tooltip { display: none !important; }
+}
+
 /* Dashboard "Recently Added" — a single full-width, horizontally-scrolling row. */
 .video-recent-grid { display: flex; align-items: flex-start; gap: 14px; overflow-x: auto; padding-bottom: 8px; scroll-snap-type: x proximity; }
 .video-recent-grid::-webkit-scrollbar { height: 6px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -4198,6 +4198,18 @@ body:not(.video-admin) .vst-combo-panels { grid-template-columns: 1fr; }
 /* ── Downloads page — reuses the music .adl-* layout; these are the video-only bits ── */
 .vdpg-wrap { padding: 4px 0 40px; }
 .adl-controls-right { display: flex; align-items: center; gap: 10px; }
+/* Phones: the video page adds History + Blocklist to the controls row, which
+   pushed Retry Failed / Clear Finished clean off-screen — wrap the row. And the
+   fixed-width status column starved the row title down to a few characters:
+   let the row wrap so art+title own the first line and status+actions drop to
+   a second line underneath. */
+@media (max-width: 520px) {
+    .vdpg-wrap .adl-controls-right { flex-wrap: wrap; }
+    .vdpg-card.adl-row { flex-wrap: wrap; }
+    .vdpg-card .adl-row-info { flex: 1 1 200px; }
+    .vdpg-card .adl-row-status { min-width: 0; text-align: left; }
+    .vdpg-card .vdpg-rowact { margin-left: auto; }
+}
 .vdpg-art { font-size: 22px; }                       /* emoji inside the .adl-row-art tile */
 .vdpg-art.vdpg-has-poster { background-size: cover; background-position: center; background-repeat: no-repeat; }
 .vdpg-rowact { flex-shrink: 0; display: flex; align-items: center; gap: 2px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -509,6 +509,13 @@ body[data-side="video"] .dashboard-header-sweep {
     justify-content: center;
     margin: 4px 0;
 }
+/* Phones: the centered no-wrap row (3 selects + Select) overflowed BOTH edges
+   — wrap it into a tidy 2-up grid instead. */
+@media (max-width: 640px) {
+    .video-library-filters { flex-wrap: wrap; gap: 8px; }
+    .video-library-filters .library-source-filter-select { flex: 1 1 calc(50% - 4px); min-width: 0; }
+    .video-library-filters .video-lib-select-btn { flex: 1 1 calc(50% - 4px); }
+}
 /* Resolution chip on a poster card (top-left, above the gradient overlay). */
 .library-artist-card .video-card-badge {
     position: absolute;


### PR DESCRIPTION
# soulsync 3.0.2: `dev` → `main`

follow-up release to 3.0: the video downloader gets sonarr-parity round 2 (daily shows, soulseek path parsing, no more silent source skips), the whole video side works on phones and tablets, and three long-standing music-side bugs are dead (library reorganize actually reorganizes now).

## video downloads: smarter searching, round 2

3.0.1 fixed wrong grabs. this round fixes missed grabs:

- **daily shows work now.** releases for daily series are named by air date ("The Daily Show 2026.07.08"), not SxxExx. the matcher now reads the date as episode identity and the retry ladder searches date forms too, so 90 day fiance and friends stop coming back "59 searched, grabbed 0"
- **soulseek results parse like soulseek, not like torrents.** soulseek returns share paths ("Show/Season 12/episode.mkv"), not scene names. we now parse the folder context path-aware, the same way the music matcher does, instead of expecting a scene-named file
- **size-inferred quality.** a release with no quality token in the name no longer scores as unknown; we infer resolution from file size (and ffprobe verifies after download)
- **no more silent degrade.** if a source in your chain didn't actually run (prowlarr not configured, soulseek down), the wishlist run log now says so instead of quietly searching half your sources

## video downloads: history + uploader blacklist

- tv episode and youtube grabs now show in the download history modal (they were invisible), and youtube gets its own tab
- you can blacklist an uploader straight from a completed download; searches, retries and requeries all skip them from then on

## the whole video side works on mobile + tablet

full responsive pass over dashboard, search, discover, library, watchlist, wishlist, downloads, calendar, detail pages, and both studios (overlay + collection). desktop unchanged. the server activity button also matches the bell/helper buttons on phones now.

## library reorganize actually reorganizes (discord report)

changing your file organization template then running reorganize (tools page job or the library page button) did nothing: every album came back "already organized." root cause: reorganize computes destinations through the shared path builder, and the builder's reuse-existing-album-folder feature (which keeps multi-batch downloads together) answered with the folder the album already lives in, the exact folder reorganize was trying to move it out of. reorganize contexts now disable folder reuse so destinations come from your current template alone. downloads keep the reuse behavior. thanks TheHomeGuy for the report

## manual imports skip the quality profile (#1017)

if you hand-match a file on the import page, you already decided you want that file; the quality profile no longer vetoes it ("rejected by quality filter"). acoustid, integrity and silence checks still run, so a mislabeled or corrupt file is still caught

## basic search results vanished on short windows (#1024)

the basic search results area is a flex column that could get starved to 0px tall on short or zoomed viewports, so results "disappeared." it has a real minimum height now

## canonical version findings can be applied (#1022)

the album version repair job could flag canonical-version mismatches but the apply button did nothing (the fix handler was missing). now it applies. thanks @sam-coodu
