### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 3.0.2)'
+        description: 'Version tag (e.g. 3.0.3)'
         required: true
-        default: '3.0.2'
+        default: '3.0.3'
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,13 @@ WORKDIR /app
 
 # Install runtime-only system dependencies (no gcc/build tools).
 # unzip is needed by the Deno installer below.
+# flac: the Corrupt File Detector's preferred decode test (`flac -t` also
+# verifies the STREAMINFO MD5 — catches damage that still decodes; #1000).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gosu \
     ffmpeg \
+    flac \
     libchromaprint-tools \
     unzip \
     && rm -rf /var/lib/apt/lists/*

--- a/api/video/enrichment.py
+++ b/api/video/enrichment.py
@@ -248,3 +248,68 @@ def register_routes(bp):
             service, body.get("kind", "movie"),
             scope=body.get("scope", "failed"), item_id=body.get("item_id"))
         return jsonify({"success": True, "reset": n})
+
+    # ── manual match editor (Manage panel "Matches" section) ──────────────────
+    # GET is open (metadata read, like the detail GET); the POSTs mutate the
+    # library and inherit the blueprint's admin gate on /api/video/enrichment.
+
+    @bp.route("/enrichment/matches/<kind>/<int:item_id>", methods=["GET"])
+    def video_item_matches(kind, item_id):
+        from . import get_video_db
+        try:
+            matches = get_video_db().item_matches(kind, item_id)
+            if matches is None:
+                return jsonify({"error": "unknown kind"}), 400
+            return jsonify({"matches": matches})
+        except Exception:
+            logger.exception("video item matches failed for %s %s", kind, item_id)
+            return jsonify({"error": "Failed to load matches"}), 500
+
+    @bp.route("/enrichment/matches/<kind>/<int:item_id>/search", methods=["POST"])
+    def video_match_search(kind, item_id):
+        """Candidate search for a manual re-match. {service, query} → results
+        straight from the service's own search endpoint (no scoring — the user
+        is the matcher here)."""
+        body = request.get_json(silent=True) or {}
+        service = (body.get("service") or "").strip().lower()
+        query = (body.get("query") or "").strip()
+        if service not in ("tmdb", "tvdb") or not query:
+            return jsonify({"error": "service (tmdb|tvdb) and query are required"}), 400
+        w = engine().workers.get(service)
+        client = getattr(w, "client", None)
+        if not client or not hasattr(client, "search_candidates"):
+            return jsonify({"error": "Service not configured"}), 503
+        try:
+            return jsonify({"results": client.search_candidates(kind, query)})
+        except Exception:
+            logger.exception("video match search failed (%s: %r)", service, query)
+            return jsonify({"error": "Search failed — try again"}), 502
+
+    @bp.route("/enrichment/matches/<kind>/<int:item_id>/apply", methods=["POST"])
+    def video_match_apply(kind, item_id):
+        """Re-point (or clear) one service's match. {service, external_id|null}.
+        The DB layer resets everything derived from the old match; the already-
+        running workers then re-enrich by the new id in the background."""
+        import re as _re
+        body = request.get_json(silent=True) or {}
+        service = (body.get("service") or "").strip().lower()
+        external_id = body.get("external_id")
+        if external_id is not None:
+            if service == "imdb":
+                external_id = str(external_id).strip()
+                if not _re.fullmatch(r"tt\d{5,10}", external_id):
+                    return jsonify({"error": "IMDb id must look like tt0944947"}), 400
+            else:
+                try:
+                    external_id = int(external_id)
+                except (TypeError, ValueError):
+                    return jsonify({"error": "external_id must be numeric"}), 400
+        from . import get_video_db
+        try:
+            ok = get_video_db().rematch_item(kind, item_id, service, external_id)
+            if not ok:
+                return jsonify({"success": False, "error": "Unknown item or service"}), 400
+            return jsonify({"success": True})
+        except Exception:
+            logger.exception("video match apply failed for %s %s (%s)", kind, item_id, service)
+            return jsonify({"success": False, "error": "Failed to update the match"}), 500

--- a/core/automation_engine.py
+++ b/core/automation_engine.py
@@ -432,6 +432,56 @@ class AutomationEngine:
             'monthly_time': self._setup_monthly_time_trigger,
         }
 
+    # --- Global per-side pause (the Automations pages' master toggles) ---
+    # One switch per side. It does NOT touch individual automations' enabled
+    # flags — those stay exactly as the user set them — it just gates whether
+    # anything RUNS: scheduled slots are skipped (schedule stays alive) and
+    # event triggers are dropped while the side is paused. Manual "Run now"
+    # still executes — an explicit click outranks the pause.
+
+    # Stored in the engine DB's `metadata` KV (music_library.db — the same DB
+    # the automations themselves live in), NOT config.json.
+    MASTER_KEYS = {'music': 'automation_master_music_enabled',
+                   'video': 'automation_master_video_enabled'}
+    # Video ships paused: most installs predate the video side and only asked
+    # for music automation. Music keeps its historic always-on behaviour.
+    MASTER_DEFAULTS = {'music': True, 'video': False}
+
+    @staticmethod
+    def automation_side(auto) -> str:
+        """Which side an automation belongs to — 'video' when the system row is
+        video-owned or a custom automation uses a video trigger/action."""
+        auto = auto or {}
+        if auto.get('owned_by') == 'video':
+            return 'video'
+        if str(auto.get('action_type') or '').startswith('video_'):
+            return 'video'
+        if str(auto.get('trigger_type') or '').startswith('video_'):
+            return 'video'
+        return 'music'
+
+    def master_enabled(self, side: str) -> bool:
+        """Live DB read — flipping the toggle applies to the very next run.
+        An absent/unreadable key means the side's shipped default."""
+        key = self.MASTER_KEYS.get(side)
+        if not key:
+            return True
+        try:
+            raw = self.db.get_metadata(key)
+        except Exception:
+            raw = None
+        if raw is None or str(raw).strip() == '':
+            return self.MASTER_DEFAULTS.get(side, True)
+        return str(raw).strip().lower() in ('1', 'true', 'yes', 'on')
+
+    def set_master_enabled(self, side: str, enabled: bool) -> bool:
+        """Persist one side's master state to the engine DB. False on bad side."""
+        key = self.MASTER_KEYS.get(side)
+        if not key:
+            return False
+        self.db.set_metadata(key, '1' if enabled else '0')
+        return True
+
     # --- Action Handler Registration ---
 
     def register_action_handler(self, action_type, handler_fn, guard_fn=None):
@@ -743,7 +793,10 @@ class AutomationEngine:
             for aid in self._event_automations.get(event_type, []):
                 auto = self.db.get_automation(aid)
                 if auto and auto.get('enabled') and auto.get('action_type') == action_type:
-                    return True
+                    # Direct-effect callers honor the per-side master pause too —
+                    # otherwise a paused side's effects would still fire through
+                    # the code paths that never route via _run_event_automation.
+                    return self.master_enabled(self.automation_side(auto))
             return False
         except Exception as e:
             logger.debug(f"is_event_action_enabled({event_type}, {action_type}) failed: {e}")
@@ -858,6 +911,14 @@ class AutomationEngine:
 
     def _run_event_automation(self, auto, automation_id, event_data):
         """Execute action for an event-triggered automation."""
+        # Global per-side pause — event triggers are simply dropped while the
+        # side is paused (nothing to reschedule; the next event fires normally
+        # once the master is back on).
+        side = self.automation_side(auto)
+        if not self.master_enabled(side):
+            logger.info(f"Event automation '{auto.get('name')}' skipped — {side} automations are paused")
+            return
+
         action_type = auto.get('action_type')
 
         # Check for action delay
@@ -978,6 +1039,19 @@ class AutomationEngine:
         auto = self.db.get_automation(automation_id)
         if not auto or not auto.get('enabled'):
             return
+
+        # Global per-side pause: a scheduled slot is skipped but the schedule
+        # stays alive (_finish_run computes the next natural slot), so flipping
+        # the master back on resumes at the normal cadence — no restart, no
+        # burst of catch-up runs. Manual run_now (skip_delay=True) bypasses.
+        if not skip_delay:
+            side = self.automation_side(auto)
+            if not self.master_enabled(side):
+                logger.info(f"Automation '{auto.get('name')}' skipped — {side} automations are paused")
+                self._finish_run(auto, automation_id,
+                                 {'status': 'skipped', 'reason': f'{side} automations are paused'},
+                                 error=None)
+                return
 
         action_type = auto.get('action_type')
 

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -987,6 +987,14 @@ def _build_post_process_context(
         'is_album_download': True,
         'has_clean_spotify_data': True,
         'has_full_spotify_metadata': True,
+        # A reorganize processes the user's OWN library files, not slskd
+        # transfers — same as the Import page (#804). Skips the integrity
+        # check's duration-agreement leg: the re-resolved API tracklist can
+        # legitimately disagree with the user's copy (a different master /
+        # long version), and that mismatch was QUARANTINING a copy of a file
+        # that stayed happily in the library (TheHomeGuy: 'Through Glass'
+        # 283s vs Discogs' 241s). Size + parse corruption legs still run.
+        'is_local_import': True,
         # Reorganize destinations must come from the CURRENT template alone.
         # The #829 existing-folder reuse would resolve to the folder the album
         # already lives in — the very folder reorganize is trying to move it

--- a/core/repair_jobs/audio_corruption_detector.py
+++ b/core/repair_jobs/audio_corruption_detector.py
@@ -44,11 +44,22 @@ _CORRUPT_CHECK_EXTS = {'.flac'}
 _DECODE_TIMEOUT_S = 600
 
 
-def _resolve(file_path: str) -> Optional[str]:
-    """Resolve a stored library path to one this process can read, falling back
-    to the raw path when it's already a real file (mirrors replaygain_filler)."""
-    resolved = resolve_library_file_path(file_path) if file_path else None
-    if not resolved and file_path and os.path.isfile(file_path):
+def _resolve(file_path: str, context: JobContext) -> Optional[str]:
+    """Resolve a stored library path to one this process can read.
+
+    MUST pass the context's transfer folder + config_manager — a bare
+    ``resolve_library_file_path(path)`` has no base directories to suffix-walk,
+    so for Docker/NAS users (whose DB paths are the MEDIA SERVER's view) every
+    single file silently resolved to None and the whole scan was skips (#1000
+    follow-up: '6741 FLAC files decode-tested, 0 corrupt, 6741 skipped' in 0.1s)."""
+    if not file_path:
+        return None
+    resolved = resolve_library_file_path(
+        file_path,
+        transfer_folder=context.transfer_folder,
+        config_manager=context.config_manager,
+    )
+    if not resolved and os.path.isfile(file_path):
         resolved = file_path
     return resolved
 
@@ -186,6 +197,9 @@ class AudioCorruptionDetectorJob(RepairJob):
         if context.report_progress:
             context.report_progress(phase=f'Decode-testing {total} FLAC files...', total=total)
 
+        tested = 0
+        unresolved = 0
+        outside_window = 0
         for i, row in enumerate(rows):
             if context.check_stop():
                 return result
@@ -195,9 +209,10 @@ class AudioCorruptionDetectorJob(RepairJob):
             result.scanned += 1
             title = row['title'] or 'Unknown'
             artist = row['artist_name'] or 'Unknown'
-            resolved = _resolve(row['file_path'])
+            resolved = _resolve(row['file_path'], context)
 
             if not resolved:
+                unresolved += 1
                 result.skipped += 1
                 continue
 
@@ -205,6 +220,7 @@ class AudioCorruptionDetectorJob(RepairJob):
             if cutoff_mtime is not None:
                 try:
                     if os.path.getmtime(resolved) < cutoff_mtime:
+                        outside_window += 1
                         result.skipped += 1
                         continue
                 except OSError:
@@ -217,6 +233,7 @@ class AudioCorruptionDetectorJob(RepairJob):
                     phase=f'Decode-testing {i + 1}/{total}...',
                     log_line=f'{artist} — {title}', log_type='info')
 
+            tested += 1
             try:
                 ok, reason = check_flac_integrity(resolved)
             except Exception as e:
@@ -272,8 +289,23 @@ class AudioCorruptionDetectorJob(RepairJob):
 
         if context.update_progress:
             context.update_progress(total, total)
-        logger.info("[Corrupt File Detector] %d FLAC files decode-tested, %d corrupt, %d skipped",
-                    result.scanned, result.findings_created, result.skipped)
+        # An honest summary: 'decode-tested' means DECODED, not merely seen —
+        # the old line reported every skip as tested, which hid the path-
+        # resolution failure completely ('6741 decode-tested ... in 0.1s').
+        logger.info(
+            "[Corrupt File Detector] %d of %d FLAC files decode-tested, %d corrupt, "
+            "%d path-unresolved, %d outside the modified window",
+            tested, total, result.findings_created, unresolved, outside_window)
+        if total and unresolved == total:
+            # Every single path failed to resolve — that's a mapping problem,
+            # not a healthy library. Say so where the user is looking.
+            msg = ("No library paths could be resolved to readable files — the DB "
+                   "stores your media server's paths. Check Settings → Library → "
+                   "Music Paths (or your Docker mounts) so SoulSync can reach them.")
+            logger.warning("[Corrupt File Detector] %s", msg)
+            if context.report_progress:
+                context.report_progress(phase='No library paths resolved',
+                                        log_line=msg, log_type='error')
         return result
 
     def estimate_scope(self, context: JobContext) -> int:

--- a/core/repair_jobs/replaygain_filler.py
+++ b/core/repair_jobs/replaygain_filler.py
@@ -41,11 +41,22 @@ def needs_replaygain(rg_tags: Optional[Dict[str, Any]]) -> bool:
     return val is None or str(val).strip() == ''
 
 
-def _resolve(file_path: str) -> Optional[str]:
-    """Resolve a stored library path to one this process can read (Docker/host
-    prefix mapping), falling back to the raw path if it's already a real file."""
-    resolved = resolve_library_file_path(file_path) if file_path else None
-    if not resolved and file_path and os.path.isfile(file_path):
+def _resolve(file_path: str, context: JobContext) -> Optional[str]:
+    """Resolve a stored library path to one this process can read.
+
+    MUST pass the context's transfer folder + config_manager — a bare
+    ``resolve_library_file_path(path)`` has no base directories to suffix-walk,
+    so for Docker/NAS users (whose DB paths are the MEDIA SERVER's view) every
+    file silently resolved to None and the scan skipped the whole library
+    (the same hole the Corrupt File Detector shipped with; #1000 follow-up)."""
+    if not file_path:
+        return None
+    resolved = resolve_library_file_path(
+        file_path,
+        transfer_folder=context.transfer_folder,
+        config_manager=context.config_manager,
+    )
+    if not resolved and os.path.isfile(file_path):
         resolved = file_path
     return resolved
 
@@ -119,7 +130,7 @@ class ReplayGainFillerJob(RepairJob):
             track_id, title, artist_name, file_path = row[:4]
             result.scanned += 1
 
-            resolved = _resolve(file_path)
+            resolved = _resolve(file_path, context)
             if not resolved:
                 # Can't read the file from here → can't analyze it on apply either.
                 result.skipped += 1

--- a/core/sync/match_overrides.py
+++ b/core/sync/match_overrides.py
@@ -44,9 +44,15 @@ def resolve_match_overrides(
         - cache_lookup returns a server_track_id
         - that server_track_id exists in server_tracks (no stale cache
           entries pointing at deleted tracks)
-        - the server_track hasn't already been claimed by an earlier
-          override (defensive — UNIQUE on the cache table prevents this
-          in practice)
+
+    TWO source rows MAY share one server track. The cache's UNIQUE
+    constraint is per (source_track_id, server_source) — it stops one
+    source having two servers, NOT two sources (a playlist carrying the
+    same song twice under different provider ids, both hand-matched to
+    the user's single library copy) sharing one server track. The old
+    first-wins rule silently dropped the second pairing, so that row
+    stayed "missing" forever no matter how many times the user re-ran
+    Find & Add (wolf39us). Both pairings are user-confirmed — honor both.
 
     Caller uses the returned dict to short-circuit the per-source
     matching loop: indices in the dict skip the exact/fuzzy passes.
@@ -63,7 +69,6 @@ def resolve_match_overrides(
                 server_id_to_idx[key] = j
 
     overrides: Dict[int, int] = {}
-    used_server: set[int] = set()
 
     for i, src in enumerate(source_tracks):
         if not isinstance(src, dict):
@@ -78,10 +83,9 @@ def resolve_match_overrides(
         if not cached_server_id:
             continue
         j = server_id_to_idx.get(str(cached_server_id))
-        if j is None or j in used_server:
+        if j is None:
             continue
         overrides[i] = j
-        used_server.add(j)
 
     return overrides
 
@@ -227,6 +231,16 @@ def build_bulk_override_lookup(
             if new_id and str(new_id) in valid_server_ids:
                 _self_heal_match_id(db, match, str(new_id))
                 return str(new_id)
+        # Every path exhausted — the user's confirmed match CANNOT apply. Say
+        # exactly why, or this renders as a bare "missing" row and looks like
+        # the match was never saved (the wolf39us report shape).
+        logger.warning(
+            "Manual match for source %s (%s) cannot apply: library track %s is not "
+            "in this playlist and the file-path fallback %s. The track likely needs "
+            "re-adding to the playlist (Find & Add), or the library row was re-keyed.",
+            sid, server_source, lib_id,
+            ("resolved nothing for %r" % (file_path,)) if file_path else "is empty (no stored path)",
+        )
         return None
 
     return _lookup
@@ -280,6 +294,13 @@ def resolve_durable_match_server_id(
         if new_id and str(new_id) in valid_server_ids:
             _self_heal_match_id(db, match, str(new_id))
             return str(new_id)
+    logger.warning(
+        "Manual match for source %s (%s) cannot apply: library track %s is not "
+        "in this playlist and the file-path fallback %s. The track likely needs "
+        "re-adding to the playlist (Find & Add), or the library row was re-keyed.",
+        source_track_id, server_source, lib_id,
+        ("resolved nothing for %r" % (file_path,)) if file_path else "is empty (no stored path)",
+    )
     return None
 
 

--- a/core/video/enrichment/clients.py
+++ b/core/video/enrichment/clients.py
@@ -151,6 +151,32 @@ class TMDBClient:
     PROFILE = "https://image.tmdb.org/t/p/w185"
     LOGO = "https://image.tmdb.org/t/p/w500"
 
+    def search_candidates(self, kind, query, limit=8):
+        """Title-search candidates for the Manage panel's match editor —
+        id/title/year/overview/poster only, no detail fetch. Raises on a failed
+        call (429/5xx) so the route reports an error instead of 'no results'."""
+        if not self.api_key or not (query or "").strip():
+            return []
+        import requests
+        path = "/search/movie" if kind == "movie" else "/search/tv"
+        r = requests.get(self.BASE + path,
+                         params={"api_key": self.api_key, "query": query.strip()}, timeout=15)
+        r.raise_for_status()
+        out = []
+        for it in ((r.json() or {}).get("results") or [])[:limit]:
+            if it.get("id") is None:
+                continue
+            date = it.get("release_date") if kind == "movie" else it.get("first_air_date")
+            year = None
+            if date and str(date)[:4].isdigit():
+                year = int(str(date)[:4])
+            out.append({"id": it["id"],
+                        "title": it.get("title") or it.get("name") or "",
+                        "year": year,
+                        "overview": it.get("overview") or "",
+                        "poster_url": (self.POSTER_W + it["poster_path"]) if it.get("poster_path") else None})
+        return out
+
     @staticmethod
     def _pick_logo(logos):
         """Prefer an English title logo, then a language-neutral one, then any."""
@@ -1093,6 +1119,25 @@ class TVDBClient:
         if tvdb_id is None:
             return None
         return {"id": tvdb_id, "metadata": {k: v for k, v in meta.items() if v}}
+
+    def search_candidates(self, kind, query, limit=8):
+        """Series-search candidates for the Manage panel's match editor. TVDB v4
+        search ids can be 'series-123' strings — normalized to the bare int."""
+        if kind != "show" or not self.api_key or not (query or "").strip():
+            return []
+        r = self._authed_get("/search", {"query": query.strip(), "type": "series"})
+        out = []
+        for it in ((r or {}).get("data") or [])[:limit]:
+            tid = _int(it.get("tvdb_id") or it.get("id"))
+            if tid is None:
+                raw = str(it.get("id") or "")
+                tid = _int(raw.rsplit("-", 1)[-1]) if "-" in raw else None
+            if tid is None:
+                continue
+            out.append({"id": tid, "title": it.get("name") or "", "year": _int(it.get("year")),
+                        "overview": it.get("overview") or "",
+                        "poster_url": it.get("image_url") or None})
+        return out
 
     def season_episodes(self, series_id, season_number):
         """A TVDB series+season's episodes (v4) → [{episode_number, title, overview, air_date,

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -1347,6 +1347,150 @@ class VideoDatabase:
         finally:
             conn.close()
 
+    # ── manual match editor (Manage panel "Matches" section) ──────────────────
+    # Services a user can re-point per kind. tmdb/tvdb have real matchers (the
+    # enrichment workers re-enrich BY the new id); imdb is a plain id the ratings
+    # + several backfills key off.
+    _MATCH_SERVICES = {"movie": ("tmdb", "imdb"), "show": ("tmdb", "tvdb", "imdb")}
+
+    # Textual metadata the old (wrong) match may have gap-filled — cleared on a
+    # re-match (unlocked fields only) so the fresh enrichment can land; gap-fill
+    # never overwrites, so leaving them would keep the wrong show's data. Art
+    # columns (poster/backdrop/logo/…) are deliberately NOT cleared: they may be
+    # server-provided or user-picked (Poster Manager), and wrong art is fixable
+    # there without data loss.
+    _REMATCH_CLEAR_COLS = {
+        "overview", "tagline", "status", "rating", "rating_critic", "content_rating",
+        "network", "studio", "first_air_date", "last_air_date", "airs_time",
+        "release_date", "runtime_minutes", "tmdb_collection_id", "tmdb_collection_name",
+        "trakt_rating", "trakt_votes", "tvmaze_rating", "anilist_score",
+        "wikidata_url", "streaming", "mediastinger", "awards", "subtitle_langs",
+    }
+
+    def item_matches(self, kind: str, item_id: int) -> list | None:
+        """Per-service match state for one movie/show — feeds the Manage panel's
+        Matches section. None for an unknown kind, [] for a missing row."""
+        tbl = self._DETAIL_TBL.get(kind)
+        services = self._MATCH_SERVICES.get(kind)
+        if not tbl or not services:
+            return None
+        conn = self._get_connection()
+        try:
+            row = conn.execute(f"SELECT * FROM {tbl} WHERE id=?", (item_id,)).fetchone()
+            if not row:
+                return []
+            keys = row.keys()
+            out = []
+            for svc in services:
+                if svc == "imdb":
+                    imdb = row["imdb_id"] if "imdb_id" in keys else None
+                    out.append({"service": "imdb", "id": imdb,
+                                "status": "matched" if imdb else None, "attempted": None})
+                    continue
+                idc, sc, ac = f"{svc}_id", f"{svc}_match_status", f"{svc}_last_attempted"
+                out.append({"service": svc,
+                            "id": row[idc] if idc in keys else None,
+                            "status": row[sc] if sc in keys else None,
+                            "attempted": row[ac] if ac in keys else None})
+            return out
+        finally:
+            conn.close()
+
+    def rematch_item(self, kind: str, item_id: int, service: str, external_id) -> bool:
+        """Re-point one service's match to ``external_id`` (or clear it with None)
+        and reset everything DERIVED from the old match so the existing workers
+        re-enrich fresh, by the new id:
+
+        - the service's match_status goes back to NULL (pending) so
+          enrichment_next re-picks the item and enriches BY the new known id —
+          or to 'not_found' on a clear;
+        - textual metadata the old match gap-filled is cleared (unlocked fields
+          only — user edits stay theirs), because gap-fill never overwrites;
+        - details/episodes/ratings sync flags and every backfill service's
+          status reset, so the whole derived pipeline re-runs;
+        - enrichment-sourced credits are dropped (they were the wrong title's).
+
+        Mirrors the music side's "re-match clears the stored id + re-enriches"
+        contract (#868)."""
+        tbl = self._DETAIL_TBL.get(kind)
+        if not tbl or service not in self._MATCH_SERVICES.get(kind, ()):
+            return False
+        conn = self._get_connection()
+        try:
+            if not conn.execute(f"SELECT 1 FROM {tbl} WHERE id=?", (item_id,)).fetchone():
+                return False
+            cols = {r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()}
+            locked = self._locked_fields_set(conn, tbl, item_id)
+            sets, params = [], []
+
+            if service == "imdb":
+                # An imdb re-point only feeds the id-keyed pipeline (ratings +
+                # imdb-based backfills) — TMDB-sourced text stays untouched.
+                sets.append("imdb_id=?")
+                params.append(external_id)
+                if "ratings_synced" in cols:
+                    sets.append("ratings_synced=0")
+                for svc, svc_map in _BACKFILL.items():
+                    spec = svc_map.get(kind)
+                    if not spec or spec[0] != tbl or "imdb_id" not in spec[3]:
+                        continue
+                    for c in (spec[1], spec[2]):
+                        if c in cols:
+                            sets.append(f"{c}=NULL")
+                    for c in sorted(_BACKFILL_COLS.get(svc, set()) & cols - locked):
+                        sets.append(f"{c}=NULL")
+            elif service == "tvdb":
+                # TVDB owns the air time + the tvdb-keyed backfills (fanart,
+                # TVmaze); TMDB-sourced text is not its blast radius.
+                sets.append("tvdb_id=?")
+                params.append(external_id)
+                sets.append("tvdb_match_status=" +
+                            ("NULL" if external_id is not None else "'not_found'"))
+                sets.append("tvdb_last_attempted=NULL")
+                if "airs_time" in cols and "airs_time" not in locked:
+                    sets.append("airs_time=NULL")
+                for svc, svc_map in _BACKFILL.items():
+                    spec = svc_map.get(kind)
+                    if not spec or spec[0] != tbl or "tvdb_id" not in spec[3]:
+                        continue
+                    for c in (spec[1], spec[2]):
+                        if c in cols:
+                            sets.append(f"{c}=NULL")
+            else:   # tmdb — the identity match; the whole derived pipeline re-runs
+                sets.append("tmdb_id=?")
+                params.append(external_id)
+                sets.append("tmdb_match_status=" +
+                            ("NULL" if external_id is not None else "'not_found'"))
+                sets.append("tmdb_last_attempted=NULL")
+                # Clear what the old match derived (never a locked field, never art).
+                for col in sorted(self._REMATCH_CLEAR_COLS & cols - locked):
+                    sets.append(f"{col}=NULL")
+                # Re-run everything: detail backfill, episode cascade, OMDb
+                # ratings, and every id-keyed backfill service.
+                for flag in ("details_synced", "episodes_synced", "ratings_synced"):
+                    if flag in cols:
+                        sets.append(f"{flag}=0")
+                for svc_map in _BACKFILL.values():
+                    spec = svc_map.get(kind)
+                    if spec and spec[0] == tbl:
+                        if spec[1] in cols:
+                            sets.append(f"{spec[1]}=NULL")
+                        if spec[2] in cols:
+                            sets.append(f"{spec[2]}=NULL")
+
+            params.append(item_id)
+            conn.execute(f"UPDATE {tbl} SET {', '.join(sets)} WHERE id=?", params)
+            # Credits came from the old TMDB match (gap-filled only-when-empty, so
+            # they'd never self-correct). Dropping them lets the fresh enrichment
+            # refill from the right title. TVDB/imdb don't source credits.
+            if service == "tmdb":
+                oc = "movie_id" if tbl == "movies" else "show_id"
+                conn.execute(f"DELETE FROM credits WHERE {oc}=?", (item_id,))
+            conn.commit()
+            return True
+        finally:
+            conn.close()
+
     def _ratings_breakdown(self) -> dict:
         """OMDb 'coverage' breakdown: matched = ratings present, pending = has an
         imdb_id but not fetched, not_found = fetched but OMDb had no rating."""

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -43,7 +43,7 @@ def _publish_video_event(event_type: str, data: dict) -> None:
 
 # Bump when video_schema.sql changes in a way worth recording. Stored in
 # PRAGMA user_version as a backstop indicator (nothing gates on it yet).
-SCHEMA_VERSION = 40   # v40: video_watchlist.lookback_years (per-person back-catalog window); v39: video_wishlist.release_date; v38: episodes.added_at
+SCHEMA_VERSION = 41   # v41: one-time details_synced heal (status-less burn victims); v40: video_watchlist.lookback_years; v39: video_wishlist.release_date
 
 _DEFAULT_DB_PATH = "database/video_library.db"
 _SCHEMA_FILE = Path(__file__).resolve().parent / "video_schema.sql"
@@ -379,10 +379,12 @@ class VideoDatabase:
         schema = _SCHEMA_FILE.read_text(encoding="utf-8")
         conn = self._get_connection()
         try:
+            prev_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
             conn.executescript(schema)
             self._ensure_columns(conn)
             self._ensure_indexes(conn)
             self._seed_named_links_from_scalar(conn)
+            self._run_data_migrations(conn, prev_version)
             conn.execute(f"PRAGMA user_version = {int(SCHEMA_VERSION)}")
             conn.commit()
             logger.info(
@@ -425,6 +427,26 @@ class VideoDatabase:
             cols = {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
             if col not in cols:
                 conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {coltype}")
+
+    @staticmethod
+    def _run_data_migrations(conn, prev_version: int) -> None:
+        """One-time data fixes, gated on the PRAGMA user_version the DB carried
+        BEFORE this boot (fresh DBs start at 0 with empty tables, so every step
+        is a no-op there)."""
+        if prev_version < 41:
+            # v41 heal: the details backfill used to swallow failed TMDB calls
+            # (429/5xx/timeout) into empty metadata and still mark
+            # details_synced=1 — permanently, since the queue only picks
+            # details_synced=0. Those burn victims sit matched-but-status-less
+            # forever: no watchlist button (unknown status reads as ended), no
+            # airing refresh, no calendar. The call-failure propagation is fixed
+            # (clients.py raises now); this re-queues the already-burned rows for
+            # one fresh attempt. Genuine TMDB 404s just settle back to synced.
+            for tbl in ("shows", "movies"):
+                conn.execute(
+                    f"UPDATE {tbl} SET details_synced=0 "
+                    f"WHERE tmdb_id IS NOT NULL AND details_synced=1 "
+                    f"AND (status IS NULL OR TRIM(status) = '')")
 
     # ── enrichment plumbing (per-source match status, like music) ─────────────
     def enrichment_next(self, service: str, retry_days: int = 30, priority=None) -> dict | None:

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -1449,7 +1449,7 @@ class VideoDatabase:
                 sets.append("tvdb_last_attempted=NULL")
                 if "airs_time" in cols and "airs_time" not in locked:
                     sets.append("airs_time=NULL")
-                for svc, svc_map in _BACKFILL.items():
+                for svc_map in _BACKFILL.values():
                     spec = svc_map.get(kind)
                     if not spec or spec[0] != tbl or "tvdb_id" not in spec[3]:
                         continue

--- a/tests/automation/test_master_pause.py
+++ b/tests/automation/test_master_pause.py
@@ -1,0 +1,142 @@
+"""The per-side global automation pause (the Automations pages' master toggles).
+
+Contract: the master gates whether anything RUNS — individual enabled flags are
+never touched. Scheduled slots skip but stay scheduled (so un-pausing resumes at
+the normal cadence), event triggers are dropped, manual run_now still executes,
+and direct-effect callers (is_event_action_enabled) see a paused side as off.
+State lives in the engine DB's `metadata` KV (music_library.db), NEVER
+config.json. Sides: owned_by='video' or a video_* trigger/action → video;
+everything else → music. Defaults: music ON (historic behaviour), video OFF
+(most installs predate the video side).
+"""
+
+from unittest.mock import MagicMock
+
+from core.automation_engine import AutomationEngine
+
+
+def _engine(masters, auto):
+    """masters = {metadata_key: '1'/'0'} — the DB rows backing the toggles."""
+    db = MagicMock()
+    db.get_automation.return_value = auto
+    db.update_automation_run = MagicMock(return_value=True)
+    db.get_metadata.side_effect = lambda key: masters.get(key)
+    db.set_metadata.side_effect = lambda key, value: masters.__setitem__(key, value)
+    eng = AutomationEngine(db)
+    eng._running = True
+    eng.schedule_automation = MagicMock()   # no real timers in tests
+    calls = []
+    eng._action_handlers[auto['action_type']] = {
+        'handler': lambda config: calls.append(config) or {'status': 'completed'},
+        'guard': None,
+    }
+    return eng, db, calls
+
+
+_MUSIC_KEY = AutomationEngine.MASTER_KEYS['music']
+_VIDEO_KEY = AutomationEngine.MASTER_KEYS['video']
+
+_MUSIC_AUTO = {'id': 1, 'name': 'Auto-Sync', 'enabled': True,
+               'action_type': 'sync_playlist', 'action_config': '{}',
+               'trigger_type': 'schedule', 'trigger_config': '{"interval": 1}',
+               'profile_id': 1}
+_VIDEO_AUTO = {'id': 2, 'name': 'Process Video Wishlist', 'enabled': True,
+               'action_type': 'video_process_episode_wishlist', 'action_config': '{}',
+               'trigger_type': 'schedule', 'trigger_config': '{"interval": 1}',
+               'owned_by': 'video', 'profile_id': 1}
+
+
+# ── side classification + defaults ───────────────────────────────────────────
+
+def test_automation_side_classification():
+    side = AutomationEngine.automation_side
+    assert side(_VIDEO_AUTO) == 'video'                                   # owned_by
+    assert side({'action_type': 'video_scan_server'}) == 'video'          # action prefix
+    assert side({'trigger_type': 'video_batch_complete'}) == 'video'      # trigger prefix
+    assert side(_MUSIC_AUTO) == 'music'
+    assert side({}) == 'music'
+
+
+def test_master_defaults_music_on_video_off():
+    # No DB rows yet → the shipped defaults apply.
+    eng, _, _ = _engine({}, _MUSIC_AUTO)
+    assert eng.master_enabled('music') is True
+    assert eng.master_enabled('video') is False
+
+
+def test_master_state_round_trips_through_the_db():
+    masters = {}
+    eng, db, _ = _engine(masters, _MUSIC_AUTO)
+    assert eng.set_master_enabled('music', False) is True
+    assert masters[_MUSIC_KEY] == '0'              # persisted as a metadata row
+    assert eng.master_enabled('music') is False    # read back live
+    eng.set_master_enabled('video', True)
+    assert eng.master_enabled('video') is True
+    assert eng.set_master_enabled('weird', True) is False
+
+
+def test_db_error_falls_back_to_the_side_default():
+    eng, db, _ = _engine({}, _MUSIC_AUTO)
+    db.get_metadata.side_effect = RuntimeError('locked')
+    assert eng.master_enabled('music') is True
+    assert eng.master_enabled('video') is False
+
+
+# ── scheduled runs ───────────────────────────────────────────────────────────
+
+def test_paused_side_skips_scheduled_run_but_keeps_the_schedule():
+    eng, db, calls = _engine({_MUSIC_KEY: '0'}, _MUSIC_AUTO)
+    eng.run_automation(1, skip_delay=False)
+    assert calls == []                                    # action never ran
+    db.update_automation_run.assert_called_once()         # skip recorded…
+    eng.schedule_automation.assert_called_once_with(1)    # …and the schedule stays alive
+
+
+def test_enabled_side_runs_scheduled_normally():
+    eng, _, calls = _engine({_MUSIC_KEY: '1'}, _MUSIC_AUTO)
+    eng.run_automation(1, skip_delay=False)
+    assert len(calls) == 1
+
+
+def test_video_default_off_pauses_video_scheduled_runs():
+    # A fresh DB (no video row saved) must NOT run video automations.
+    eng, _, calls = _engine({}, _VIDEO_AUTO)
+    eng.run_automation(2, skip_delay=False)
+    assert calls == []
+
+
+def test_video_pause_does_not_touch_music():
+    eng, _, calls = _engine({_VIDEO_KEY: '0', _MUSIC_KEY: '1'}, _MUSIC_AUTO)
+    eng.run_automation(1, skip_delay=False)
+    assert len(calls) == 1
+
+
+def test_manual_run_now_bypasses_the_pause():
+    # An explicit click outranks the global pause.
+    eng, _, calls = _engine({_VIDEO_KEY: '0'}, _VIDEO_AUTO)
+    eng.run_automation(2, skip_delay=True)
+    assert len(calls) == 1
+
+
+# ── event triggers ───────────────────────────────────────────────────────────
+
+def test_paused_side_drops_event_automations():
+    eng, _, calls = _engine({_VIDEO_KEY: '0'}, _VIDEO_AUTO)
+    eng._run_event_automation(_VIDEO_AUTO, 2, {'some': 'event'})
+    assert calls == []
+
+
+def test_enabled_side_runs_event_automations():
+    eng, _, calls = _engine({_VIDEO_KEY: '1'}, _VIDEO_AUTO)
+    eng._run_event_automation(_VIDEO_AUTO, 2, {'some': 'event'})
+    assert len(calls) == 1
+
+
+def test_is_event_action_enabled_honors_the_pause():
+    masters = {_MUSIC_KEY: '0'}
+    eng, db, _ = _engine(masters, dict(_MUSIC_AUTO, trigger_type='batch_complete'))
+    eng._event_automations = {'batch_complete': [1]}
+    eng._event_cache_dirty = False
+    assert eng.is_event_action_enabled('batch_complete', 'sync_playlist') is False
+    masters[_MUSIC_KEY] = '1'
+    assert eng.is_event_action_enabled('batch_complete', 'sync_playlist') is True

--- a/tests/repair_jobs/test_audio_corruption_detector.py
+++ b/tests/repair_jobs/test_audio_corruption_detector.py
@@ -123,7 +123,7 @@ def _prep(monkeypatch, verdicts):
     """Force a decoder to be 'available' and stub the decode test with a
     path→(ok, reason) mapping."""
     monkeypatch.setattr(mod, "_decoder_available", lambda: True)
-    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p: p)
+    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p, **kw: p)
     monkeypatch.setattr(mod, "check_flac_integrity",
                         lambda path: verdicts.get(path, (True, "")))
 
@@ -159,7 +159,7 @@ def test_scan_ignores_non_flac(tmp_path, monkeypatch):
     mp3.write_bytes(b"x")
     called = {"n": 0}
     monkeypatch.setattr(mod, "_decoder_available", lambda: True)
-    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p: p)
+    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p, **kw: p)
     monkeypatch.setattr(mod, "check_flac_integrity",
                         lambda p: (called.__setitem__("n", called["n"] + 1), (True, ""))[1])
 
@@ -196,3 +196,46 @@ def test_scan_only_modified_within_days_narrows(tmp_path, monkeypatch):
     result = AudioCorruptionDetectorJob().scan(ctx)
 
     assert findings == [] and result.skipped == 1
+
+
+def test_scan_resolves_paths_with_the_job_context(tmp_path, monkeypatch):
+    """#1000 follow-up (abclive): the scan called the path resolver BARE — no
+    transfer folder, no config_manager — so it had zero base directories to
+    suffix-walk and every Docker/NAS library path silently resolved to None:
+    '6741 FLAC files decode-tested, 0 corrupt, 6741 skipped' in 0.1s. The
+    resolver must receive the context's transfer folder + config manager."""
+    seen = {}
+
+    def _spy(p, **kw):
+        seen.update(kw)
+        return p
+
+    monkeypatch.setattr(mod, "_decoder_available", lambda: True)
+    monkeypatch.setattr(mod, "resolve_library_file_path", _spy)
+    monkeypatch.setattr(mod, "check_flac_integrity", lambda p: (True, ""))
+
+    f = tmp_path / "06 - Track.flac"
+    f.write_bytes(b"x")
+    ctx, _ = _context([_row(12, "Track", str(f))], tmp_path)
+    AudioCorruptionDetectorJob().scan(ctx)
+
+    assert seen.get("transfer_folder") == str(tmp_path)
+    assert seen.get("config_manager") is ctx.config_manager
+
+
+def test_scan_surfaces_total_resolution_failure(tmp_path, monkeypatch):
+    """When EVERY path fails to resolve (the Docker path-mapping case), the job
+    must say so loudly instead of quietly reporting a healthy all-skip run."""
+    monkeypatch.setattr(mod, "_decoder_available", lambda: True)
+    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p, **kw: None)
+    monkeypatch.setattr(mod, "check_flac_integrity",
+                        lambda p: (_ for _ in ()).throw(AssertionError("nothing should be tested")))
+
+    reports = []
+    ctx, _ = _context([_row(13, "Ghost", "/plex/sees/this.flac")], tmp_path)
+    ctx.report_progress = lambda **kw: reports.append(kw)
+    result = AudioCorruptionDetectorJob().scan(ctx)
+
+    assert result.skipped == 1 and result.findings_created == 0
+    assert any(r.get("log_type") == "error" and "No library paths" in (r.get("log_line") or "")
+               for r in reports)

--- a/tests/repair_jobs/test_replaygain_filler_resolve.py
+++ b/tests/repair_jobs/test_replaygain_filler_resolve.py
@@ -1,0 +1,68 @@
+"""ReplayGain Filler shared the Corrupt File Detector's resolver hole (#1000
+follow-up): it called resolve_library_file_path BARE — no transfer folder, no
+config_manager — so Docker/NAS users' media-server paths all resolved to None
+and the scan silently skipped the entire library. Pin that the resolver now
+receives the job context's search space."""
+
+from unittest.mock import MagicMock
+
+import core.repair_jobs.replaygain_filler as mod
+from core.repair_jobs.base import JobContext
+from core.repair_jobs.replaygain_filler import ReplayGainFillerJob
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def execute(self, *_a, **_k):
+        return self
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def cursor(self):
+        return _FakeCursor(self._rows)
+
+    def close(self):
+        pass
+
+
+class _FakeDB:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def _get_connection(self):
+        return _FakeConn(self._rows)
+
+
+def test_scan_resolves_paths_with_the_job_context(tmp_path, monkeypatch):
+    import sys
+    import types
+    fake_rg = types.SimpleNamespace(is_ffmpeg_available=lambda: True,
+                                    read_replaygain_tags=lambda p: {"track_gain": "-3.1 dB"})
+    monkeypatch.setitem(sys.modules, "core.replaygain", fake_rg)
+
+    seen = {}
+
+    def _spy(p, **kw):
+        seen.update(kw)
+        return p
+
+    monkeypatch.setattr(mod, "resolve_library_file_path", _spy)
+
+    f = tmp_path / "01 - Track.flac"
+    f.write_bytes(b"x")
+    cfg = MagicMock()
+    cfg.get.side_effect = lambda key, default=None: default
+    ctx = JobContext(db=_FakeDB([(1, "Track", "Artist", str(f))]),
+                     transfer_folder=str(tmp_path), config_manager=cfg)
+    ReplayGainFillerJob().scan(ctx)
+
+    assert seen.get("transfer_folder") == str(tmp_path)
+    assert seen.get("config_manager") is cfg

--- a/tests/sync/test_match_overrides.py
+++ b/tests/sync/test_match_overrides.py
@@ -79,14 +79,19 @@ def test_server_id_str_int_coercion():
     assert result == {0: 0}
 
 
-def test_two_sources_pointing_at_same_server_track_only_first_wins():
-    # Defensive — UNIQUE constraint prevents this in production but
-    # cache_lookup is injectable so we verify the safety.
+def test_two_sources_pointing_at_same_server_track_both_win():
+    # Two DIFFERENT source ids sharing one server track is legitimate (a
+    # playlist carrying the same song twice under different provider ids,
+    # both hand-matched to the user's single library copy). The old
+    # first-wins rule silently dropped the second pairing, so that row read
+    # "missing" forever no matter how many times Find & Add was re-run
+    # (wolf39us). The cache's UNIQUE is per (source_track_id, server_source)
+    # — it never prevented this case. Both are user-confirmed: honor both.
     sources = [{"source_track_id": "a"}, {"source_track_id": "b"}]
     servers = [{"id": 5001, "title": "Iron Man"}]
     cache = {"a": 5001, "b": 5001}
     result = resolve_match_overrides(sources, servers, lambda sid: cache.get(sid))
-    assert result == {0: 0}
+    assert result == {0: 0, 1: 0}
 
 
 def test_cache_lookup_raising_treated_as_miss():

--- a/tests/test_library_reorganize_orchestrator.py
+++ b/tests/test_library_reorganize_orchestrator.py
@@ -1436,6 +1436,26 @@ def test_reorganize_context_disables_folder_reuse():
     assert context['_no_album_folder_reuse'] is True
 
 
+def test_reorganize_context_is_a_local_import():
+    """Reorganize handles the user's OWN library files — the integrity check's
+    duration-agreement leg must not apply (#804 semantics). Without this flag,
+    a file whose duration drifts from the re-resolved API tracklist (a
+    different master / long version) got a copy QUARANTINED during reorganize
+    (TheHomeGuy: 'Through Glass' 283s vs Discogs' 241s → quarantine + failed)."""
+    context = library_reorganize._build_post_process_context(
+        {'id': 'dz-1', 'name': 'Come What(ever) May'},
+        {'id': 'a1', 'name': 'Through Glass', 'track_number': 8, 'duration_ms': 241000},
+        'Stone Sour', 'Come What(ever) May', 1,
+    )
+    assert context['is_local_import'] is True
+
+    # And the pipeline seam this flag drives: a local import never carries an
+    # expected duration into the integrity check.
+    from core.imports.file_integrity import expected_duration_for_check
+    assert expected_duration_for_check(241000, True) is None
+    assert expected_duration_for_check(241000, False) == 241000
+
+
 def test_preview_uses_same_logic_as_apply(monkeypatch, tmpdirs):
     """Sanity check: a multi-disc album previewed and then applied
     should show the same destinations. If preview drift creeps in

--- a/tests/test_video_database.py
+++ b/tests/test_video_database.py
@@ -60,6 +60,49 @@ def test_health_check_ok(db):
     assert db.health_check() is True
 
 
+def test_v41_heal_requeues_statusless_burned_details(tmp_path):
+    """v41 data migration: the old details backfill swallowed failed TMDB calls
+    and still marked details_synced=1 — permanently, since the queue only picks
+    details_synced=0. Rows left matched-but-status-less (no watchlist button,
+    no airing refresh — the 90 Day Fiancé report) must be re-queued exactly
+    once on upgrade; rows whose status DID land stay synced."""
+    import database.video_database as vdb
+
+    path = str(tmp_path / "video_library.db")
+    db = VideoDatabase(database_path=path)
+    burned = db.upsert_show_tree("plex", {"server_id": "s1", "title": "Burned", "tmdb_id": 61575, "seasons": []})
+    healthy = db.upsert_show_tree("plex", {"server_id": "s2", "title": "Healthy", "tmdb_id": 73319, "seasons": []})
+    movie = db.upsert_movie("plex", {"server_id": "m1", "title": "Burned Movie", "tmdb_id": 500})
+    with db.connect() as conn:
+        conn.execute("UPDATE shows SET details_synced=1, status=NULL")
+        conn.execute("UPDATE shows SET status='Returning Series' WHERE id=?", (healthy,))
+        conn.execute("UPDATE movies SET details_synced=1, status=NULL")
+        conn.execute("PRAGMA user_version = 40")   # pre-heal era
+
+    # Re-init the same file as a fresh process would (drop the once-per-process guard).
+    vdb._initialized_paths.discard(str(Path(path).resolve()))
+    db2 = VideoDatabase(database_path=path)
+    with db2.connect() as conn:
+        synced = {row["id"]: row["details_synced"] for row in
+                  conn.execute("SELECT id, details_synced FROM shows")}
+        movie_synced = conn.execute(
+            "SELECT details_synced FROM movies WHERE id=?", (movie,)).fetchone()[0]
+    assert synced[burned] == 0        # re-queued for one fresh attempt
+    assert synced[healthy] == 1       # status landed → left alone
+    assert movie_synced == 0
+    assert db2.schema_version == SCHEMA_VERSION
+
+    # One-time: at the current version the heal doesn't run again, so a row
+    # re-marked synced (the worker's fresh attempt) stays synced on next boot.
+    with db2.connect() as conn:
+        conn.execute("UPDATE shows SET details_synced=1 WHERE id=?", (burned,))
+    vdb._initialized_paths.discard(str(Path(path).resolve()))
+    db3 = VideoDatabase(database_path=path)
+    with db3.connect() as conn:
+        assert conn.execute("SELECT details_synced FROM shows WHERE id=?",
+                            (burned,)).fetchone()[0] == 1
+
+
 # ── no-polymorphic-id CHECK constraints ──────────────────────────────────────
 
 def test_media_file_requires_exactly_one_owner(db):

--- a/tests/test_video_enrichment.py
+++ b/tests/test_video_enrichment.py
@@ -1399,3 +1399,113 @@ def test_retry_all_failed_requeues_across_all_services(db):
     assert conn.execute("SELECT trakt_status FROM shows WHERE server_id='s1'").fetchone()[0] is None
     assert conn.execute("SELECT dearrow_status FROM youtube_video_stats WHERE youtube_id='v1'").fetchone()[0] is None
     conn.close()
+
+
+# ── manual match editor (Manage panel "Matches" section) ─────────────────────
+
+def test_tmdb_search_candidates_parses_results(monkeypatch):
+    class _Resp:
+        status_code = 200
+        def raise_for_status(self): pass
+        def json(self):
+            return {"results": [
+                {"id": 61575, "name": "90 Day Fiancé", "first_air_date": "2014-01-12",
+                 "overview": "Couples.", "poster_path": "/p.jpg"},
+                {"id": None, "name": "ghost"},                       # no id → dropped
+                {"id": 7, "name": "No Date"},                        # missing date → year None
+            ]}
+    urls = []
+    fake = types.SimpleNamespace(get=lambda url, **kw: (urls.append(url), _Resp())[1])
+    monkeypatch.setitem(sys.modules, "requests", fake)
+
+    out = TMDBClient("KEY").search_candidates("show", "90 day fiance")
+    assert any("/search/tv" in u for u in urls)
+    assert out[0] == {"id": 61575, "title": "90 Day Fiancé", "year": 2014,
+                      "overview": "Couples.",
+                      "poster_url": TMDBClient.POSTER_W + "/p.jpg"}
+    assert out[1]["year"] is None
+    assert len(out) == 2
+
+
+def test_tvdb_search_candidates_normalizes_string_ids(monkeypatch):
+    c = TVDBClient("KEY")
+    monkeypatch.setattr(c, "_authed_get", lambda path, params=None: {
+        "data": [
+            {"id": "series-392256", "name": "90 Day: The Last Resort", "year": "2023",
+             "overview": "Spinoff.", "image_url": "https://art/x.jpg"},
+            {"tvdb_id": 279121, "name": "Plain Int"},
+        ]})
+    out = c.search_candidates("show", "90 day")
+    assert out[0]["id"] == 392256          # 'series-392256' → 392256
+    assert out[1]["id"] == 279121
+    assert c.search_candidates("movie", "90 day") == []   # TVDB is shows-only
+
+
+def test_item_matches_reports_per_service_state(db):
+    sid = db.upsert_show_tree("plex", {"server_id": "s1", "title": "S", "tmdb_id": 61575, "seasons": []})
+    with db.connect() as conn:
+        conn.execute("UPDATE shows SET tmdb_match_status='matched', imdb_id='tt2237392' WHERE id=?", (sid,))
+    matches = {m["service"]: m for m in db.item_matches("show", sid)}
+    assert matches["tmdb"]["id"] == 61575 and matches["tmdb"]["status"] == "matched"
+    assert matches["tvdb"]["id"] is None
+    assert matches["imdb"]["id"] == "tt2237392" and matches["imdb"]["status"] == "matched"
+    assert db.item_matches("movie", sid) == []            # wrong kind → no row
+    assert db.item_matches("weird", sid) is None          # unknown kind
+
+
+def test_rematch_tmdb_resets_the_derived_pipeline(db):
+    sid = db.upsert_show_tree("plex", {"server_id": "s1", "title": "S", "tmdb_id": 111, "seasons": []})
+    with db.connect() as conn:
+        conn.execute(
+            "UPDATE shows SET tmdb_match_status='matched', details_synced=1, episodes_synced=1, "
+            "ratings_synced=1, status='Ended', overview='wrong show', tagline='nope', "
+            "trakt_status='ok', trakt_rating=7.5, poster_url='https://art/keep.jpg', "
+            "locked_fields='[\"overview\"]' WHERE id=?", (sid,))
+        conn.execute("INSERT INTO people (name) VALUES ('Wrong Actor')")
+        pid = conn.execute("SELECT id FROM people").fetchone()[0]
+        conn.execute("INSERT INTO credits (show_id, person_id, department) VALUES (?, ?, 'cast')", (sid, pid))
+
+    assert db.rematch_item("show", sid, "tmdb", 61575) is True
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM shows WHERE id=?", (sid,)).fetchone()
+        credits = conn.execute("SELECT COUNT(*) FROM credits WHERE show_id=?", (sid,)).fetchone()[0]
+    assert row["tmdb_id"] == 61575
+    assert row["tmdb_match_status"] is None               # worker re-picks, enriches BY the new id
+    assert row["status"] is None and row["tagline"] is None    # old match's text cleared
+    assert row["overview"] == "wrong show"                # locked field stays the user's
+    assert row["poster_url"] == "https://art/keep.jpg"    # art is never cleared
+    assert (row["details_synced"], row["episodes_synced"], row["ratings_synced"]) == (0, 0, 0)
+    assert row["trakt_status"] is None and row["trakt_rating"] is None
+    assert credits == 0                                   # wrong title's credits dropped
+
+
+def test_rematch_clear_reverts_to_not_found(db):
+    mid = db.upsert_movie("plex", {"server_id": "m1", "title": "M", "tmdb_id": 9})
+    with db.connect() as conn:
+        conn.execute("UPDATE movies SET tmdb_match_status='matched' WHERE id=?", (mid,))
+    assert db.rematch_item("movie", mid, "tmdb", None) is True
+    with db.connect() as conn:
+        row = conn.execute("SELECT tmdb_id, tmdb_match_status FROM movies WHERE id=?", (mid,)).fetchone()
+    assert row["tmdb_id"] is None and row["tmdb_match_status"] == "not_found"
+
+
+def test_rematch_imdb_only_touches_the_id_keyed_pipeline(db):
+    mid = db.upsert_movie("plex", {"server_id": "m1", "title": "M", "tmdb_id": 9})
+    with db.connect() as conn:
+        conn.execute(
+            "UPDATE movies SET overview='right movie', details_synced=1, ratings_synced=1, "
+            "awards_status='ok', awards='Won 1 Oscar', imdb_id='tt0000001' WHERE id=?", (mid,))
+    assert db.rematch_item("movie", mid, "imdb", "tt7286456") is True
+    with db.connect() as conn:
+        row = conn.execute("SELECT * FROM movies WHERE id=?", (mid,)).fetchone()
+    assert row["imdb_id"] == "tt7286456"
+    assert row["overview"] == "right movie"       # TMDB text untouched
+    assert row["details_synced"] == 1             # TMDB pipeline untouched
+    assert row["ratings_synced"] == 0             # ratings re-fetch with the new id
+    assert row["awards_status"] is None and row["awards"] is None
+
+
+def test_rematch_rejects_unknown_service_or_item(db):
+    mid = db.upsert_movie("plex", {"server_id": "m1", "title": "M"})
+    assert db.rematch_item("movie", mid, "tvdb", 5) is False    # tvdb is shows-only
+    assert db.rematch_item("movie", 99999, "tmdb", 5) is False  # no such row

--- a/web_server.py
+++ b/web_server.py
@@ -13215,12 +13215,15 @@ def _resolve_library_file_path(file_path):
             if found:
                 return found
 
-    # Couldn't resolve — log the bases we searched ONCE so a path/mount mismatch
-    # is diagnosable (e.g. files live under a dir that isn't transfer/download/
-    # a configured library path).
+    # Couldn't resolve — log the bases we searched, throttled to once per 10
+    # minutes. The old once-per-PROCESS guard self-silenced forever, which hid
+    # intermittent failures completely (TheHomeGuy: an NFS mount that drops and
+    # comes back reads as 'occasionally get this error' with no pattern —
+    # because all the other occurrences were swallowed).
     global _resolve_library_diag_logged
-    if not _resolve_library_diag_logged:
-        _resolve_library_diag_logged = True
+    _now = time.monotonic()
+    if not isinstance(_resolve_library_diag_logged, float) or _now - _resolve_library_diag_logged > 600:
+        _resolve_library_diag_logged = _now
         logger.warning(
             "[PathResolve] Could not resolve %r — tried direct-join + suffix-scan under %r (cwd=%r). "
             "If files live elsewhere, set soulseek.transfer_path to the absolute mount or add "

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.0.2"
+_SOULSYNC_BASE_VERSION = "3.0.3"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/web_server.py
+++ b/web_server.py
@@ -13224,11 +13224,30 @@ def _resolve_library_file_path(file_path):
     _now = time.monotonic()
     if not isinstance(_resolve_library_diag_logged, float) or _now - _resolve_library_diag_logged > 600:
         _resolve_library_diag_logged = _now
+        # Name the FAILURE MODE, not just the miss: a genuinely absent file
+        # stats as ENOENT, while a broken NFS/bind mount surfaces ESTALE or
+        # EIO — and a base dir that suddenly lists 0 entries is an unmounted
+        # mountpoint. Turns "file not found, shrug" into "the mount under it
+        # is broken" (TheHomeGuy's Proxmox LXC bind-of-NFS).
+        import errno as _errno
+        _stat_err = 'ENOENT (plain not-found)'
+        try:
+            os.stat(file_path)
+        except OSError as _se:
+            _stat_err = '%s (errno=%s)' % (_errno.errorcode.get(_se.errno, type(_se).__name__), _se.errno)
+        _base_counts = []
+        for _b in abs_bases:
+            try:
+                _base_counts.append('%s: %d entries' % (_b, len(os.listdir(_b))))
+            except OSError as _le:
+                _base_counts.append('%s: UNLISTABLE (%s)' % (_b, _errno.errorcode.get(_le.errno, type(_le).__name__)))
         logger.warning(
             "[PathResolve] Could not resolve %r — tried direct-join + suffix-scan under %r (cwd=%r). "
+            "Raw-path stat: %s. Base dirs: %s. "
             "If files live elsewhere, set soulseek.transfer_path to the absolute mount or add "
-            "the dir under Settings > Library music paths.",
-            file_path, abs_bases, os.getcwd(),
+            "the dir under Settings > Library music paths. A base showing 0 entries or "
+            "ESTALE/EIO means the mount under it is broken (remount / restart the container).",
+            file_path, abs_bases, os.getcwd(), _stat_err, '; '.join(_base_counts) or 'none',
         )
     return None
 

--- a/web_server.py
+++ b/web_server.py
@@ -4031,6 +4031,42 @@ def list_automations():
         logger.error(f"Error listing automations: {e}")
         return jsonify({"error": str(e)}), 500
 
+
+@app.route('/api/automations/master', methods=['GET'])
+def get_automations_master():
+    """The per-side global pause state ({music: bool, video: bool}).
+    It gates whether ANY automation runs on that side — individual enabled
+    flags are untouched, so un-pausing restores exactly what the user had."""
+    try:
+        from core.automation_engine import AutomationEngine
+        return jsonify({side: (automation_engine.master_enabled(side) if automation_engine
+                               else AutomationEngine.MASTER_DEFAULTS[side])
+                        for side in ('music', 'video')})
+    except Exception as e:
+        logger.error(f"Error reading automations master state: {e}")
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route('/api/automations/master', methods=['POST'])
+@admin_only
+def set_automations_master():
+    """Flip one side's global automation pause. Body: {side, enabled}.
+    Admin-only — it silences every automation on a side, not just yours."""
+    try:
+        data = request.get_json(silent=True) or {}
+        side = (data.get('side') or '').strip().lower()
+        if side not in ('music', 'video'):
+            return jsonify({"success": False, "error": "side must be music or video"}), 400
+        if automation_engine is None:
+            return jsonify({"success": False, "error": "Automation engine unavailable"}), 503
+        enabled = bool(data.get('enabled'))
+        automation_engine.set_master_enabled(side, enabled)   # persists to the engine DB
+        logger.info("Automations master for %s side set to %s", side, 'ON' if enabled else 'PAUSED')
+        return jsonify({"success": True, "side": side, "enabled": enabled})
+    except Exception as e:
+        logger.error(f"Error setting automations master state: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
 @app.route('/api/automations', methods=['POST'])
 def create_automation():
     """Create a new automation."""

--- a/web_server.py
+++ b/web_server.py
@@ -21310,6 +21310,13 @@ def _persist_find_and_add_match(source_track_id, server_source, server_track_id,
        Find & Add now also records a manual library match (one-way; the manual
        match tool has no playlist to act on, so it doesn't reverse-create)."""
     if not source_track_id:
+        # Nothing to key the override by — the pairing will NOT survive a
+        # reload. Loud, because to the user this looks like "matched it, then
+        # it unmatched itself" (the wolf39us report shape).
+        logger.warning(
+            "[ServerPlaylist] Find & Add match for '%s' NOT persisted — the source row "
+            "carries no source_track_id, so the pairing can't be stored and will "
+            "revert on the next compare load.", server_track_title or source_title or server_track_id)
         return
     db = get_database()
     try:

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3404,16 +3404,17 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.0.2': [
-        { date: 'July 2026 — 3.0.2' },
-        { title: 'Video downloads: daily shows + smarter searching', desc: 'daily series match by air date now ("The Daily Show 2026.07.08" style releases), soulseek results parse their share paths the way the music matcher does, releases with no quality token get size-inferred quality, and the wishlist run log names any source that was skipped (like prowlarr not being configured) instead of silently degrading.' },
-        { title: 'Download history: TV + YouTube, and uploader blacklisting', desc: 'tv episode and youtube grabs now show in the download history modal (youtube gets its own tab), and you can blacklist an uploader straight from a completed download — searches, retries and requeries all skip them from then on.' },
-        { title: 'The whole video side works on your phone', desc: 'full mobile/tablet pass: dashboard, search, discover, library, watchlist, wishlist, downloads, calendar, detail pages, and both studios (overlay + collection). desktop unchanged.' },
-        { title: 'Library Reorganize actually moves files', desc: 'after a template change, reorganize reported every album as "already organized" and moved nothing — the keep-albums-together folder reuse was answering with the very folder you were moving out of. destinations now come from your current template alone. thanks TheHomeGuy for the report.' },
-        { title: 'Manual imports skip the quality profile (#1017)', desc: 'a file you hand-match on the import page is your call — the quality profile no longer vetoes it. acoustid, integrity and silence checks still run.' },
-        { title: 'Basic search results no longer vanish (#1024)', desc: 'the results area could get starved to zero height on short or zoomed-out windows. it has a real minimum height now.' },
-        { title: 'Canonical version findings apply now (#1022)', desc: 'the album version repair job could flag canonical-version mismatches but the apply button did nothing (the fix handler was missing). thanks @sam-coodu.' },
-        { title: 'Earlier versions', desc: '3.0.1 shipped the entire video side (movies, tv & youtube): library scanning, enrichment, a tv calendar, kometa-style overlays & collections, Server Activity (tautulli-style), and radarr/sonarr-parity download matching. before that: 2.8.9 fixed multi-disc downloads (#1009), 2.8.8 stopped a tag write from corrupting FLAC audio (#1000), 2.8.4 added Artist Web + Quality Profiles, and 2.7.0 made multi-user real.' },
+    '3.0.3': [
+        { date: 'July 2026 — 3.0.3' },
+        { title: 'Video: wishlist a whole show in one click', desc: 'a "Wishlist Missing" button on the show detail page adds every missing aired episode across ALL seasons (loading the ones you never browsed), and the Get Missing modal gets a matching "Select all missing" button. both were season-at-a-time before.' },
+        { title: 'Video: fix a wrong match from the Manage panel', desc: 'a new Matches section on movie/show Manage panels — per-service rows (TMDB, TVDB, IMDb) with a search to re-point a wrong match to the right title. re-pointing clears what the old match filled in and re-enriches by the new id in the background; your locked fields and art are never touched.' },
+        { title: 'Video: shows stuck with no status heal themselves', desc: 'some shows had no airing info and no watchlist button because their TMDB status never landed (an old bug marked them done even when the call failed). a one-time migration re-queues them — status, watchlist button and airing refresh come back on their own.' },
+        { title: 'Automations: a global pause per side', desc: 'both automations pages get a master toggle. it never touches your individual switches — it just gates whether anything RUNS on that side. scheduled slots skip but keep their schedule, manual Run still works. music defaults on, video defaults off.' },
+        { title: 'Corrupt File Detector actually finds files (#1000)', desc: 'the scan silently skipped every file on docker/nas setups (the path resolver was called with no search directories). it resolves properly now, says what it actually decoded, and shouts when no paths resolve at all. flac is in the docker image so the md5-verifying check works out of the box.' },
+        { title: 'Manual match no longer refuses to stick', desc: 'when two playlist entries pointed at the same server track, the second match was silently dropped forever — no matter how many times you re-matched it. both count now, and every remaining failure in that flow logs exactly why.' },
+        { title: 'Reorganize no longer quarantines your own files', desc: 'a library file that\'s a different master than the metadata source\'s tracklist (a long version, say) got flagged as a "wrong file" during reorganize. it\'s your file — the download-oriented duration check no longer applies. real corruption checks still run.' },
+        { title: 'Player modal fix', desc: 'the now-playing modal clipped its controls on short or zoomed-in windows. the body scrolls now; larger screens are pixel-identical.' },
+        { title: 'Earlier versions', desc: '3.0.2 made video downloads smarter (daily shows, soulseek path parsing, uploader blacklisting), took the whole video side mobile, and fixed Library Reorganize ignoring template changes. 3.0.1 shipped the entire video side: movies, tv & youtube, kometa-style overlays & collections, Server Activity, and radarr/sonarr-parity download matching. before that: 2.8.9 fixed multi-disc downloads, 2.8.8 stopped a tag write from corrupting FLAC audio, 2.8.4 added Artist Web + Quality Profiles.' },
     ],
 };
 
@@ -3444,7 +3445,20 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.0.2 — the follow-up polish release",
+        title: "3.0.3 — quality of life across both sides",
+        description: "whole-show wishlisting + a match editor on video, global automation pause toggles, and four reported music bugs dead — including the corrupt file detector that scanned nothing.",
+        features: [
+            "wishlist a whole show in one click: 'Wishlist Missing' on the show detail page grabs every missing aired episode across all seasons (loading ones you never browsed), and the Get Missing modal gets a matching 'Select all missing' button",
+            "fix a wrong match without deleting anything: movie/show Manage panels get a Matches section — per-service rows (TMDB, TVDB, IMDb) with search, re-point, and clear. re-pointing wipes what the wrong match filled in and re-enriches by the new id; locked fields and art are never touched",
+            "shows stuck with no status heal themselves: an old bug could mark a show's TMDB details done even when the call failed, leaving it with no airing info and no watchlist button forever (the 90 Day Fiancé report). a one-time migration re-queues them",
+            "a global automation pause per side: one master toggle on each Automations page that gates whether anything runs without touching your individual switches. music defaults on, video defaults off — flip it on once if you use video automations",
+            "Corrupt File Detector actually finds files (#1000): the scan silently skipped every file on docker/NAS setups because the path resolver had no search directories. fixed (ReplayGain Filler had the same hole), the summary reports what was really decoded, and flac ships in the docker image for the md5-verifying check",
+            "manual match sticks now: two playlist entries matched to the same server track no longer silently lose the second pairing forever, and reorganize no longer quarantines your own files for being a different master than the metadata source's tracklist",
+            "the now-playing modal no longer clips its controls on short/zoomed windows, and unresolvable-path warnings now repeat and name the actual filesystem error — so a dead NFS/bind mount diagnoses itself instead of masquerading as missing files",
+        ],
+    },
+    {
+        title: "Earlier in 3.0.2 — the follow-up polish release",
         description: "video downloading gets sonarr-parity round 2, the entire video side goes mobile, and three music-side bugs are dead (library reorganize works again).",
         features: [
             "smarter video searching: daily shows match by air date ('The Daily Show 2026.07.08' style releases), soulseek results parse their share paths the way the music matcher does, releases with no quality token get size-inferred quality, and the wishlist run log now names any source that was skipped (like prowlarr not being configured) instead of silently degrading",

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -3253,6 +3253,49 @@ async function _bulkToggleGroup(groupName, currentlyAllEnabled) {
     } catch (err) { showToast('Error: ' + err.message, 'error'); }
 }
 
+// --- Global per-side automations master toggle (the big pause switch) ---
+// It gates whether ANYTHING runs on a side: scheduled slots are skipped (their
+// schedule stays alive) and event triggers are dropped. Individual enabled
+// switches are untouched, so un-pausing restores exactly what the user had.
+// Manual "Run now" still executes. Shared by the music page (side='music')
+// and the video automations page (side='video', video-automations.js).
+async function renderAutomationsMasterToggle(host, side) {
+    if (!host) return;
+    let enabled = side !== 'video';   // optimistic defaults: music on, video off
+    try {
+        const res = await fetch('/api/automations/master');
+        const data = await res.json();
+        if (data && typeof data[side] === 'boolean') enabled = data[side];
+    } catch (e) { /* keep the default */ }
+    const old = host.querySelector('.auto-master-toggle');
+    if (old) old.remove();
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'auto-master-toggle' + (enabled ? ' on' : '');
+    btn.title = enabled
+        ? 'Automations are live. Click to pause every scheduled and event run on this side — individual switches keep their state, and manual Run still works.'
+        : 'Automations are paused: nothing runs on a schedule or event. Individual switches keep their state, and manual Run still works.';
+    btn.innerHTML = '<span class="auto-master-sw"></span><span class="auto-master-label">' +
+        (enabled ? 'Automations on' : 'Automations paused') + '</span>';
+    btn.onclick = async () => {
+        btn.disabled = true;
+        try {
+            const res = await fetch('/api/automations/master', {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ side, enabled: !enabled }),
+            });
+            const data = await res.json();
+            if (!data || !data.success) throw new Error((data && data.error) || 'failed');
+            showToast((side === 'video' ? 'Video' : 'Music') + ' automations ' +
+                (!enabled ? 'resumed' : 'paused'), !enabled ? 'success' : 'info');
+        } catch (e) {
+            showToast('Couldn’t update the master switch' + (e && e.message ? ': ' + e.message : ''), 'error');
+        }
+        renderAutomationsMasterToggle(host, side);
+    };
+    host.prepend(btn);
+}
+
 async function loadAutomations() {
     const list = document.getElementById('automations-list');
     const empty = document.getElementById('automations-empty');
@@ -3268,7 +3311,7 @@ async function loadAutomations() {
         const automations = (Array.isArray(payload) ? payload : []).filter(a => a.owned_by !== 'video');
         if (!automations.length) {
             list.innerHTML = ''; empty.style.display = '';
-            if (statsBar) statsBar.innerHTML = '';
+            if (statsBar) { statsBar.innerHTML = ''; renderAutomationsMasterToggle(statsBar, 'music'); }
             return;
         }
         empty.style.display = 'none';
@@ -3308,6 +3351,7 @@ async function loadAutomations() {
                 <span class="auto-stat"><strong>${sys}</strong> System</span>
                 <span class="auto-stat"><strong>${custom}</strong> Custom</span>
             `;
+            renderAutomationsMasterToggle(statsBar, 'music');
         }
 
         // Filter bar — show when 6+ automations

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -47168,6 +47168,61 @@ body.downloads-disabled [onclick*="DownloadMissing"]:not([onclick*="close"]) {
     color: rgb(var(--accent-light-rgb));
 }
 
+/* --- Global per-side master pause toggle (music + video automations pages) --- */
+.auto-master-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 9px;
+    padding: 5px 14px 5px 8px;
+    border-radius: 999px;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 800;
+    border: 1px solid rgba(255, 99, 99, 0.4);
+    background: rgba(255, 99, 99, 0.08);
+    color: #ff8484;
+    transition: all 0.15s ease;
+}
+.auto-master-toggle.on {
+    border-color: rgba(76, 207, 133, 0.4);
+    background: rgba(76, 207, 133, 0.08);
+    color: #6fdd9d;
+}
+.auto-master-toggle:hover:not(:disabled) {
+    filter: brightness(1.15);
+}
+.auto-master-toggle:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+.auto-master-sw {
+    position: relative;
+    width: 34px;
+    height: 19px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.14);
+    transition: background 0.16s;
+    flex: 0 0 auto;
+}
+.auto-master-sw::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    background: #fff;
+    transition: transform 0.16s;
+}
+.auto-master-toggle.on .auto-master-sw {
+    background: #4ccf85;
+}
+.auto-master-toggle.on .auto-master-sw::after {
+    transform: translateX(15px);
+}
+
 /* --- Automation Card --- */
 .automation-card {
     background: rgba(22, 22, 22, 0.95);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -50919,12 +50919,36 @@ textarea.enhanced-meta-field-input {
 }
 
 /* Layout */
+/* Short-viewport safety (the #1024 bug class): the modal is clamped to 85vh
+   with overflow:hidden, so on zoomed-in / short windows everything below the
+   fold (controls, progress bar, the lyrics/queue headers) was CLIPPED with no
+   way to reach it. Flex-column + an internally scrolling body keeps every
+   control reachable — the close button (absolute) and the panel headers stay
+   pinned, the body scrolls. Tall viewports fit as before: no scrollbar, no
+   visual change. Mobile already does this (np-body scrolls at ≤768px). */
+.np-modal {
+    display: flex;
+    flex-direction: column;
+}
 .np-body {
     display: flex;
     flex-direction: row;
     padding: 48px 40px 36px;
     gap: 48px;
     align-items: flex-start;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+}
+.np-body::-webkit-scrollbar {
+    width: 8px;
+}
+.np-body::-webkit-scrollbar-track {
+    background: transparent;
+}
+.np-body::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 4px;
 }
 .np-left {
     flex: 0 0 auto;

--- a/webui/static/video/video-automations.js
+++ b/webui/static/video/video-automations.js
@@ -135,11 +135,17 @@
     function renderStats(sys, user) {
         var el = document.querySelector('[data-vauto-stats]'); if (!el) return;
         var all = sys.concat(user || []);
-        if (!all.length) { el.innerHTML = ''; return; }
         var active = all.filter(function (a) { return a.enabled; }).length;
-        el.innerHTML = '<span class="auto-stat"><strong>' + active + '</strong> Active</span>' +
-            '<span class="auto-stat"><strong>' + sys.length + '</strong> System</span>' +
-            '<span class="auto-stat"><strong>' + (user || []).length + '</strong> Custom</span>';
+        el.innerHTML = all.length
+            ? '<span class="auto-stat"><strong>' + active + '</strong> Active</span>' +
+              '<span class="auto-stat"><strong>' + sys.length + '</strong> System</span>' +
+              '<span class="auto-stat"><strong>' + (user || []).length + '</strong> Custom</span>'
+            : '';
+        // The global pause switch for the VIDEO side (shared helper from
+        // stats-automations.js; defaults OFF — most installs predate video).
+        if (typeof renderAutomationsMasterToggle === 'function') {
+            renderAutomationsMasterToggle(el, 'video');
+        }
     }
 
     var _lastSig = null;

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -495,6 +495,15 @@
                 '<span class="discog-btn-icon">⭳</span><span class="discog-btn-text">' + showGetLabel + '</span>' +
                 '<span class="discog-btn-shimmer"></span></button>';
         }
+        // Whole-show wishlist — every missing AIRED episode across every season in
+        // one click (the season bar only covers the selected season). YouTube
+        // channels have their own wishlist system (yt wish buttons), so skip them.
+        if (d.kind === 'show' && d.source !== 'youtube' && window.VideoGrab) {
+            html += '<button class="discog-download-btn discog-btn-compact" type="button" data-vd-act="wishlist-missing" ' +
+                'title="Add every missing aired episode across all seasons to the wishlist">' +
+                '<span class="discog-btn-icon">＋</span><span class="discog-btn-text">Wishlist Missing</span>' +
+                '<span class="discog-btn-shimmer"></span></button>';
+        }
         // Manage Poster — library items only (we need a server id + folder to push a
         // new poster to) and a tmdb id (to fetch the alternates). Opens VideoPoster.
         var ownLibItem = (d.source !== 'tmdb') || d.owned;
@@ -2201,6 +2210,7 @@
             if (which === 'watchlist') toggleWatchlist();
             else if (which === 'get') openGetModal();
             else if (which === 'missing') openGetModal(true);
+            else if (which === 'wishlist-missing') wishlistAllMissing(act);
             else if (which === 'poster') openPosterModal();
             else if (which === 'manage') openManagePanel();
             else if (which === 'yt-follow') toggleYtFollow();
@@ -2388,6 +2398,63 @@
             if (ok) { _btnLabel(btn, 'Wishlisted'); toast('Added ' + eps.length + ' episode' + (eps.length === 1 ? '' : 's') + ' to wishlist', 'success'); }
             else { btn.disabled = false; toast('Could not add to wishlist', 'error'); }
         });
+    }
+
+    // ── Whole-show wishlist ("Wishlist Missing" hero button) ──
+    // Library shows ship every season's episodes with the detail payload; TMDB
+    // previews load per-season on demand — fetch whatever the user never opened
+    // so "all missing" really means ALL seasons, not just the browsed ones.
+    function _ensureAllSeasonsLoaded() {
+        if (!data || data.source !== 'tmdb') return Promise.resolve();
+        var sid = data.id;
+        var pending = (data.seasons || []).filter(function (s) {
+            return !s._loaded && !(s.episodes && s.episodes.length);
+        });
+        return Promise.all(pending.map(function (s) {
+            return fetch(TMDB_URL + 'show/' + sid + '/season/' + s.season_number, { headers: { 'Accept': 'application/json' } })
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (se) {
+                    s._loaded = true;
+                    if (se && se.episodes) { s.episodes = se.episodes; s.episode_total = se.episodes.length; }
+                })
+                .catch(function () { s._loaded = true; });
+        }));
+    }
+    // Missing = not owned AND already aired — un-aired episodes are the airing
+    // watchlist's job, not a backlog wishlist's (mirrors the get-modal's epState).
+    function _allMissingMetas() {
+        var today = new Date().toISOString().slice(0, 10);
+        var out = [];
+        (data.seasons || []).forEach(function (s) {
+            (s.episodes || []).forEach(function (ep) {
+                if (ep.owned) return;
+                if (ep.air_date && ep.air_date > today) return;
+                var still = (data.source === 'tmdb')
+                    ? (ep.still_url || null)
+                    : (ep.has_still && ep.id != null ? '/api/video/poster/episode/' + ep.id : null);
+                out.push({ season_number: s.season_number, episode_number: ep.episode_number,
+                    title: ep.title, air_date: ep.air_date, still_url: still, overview: ep.overview,
+                    season_poster_url: seasonArt(s) || null });
+            });
+        });
+        return out;
+    }
+    function wishlistAllMissing(btn) {
+        if (!window.VideoGrab || !data || data.kind !== 'show') return;
+        if (!data.tmdb_id) { toast('Can’t wishlist — this show isn’t matched to TMDB yet', 'error'); return; }
+        if (btn) { btn.disabled = true; _btnLabel(btn, 'Wishlisting…'); }
+        var reset = function () { if (btn) { btn.disabled = false; _btnLabel(btn, 'Wishlist Missing'); } };
+        _ensureAllSeasonsLoaded().then(function () {
+            var eps = _allMissingMetas();
+            if (!eps.length) { reset(); toast('Nothing missing — you have every aired episode', 'info'); return; }
+            VideoGrab.wishlistEpisodes(_showIdentity(), eps).then(function (ok) {
+                if (ok) {
+                    if (btn) _btnLabel(btn, 'Wishlisted');
+                    toast('Added ' + eps.length + ' missing episode' + (eps.length === 1 ? '' : 's') + ' to wishlist', 'success');
+                    document.dispatchEvent(new CustomEvent('soulsync:video-wishlist-changed'));
+                } else { reset(); toast('Could not add to wishlist', 'error'); }
+            });
+        }).catch(reset);
     }
 
     // Manual search — a dedicated modal that auto-searches every configured source

--- a/webui/static/video/video-get-modal.js
+++ b/webui/static/video/video-get-modal.js
@@ -248,6 +248,8 @@
                 }
                 return;
             }
+            var selMissing = e.target.closest('[data-vgm-select-missing]');
+            if (selMissing) { selectAllMissing(ov, selMissing); return; }
             if (e.target.closest('[data-vgm-download]')) { enterDownload(ov, o); return; }
             if (e.target.closest('[data-vgm-back]')) { exitDownload(ov); return; }
             if (e.target.closest('[data-vgm-wishlist]')) { submitWishlist(ov); }
@@ -368,8 +370,11 @@
         modalState = { kind: 'show', sel: new Set(), tvId: tvId, today: today, epMeta: {}, seasonPoster: {} };
         var totalMissing = 0, anyLazy = false;
         var html = '<div class="vgm-eps-head"><span class="vgm-eps-h">Episodes</span>' +
+            '<div class="vgm-eps-head-actions">' +
+            '<button class="vgm-select-missing" type="button" data-vgm-select-missing ' +
+                'title="Load every season and select every missing aired episode">Select all missing</button>' +
             '<label class="vgm-eps-toggle"><input type="checkbox" data-vgm-missing-only checked>' +
-            '<span>Missing only</span></label></div><div class="vgm-eps-list">';
+            '<span>Missing only</span></label></div></div><div class="vgm-eps-list">';
         d.seasons.forEach(function (s) {
             // Capture this season's poster (owned → proxy by season id, tmdb → direct).
             modalState.seasonPoster[String(s.season_number)] = (o && o.source === 'library')
@@ -419,11 +424,45 @@
         wrap.innerHTML = html;
         wrap.classList.add('vgm-eps--missing-only');
         wrap.hidden = false;
+        // Nothing to select when you own everything (and no lazy seasons to load).
+        var sm = wrap.querySelector('[data-vgm-select-missing]');
+        if (sm) sm.hidden = (totalMissing === 0 && !anyLazy);
         // initial season-checkbox states reflect the (missing-only) selection
         d.seasons.forEach(function (s) { syncSeasonCheck(modalEl, s.season_number); });
         // Prefetch the first real season of an un-owned show so its first expand
         // is instant (and its missing episodes pre-count in the footer).
         if (anyLazy) prefetchFirstSeason(wrap);
+    }
+
+    // "Select all missing" — load every unexpanded (lazy) season, then tick every
+    // missing-aired episode across the whole show so one Add click wishlists it
+    // all. Re-ticks boxes the user may have unchecked; owned rows (re-download)
+    // and upcoming rows (no checkbox) are untouched.
+    function selectAllMissing(ov, btn) {
+        if (!modalState || modalState.kind !== 'show') return;
+        var els = ov.querySelectorAll('.vgm-season[data-vgm-lazy="1"]:not([data-vgm-loaded])');
+        var lazies = [];
+        for (var i = 0; i < els.length; i++) lazies.push(els[i]);
+        var label = btn.textContent;
+        btn.disabled = true;
+        if (lazies.length) btn.textContent = 'Loading seasons…';
+        Promise.all(lazies.map(function (el) { return loadSeason(el) || Promise.resolve(); }))
+            .then(function () {
+                if (!modalEl) return;   // modal closed mid-load
+                var boxes = ov.querySelectorAll('.vgm-ep--missing .vgm-ep-cb');
+                for (var j = 0; j < boxes.length; j++) {
+                    boxes[j].checked = true;
+                    toggleSel(boxes[j].getAttribute('data-vgm-ep'), true);
+                }
+                var sas = ov.querySelectorAll('[data-vgm-season-all]');
+                for (var k = 0; k < sas.length; k++) syncSeasonCheck(ov, sas[k].getAttribute('data-vgm-season-all'));
+                btn.disabled = false; btn.textContent = label;
+                updateFooter();
+                var n = modalState.sel.size;
+                toast(n ? n + ' episode' + (n === 1 ? '' : 's') + ' selected — hit Add to wishlist them'
+                        : 'Nothing missing to select', n ? 'success' : 'info');
+            })
+            .catch(function () { btn.disabled = false; btn.textContent = label; });
     }
 
     function prefetchFirstSeason(wrap) {
@@ -440,12 +479,12 @@
     // Fetch a tmdb season's episodes the first time it's expanded, render them,
     // and pre-select the missing-aired ones (everything un-owned that has aired).
     function loadSeason(seasonEl) {
-        if (!modalState || !modalState.tvId || !seasonEl) return;
+        if (!modalState || !modalState.tvId || !seasonEl) return Promise.resolve();
         var sn = parseInt(seasonEl.getAttribute('data-vgm-season'), 10);
         seasonEl.setAttribute('data-vgm-loaded', '1');   // guard double-fetch
         var body = seasonEl.querySelector('.vgm-season-eps');
         if (body) body.innerHTML = '<div class="vgm-season-loading">Loading episodes…</div>';
-        fetch('/api/video/tmdb/show/' + modalState.tvId + '/season/' + sn, { headers: { Accept: 'application/json' } })
+        return fetch('/api/video/tmdb/show/' + modalState.tvId + '/season/' + sn, { headers: { Accept: 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (data) {
                 if (!modalEl || !seasonEl.parentNode) return;

--- a/webui/static/video/video-manage-panel.js
+++ b/webui/static/video/video-manage-panel.js
@@ -103,6 +103,41 @@
                 'background:#fff;transition:transform .16s;}' +
             '.vmg-toggle--on .vmg-sw{background:rgb(' + A + ');}' +
             '.vmg-toggle--on .vmg-sw::after{transform:translateX(15px);}' +
+            // matches (per-service re-match editor)
+            '.vmg-matches{display:flex;flex-direction:column;gap:8px;}' +
+            '.vmg-match-row{display:flex;align-items:center;gap:9px;padding:9px 12px;border-radius:11px;' +
+                'background:rgba(255,255,255,.035);border:1px solid rgba(255,255,255,.07);font-size:12.5px;}' +
+            '.vmg-match-svc{font-weight:800;color:#eef1f7;min-width:44px;}' +
+            '.vmg-match-chip{padding:2px 9px;border-radius:999px;font-size:10px;font-weight:800;text-transform:uppercase;' +
+                'letter-spacing:.05em;border:1px solid transparent;}' +
+            '.vmg-match-chip--ok{background:rgba(76,207,133,.14);border-color:rgba(76,207,133,.4);color:#6fdd9d;}' +
+            '.vmg-match-chip--no{background:rgba(255,99,99,.12);border-color:rgba(255,99,99,.38);color:#ff8484;}' +
+            '.vmg-match-chip--wait{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.16);color:rgba(255,255,255,.55);}' +
+            '.vmg-match-id{color:rgba(255,255,255,.45);font-size:11.5px;overflow:hidden;text-overflow:ellipsis;' +
+                'white-space:nowrap;flex:1;min-width:0;}' +
+            '.vmg-match-btn{all:unset;cursor:pointer;padding:4px 11px;border-radius:999px;font-size:11px;font-weight:800;' +
+                'border:1px solid rgba(' + A + ',.4);background:rgba(' + A + ',.12);color:rgb(' + A + ');transition:background .13s;}' +
+            '.vmg-match-btn:hover{background:rgba(' + A + ',.24);}' +
+            '.vmg-match-btn--danger{border-color:rgba(255,99,99,.35);background:rgba(255,99,99,.08);color:#ff8484;}' +
+            '.vmg-match-btn--danger:hover{background:rgba(255,99,99,.18);}' +
+            '.vmg-match-imdb-in{width:118px;padding:5px 9px;border-radius:8px;font-size:12px;font-family:inherit;' +
+                'background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.12);color:#eef1f7;outline:none;}' +
+            '.vmg-match-imdb-in:focus{border-color:rgba(' + A + ',.6);}' +
+            // matches: inline search sub-view
+            '.vmg-msearch{display:flex;flex-direction:column;gap:9px;padding:11px;border-radius:12px;' +
+                'background:rgba(255,255,255,.035);border:1px solid rgba(' + A + ',.3);}' +
+            '.vmg-msearch-row{display:flex;gap:8px;}' +
+            '.vmg-msearch-in{flex:1;min-width:0;padding:8px 11px;border-radius:9px;font-size:12.5px;font-family:inherit;' +
+                'background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.12);color:#eef1f7;outline:none;}' +
+            '.vmg-msearch-in:focus{border-color:rgba(' + A + ',.6);}' +
+            '.vmg-mresult{display:flex;gap:10px;align-items:flex-start;padding:8px;border-radius:10px;' +
+                'background:rgba(0,0,0,.22);border:1px solid rgba(255,255,255,.06);}' +
+            '.vmg-mresult img{width:38px;aspect-ratio:2/3;border-radius:5px;object-fit:cover;background:#1b1b22;flex:0 0 auto;}' +
+            '.vmg-mresult-tt{font-size:12.5px;font-weight:800;color:#fff;}' +
+            '.vmg-mresult-ov{font-size:11px;color:rgba(255,255,255,.45);line-height:1.4;display:-webkit-box;' +
+                '-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}' +
+            '.vmg-mresult-body{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px;}' +
+            '.vmg-msearch-hint{font-size:11.5px;color:rgba(255,255,255,.4);}' +
             // save (in the header, clear of the app's floating bell/help orbs)
             '.vmg-hint{font-size:11.5px;color:rgba(255,255,255,.4);line-height:1.5;' +
                 'padding:2px 0 30px;}' +
@@ -183,10 +218,152 @@
                 '<div class="vmg-toggle' + (d.monitored ? ' vmg-toggle--on' : '') + '" data-vmg-monitored role="switch" ' +
                     'aria-checked="' + (d.monitored ? 'true' : 'false') + '" tabindex="0"><span>Monitored</span><span class="vmg-sw"></span></div>' +
             '</div>' +
+            '<div class="vmg-sect">Matches</div>' +
+            '<div class="vmg-matches" data-vmg-matches>' +
+                '<div class="vmg-msearch-hint">Loading matches…</div>' +
+            '</div>' +
             (window.VideoIssues
                 ? '<button class="vmg-btn-ghost vmg-report" type="button" data-vmg-report>⚑ Report an issue</button>'
                 : '')
         );
+    }
+
+    // ── matches (per-service re-match editor) ────────────────────────────────
+    var MATCH_LABELS = { tmdb: 'TMDB', tvdb: 'TVDB', imdb: 'IMDb' };
+
+    function matchChip(status) {
+        if (status === 'matched') return '<span class="vmg-match-chip vmg-match-chip--ok">matched</span>';
+        if (status === 'not_found') return '<span class="vmg-match-chip vmg-match-chip--no">not found</span>';
+        if (status === 'error') return '<span class="vmg-match-chip vmg-match-chip--no">error</span>';
+        return '<span class="vmg-match-chip vmg-match-chip--wait">pending</span>';
+    }
+
+    function renderMatches(matches) {
+        var host = state && state.overlay.querySelector('[data-vmg-matches]');
+        if (!host) return;
+        state.matches = matches;
+        host.innerHTML = matches.map(function (m) {
+            var label = MATCH_LABELS[m.service] || m.service;
+            if (m.service === 'imdb') {
+                return '<div class="vmg-match-row"><span class="vmg-match-svc">' + label + '</span>' +
+                    matchChip(m.status) +
+                    '<input class="vmg-match-imdb-in" data-vmg-imdb-in value="' + esc(m.id || '') + '" ' +
+                        'placeholder="tt0944947" spellcheck="false">' +
+                    '<button class="vmg-match-btn" type="button" data-vmg-imdb-save>Set</button>' +
+                    (m.id ? '<button class="vmg-match-btn vmg-match-btn--danger" type="button" ' +
+                        'data-vmg-match-clear="imdb">Clear</button>' : '') +
+                '</div>';
+            }
+            return '<div class="vmg-match-row"><span class="vmg-match-svc">' + label + '</span>' +
+                matchChip(m.status) +
+                '<span class="vmg-match-id">' + (m.id != null ? '#' + esc(m.id) : '—') + '</span>' +
+                '<button class="vmg-match-btn" type="button" data-vmg-match-fix="' + esc(m.service) + '">' +
+                    (m.id != null ? 'Fix…' : 'Find…') + '</button>' +
+                (m.id != null ? '<button class="vmg-match-btn vmg-match-btn--danger" type="button" ' +
+                    'data-vmg-match-clear="' + esc(m.service) + '">Clear</button>' : '') +
+            '</div>';
+        }).join('') +
+        '<div class="vmg-msearch-hint">Re-pointing a match clears the old data and re-enriches in the background.</div>';
+    }
+
+    function loadMatches() {
+        if (!state) return;
+        fetch('/api/video/enrichment/matches/' + state.kind + '/' + state.id)
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (res) {
+                if (!state) return;
+                if (res && res.matches && res.matches.length) renderMatches(res.matches);
+                else { var h = state.overlay.querySelector('[data-vmg-matches]'); if (h) h.innerHTML = ''; }
+            })
+            .catch(function () { /* section is a nicety — leave the loading hint */ });
+    }
+
+    function applyMatch(service, externalId, doneLabel) {
+        return fetch('/api/video/enrichment/matches/' + state.kind + '/' + state.id + '/apply', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ service: service, external_id: externalId }),
+        }).then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+        .then(function (res) {
+            if (!res.ok || !res.body || !res.body.success) {
+                throw new Error((res.body && res.body.error) || 'update failed');
+            }
+            toast(doneLabel || 'Match updated — re-enriching in the background', 'success');
+            loadMatches();
+            document.dispatchEvent(new CustomEvent('soulsync:video-meta-changed', {
+                detail: { kind: state.kind, id: state.id },
+            }));
+        }).catch(function (e) {
+            toast(e && e.message ? e.message : 'Couldn’t update the match', 'error');
+        });
+    }
+
+    function clearMatch(service) {
+        var label = MATCH_LABELS[service] || service;
+        confirmDlg({
+            title: 'Clear ' + label + ' match?',
+            message: service === 'imdb'
+                ? 'Removes the IMDb id — ratings and IMDb-based extras will re-resolve when a new id lands.'
+                : 'The item reverts to "not found" on ' + label + ' and its data from that match is cleared.',
+            confirmText: 'Clear', cancelText: 'Keep', destructive: true,
+        }).then(function (yes) {
+            if (!yes || !state) return;
+            applyMatch(service, null, label + ' match cleared');
+        });
+    }
+
+    function openMatchSearch(service) {
+        var host = state && state.overlay.querySelector('[data-vmg-matches]');
+        if (!host) return;
+        var label = MATCH_LABELS[service] || service;
+        host.innerHTML =
+            '<div class="vmg-msearch" data-vmg-msearch="' + esc(service) + '">' +
+                '<div class="vmg-msearch-row">' +
+                    '<input class="vmg-msearch-in" data-vmg-msearch-in value="' + esc(state.data.title || '') + '" ' +
+                        'placeholder="Search ' + esc(label) + '…" spellcheck="false">' +
+                    '<button class="vmg-match-btn" type="button" data-vmg-msearch-go>Search</button>' +
+                    '<button class="vmg-match-btn" type="button" data-vmg-msearch-back>Back</button>' +
+                '</div>' +
+                '<div data-vmg-msearch-results><div class="vmg-msearch-hint">Pick the correct title — its metadata replaces the current match.</div></div>' +
+            '</div>';
+        var input = host.querySelector('[data-vmg-msearch-in]');
+        if (input) { input.focus(); input.select(); }
+        runMatchSearch(service);   // auto-search with the item's own title
+    }
+
+    function runMatchSearch(service) {
+        var host = state && state.overlay.querySelector('[data-vmg-matches]');
+        if (!host) return;
+        var input = host.querySelector('[data-vmg-msearch-in]');
+        var results = host.querySelector('[data-vmg-msearch-results]');
+        var q = input ? input.value.trim() : '';
+        if (!q || !results) return;
+        results.innerHTML = '<div class="vmg-msearch-hint">Searching…</div>';
+        fetch('/api/video/enrichment/matches/' + state.kind + '/' + state.id + '/search', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ service: service, query: q }),
+        }).then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+        .then(function (res) {
+            if (!state) return;
+            if (!res.ok) throw new Error((res.body && res.body.error) || 'search failed');
+            var items = (res.body && res.body.results) || [];
+            if (!items.length) {
+                results.innerHTML = '<div class="vmg-msearch-hint">No results — try another spelling.</div>';
+                return;
+            }
+            results.innerHTML = items.map(function (it) {
+                return '<div class="vmg-mresult">' +
+                    (it.poster_url ? '<img src="' + esc(it.poster_url) + '" alt="" loading="lazy">' : '<img alt="">') +
+                    '<div class="vmg-mresult-body">' +
+                        '<div class="vmg-mresult-tt">' + esc(it.title) + (it.year ? ' (' + it.year + ')' : '') + '</div>' +
+                        (it.overview ? '<div class="vmg-mresult-ov">' + esc(it.overview) + '</div>' : '') +
+                    '</div>' +
+                    '<button class="vmg-match-btn" type="button" data-vmg-muse="' + esc(it.id) + '">Use</button>' +
+                '</div>';
+            }).join('');
+        }).catch(function (e) {
+            if (results) results.innerHTML = '<div class="vmg-msearch-hint">' +
+                esc(e && e.message ? e.message : 'Search failed') + '</div>';
+        });
     }
 
     function panelHtml(d) {
@@ -406,6 +583,35 @@
                 }
                 return;
             }
+            // Matches section (re-match editor)
+            var mfix = e.target.closest('[data-vmg-match-fix]');
+            if (mfix) { openMatchSearch(mfix.getAttribute('data-vmg-match-fix')); return; }
+            var mclear = e.target.closest('[data-vmg-match-clear]');
+            if (mclear) { clearMatch(mclear.getAttribute('data-vmg-match-clear')); return; }
+            var mgo = e.target.closest('[data-vmg-msearch-go]');
+            if (mgo) {
+                var msv = state.overlay.querySelector('[data-vmg-msearch]');
+                if (msv) runMatchSearch(msv.getAttribute('data-vmg-msearch'));
+                return;
+            }
+            if (e.target.closest('[data-vmg-msearch-back]')) { loadMatches(); return; }
+            var muse = e.target.closest('[data-vmg-muse]');
+            if (muse) {
+                var ms2 = state.overlay.querySelector('[data-vmg-msearch]');
+                if (ms2) {
+                    muse.disabled = true;
+                    applyMatch(ms2.getAttribute('data-vmg-msearch'),
+                               parseInt(muse.getAttribute('data-vmg-muse'), 10));
+                }
+                return;
+            }
+            if (e.target.closest('[data-vmg-imdb-save]')) {
+                var iin = state.overlay.querySelector('[data-vmg-imdb-in]');
+                var iv = iin ? iin.value.trim() : '';
+                if (!/^tt\d{5,10}$/.test(iv)) { toast('An IMDb id looks like tt0944947', 'error'); return; }
+                applyMatch('imdb', iv, 'IMDb id set — ratings will refresh');
+                return;
+            }
             var tw = e.target.closest('[data-vmg-watched]');
             if (tw) { toggle('watched', tw); return; }
             var tm = e.target.closest('[data-vmg-monitored]');
@@ -417,6 +623,13 @@
             if (e.target.closest('[data-vmg-f]')) markDirty();
         });
         ov.addEventListener('keydown', function (e) {
+            var msin = e.target.closest('[data-vmg-msearch-in]');
+            if (msin && e.key === 'Enter') {
+                e.preventDefault();
+                var msv = state.overlay.querySelector('[data-vmg-msearch]');
+                if (msv) runMatchSearch(msv.getAttribute('data-vmg-msearch'));
+                return;
+            }
             var ci = e.target.closest('[data-vmg-chip-in]');
             if (ci) {
                 if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); addGenre(ci.value); ci.value = ''; }
@@ -457,6 +670,7 @@
                 renderChips();
                 wire();
                 loadGenreSuggestions(d.kind);
+                loadMatches();
                 requestAnimationFrame(function () { ov.classList.add('vmg-open'); });
             })
             .catch(function () { toast('Couldn’t load item', 'error'); });

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -2617,6 +2617,14 @@ body:not(.video-admin) .vst-combo-panels { grid-template-columns: 1fr; }
 .vgm-eps-toggle { display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; font-weight: 700;
     color: rgba(255, 255, 255, 0.6); cursor: pointer; user-select: none; }
 .vgm-eps-toggle input { accent-color: rgb(var(--accent-rgb, 88 101 242)); width: 15px; height: 15px; cursor: pointer; }
+.vgm-eps-head-actions { display: inline-flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+.vgm-select-missing { font-size: 12px; font-weight: 700; padding: 5px 11px; border-radius: 999px;
+    border: 1px solid rgba(var(--accent-rgb, 88 101 242), 0.4); background: rgba(var(--accent-rgb, 88 101 242), 0.12);
+    color: rgb(var(--accent-light-rgb, 148 158 255)); cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+.vgm-select-missing:hover:not(:disabled) { background: rgba(var(--accent-rgb, 88 101 242), 0.22);
+    border-color: rgba(var(--accent-rgb, 88 101 242), 0.6); }
+.vgm-select-missing:disabled { opacity: 0.55; cursor: default; }
+.vgm-select-missing[hidden] { display: none; }
 
 .vgm-eps-list { display: flex; flex-direction: column; gap: 8px; }
 .vgm-season { border: 1px solid rgba(255, 255, 255, 0.07); border-radius: 12px; background: rgba(255, 255, 255, 0.02); overflow: hidden; }


### PR DESCRIPTION
# soulsync 3.0.3: `dev` → `main`

video gets whole-show wishlisting, a match editor, and global automation pause toggles. music side kills four reported bugs, including the corrupt file detector that scanned nothing and the manual match that refused to stick.

## video: wishlist a whole show in one click

the show detail page gets a "Wishlist Missing" button next to Get Missing: it loads every season (including ones you never browsed on a tmdb preview), collects every missing aired episode, and wishlists them all with full art context. the get missing modal gets a matching "Select all missing" button that loads all lazy seasons and ticks every missing episode so one Add click covers the entire show. previously both were season-at-a-time.

## video: fix a wrong match from the manage panel

movies and shows now have a Matches section in the manage panel, music parity style. per-service rows (tmdb, tvdb for shows, imdb) with match status, a search to re-point the match to the right title, clear, and a paste-an-id field for imdb. re-pointing clears everything the old wrong match filled in (your locked fields and art are never touched) and the existing workers re-enrich by the new id in the background.

## video: shows stuck with no status (the 90 day fiance report)

some shows had no airing info and no watchlist button because their tmdb status never landed: an old bug marked their details as synced even when the tmdb call failed, permanently. a one-time migration re-queues those shows so the background worker fills their status in, and the watchlist button plus airing refresh come back on their own.

## automations: a global pause per side

both automations pages get a master toggle. it does not touch your individual automation switches, it just gates whether anything runs on that side: scheduled slots skip but keep their schedule, event triggers drop, manual Run still works. music defaults on, video defaults off (most installs predate the video side). stored in the db, flips apply instantly.

## corrupt file detector actually finds files now (#1000 follow-up)

abclive's report: "6741 FLAC files decode-tested, 0 corrupt, 6741 skipped" in 0.1 seconds. nothing was decoded: the scan called the path resolver with no search directories, so every docker/nas library path silently resolved to nothing. the resolver now gets the transfer folder + your music paths, the summary reports what was actually decoded vs unresolved, and a total resolution failure logs a loud "check your music paths / mounts" instead of a healthy-looking run. replaygain filler had the same hole, same fix. flac is now in the docker image so the md5-verifying `flac -t` check is available out of the box.

## manual match refuses to work (wolf39us)

when two source entries pointed at the same server track (same song twice in a playlist, both matched to your one library copy), the match engine silently threw the second one away, forever, no matter how many times you re-matched it. both are your calls now, both count. every remaining silent failure in that flow also logs exactly which gate it died at.

## reorganize no longer quarantines your own files

full reorganize ran your files through the duration check meant for fresh downloads, so a file that's a different master than the metadata source's tracklist (a long version, say) got a copy quarantined and the track failed with a scary "wrong file" reason. reorganize files are your own library files, identity not in question: the duration check no longer applies to them. real corruption checks still run.

## player + diagnostics fixes

- the now playing modal clipped its controls on short or zoomed-in windows (same bug family as the basic search one in 3.0.2). the body scrolls now; tall viewports are pixel-identical
- the "could not resolve path" warning logged once per boot then went silent forever, hiding intermittent mount failures. it now repeats every 10 minutes and names the actual filesystem error plus how many entries each search folder lists, so a dead nfs/bind mount diagnoses itself
