### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,7 +11,7 @@ on:
       version_tag:
         description: 'Version tag (e.g. 3.1.0)'
         required: true
-        default: '3.1.0'
+        default: '3.1.1'
 
 jobs:
   build-and-push:

--- a/api/video/__init__.py
+++ b/api/video/__init__.py
@@ -94,7 +94,9 @@ def create_video_blueprint() -> Blueprint:
                 or path.endswith(("/metadata", "/lock", "/refresh-art",
                                   # per-title acquisition settings (P2/P8) — management,
                                   # same as the metadata edits above
-                                  "/quality-profile", "/series-type"))
+                                  "/quality-profile", "/series-type",
+                                  # per-show Synchronize — mutates library rows
+                                  "/sync"))
         if admin and not is_admin:
             return jsonify({"error": "Admin only."}), 403
 

--- a/api/video/detail.py
+++ b/api/video/detail.py
@@ -118,6 +118,24 @@ def register_routes(bp):
             return jsonify({"error": "not found"}), 404
         return jsonify(data)
 
+    @bp.route("/detail/show/<int:show_id>/sync", methods=["POST"])
+    def video_show_sync(show_id):
+        """Per-show Synchronize: re-read THIS show from the server and
+        reconcile local rows (adds, updates, prunes vanished episodes; removes
+        the show if the server verifiably no longer has it). Admin-gated via
+        the blueprint's /sync write rule. Synchronous — a single show reads in
+        seconds, and the response carries what changed."""
+        from . import get_video_db
+        try:
+            from core.video.show_sync import ShowSyncError, sync_show
+            res = sync_show(get_video_db(), show_id)
+            return jsonify({"success": True, **res})
+        except ShowSyncError as e:
+            return jsonify({"success": False, "error": str(e)}), 409
+        except Exception:
+            logger.exception("show sync failed for %s", show_id)
+            return jsonify({"success": False, "error": "Sync failed — see app.log"}), 500
+
     @bp.route("/detail/show/<int:show_id>/refresh-art", methods=["POST"])
     def video_show_refresh_art(show_id):
         """Lazy on-view backfill: pull missing season posters / episode art from

--- a/api/video/enrichment.py
+++ b/api/video/enrichment.py
@@ -159,6 +159,28 @@ def register_routes(bp):
                 logger.exception("video enrichment: engine rebuild after key change failed")
         return jsonify({"status": "saved"})
 
+    @bp.route("/enrichment/status-all", methods=["GET"])
+    def video_enrichment_status_all():
+        """Every video enrichment worker's status in ONE response — the
+        page-load hydrate (replaces ~15 individual /status requests). Workers
+        are in-process objects so collection is cheap; a failing one degrades
+        to its own error field, never the whole bundle."""
+        out = {}
+        try:
+            for sid, w in (engine().workers or {}).items():
+                try:
+                    out[sid] = w.get_stats()
+                except Exception as e:   # noqa: BLE001 - per-service isolation
+                    logger.exception("status-all: %s failed", sid)
+                    out[sid] = {"error": str(e)}
+        except Exception:
+            logger.exception("status-all: engine unavailable")
+        try:
+            out["youtube"] = _yt_enricher().stats()
+        except Exception as e:   # noqa: BLE001
+            out["youtube"] = {"error": str(e)}
+        return jsonify({"services": out})
+
     @bp.route("/enrichment/<service>/status", methods=["GET"])
     def video_enrichment_status(service):
         if service == "youtube":   # the standalone date enricher (not an engine worker)

--- a/core/automation/handlers/video_process_wishlist.py
+++ b/core/automation/handlers/video_process_wishlist.py
@@ -391,6 +391,27 @@ def _default_enqueue(item: Dict[str, Any], best: Dict[str, Any], candidates: Lis
 _running: Dict[str, bool] = {"movie": False, "episode": False}
 
 
+def _default_record_outcome(item: Dict[str, Any], media_type: str, grabbed: bool) -> None:
+    """Persist the drain search outcome on the wishlist row (#liveleak-failing-hub):
+    a grab resets search_attempts, a fruitless search increments it. Callers skip
+    this entirely when the search never ran (slskd down) — that's not evidence
+    the release doesn't exist. Best-effort: a db hiccup never breaks the drain."""
+    try:
+        from api.video import get_video_db
+        # episode drain items alias the show id as show_tmdb_id (movie items
+        # carry plain tmdb_id) — read both or episodes silently never record
+        tmdb = item.get('tmdb_id') or item.get('show_tmdb_id')
+        if not tmdb:
+            return
+        get_video_db().record_wishlist_search_outcome(
+            'movie' if media_type == 'movie' else 'episode',
+            tmdb, grabbed,
+            season_number=item.get('season_number'),
+            episode_number=item.get('episode_number'))
+    except Exception:   # noqa: BLE001 - visibility must never break acquisition
+        logger.debug("record_wishlist_search_outcome failed", exc_info=True)
+
+
 def is_running(media_type: str) -> bool:
     return bool(_running.get(media_type))
 
@@ -405,6 +426,7 @@ def auto_video_process_wishlist(
     target_dir: Optional[Callable[[str], str]] = None,
     search: Optional[Callable[[Dict[str, Any], str], List[Dict[str, Any]]]] = None,
     enqueue: Optional[Callable[..., bool]] = None,
+    record_outcome: Optional[Callable[[Dict[str, Any], str, bool], None]] = None,
 ) -> Dict[str, Any]:
     """Auto-grab the wished movies (or episodes): search Soulseek, pick the best release,
     enqueue. Processes the whole eligible wishlist, a few searches at a time.
@@ -415,6 +437,7 @@ def auto_video_process_wishlist(
     target_dir = target_dir or _default_target_dir
     search = search or _default_search
     enqueue = enqueue or _default_enqueue
+    record_outcome = record_outcome or _default_record_outcome
     automation_id = config.get('_automation_id')
     concurrency = max(1, int(config.get('max_concurrent', 3) or 3))
     label = 'movie' if media_type == 'movie' else 'episode'
@@ -500,6 +523,12 @@ def auto_video_process_wishlist(
                 msg, lt = "%d result(s) for '%s', none accepted — %s" % (len(cands), name, why), 'info'
                 if err:
                     msg, lt = msg + " · " + str(err), 'warning'
+            # Failing visibility (#liveleak-failing-hub): record the outcome on
+            # the wishlist row — but only when the search actually RAN. A search
+            # that never ran (slskd down / rate-limited) says nothing about
+            # whether the release exists and must not push a row toward failing.
+            if not didnt_run:
+                record_outcome(it, media_type, ok)
             with lock:
                 searched[0] += 1
                 if ok:

--- a/core/database_update_worker.py
+++ b/core/database_update_worker.py
@@ -300,10 +300,28 @@ class DatabaseUpdateWorker:
             # Fetch ALL artists from server (does NOT clear server data)
             artists = self._get_all_artists()
             if not artists:
-                self._emit_signal('error', f"Deep scan: No artists found in {self.server_type} library")
-                return
+                # A failed fetch must never look like an empty library — abort
+                # exactly as before.
+                if not getattr(self, '_artists_fetch_verified', False):
+                    self._emit_signal('error', f"Deep scan: No artists found in {self.server_type} library")
+                    return
+                # The server ANSWERED with zero artists — e.g. the user switched
+                # the library selection to an empty library (#stale-artists).
+                # Confirm with a second fetch so a transient empty response
+                # can't wipe a library, then fall through with an empty seen-set:
+                # stale removal clears out what the old selection left behind.
+                self._emit_signal('phase_changed', "Deep scan: Library returned no artists — verifying...")
+                artists = self._get_all_artists()
+                if not artists and not getattr(self, '_artists_fetch_verified', False):
+                    self._emit_signal('error', f"Deep scan: No artists found in {self.server_type} library")
+                    return
+                if not artists:
+                    logger.info(f"Deep scan: {self.server_type} library verified empty (two answers) — "
+                                f"existing {self.server_type} data will be removed as stale")
+                    self._emit_signal('phase_changed', "Deep scan: Library is empty — removing stale data...")
 
-            logger.info(f"Deep scan: Found {len(artists)} artists in {self.server_type} library")
+            if artists:
+                logger.info(f"Deep scan: Found {len(artists)} artists in {self.server_type} library")
 
             # Phase 2: Process all artists — skip existing tracks, collect seen IDs
             self._emit_signal('phase_changed', "Deep scan: Processing library content...")
@@ -317,11 +335,23 @@ class DatabaseUpdateWorker:
             stale_removed = 0
 
             if stale:
+                # A fully-trusted scan may exceed the 50% threshold: the server
+                # answered (verified fetch), every artist processed cleanly, and
+                # the scan wasn't stopped mid-run. That's the "switched the
+                # library selection to a smaller/empty library" case — the mass
+                # staleness is real, not an API failure (#stale-artists).
+                scan_trusted = (getattr(self, '_artists_fetch_verified', False)
+                                and self.failed_operations == 0
+                                and not self.should_stop)
                 # Safety: if stale > 50% of DB count AND DB has >100 tracks, likely API failure
-                if len(stale) > len(db_track_ids) * 0.5 and len(db_track_ids) > 100:
+                if (len(stale) > len(db_track_ids) * 0.5 and len(db_track_ids) > 100
+                        and not scan_trusted):
                     logger.warning(f"Deep scan safety: {len(stale)} stale tracks ({len(stale)}/{len(db_track_ids)} = "
                                    f"{len(stale)/len(db_track_ids)*100:.0f}%) exceeds 50% threshold — skipping removal")
                 else:
+                    if len(stale) > len(db_track_ids) * 0.5 and len(db_track_ids) > 100:
+                        logger.info(f"Deep scan: removing {len(stale)}/{len(db_track_ids)} tracks — allowed because "
+                                    f"the scan is fully trusted (server answered, no per-artist failures, not stopped)")
                     logger.info(f"Deep scan: Removing {len(stale)} stale tracks from database")
                     stale_removed = self.database.delete_stale_tracks(stale, self.server_type)
 
@@ -416,7 +446,15 @@ class DatabaseUpdateWorker:
                 self._emit_signal('artist_processed', artist_name, False, f"Error: {str(e)}", 0, 0)
 
     def _get_all_artists(self) -> List:
-        """Get all artists from media server library"""
+        """Get all artists from media server library.
+
+        Sets ``self._artists_fetch_verified``: True only when the server
+        ANSWERED — connection up and the client call returned an actual list.
+        That lets callers tell "the library is genuinely empty" (verified
+        empty, e.g. after switching the library selection to an empty one)
+        apart from "the fetch failed" (unverified), which must never trigger
+        stale removal."""
+        self._artists_fetch_verified = False
         try:
             if not self.media_client.ensure_connection():
                 logger.error(f"Could not connect to {self.server_type} server — check URL, credentials, and network (Docker users: use container name or host.docker.internal instead of host IP)")
@@ -425,7 +463,10 @@ class DatabaseUpdateWorker:
             logger.info(f"_get_all_artists: Calling media_client.get_all_artists() for {self.server_type}")
             artists = self.media_client.get_all_artists()
             logger.info(f"_get_all_artists: Received {len(artists) if artists else 0} artists from {self.server_type}")
-            return artists
+            # Only an actual list counts as a verified answer — a client that
+            # swallowed an error into None must stay untrusted.
+            self._artists_fetch_verified = isinstance(artists, list)
+            return artists or []
 
         except Exception as e:
             logger.error(f"Error getting artists from {self.server_type}: {e}")

--- a/core/database_update_worker.py
+++ b/core/database_update_worker.py
@@ -155,6 +155,10 @@ class DatabaseUpdateWorker:
                         self.media_client.set_progress_callback(lambda msg: self._emit_signal('phase_changed', msg))
                         logger.info("Connected Navidrome progress callback")
 
+                # A full refresh re-reads the whole server — stale listings
+                # cached by earlier runs must not survive into it.
+                self._clear_media_cache("before full refresh (full server re-read)")
+
                 # For full refresh, get all artists
                 artists_to_process = self._get_all_artists()
                 if not artists_to_process:
@@ -177,6 +181,11 @@ class DatabaseUpdateWorker:
                                 logger.info(f"Merged {merged} duplicate artists")
                         except Exception as e:
                             logger.warning(f"Could not merge duplicate artists: {e}")
+                    # This early exit used to skip the end-of-run cache clear:
+                    # the "nothing new" probe itself caches album/track listings
+                    # on the singleton client, and that pre-import view then
+                    # poisoned the NEXT deep scan (#torrent-album-missing).
+                    self._clear_media_cache("after incremental (no new content)")
                     self._emit_finished(0, 0, 0, 0, 0)
                     return
                 logger.info(f"Incremental update: Found {len(artists_to_process)} artists to process")
@@ -200,8 +209,12 @@ class DatabaseUpdateWorker:
                 except Exception as e:
                     logger.warning(f"Could not record full refresh completion: {e}")
             
-            # Clear cache after full refresh to free memory
-            if self.full_refresh and self.server_type in ["jellyfin", "navidrome"]:
+            # Clear cache after EVERY run (was full-refresh-only): the client
+            # is a process-wide singleton, so an incremental run's cached
+            # album/track listings used to outlive it and poison the next
+            # deep scan / full refresh with a pre-import view of the library
+            # (#torrent-album-missing).
+            if self.server_type in ["jellyfin", "navidrome"]:
                 try:
                     if hasattr(self.media_client, 'get_cache_stats'):
                         cache_stats = self.media_client.get_cache_stats()
@@ -209,7 +222,7 @@ class DatabaseUpdateWorker:
                     else:
                         freed_items = "cache data"
                     self.media_client.clear_cache()
-                    logger.info(f"Cleared {self.server_type} cache after full refresh - freed ~{freed_items} items from memory")
+                    logger.info(f"Cleared {self.server_type} cache after scan - freed ~{freed_items} items from memory")
                 except Exception as e:
                     logger.warning(f"Could not clear {self.server_type} cache: {e}")
             
@@ -296,6 +309,11 @@ class DatabaseUpdateWorker:
                 self._emit_signal('phase_changed', "Deep scan: Connecting to Navidrome...")
                 if hasattr(self.media_client, 'set_progress_callback'):
                     self.media_client.set_progress_callback(lambda msg: self._emit_signal('phase_changed', msg))
+
+            # A deep scan is a full re-read of the server — it must not trust
+            # album/track listings cached by earlier (incremental) runs, or a
+            # newly imported album is invisible to it (#torrent-album-missing).
+            self._clear_media_cache("before deep scan (full server re-read)")
 
             # Fetch ALL artists from server (does NOT clear server data)
             artists = self._get_all_artists()
@@ -444,6 +462,23 @@ class DatabaseUpdateWorker:
             except Exception as e:
                 logger.error(f"Deep scan: Error processing artist {artist_name}: {e}")
                 self._emit_signal('artist_processed', artist_name, False, f"Error: {str(e)}", 0, 0)
+
+    def _clear_media_cache(self, when: str) -> None:
+        """Drop the media client's cached per-artist album / per-album track
+        listings (jellyfin + navidrome keep them on a process-wide singleton).
+
+        Scans that promise a full server re-read (deep scan, full refresh)
+        MUST clear BEFORE fetching: the caches survive across scans, so an
+        earlier incremental run leaves a pre-import view behind and a newly
+        imported album silently never reaches the database — it then shows
+        as MISSING even though the server has it (#torrent-album-missing)."""
+        if self.server_type not in ("jellyfin", "navidrome"):
+            return
+        try:
+            self.media_client.clear_cache()
+            logger.info(f"Cleared {self.server_type} cache {when}")
+        except Exception as e:
+            logger.warning(f"Could not clear {self.server_type} cache {when}: {e}")
 
     def _get_all_artists(self) -> List:
         """Get all artists from media server library.

--- a/core/database_update_worker.py
+++ b/core/database_update_worker.py
@@ -464,8 +464,13 @@ class DatabaseUpdateWorker:
             artists = self.media_client.get_all_artists()
             logger.info(f"_get_all_artists: Received {len(artists) if artists else 0} artists from {self.server_type}")
             # Only an actual list counts as a verified answer — a client that
-            # swallowed an error into None must stay untrusted.
-            self._artists_fetch_verified = isinstance(artists, list)
+            # swallowed an error into None must stay untrusted. The real
+            # clients additionally mark last_fetch_failed when they swallowed
+            # an API failure into [] (they all do), so a failing artists
+            # endpoint on a reachable server can never read as "empty library".
+            self._artists_fetch_verified = (
+                isinstance(artists, list)
+                and not getattr(self.media_client, 'last_fetch_failed', False))
             return artists or []
 
         except Exception as e:

--- a/core/enrichment/api.py
+++ b/core/enrichment/api.py
@@ -134,6 +134,31 @@ def create_blueprint() -> Blueprint:
     """Build the Flask blueprint — call once during host startup."""
     bp = Blueprint('enrichment_api', __name__)
 
+    @bp.route('/api/enrichment/status-all', methods=['GET'])
+    def enrichment_status_all():
+        """Every service's status in ONE response — the page-load hydrate
+        (replaces ~13 individual /status requests). Collected CONCURRENTLY:
+        a serial pass would SUM the slow collectors (jiosaavn/bandcamp run
+        3-4s cold) into a 10s+ request. A failing service degrades to its own
+        error field, never the whole bundle."""
+        from concurrent.futures import ThreadPoolExecutor
+        from core.enrichment.services import all_services
+        services = all_services()
+
+        def one(svc):
+            try:
+                return svc.id, _cached_stats(svc)
+            except Exception as e:   # noqa: BLE001 - per-service isolation
+                logger.error("status-all: %s failed: %s", svc.id, e)
+                return svc.id, {'error': str(e)}
+
+        out = {}
+        if services:
+            with ThreadPoolExecutor(max_workers=min(8, len(services))) as ex:
+                for sid, payload in ex.map(one, services):
+                    out[sid] = payload
+        return jsonify({'services': out}), 200
+
     @bp.route('/api/enrichment/<service_id>/status', methods=['GET'])
     def enrichment_status(service_id: str):
         service = get_service(service_id)

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -122,16 +122,22 @@ def _replacement_length_is_safe(existing_path: str, incoming_path: str,
 
 
 def _batch_force_replace(context: dict) -> bool:
-    """True when the user explicitly forced this download (the 'Force
+    """True when the USER explicitly forced this download (the 'Force
     download' toggle on the download modal). An explicit re-download of a
     track they already own is replace-intent — the metadata-protection skip
-    must not silently discard it (#1045). Anything missing or unreadable →
-    False, i.e. the protective default."""
+    must not silently discard it (#1045).
+
+    Reads the batch's ``force_replace`` key, which web_server sets ONLY for a
+    user-checked toggle (wing_it excluded). Deliberately NOT
+    ``force_download_all``: the wishlist sets that on every background batch
+    (it means "skip ownership checks" there) and Wing It auto-enables it —
+    neither may ever overwrite library files. Anything missing or unreadable
+    → False, i.e. the protective default."""
     try:
         batch_id = (context or {}).get('batch_id')
         if not batch_id:
             return False
-        return bool((download_batches.get(batch_id) or {}).get('force_download_all'))
+        return bool((download_batches.get(batch_id) or {}).get('force_replace'))
     except Exception:   # noqa: BLE001 - protection is the safe default
         return False
 

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -121,6 +121,21 @@ def _replacement_length_is_safe(existing_path: str, incoming_path: str,
     return incoming_s >= existing_s * min_ratio
 
 
+def _batch_force_replace(context: dict) -> bool:
+    """True when the user explicitly forced this download (the 'Force
+    download' toggle on the download modal). An explicit re-download of a
+    track they already own is replace-intent — the metadata-protection skip
+    must not silently discard it (#1045). Anything missing or unreadable →
+    False, i.e. the protective default."""
+    try:
+        batch_id = (context or {}).get('batch_id')
+        if not batch_id:
+            return False
+        return bool((download_batches.get(batch_id) or {}).get('force_download_all'))
+    except Exception:   # noqa: BLE001 - protection is the safe default
+        return False
+
+
 def _should_skip_quarantine_check(context: dict, check_name: str) -> bool:
     bypass = context.get('_skip_quarantine_check')
     if bypass == 'all':
@@ -945,6 +960,11 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
             except (json.JSONDecodeError, TypeError):
                 _enhance_source_info = {}
         is_enhance_download = _enhance_source_info.get('enhance', False)
+        # "Force download" is replace-intent: the user explicitly re-downloaded
+        # something they already own, so the metadata-protection skip must not
+        # discard it (#1045). Rides the same replace path as enhance — the
+        # short-file replacement guard above still applies.
+        force_replace = _batch_force_replace(context)
 
         logger.info(f"Moving '{os.path.basename(file_path)}' to '{final_path}'")
         if os.path.exists(final_path):
@@ -991,7 +1011,7 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                 from mutagen import File as MutagenFile
                 existing_file = MutagenFile(final_path)
                 has_metadata = existing_file is not None and len(existing_file.tags or {}) > 2
-                if has_metadata and not is_enhance_download:
+                if has_metadata and not is_enhance_download and not force_replace:
                     _replace_lower = _resolve_context_quality_profile(context).get(
                         'replace_lower_quality',
                         config_manager.get('import.replace_lower_quality', False))
@@ -1026,8 +1046,11 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
                         except Exception as e:
                             logger.error(f"[Protection] Error removing redundant file: {e}")
                         return
-                elif is_enhance_download:
-                    logger.info(f"[Enhance] Quality enhance mode — replacing existing file: {os.path.basename(final_path)}")
+                elif is_enhance_download or force_replace:
+                    if is_enhance_download:
+                        logger.info(f"[Enhance] Quality enhance mode — replacing existing file: {os.path.basename(final_path)}")
+                    else:
+                        logger.info(f"[Force] User-forced re-download — replacing existing file: {os.path.basename(final_path)}")
                     try:
                         os.remove(final_path)
                     except Exception as e:

--- a/core/jellyfin_client.py
+++ b/core/jellyfin_client.py
@@ -665,13 +665,16 @@ class JellyfinClient(MediaServerClient):
     
     def get_all_artists(self) -> List[JellyfinArtist]:
         """Get all artists from the music library - matches Plex interface"""
+        # last_fetch_failed lets callers tell "library is genuinely empty"
+        # from "the fetch failed" — both come back as [] (#stale-artists).
+        self.last_fetch_failed = True
         if not self.ensure_connection() or not self.music_library_id:
             logger.error("Not connected to Jellyfin server or no music library")
             return []
-        
+
         # PERFORMANCE OPTIMIZATION: Pre-populate ALL caches upfront for massive speedup
         self._populate_aggressive_cache()
-        
+
         try:
             # Use proper AlbumArtists endpoint to match Jellyfin's "Album Artists" tab
             # This should return 3,966 artists including Weird Al
@@ -684,18 +687,21 @@ class JellyfinClient(MediaServerClient):
 
             response = self._make_request('/Artists/AlbumArtists', params)
             if not response:
+                # a failed/empty HTTP response is a FAILURE, not an empty
+                # library — an empty library still answers with Items: []
                 return []
-            
+
             artists = []
             for item in response.get('Items', []):
                 artist = JellyfinArtist(item, self)
                 # Cache the artist for quick lookup
                 self._artist_cache[artist.ratingKey] = artist
                 artists.append(artist)
-            
+
             logger.info(f"Retrieved {len(artists)} album artists from Jellyfin AlbumArtists endpoint (with aggressive caching)")
+            self.last_fetch_failed = False
             return artists
-            
+
         except Exception as e:
             logger.error(f"Error getting artists from Jellyfin: {e}")
             return []

--- a/core/matching_engine.py
+++ b/core/matching_engine.py
@@ -22,10 +22,16 @@ class MatchResult:
     plex_track: Optional[TrackInfo]
     confidence: float
     match_type: str
-    
+    # The bar a resolved track must clear to count as matched. Callers whose
+    # finder already accepted a lower confidence (playlist sync's db lookup
+    # runs at 0.7 — the app-wide "you own this" bar) pass their own threshold,
+    # otherwise a 0.70-0.79 match resolves to a live server track yet still
+    # counts unmatched: wishlisted AND never added to the playlist (#1047).
+    match_threshold: float = 0.8
+
     @property
     def is_match(self) -> bool:
-        return self.plex_track is not None and self.confidence >= 0.8
+        return self.plex_track is not None and self.confidence >= self.match_threshold
 
 class MusicMatchingEngine:
     def __init__(self):

--- a/core/metadata/completion.py
+++ b/core/metadata/completion.py
@@ -98,6 +98,18 @@ def _resolve_completion_track_total(release: Dict[str, Any], source_chain: List[
     return 0
 
 
+def _release_year_of(release: Dict[str, Any]) -> Optional[str]:
+    """The card's release year ('2024') or None — feeds the matcher's re-release
+    year gate. Never raises; unknown/blank stays None (gate stays off)."""
+    year = _extract_lookup_value(release, 'year')
+    if year:
+        return str(year)
+    release_date = _extract_lookup_value(release, 'release_date')
+    if release_date:
+        return str(release_date)[:4]
+    return None
+
+
 def _resolve_canonical_album_completion(db, db_album: Any) -> Optional[Dict[str, Any]]:
     """Recalculate completion from a local album's exact pinned release.
 
@@ -181,6 +193,7 @@ def check_album_completion(
                 server_source=active_server,
                 candidate_albums=candidate_albums,
                 strict_discography_match=True,
+                expected_year=_release_year_of(album_data),
             )
 
             canonical_completion = _resolve_canonical_album_completion(db, db_album)
@@ -301,6 +314,7 @@ def check_single_completion(
                     server_source=active_server,
                     candidate_albums=candidate_albums,
                     strict_discography_match=True,
+                    expected_year=_release_year_of(single_data),
                 )
             except Exception as db_error:
                 logger.error(f"Database error for EP '{single_name}': {db_error}")

--- a/core/metadata/completion.py
+++ b/core/metadata/completion.py
@@ -110,6 +110,46 @@ def _release_year_of(release: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def _canonical_pin_denies_card(db, db_album: Any, card_source: Optional[str],
+                               card_id: Any) -> bool:
+    """True when the matched local album is PINNED to a different release of the
+    card's own source — the user's files are a known specific edition, and this
+    card is not it (the re-release problem: a name match must not light up a
+    sibling edition once we know exactly which release the files are).
+
+    Deliberately strict about proof so it can never false-deny:
+      • no pin / no card id / pin from another source → False (old behavior)
+      • the card id must actually RESOLVE in the pin's source (its tracklist
+        loads) — a card that slipped in from a fallback source carries an id
+        from a different id-space and must not be compared against the pin
+    """
+    if not card_source or not card_id:
+        return False
+    local_album_id = _extract_lookup_value(db_album, 'id')
+    get_canonical = getattr(db, 'get_album_canonical', None)
+    if not local_album_id or not callable(get_canonical):
+        return False
+    canonical = get_canonical(local_album_id)
+    if not canonical:
+        return False
+    pin_source = str(_extract_lookup_value(
+        canonical, 'source', 'canonical_source', default='') or '').strip().lower()
+    pin_id = str(_extract_lookup_value(
+        canonical, 'album_id', 'canonical_album_id', default='') or '').strip()
+    if not pin_source or not pin_id:
+        return False
+    if pin_source != str(card_source).strip().lower():
+        return False
+    if pin_id == str(card_id).strip():
+        return False
+    try:
+        items = _extract_track_items(
+            get_album_tracks_for_source(pin_source, str(card_id)))
+    except Exception:
+        return False   # can't prove the card belongs to the pin's source
+    return bool(items)
+
+
 def _resolve_canonical_album_completion(db, db_album: Any) -> Optional[Dict[str, Any]]:
     """Recalculate completion from a local album's exact pinned release.
 
@@ -195,6 +235,26 @@ def check_album_completion(
                 strict_discography_match=True,
                 expected_year=_release_year_of(album_data),
             )
+
+            # Canonical pin deny: the files are pinned to a specific release of
+            # this card's source, and this card is a different one — a name
+            # match must not credit it (re-releases-as-owned, second layer).
+            if db_album is not None and _canonical_pin_denies_card(
+                    db, db_album, source_chain[0] if source_chain else None, album_id):
+                logger.debug(
+                    "Canonical pin denies '%s' (%s): local album %s is pinned to a different release",
+                    album_name, album_id, _extract_lookup_value(db_album, 'id'))
+                return {
+                    "id": album_id,
+                    "name": album_name,
+                    "status": "missing",
+                    "owned_tracks": 0,
+                    "expected_tracks": total_tracks,
+                    "completion_percentage": 0,
+                    "confidence": 0.0,
+                    "found_in_db": False,
+                    "formats": [],
+                }
 
             canonical_completion = _resolve_canonical_album_completion(db, db_album)
             if canonical_completion is not None:

--- a/core/navidrome_client.py
+++ b/core/navidrome_client.py
@@ -493,6 +493,9 @@ class NavidromeClient(MediaServerClient):
 
     def get_all_artists(self) -> List[NavidromeArtist]:
         """Get all artists from the music library"""
+        # last_fetch_failed lets callers tell "library is genuinely empty"
+        # from "the fetch failed" — both come back as [] (#stale-artists).
+        self.last_fetch_failed = True
         if not self.ensure_connection():
             logger.error("Not connected to Navidrome server")
             return []
@@ -506,6 +509,8 @@ class NavidromeClient(MediaServerClient):
                 params['musicFolderId'] = self.music_folder_id
             response = self._make_request('getArtists', params if params else None)
             if not response:
+                # a failed request is a FAILURE, not an empty library — an
+                # empty library still answers with an artists envelope
                 return []
 
             if self._progress_callback:
@@ -530,6 +535,7 @@ class NavidromeClient(MediaServerClient):
                 self._progress_callback(f"Retrieved {len(artists)} artists from Navidrome")
 
             logger.info(f"Retrieved {len(artists)} artists from Navidrome")
+            self.last_fetch_failed = False
             return artists
 
         except Exception as e:

--- a/core/plex_client.py
+++ b/core/plex_client.py
@@ -477,6 +477,33 @@ class PlexClient(MediaServerClient):
             logger.error(f"Error fetching playlist '{name}': {e}")
             return None
     
+    # A single createPlaylist/addItems call with ~1000 ratingKeys builds an
+    # oversized request that Plex (or a reverse proxy) can reject outright or
+    # silently truncate — the sync then reports success while the playlist is
+    # short (#1047). All playlist writes go through bounded chunks instead.
+    _PLAYLIST_ADD_CHUNK = 200
+
+    def _add_items_chunked(self, playlist, tracks) -> None:
+        """addItems in bounded chunks; raises on a failed chunk so callers
+        can't mistake a partial write for success."""
+        for i in range(0, len(tracks), self._PLAYLIST_ADD_CHUNK):
+            playlist.addItems(tracks[i:i + self._PLAYLIST_ADD_CHUNK])
+
+    def _verify_playlist_count(self, name: str, expected: int) -> None:
+        """Read the playlist back and say honestly when Plex stored fewer
+        tracks than were sent (a silent partial add). Log-only — the write
+        already happened; this makes the discrepancy visible instead of
+        letting 'synced N' over-report."""
+        try:
+            pl = self.server.playlist(name)
+            actual = len([i for i in pl.items() if hasattr(i, 'ratingKey')])
+            if actual < expected:
+                logger.warning(f"Plex playlist '{name}': sent {expected} tracks but the server holds {actual} — partial add")
+            else:
+                logger.info(f"Plex playlist '{name}': verified {actual} tracks on server")
+        except Exception as e:
+            logger.debug(f"Playlist verify failed for '{name}': {e}")
+
     def create_playlist(self, name: str, tracks) -> bool:
         if not self.ensure_connection():
             logger.error("Not connected to Plex server")
@@ -517,40 +544,47 @@ class PlexClient(MediaServerClient):
                     logger.debug("About to create playlist with tracks:")
                     for i, track in enumerate(valid_tracks):
                         logger.debug(f"  Track {i+1}: {track.title} (type: {type(track)}, ratingKey: {track.ratingKey})")
-                    
+
+                    # Create with the FIRST chunk only, then append the rest in
+                    # bounded chunks (#1047) — the compatibility cascade below
+                    # stays, it just never sends an oversized single request.
+                    first = valid_tracks[:self._PLAYLIST_ADD_CHUNK]
+                    rest = valid_tracks[self._PLAYLIST_ADD_CHUNK:]
+                    playlist = None
                     try:
-                        playlist = self.server.createPlaylist(name, valid_tracks)
-                        logger.info(f"Created playlist '{name}' with {len(valid_tracks)} tracks")
-                        return True
+                        playlist = self.server.createPlaylist(name, first)
                     except Exception as create_error:
                         logger.error(f"CreatePlaylist failed: {create_error}")
                         # Try alternative approach - pass items as list
                         try:
-                            playlist = self.server.createPlaylist(name, items=valid_tracks)
-                            logger.info(f"Created playlist '{name}' with {len(valid_tracks)} tracks (using items parameter)")
-                            return True
+                            playlist = self.server.createPlaylist(name, items=first)
+                            logger.debug("createPlaylist succeeded using items parameter")
                         except Exception as alt_error:
                             logger.error(f"Alternative createPlaylist also failed: {alt_error}")
                             # Try creating empty playlist first, then adding tracks
                             try:
                                 logger.debug("Trying to create empty playlist first, then add tracks...")
                                 playlist = self.server.createPlaylist(name, [])
-                                playlist.addItems(valid_tracks)
-                                logger.info(f"Created empty playlist and added {len(valid_tracks)} tracks")
-                                return True
+                                self._add_items_chunked(playlist, first)
                             except Exception as empty_error:
                                 logger.error(f"Empty playlist approach also failed: {empty_error}")
                                 # Final attempt: Create with first item, then add the rest
                                 try:
                                     logger.debug("Trying to create playlist with first track, then add remaining...")
-                                    playlist = self.server.createPlaylist(name, valid_tracks[0])
-                                    if len(valid_tracks) > 1:
-                                        playlist.addItems(valid_tracks[1:])
-                                    logger.info(f"Created playlist with first track and added {len(valid_tracks)-1} more tracks")
-                                    return True
+                                    playlist = self.server.createPlaylist(name, first[0])
+                                    if len(first) > 1:
+                                        self._add_items_chunked(playlist, first[1:])
                                 except Exception as final_error:
                                     logger.error(f"Final playlist creation attempt failed: {final_error}")
                                     raise create_error from final_error
+                    if playlist is not None:
+                        if rest:
+                            self._add_items_chunked(playlist, rest)
+                        logger.info(f"Created playlist '{name}' with {len(valid_tracks)} tracks "
+                                    f"({(len(rest) // self._PLAYLIST_ADD_CHUNK) + 1 if rest else 1} chunk(s))")
+                        self._verify_playlist_count(name, len(valid_tracks))
+                        return True
+                    return False
                 else:
                     logger.error(f"No valid tracks with ratingKeys for playlist '{name}'")
                     return False
@@ -657,11 +691,12 @@ class PlexClient(MediaServerClient):
                 )
                 return True
 
-            existing_playlist.addItems(new_tracks)
+            self._add_items_chunked(existing_playlist, new_tracks)
             logger.info(
                 f"Plex append: added {len(new_tracks)} new tracks to '{playlist_name}' "
                 f"(skipped {len(tracks) - len(new_tracks)} already present)"
             )
+            self._verify_playlist_count(playlist_name, len(existing_keys) + len(new_tracks))
             return True
         except Exception as e:
             logger.error(f"Error appending to Plex playlist '{playlist_name}': {e}")
@@ -694,7 +729,7 @@ class PlexClient(MediaServerClient):
             to_remove = [i for i in current_items if str(i.ratingKey) in remove_set]
 
             if to_add:
-                existing.addItems(to_add)
+                self._add_items_chunked(existing, to_add)
             if to_remove:
                 try:
                     existing.removeItems(to_remove)
@@ -709,6 +744,7 @@ class PlexClient(MediaServerClient):
                 f"Plex reconcile '{playlist_name}': +{len(to_add)} / -{len(to_remove)} "
                 f"(playlist preserved)"
             )
+            self._verify_playlist_count(playlist_name, len(desired_ids))
             return True
         except Exception as e:
             logger.error(f"Error reconciling Plex playlist '{playlist_name}': {e}")

--- a/core/plex_client.py
+++ b/core/plex_client.py
@@ -1123,6 +1123,9 @@ class PlexClient(MediaServerClient):
         doesn't show "Drake" twice when Drake is in two sections.
         Single-library mode is unaffected — dedup helper is a no-op.
         """
+        # last_fetch_failed lets callers tell "library is genuinely empty"
+        # from "the fetch failed" — both come back as [] (#stale-artists).
+        self.last_fetch_failed = True
         if not self.ensure_connection() or not self._can_query():
             logger.error("Not connected to Plex server or no music library")
             return []
@@ -1137,6 +1140,7 @@ class PlexClient(MediaServerClient):
                 )
             else:
                 logger.info(f"Found {len(artists)} artists in Plex library")
+            self.last_fetch_failed = False
             return artists
         except Exception as e:
             logger.error(f"Error getting all artists: {e}")

--- a/core/video/enrichment/engine.py
+++ b/core/video/enrichment/engine.py
@@ -353,12 +353,30 @@ class VideoEnrichmentEngine:
                         out[rail] = self._stamp_owned(list(out[rail]))
         srv = self._server_watch_link(kind, item_id)
         if srv:
+            if kind == "show":
+                # Continue Watching: point the CTA at the NEXT episode, not the
+                # show root — Plex/Jellyfin resume an in-progress item themselves.
+                try:
+                    nu = self.db.show_next_up(item_id)
+                except Exception:
+                    nu = None
+                if nu and nu.get("server_id"):
+                    ep_link = self._server_watch_link(kind, item_id,
+                                                      episode_sid=nu["server_id"])
+                    if ep_link:
+                        srv = dict(srv)
+                        srv["episode_url"] = ep_link["url"]
+                        srv["next_up"] = {"season": nu["season_number"],
+                                          "episode": nu["episode_number"],
+                                          "resume": bool(nu.get("resume"))}
             out["server"] = srv
         return out
 
-    def _server_watch_link(self, kind, item_id) -> dict | None:
+    def _server_watch_link(self, kind, item_id, episode_sid=None) -> dict | None:
         """A 'play on your media server' deep link for an owned item, or None.
-        Plex → the Plex web app at the item; Jellyfin → its web detail page."""
+        Plex → the Plex web app at the item; Jellyfin → its web detail page.
+        ``episode_sid`` swaps in an EPISODE's server id (same server as its
+        show) for a Continue-Watching deep link straight to the episode."""
         table = "movies" if kind == "movie" else "shows"
         try:
             with self.db.connect() as c:
@@ -371,6 +389,8 @@ class VideoEnrichmentEngine:
         source, sid = row["server_source"], row["server_id"]
         if not source or not sid:
             return None                      # not on a server (e.g. a wishlist row)
+        if episode_sid:
+            sid = episode_sid                # deep-link the episode, same server
         try:
             # Use the VIDEO side's effective connection (its own creds, or inherited
             # from music) — the item lives on the server the video side scanned.

--- a/core/video/show_sync.py
+++ b/core/video/show_sync.py
@@ -118,6 +118,19 @@ def sync_show(db, show_id: int) -> dict:
         finally:
             conn.close()
 
+    # Episode-list refresh from TMDB (best-effort): the server only knows about
+    # FILES — the aired-episode schedule comes from enrichment, and a hole in it
+    # (an episode row lost before the demote fix existed) would otherwise stay a
+    # hole. recent_seasons_only keeps it to 1-2 API calls; a TMDB hiccup must
+    # never fail the sync itself. Runs BEFORE the counts so restored episodes
+    # show up in the toast.
+    try:
+        from core.video.enrichment.engine import get_video_enrichment_engine
+        get_video_enrichment_engine().refresh_show_art(
+            target_id, with_ratings=False, recent_seasons_only=True)
+    except Exception:   # noqa: BLE001 - schedule refresh is a bonus, not the sync
+        logger.debug("show sync: episode-list refresh failed", exc_info=True)
+
     eps_after, files_after = _counts(db, target_id)
     return {
         "status": "ok", "title": row["title"], "show_removed": False,

--- a/core/video/show_sync.py
+++ b/core/video/show_sync.py
@@ -118,23 +118,35 @@ def sync_show(db, show_id: int) -> dict:
         finally:
             conn.close()
 
-    # Episode-list refresh from TMDB (best-effort): the server only knows about
-    # FILES — the aired-episode schedule comes from enrichment, and a hole in it
-    # (an episode row lost before the demote fix existed) would otherwise stay a
-    # hole. recent_seasons_only keeps it to 1-2 API calls; a TMDB hiccup must
-    # never fail the sync itself. Runs BEFORE the counts so restored episodes
-    # show up in the toast.
+    # Episode-list refresh from TMDB: the server only knows about FILES — the
+    # aired-episode schedule comes from enrichment, and a hole in it (an
+    # episode row lost before the demote fix existed) would otherwise stay a
+    # hole. recent_seasons_only keeps it to 1-2 API calls; a TMDB failure must
+    # never fail the sync itself — but it must be VISIBLE (result surfaced in
+    # the response + logged at info), not a silent fire-and-forget: an
+    # unobservable heal is indistinguishable from no heal. Runs BEFORE the
+    # counts so restored episodes show up in the toast.
+    schedule_refresh = "skipped"
     try:
         from core.video.enrichment.engine import get_video_enrichment_engine
-        get_video_enrichment_engine().refresh_show_art(
+        res = get_video_enrichment_engine().refresh_show_art(
             target_id, with_ratings=False, recent_seasons_only=True)
-    except Exception:   # noqa: BLE001 - schedule refresh is a bonus, not the sync
-        logger.debug("show sync: episode-list refresh failed", exc_info=True)
+        if res and res.get("ok"):
+            schedule_refresh = "ok"
+            logger.info("show sync: episode schedule refreshed for '%s'", row["title"])
+        else:
+            schedule_refresh = "failed:%s" % ((res or {}).get("reason") or "unknown")
+            logger.warning("show sync: episode schedule refresh for '%s' did not run: %s",
+                           row["title"], schedule_refresh)
+    except Exception as e:   # noqa: BLE001 - schedule refresh is a bonus, not the sync
+        schedule_refresh = "error:%s" % e
+        logger.warning("show sync: episode-list refresh failed for '%s': %s", row["title"], e)
 
     eps_after, files_after = _counts(db, target_id)
     return {
         "status": "ok", "title": row["title"], "show_removed": False,
         "show_id": target_id, "rekeyed": target_id != int(show_id),
+        "schedule_refresh": schedule_refresh,
         "episodes_added": max(0, eps_after - eps_before),
         "episodes_removed": max(0, eps_before - eps_after),
         "files_added": max(0, files_after - files_before),

--- a/core/video/show_sync.py
+++ b/core/video/show_sync.py
@@ -1,0 +1,104 @@
+"""Per-show synchronize — a deep scan scoped to ONE show.
+
+Fetches the show's full tree from the active video server and reconciles the
+local rows through the scanner's own ingest (upsert_show_tree adds/updates
+episodes + files and prunes the ones the payload no longer carries). A show
+the server verifiably no longer has is removed entirely (cascades clean its
+children).
+
+Safety, in order of paranoia:
+  • a server ERROR (down, timeout) aborts — it never reads as "show gone"
+  • "gone" requires the source to positively distinguish not-found from a
+    failed request (Plex: NotFound; Jellyfin: item missing while the server
+    still answers)
+  • an EMPTY tree (0 episodes) against local episodes is refused — Plex's
+    tree builder swallows a mid-fetch episodes() failure into an empty
+    seasons list, and blindly upserting that would prune the whole show
+"""
+
+from __future__ import annotations
+
+from utils.logging_config import get_logger
+
+logger = get_logger("video.show_sync")
+
+
+class ShowSyncError(RuntimeError):
+    """Sync could not run (server unreachable, wrong server, busy…)."""
+
+
+def _counts(db, show_id: int) -> tuple:
+    conn = db._get_connection()
+    try:
+        eps = conn.execute("SELECT COUNT(*) c FROM episodes WHERE show_id=?",
+                           (show_id,)).fetchone()["c"]
+        files = conn.execute(
+            "SELECT COUNT(*) c FROM media_files f JOIN episodes e ON f.episode_id=e.id "
+            "WHERE e.show_id=?", (show_id,)).fetchone()["c"]
+        return eps, files
+    finally:
+        conn.close()
+
+
+def sync_show(db, show_id: int) -> dict:
+    """Reconcile ONE local show against the server. Returns
+    {status, title, episodes_added, episodes_removed, files_added,
+    files_removed, show_removed} or raises ShowSyncError."""
+    conn = db._get_connection()
+    try:
+        row = conn.execute(
+            "SELECT id, title, server_id, server_source FROM shows WHERE id=?",
+            (int(show_id),)).fetchone()
+    finally:
+        conn.close()
+    if not row:
+        raise ShowSyncError("Show not found in the library")
+
+    from core.video.scanner import get_video_scanner
+    if (get_video_scanner(db).get_status() or {}).get("state") == "running":
+        raise ShowSyncError("A library scan is already running — try again when it finishes")
+
+    from core.video.sources import get_active_video_source
+    source = get_active_video_source()
+    if source is None:
+        raise ShowSyncError("No video server configured/reachable")
+    if source.server_name != row["server_source"]:
+        raise ShowSyncError(
+            "This show belongs to %s but the active server is %s"
+            % (row["server_source"], source.server_name))
+
+    tree = source.show_tree(row["server_id"])   # raises on server errors
+
+    if tree is None:
+        # Verified gone from the server — remove it here too (cascades).
+        conn = db._get_connection()
+        try:
+            conn.execute("DELETE FROM shows WHERE id=?", (int(show_id),))
+            conn.commit()
+        finally:
+            conn.close()
+        logger.info("show sync: '%s' verified gone from %s — removed locally",
+                    row["title"], row["server_source"])
+        return {"status": "ok", "title": row["title"], "show_removed": True,
+                "episodes_added": 0, "episodes_removed": 0,
+                "files_added": 0, "files_removed": 0}
+
+    eps_before, files_before = _counts(db, int(show_id))
+    tree_eps = sum(len(s.get("episodes", [])) for s in tree.get("seasons", []))
+    if tree_eps == 0 and eps_before > 0:
+        # Plex's tree builder swallows a mid-fetch episodes() failure into an
+        # empty seasons list — upserting that would prune the entire show.
+        raise ShowSyncError(
+            "The server returned no episodes for this show — refusing to remove "
+            "local data on a possibly-failed read. Run a Deep Scan if the show "
+            "is really empty now.")
+
+    db.upsert_show_tree(row["server_source"], tree, preserve_enrichment=True)
+    eps_after, files_after = _counts(db, int(show_id))
+    return {
+        "status": "ok", "title": row["title"], "show_removed": False,
+        "episodes_added": max(0, eps_after - eps_before),
+        "episodes_removed": max(0, eps_before - eps_after),
+        "files_added": max(0, files_after - files_before),
+        "files_removed": max(0, files_before - files_after),
+    }

--- a/core/video/show_sync.py
+++ b/core/video/show_sync.py
@@ -47,7 +47,7 @@ def sync_show(db, show_id: int) -> dict:
     conn = db._get_connection()
     try:
         row = conn.execute(
-            "SELECT id, title, server_id, server_source FROM shows WHERE id=?",
+            "SELECT id, title, server_id, server_source, tmdb_id FROM shows WHERE id=?",
             (int(show_id),)).fetchone()
     finally:
         conn.close()
@@ -67,7 +67,10 @@ def sync_show(db, show_id: int) -> dict:
             "This show belongs to %s but the active server is %s"
             % (row["server_source"], source.server_name))
 
-    tree = source.show_tree(row["server_id"])   # raises on server errors
+    # title + tmdb_id let Plex verify a NotFound isn't just a re-keyed item
+    # (metadata refresh/optimize changes ratingKeys) before we believe "gone".
+    tree = source.show_tree(row["server_id"], title=row["title"],
+                            tmdb_id=row["tmdb_id"])   # raises on server errors
 
     if tree is None:
         # Verified gone from the server — remove it here too (cascades).
@@ -94,9 +97,31 @@ def sync_show(db, show_id: int) -> dict:
             "is really empty now.")
 
     db.upsert_show_tree(row["server_source"], tree, preserve_enrichment=True)
-    eps_after, files_after = _counts(db, int(show_id))
+
+    # Healed key: the source found the show under a NEW server id (Plex re-key).
+    # The upsert landed on a fresh row — retire the stale one and count against
+    # the row the data actually lives on now.
+    target_id = int(show_id)
+    if str(tree.get("server_id")) != str(row["server_id"]):
+        conn = db._get_connection()
+        try:
+            new_row = conn.execute(
+                "SELECT id FROM shows WHERE server_source=? AND server_id=?",
+                (row["server_source"], str(tree.get("server_id")))).fetchone()
+            if new_row and int(new_row["id"]) != int(show_id):
+                target_id = int(new_row["id"])
+                conn.execute("DELETE FROM shows WHERE id=?", (int(show_id),))
+                conn.commit()
+                logger.info("show sync: '%s' re-keyed on %s (%s → %s) — row healed",
+                            row["title"], row["server_source"],
+                            row["server_id"], tree.get("server_id"))
+        finally:
+            conn.close()
+
+    eps_after, files_after = _counts(db, target_id)
     return {
         "status": "ok", "title": row["title"], "show_removed": False,
+        "show_id": target_id, "rekeyed": target_id != int(show_id),
         "episodes_added": max(0, eps_after - eps_before),
         "episodes_removed": max(0, eps_before - eps_after),
         "files_added": max(0, files_after - files_before),

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -474,19 +474,39 @@ class PlexVideoSource:
                 except Exception:
                     logger.exception("Plex: skipping movie %s", getattr(m, "title", "?"))
 
-    def show_tree(self, server_id):
+    def show_tree(self, server_id, title=None, tmdb_id=None):
         """The full tree for ONE show (same shape iter_shows yields) — the
         per-show Synchronize. Returns None ONLY when Plex positively says the
-        item is gone (NotFound); any other failure raises, so a server hiccup
-        can never read as 'show removed'."""
+        item is gone AND a title/tmdb search of the TV sections can't find it
+        either — Plex re-keys items on metadata refresh/optimize, so a stale
+        ratingKey alone must never read as 'show removed' (the tree returned
+        from the search carries the NEW server_id; the caller heals the row).
+        Any other failure raises, so a server hiccup can't delete anything."""
         from plexapi.exceptions import NotFound
         try:
             item = self._server.fetchItem(int(server_id))
         except NotFound:
-            return None
-        if getattr(item, "type", "") != "show":
-            return None   # re-keyed to something else entirely — treat as gone
-        return self._show(item)
+            item = None
+        if item is not None and getattr(item, "type", "") == "show":
+            return self._show(item)
+        # Stale/re-keyed id — look the show up the durable way before giving up.
+        want_tmdb = str(tmdb_id) if tmdb_id else None
+        for section in self._scan_sections("show", self._tv_lib):
+            try:
+                hits = section.search(title=title) if title else []
+            except Exception:
+                logger.exception("Plex: rekey-check search failed for %r", title)
+                raise
+            for h in hits:
+                if getattr(h, "type", "") != "show":
+                    continue
+                if want_tmdb and _parse_plex_guids(h).get("tmdb_id"):
+                    if str(_parse_plex_guids(h).get("tmdb_id")) == want_tmdb:
+                        return self._show(h)
+                    continue
+                if title and (getattr(h, "title", "") or "").strip().lower() == title.strip().lower():
+                    return self._show(h)
+        return None
 
     def iter_shows(self, incremental=False, since=None):
         for section in self._scan_sections("show", self._tv_lib):
@@ -1526,8 +1546,10 @@ class JellyfinVideoSource:
         d.update(_parse_jf_providers(it))
         return d
 
-    def show_tree(self, server_id):
+    def show_tree(self, server_id, title=None, tmdb_id=None):
         """The full tree for ONE show — the per-show Synchronize. Jellyfin's
+        item ids are durable GUIDs (no Plex-style re-keying), so the extra
+        title/tmdb args are accepted for interface parity but unused. Its
         request helper collapses every failure into None, so 'gone' is only
         believed when the item is missing while the server still answers a
         health probe; an unreachable server raises instead (a hiccup must

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -474,6 +474,20 @@ class PlexVideoSource:
                 except Exception:
                     logger.exception("Plex: skipping movie %s", getattr(m, "title", "?"))
 
+    def show_tree(self, server_id):
+        """The full tree for ONE show (same shape iter_shows yields) — the
+        per-show Synchronize. Returns None ONLY when Plex positively says the
+        item is gone (NotFound); any other failure raises, so a server hiccup
+        can never read as 'show removed'."""
+        from plexapi.exceptions import NotFound
+        try:
+            item = self._server.fetchItem(int(server_id))
+        except NotFound:
+            return None
+        if getattr(item, "type", "") != "show":
+            return None   # re-keyed to something else entirely — treat as gone
+        return self._show(item)
+
     def iter_shows(self, incremental=False, since=None):
         for section in self._scan_sections("show", self._tv_lib):
             # Delta = shows ADDED since our last scan (addedAt, not updatedAt — Plex's nightly
@@ -1511,6 +1525,22 @@ class JellyfinVideoSource:
         }
         d.update(_parse_jf_providers(it))
         return d
+
+    def show_tree(self, server_id):
+        """The full tree for ONE show — the per-show Synchronize. Jellyfin's
+        request helper collapses every failure into None, so 'gone' is only
+        believed when the item is missing while the server still answers a
+        health probe; an unreachable server raises instead (a hiccup must
+        never read as 'show removed')."""
+        it = self._req(f"/Users/{self.uid}/Items/{server_id}",
+                       {"Fields": _JF_SHOW_FIELDS})
+        if it and it.get("Id"):
+            if (it.get("Type") or "") != "Series":
+                return None   # re-keyed to something else entirely — treat as gone
+            return self._show(it)
+        if self._req(f"/Users/{self.uid}/Views") is None:
+            raise RuntimeError("Jellyfin unreachable — cannot verify the show's state")
+        return None
 
     def iter_shows(self, incremental=False, since=None):
         path = f"/Users/{self.uid}/Items"

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -389,6 +389,15 @@ def _union_episode_delta_shows(section, since, shows):
         except Exception:   # noqa: BLE001 - the episode delta is an assist over the show delta
             logger.debug("Plex: episode addedAt delta search failed", exc_info=True)
             eps = []
+        try:
+            # WATCH delta: watching (even partially) bumps an episode's lastViewedAt but not
+            # the show's addedAt, so without this an incremental never refreshes per-episode
+            # play_count/viewOffset (Continue Watching would go stale until a deep scan).
+            eps = list(eps) + list(section.search(libtype="episode",
+                                                  filters={"lastViewedAt>>": since},
+                                                  sort="lastViewedAt:desc", maxresults=500))
+        except Exception:   # noqa: BLE001 - the watch delta is an assist too
+            logger.debug("Plex: episode lastViewedAt delta search failed", exc_info=True)
         for ep in eps:
             gk = str(getattr(ep, "grandparentRatingKey", "") or "")
             if gk and gk not in seen:
@@ -965,6 +974,7 @@ class PlexVideoSource:
             "rating_critic": getattr(m, "rating", None),
             "play_count": int(getattr(m, "viewCount", 0) or 0),
             "last_viewed_at": _iso_dt(getattr(m, "lastViewedAt", None)),
+            "view_offset_ms": int(getattr(m, "viewOffset", 0) or 0),   # resume position
             "genres": self._tags(getattr(m, "genres", None)),
             "runtime_minutes": int(dur / 60000) if dur else None,
             "files": self._part_files(m),
@@ -988,6 +998,10 @@ class PlexVideoSource:
             "rating": getattr(ep, "audienceRating", None),
             "tvdb_id": _parse_plex_guids(ep).get("tvdb_id"),
             "added_at": _iso_dt(getattr(ep, "addedAt", None)),   # ranks the show in Recently Added
+            # Continue Watching: per-episode watch state + resume position
+            "play_count": int(getattr(ep, "viewCount", 0) or 0),
+            "last_viewed_at": _iso_dt(getattr(ep, "lastViewedAt", None)),
+            "view_offset_ms": int(getattr(ep, "viewOffset", 0) or 0),
             "files": self._part_files(ep),
             "file": self._part_file(ep),
         }
@@ -1053,7 +1067,7 @@ class PlexVideoSource:
 _JF_MOVIE_FIELDS = ("Overview,Path,MediaSources,ProductionYear,OfficialRating,RunTimeTicks,Studios,"
                     "ProviderIds,Genres,Taglines,CommunityRating,CriticRating,UserData")
 _JF_EP_FIELDS = ("Overview,Path,MediaSources,PremiereDate,RunTimeTicks,IndexNumber,ParentIndexNumber,"
-                 "ProviderIds,CommunityRating,DateCreated")
+                 "ProviderIds,CommunityRating,DateCreated,UserData")
 _JF_SHOW_FIELDS = ("Overview,ProductionYear,OfficialRating,ProviderIds,Genres,Taglines,CommunityRating,"
                    "PremiereDate,EndDate,UserData,RecursiveItemCount")
 
@@ -1071,8 +1085,21 @@ def _union_jf_episode_delta_series(req, uid, view_id, since, series_items, show_
         ep_resp = req(f"/Users/{uid}/Items", {
             "ParentId": view_id, "IncludeItemTypes": "Episode", "Recursive": "true",
             "MinDateLastSaved": since.isoformat(), "Fields": "SeriesId", "Limit": "1000"}) or {}
+        ep_items = list(ep_resp.get("Items", []))
+        try:
+            # WATCH delta: playback updates an episode's USER DATA, not its DateLastSaved,
+            # so the metadata delta alone never refreshes play state (Continue Watching
+            # would go stale until a deep scan). MinDateLastSavedForUser is the user-data
+            # twin of MinDateLastSaved.
+            watch_resp = req(f"/Users/{uid}/Items", {
+                "ParentId": view_id, "IncludeItemTypes": "Episode", "Recursive": "true",
+                "MinDateLastSavedForUser": since.isoformat(),
+                "Fields": "SeriesId", "Limit": "500"}) or {}
+            ep_items += watch_resp.get("Items", [])
+        except Exception:   # noqa: BLE001 - the watch delta is an assist too
+            logger.debug("Jellyfin: episode user-data delta failed", exc_info=True)
         new_ids = []
-        for ep in ep_resp.get("Items", []):
+        for ep in ep_items:
             sid = str(ep.get("SeriesId") or "")
             if sid and sid not in seen:
                 seen.add(sid)
@@ -1505,6 +1532,19 @@ class JellyfinVideoSource:
                 # just new adds (the Jellyfin twin of Plex's updatedAt delta).
                 params.update({"MinDateLastSaved": since.isoformat()})
                 items = (self._req(path, params) or {}).get("Items", [])
+                try:
+                    # WATCH delta: playback updates USER DATA, not DateLastSaved — union in
+                    # movies whose play state changed so Continue Watching stays fresh
+                    # between deep scans (the Jellyfin twin of Plex's lastViewedAt delta).
+                    wparams = dict(params)
+                    wparams.pop("MinDateLastSaved", None)
+                    wparams.update({"MinDateLastSavedForUser": since.isoformat(), "Limit": "500"})
+                    seen_ids = {str(x.get("Id")) for x in items}
+                    items = list(items) + [
+                        w for w in (self._req(path, wparams) or {}).get("Items", [])
+                        if str(w.get("Id")) not in seen_ids]
+                except Exception:   # noqa: BLE001 - the watch delta is an assist
+                    logger.debug("Jellyfin: movie user-data delta failed", exc_info=True)
             elif incremental:
                 params.update({"SortBy": "DateCreated", "SortOrder": "Descending", "Limit": "100"})
                 items = (self._req(path, params) or {}).get("Items", [])
@@ -1538,6 +1578,8 @@ class JellyfinVideoSource:
             "play_count": int((it.get("UserData") or {}).get("PlayCount")
                               or (1 if (it.get("UserData") or {}).get("Played") else 0)),
             "last_viewed_at": _iso_dt((it.get("UserData") or {}).get("LastPlayedDate")),
+            # JF ticks are 100ns units → ms
+            "view_offset_ms": int(((it.get("UserData") or {}).get("PlaybackPositionTicks") or 0) // 10_000),
             "genres": it.get("Genres") or [],
             "runtime_minutes": int(ticks / 600_000_000) if ticks else None,
             "files": self._files(it),
@@ -1618,6 +1660,11 @@ class JellyfinVideoSource:
                     "rating": ep.get("CommunityRating"),
                     "tvdb_id": _parse_jf_providers(ep).get("tvdb_id"),
                     "added_at": ((ep.get("DateCreated") or "").replace("T", " ")[:19] or None),
+                    # Continue Watching: UserData rides the user-scoped episodes call
+                    "play_count": int((ep.get("UserData") or {}).get("PlayCount")
+                                      or (1 if (ep.get("UserData") or {}).get("Played") else 0)),
+                    "last_viewed_at": _iso_dt((ep.get("UserData") or {}).get("LastPlayedDate")),
+                    "view_offset_ms": int(((ep.get("UserData") or {}).get("PlaybackPositionTicks") or 0) // 10_000),
                     "files": self._files(ep),
                     "file": self._file(ep),
                 })

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -371,6 +371,31 @@ def list_video_libraries():
 
 
 # ── Plex ──────────────────────────────────────────────────────────────────────
+def _format_from_name(path: str) -> dict:
+    """Release-name format tokens (Radarr-style): HDR flavor + Atmos from the
+    FILENAME. This is the only cheap signal Plex gives us — stream-level HDR
+    data needs a per-item reload (an N+1 the scan must never do). Jellyfin
+    overrides with real stream facts where it has them."""
+    s = (path or "").lower().replace(".", " ").replace("_", " ")
+    out = {}
+    dv = bool(re.search(r"\b(dv|dovi|dolby.?vision)\b", s))
+    hdr10p = bool(re.search(r"\bhdr10(\+|plus)\b", s))
+    hdr = hdr10p or bool(re.search(r"\bhdr(10)?\b", s))
+    hlg = bool(re.search(r"\bhlg\b", s))
+    parts = []
+    if dv:
+        parts.append("DV")
+    if hdr:
+        parts.append("HDR10+" if hdr10p else "HDR10")
+    elif hlg:
+        parts.append("HLG")
+    if parts:
+        out["dynamic_range"] = " ".join(parts)
+    if re.search(r"\batmos\b", s):
+        out["atmos"] = True
+    return out
+
+
 def _union_episode_delta_shows(section, since, shows):
     """Union into ``shows`` the parent shows of any EPISODE ADDED since ``since``.
 
@@ -924,15 +949,20 @@ class PlexVideoSource:
                 parts = media.parts or []
                 if not parts:
                     continue
-                out.append({
+                entry = {
                     "relative_path": parts[0].file,
                     "size_bytes": sum(int(getattr(p, "size", 0) or 0) for p in parts) or None,
                     "resolution": getattr(media, "videoResolution", None),
                     "aspect": getattr(media, "aspectRatio", None),
                     "video_codec": getattr(media, "videoCodec", None),
                     "audio_codec": getattr(media, "audioCodec", None),
+                    # format badges: channel count is real container data; HDR/
+                    # Atmos come from the release name (stream data would be N+1)
+                    "audio_channels": int(getattr(media, "audioChannels", 0) or 0) or None,
                     "runtime_seconds": runtime,
-                })
+                }
+                entry.update(_format_from_name(parts[0].file))
+                out.append(entry)
             except Exception:   # noqa: BLE001 - one unreadable version never hides the rest
                 continue
         return out
@@ -1504,16 +1534,29 @@ class JellyfinVideoSource:
             streams = src.get("MediaStreams") or []
             vid = next((s for s in streams if s.get("Type") == "Video"), {})
             aud = next((s for s in streams if s.get("Type") == "Audio"), {})
-            out.append({
-                "relative_path": src.get("Path") or item.get("Path") or "",
+            fpath = src.get("Path") or item.get("Path") or ""
+            entry = {
+                "relative_path": fpath,
                 "size_bytes": src.get("Size"),
                 "resolution": (str(vid.get("Height")) + "p") if vid.get("Height") else None,
                 "aspect": vid.get("AspectRatio") or (
                     (vid.get("Width") / vid.get("Height")) if vid.get("Width") and vid.get("Height") else None),
                 "video_codec": vid.get("Codec"),
                 "audio_codec": aud.get("Codec"),
+                "audio_channels": aud.get("Channels"),
                 "runtime_seconds": JellyfinVideoSource._ticks_to_seconds(item.get("RunTimeTicks")),
-            })
+            }
+            # release-name tokens first, then REAL stream facts override them
+            entry.update(_format_from_name(fpath))
+            vrange = (vid.get("VideoRangeType") or "").upper()   # HDR10 | HDR10Plus | DOVI | HLG
+            if vrange and vrange != "SDR":
+                entry["dynamic_range"] = {"DOVI": "DV", "HDR10PLUS": "HDR10+",
+                                          "DOVIWITHHDR10": "DV HDR10"}.get(vrange, vrange)
+            elif (vid.get("VideoRange") or "").upper() == "HDR" and not entry.get("dynamic_range"):
+                entry["dynamic_range"] = "HDR"
+            if "atmos" in ((aud.get("DisplayTitle") or "") + " " + (aud.get("Profile") or "")).lower():
+                entry["atmos"] = True
+            out.append(entry)
         return out
 
     @classmethod

--- a/core/video/youtube_download.py
+++ b/core/video/youtube_download.py
@@ -208,16 +208,20 @@ def download_one(video_id: Any, dest_dir: str, dest_stem: str, profile: Any, con
 
 
 def authoritative_download_fields(dl: Dict[str, Any], res: Dict[str, Any]) -> Dict[str, Any]:
-    """Fold yt-dlp's extracted title/date back into a row whose enqueue-time
-    context LOST them (an upstream title-parser change can blank every scanned
-    title — files then land as '$channel - $date -'). The extractor is the last
-    word: when the context already carries a real video title the row returns
-    unchanged; otherwise the returned copy carries the real title (+ date when
-    missing) in both the row and its search_ctx, so the organised path, the
-    sidecars, AND the history snapshot all get it. Pure."""
-    title = (res or {}).get("title")
-    if not title:
-        return dl
+    """Fold yt-dlp's extracted title/date back into the row — the extractor is
+    the last word, and a changed row makes the caller RE-PLAN the organised
+    path (rename), so the file, sidecars, AND history snapshot all agree.
+
+    Title: filled only when the enqueue-time context lost it (an upstream
+    title-parser change can blank every scanned title — files then land as
+    '$channel - $date -').
+
+    Date: the extractor's upload_date ALWAYS overrides a differing context
+    date. The channel scan estimates dates from YouTube's relative labels
+    ('1 month ago' → today − 30.44d), month-level precision at best — and
+    that estimate used to mint the canonical episode number (season=year,
+    episode=MMDD): five backlog videos all labelled '1 month ago' landed as
+    five colliding e0617 files (the GMM incident). Pure."""
     ctx = dl.get("search_ctx")
     if isinstance(ctx, str):
         try:
@@ -225,12 +229,26 @@ def authoritative_download_fields(dl: Dict[str, Any], res: Dict[str, Any]) -> Di
         except (ValueError, TypeError):
             ctx = {}
     ctx = dict(ctx) if isinstance(ctx, dict) else {}
-    if str(ctx.get("video_title") or "").strip():
+
+    changed = False
+    out_title = None
+    title = (res or {}).get("title")
+    if title and not str(ctx.get("video_title") or "").strip():
+        ctx["video_title"] = title
+        out_title = title
+        changed = True
+
+    real_date = str((res or {}).get("published_at") or "")[:10]
+    if real_date and str(ctx.get("published_at") or "")[:10] != real_date:
+        ctx["published_at"] = real_date
+        changed = True
+
+    if not changed:
         return dl
-    ctx["video_title"] = title
-    if not ctx.get("published_at") and (res or {}).get("published_at"):
-        ctx["published_at"] = res["published_at"]
-    return dict(dl, title=title, search_ctx=json.dumps(ctx))
+    updated = dict(dl, search_ctx=json.dumps(ctx))
+    if out_title:
+        updated["title"] = out_title
+    return updated
 
 
 _MOVE_CHUNK = 8 * 1024 * 1024   # 8 MiB — smooth progress without syscall spam
@@ -610,7 +628,9 @@ def process_youtube_download(
         return {"status": "failed", "error": err}
 
     # The extractor's metadata is authoritative: a titleless row re-plans its
-    # destination with the REAL title so files never land as '$channel - $date -'.
+    # destination with the REAL title, and a scan-ESTIMATED date ('1 month
+    # ago' → ±weeks) is replaced by the real upload date — the episode number
+    # is MMDD, so a wrong date is a wrong (and colliding) episode number.
     fixed = authoritative_download_fields(dl, res)
     replanned = fixed is not dl
     if replanned:

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -8189,7 +8189,7 @@ class MusicDatabase:
             logger.error(f"Error fetching candidate tracks for {len(album_ids)} album IDs: {e}")
             return []
 
-    def check_album_exists_with_completeness(self, title: str, artist: str, expected_track_count: Optional[int] = None, confidence_threshold: float = 0.8, server_source: Optional[str] = None, candidate_albums: Optional[List[DatabaseAlbum]] = None, strict_discography_match: bool = False) -> Tuple[Optional[DatabaseAlbum], float, int, int, bool, List[str]]:
+    def check_album_exists_with_completeness(self, title: str, artist: str, expected_track_count: Optional[int] = None, confidence_threshold: float = 0.8, server_source: Optional[str] = None, candidate_albums: Optional[List[DatabaseAlbum]] = None, strict_discography_match: bool = False, expected_year=None) -> Tuple[Optional[DatabaseAlbum], float, int, int, bool, List[str]]:
         """
         Check if an album exists in the database with completeness information.
         Enhanced to handle edition matching (standard <-> deluxe variants).
@@ -8201,7 +8201,7 @@ class MusicDatabase:
         """
         try:
             # Try enhanced edition-aware matching first with expected track count for Smart Edition Matching
-            album, confidence = self.check_album_exists_with_editions(title, artist, confidence_threshold, expected_track_count, server_source, candidate_albums=candidate_albums, strict_discography_match=strict_discography_match)
+            album, confidence = self.check_album_exists_with_editions(title, artist, confidence_threshold, expected_track_count, server_source, candidate_albums=candidate_albums, strict_discography_match=strict_discography_match, expected_year=expected_year)
 
             if not album:
                 return None, 0.0, 0, 0, False, []
@@ -8215,7 +8215,7 @@ class MusicDatabase:
             logger.error(f"Error checking album existence with completeness for '{title}' by '{artist}': {e}")
             return None, 0.0, 0, 0, False, []
     
-    def check_album_exists_with_editions(self, title: str, artist: str, confidence_threshold: float = 0.8, expected_track_count: Optional[int] = None, server_source: Optional[str] = None, candidate_albums: Optional[List[DatabaseAlbum]] = None, strict_discography_match: bool = False) -> Tuple[Optional[DatabaseAlbum], float]:
+    def check_album_exists_with_editions(self, title: str, artist: str, confidence_threshold: float = 0.8, expected_track_count: Optional[int] = None, server_source: Optional[str] = None, candidate_albums: Optional[List[DatabaseAlbum]] = None, strict_discography_match: bool = False, expected_year=None) -> Tuple[Optional[DatabaseAlbum], float]:
         """
         Enhanced album existence check that handles edition variants.
         Matches standard albums with deluxe/platinum/special editions and vice versa.
@@ -8238,7 +8238,7 @@ class MusicDatabase:
                 # per-variation SQL widening that the legacy path does.
                 logger.debug(f"Edition matching for '{title}' by '{artist}': batched against {len(candidate_albums)} candidates")
                 for album in candidate_albums:
-                    confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match)
+                    confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match, expected_year=expected_year)
                     if confidence > best_confidence:
                         best_confidence = confidence
                         best_match = album
@@ -8271,7 +8271,7 @@ class MusicDatabase:
 
                     # Score each potential match with Smart Edition Matching
                     for album in albums:
-                        confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match)
+                        confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match, expected_year=expected_year)
                         logger.debug(f"  '{album.title}' confidence: {confidence:.3f}")
 
                         if confidence > best_confidence:
@@ -8307,7 +8307,7 @@ class MusicDatabase:
                             logger.debug(f"  Found {len(artist_albums)} total albums for artist fallback")
 
                         for album in artist_albums:
-                            confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match)
+                            confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match, expected_year=expected_year)
                             if confidence > best_confidence:
                                 best_confidence = confidence
                                 best_match = album
@@ -8326,7 +8326,7 @@ class MusicDatabase:
                 try:
                     title_only_albums = self.search_albums(title=title, artist="", limit=20, server_source=server_source)
                     for album in title_only_albums:
-                        confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match)
+                        confidence = self._calculate_album_confidence(title, artist, album, expected_track_count, strict_discography_match=strict_discography_match, expected_year=expected_year)
                         # Slightly penalize cross-artist matches to prefer same-artist when possible
                         if confidence > best_confidence:
                             best_confidence = confidence
@@ -8443,7 +8443,27 @@ class MusicDatabase:
         
         return unique_variations
     
-    def _calculate_album_confidence(self, search_title: str, search_artist: str, db_album: DatabaseAlbum, expected_track_count: Optional[int] = None, strict_discography_match: bool = False) -> float:
+    @staticmethod
+    def _release_years_conflict(expected_year, album_year, tolerance: int = 1) -> bool:
+        """True when BOTH years are known and disagree beyond tolerance.
+
+        The re-release guard (#re-releases-as-owned): two same-named releases in
+        a discography only exist as separate cards when their years differ (the
+        variant dedup collapses same-year editions), so a year mismatch means
+        the card is a genuinely different release than the local album. Either
+        year missing/unparseable → False, so behavior falls back to the
+        original name-based matching.
+        """
+        try:
+            ey = int(str(expected_year)[:4])
+            ay = int(str(album_year)[:4])
+        except (TypeError, ValueError):
+            return False
+        if ey <= 0 or ay <= 0:
+            return False
+        return abs(ey - ay) > tolerance
+
+    def _calculate_album_confidence(self, search_title: str, search_artist: str, db_album: DatabaseAlbum, expected_track_count: Optional[int] = None, strict_discography_match: bool = False, expected_year=None) -> float:
         """Calculate confidence score for album match with Smart Edition Matching"""
         try:
             # Simple confidence based on string similarity
@@ -8473,6 +8493,19 @@ class MusicDatabase:
                 db_album.track_count,
             ):
                 logger.debug("  Strict discography match rejected: '%s' -> '%s'", search_title, db_album.title)
+                return 0.0
+
+            # Re-release year gate (discography surfaces only): a same-named card
+            # from a different year is a different release — owning the original
+            # must not light up its re-releases. Fires only when BOTH years are
+            # known (±1yr tolerance for edition-date drift); otherwise the match
+            # behaves exactly as before.
+            if (strict_discography_match
+                    and self._release_years_conflict(expected_year,
+                                                     getattr(db_album, 'year', None))):
+                logger.debug(
+                    "  Year gate rejected: '%s' (%s) -> '%s' (%s)",
+                    search_title, expected_year, db_album.title, db_album.year)
                 return 0.0
 
             # Log when normalized matching helps (only if it's the best score and better than others)

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -43,7 +43,7 @@ def _publish_video_event(event_type: str, data: dict) -> None:
 
 # Bump when video_schema.sql changes in a way worth recording. Stored in
 # PRAGMA user_version as a backstop indicator (nothing gates on it yet).
-SCHEMA_VERSION = 44   # v44: video_wishlist.search_attempts/last_search_at (failing visibility); v43: shows.series_type (daily/anime, P8); v42: video_requests (in-app Overseerr, arr-parity P4)
+SCHEMA_VERSION = 45   # v45: per-episode watch state + resume offsets (Continue Watching); v44: video_wishlist.search_attempts/last_search_at; v43: shows.series_type (daily/anime, P8)
 
 _DEFAULT_DB_PATH = "database/video_library.db"
 _SCHEMA_FILE = Path(__file__).resolve().parent / "video_schema.sql"
@@ -157,6 +157,13 @@ _BACKFILL_COLS = {
 
 # Columns ensured on existing DBs (ALTER TABLE ADD COLUMN; idempotent).
 _COLUMN_MIGRATIONS = [
+    # Continue Watching (v45): per-episode watch state + resume offsets, scanned
+    # from the server (Plex viewCount/viewOffset, Jellyfin UserData) — powers
+    # episode checkmarks, progress bars, and the Resume/Next-Up CTA.
+    ("episodes", "play_count", "INTEGER"),
+    ("episodes", "last_viewed_at", "TEXT"),
+    ("episodes", "view_offset_ms", "INTEGER"),
+    ("movies", "view_offset_ms", "INTEGER"),
     # video_wishlist — consecutive fruitless drain searches per row, so the UI can
     # mark repeatedly-failing items (#liveleak-failing-hub). Reset on a grab.
     ("video_wishlist", "search_attempts", "INTEGER DEFAULT 0"),
@@ -2783,6 +2790,7 @@ class VideoDatabase:
                 "rating": item.get("rating"), "rating_critic": item.get("rating_critic"),
                 "play_count": item.get("play_count"),
                 "last_viewed_at": item.get("last_viewed_at"),
+                "view_offset_ms": item.get("view_offset_ms"),
                 "poster_url": item.get("poster_url"),
                 "has_file": 1 if (item.get("files") or item.get("file")) else 0,
             }, {"tmdb_id": item.get("tmdb_id"), "imdb_id": item.get("imdb_id")},
@@ -2863,8 +2871,9 @@ class VideoDatabase:
                     conn.execute(
                         "INSERT INTO episodes (show_id, season_id, server_source, server_id, "
                         "season_number, episode_number, title, overview, air_date, "
-                        "runtime_minutes, still_url, rating, tvdb_id, has_file, added_at) "
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
+                        "runtime_minutes, still_url, rating, tvdb_id, has_file, added_at, "
+                        "play_count, last_viewed_at, view_offset_ms) "
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
                         "ON CONFLICT(show_id, season_number, episode_number) DO UPDATE SET "
                         "season_id=excluded.season_id, server_source=excluded.server_source, "
                         "server_id=excluded.server_id, title=excluded.title, "
@@ -2873,12 +2882,16 @@ class VideoDatabase:
                         "rating=excluded.rating, tvdb_id=excluded.tvdb_id, has_file=excluded.has_file, "
                         # keep the earliest known add-date: don't clobber it with a NULL from a
                         # source that didn't report one.
-                        "added_at=COALESCE(episodes.added_at, excluded.added_at)",
+                        "added_at=COALESCE(episodes.added_at, excluded.added_at), "
+                        # watch state is server truth — always take the fresh values
+                        "play_count=excluded.play_count, last_viewed_at=excluded.last_viewed_at, "
+                        "view_offset_ms=excluded.view_offset_ms",
                         (show_id, season_id, server_source, ep.get("server_id"), snum, enum,
                          ep.get("title"), ep.get("overview"), ep.get("air_date"),
                          ep.get("runtime_minutes"), ep.get("still_url"), ep.get("rating"),
                          ep.get("tvdb_id"), 1 if (ep.get("files") or ep.get("file")) else 0,
-                         ep.get("added_at")),
+                         ep.get("added_at"),
+                         ep.get("play_count"), ep.get("last_viewed_at"), ep.get("view_offset_ms")),
                     )
                     ep_id = conn.execute(
                         "SELECT id FROM episodes WHERE show_id=? AND season_number=? AND episode_number=?",
@@ -4273,6 +4286,7 @@ class VideoDatabase:
             eps = conn.execute(
                 "SELECT id, season_number, episode_number, title, overview, air_date, "
                 "runtime_minutes, rating, monitored, has_file, "
+                "play_count, last_viewed_at, view_offset_ms, "
                 "(still_url IS NOT NULL AND still_url<>'') AS has_still, "
                 # A server may hold several COPIES of one episode — surface them.
                 "(SELECT COUNT(*) FROM media_files f WHERE f.episode_id=episodes.id) AS versions, "
@@ -4292,6 +4306,10 @@ class VideoDatabase:
                 "has_still": bool(e["has_still"]),
                 "monitored": bool(e["monitored"]), "owned": bool(e["has_file"]),
                 "versions": e["versions"], "resolution": e["resolution"],
+                # Continue Watching: server watch state (scanned per episode)
+                "watched": (e["play_count"] or 0) > 0,
+                "last_viewed_at": e["last_viewed_at"],
+                "view_offset_ms": e["view_offset_ms"] or 0,
             })
 
         # Seasons declared in the seasons table, plus any season numbers that only
@@ -4327,6 +4345,7 @@ class VideoDatabase:
             "series_type": show["series_type"] or "standard",
             "locked_fields": sorted(self._parse_locked(show["locked_fields"])),
             "watched": (show["watched_episodes"] or 0) >= total > 0,
+            "watched_episodes": show["watched_episodes"] or 0,   # raw count for "N of M watched"
             "overview": show["overview"], "status": show["status"], "network": show["network"],
             "content_rating": show["content_rating"], "runtime_minutes": show["runtime_minutes"],
             "tagline": show["tagline"], "rating": show["rating"],
@@ -4347,7 +4366,45 @@ class VideoDatabase:
             "season_count": len(out_seasons),
             "episode_total": total, "episode_owned": owned_total,
             "seasons": out_seasons,
+            # Continue Watching: the episode to play next (None until something
+            # has actually been watched — a fresh show has no 'continue' story)
+            "next_up": self.show_next_up(show_id),
         }
+
+    def show_next_up(self, show_id: int) -> dict | None:
+        """The episode to watch NEXT (the Netflix 'Next Up' slot): the most
+        recently started-but-unfinished OWNED episode wins (resume), else the
+        first unwatched owned episode in airing order (specials sort last).
+        Returns None when nothing is owned, nothing has been watched yet, or
+        everything owned is already watched — the hero CTA then stays a plain
+        'Play on <server>'."""
+        conn = self._get_connection()
+        try:
+            rows = conn.execute(
+                "SELECT season_number, episode_number, title, server_id, "
+                "view_offset_ms, runtime_minutes, play_count, last_viewed_at "
+                "FROM episodes WHERE show_id=? AND has_file=1 "
+                "ORDER BY (season_number=0), season_number, episode_number",
+                (show_id,)).fetchall()
+        finally:
+            conn.close()
+        if not rows or not any((r["play_count"] or 0) or (r["view_offset_ms"] or 0) for r in rows):
+            return None    # nothing watched yet — no continue story
+        started = [r for r in rows
+                   if (r["view_offset_ms"] or 0) > 0 and not (r["play_count"] or 0)]
+        if started:
+            r = max(started, key=lambda x: x["last_viewed_at"] or "")
+            resume = True
+        else:
+            unwatched = [r for r in rows if not (r["play_count"] or 0)]
+            if not unwatched:
+                return None    # all owned episodes watched
+            r = unwatched[0]
+            resume = False
+        return {"season_number": r["season_number"], "episode_number": r["episode_number"],
+                "title": r["title"], "server_id": r["server_id"],
+                "view_offset_ms": r["view_offset_ms"] or 0,
+                "runtime_minutes": r["runtime_minutes"], "resume": resume}
 
     def set_monitored(self, kind: str, item_id: int, monitored: bool) -> bool:
         """Toggle the 'follow/watchlist' flag on a movie or show. Returns True if a
@@ -7080,6 +7137,10 @@ class VideoDatabase:
             "quality_profile_id": m["quality_profile_id"] or 0,
             "locked_fields": sorted(self._parse_locked(m["locked_fields"])),
             "watched": (m["play_count"] or 0) > 0,
+            # Continue Watching raw state (v45): last watched + resume position
+            "play_count": m["play_count"] or 0,
+            "last_viewed_at": m["last_viewed_at"],
+            "view_offset_ms": m["view_offset_ms"] or 0,
             "overview": m["overview"], "status": m["status"], "studio": m["studio"],
             "release_date": m["release_date"], "runtime_minutes": m["runtime_minutes"],
             "content_rating": m["content_rating"], "tagline": m["tagline"],

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -4285,7 +4285,7 @@ class VideoDatabase:
                 "FROM seasons WHERE show_id=? ORDER BY season_number", (show_id,)).fetchall()
             eps = conn.execute(
                 "SELECT id, season_number, episode_number, title, overview, air_date, "
-                "runtime_minutes, rating, monitored, has_file, "
+                "runtime_minutes, rating, monitored, has_file, added_at, "
                 "play_count, last_viewed_at, view_offset_ms, "
                 "(still_url IS NOT NULL AND still_url<>'') AS has_still, "
                 # A server may hold several COPIES of one episode — surface them.
@@ -4310,6 +4310,7 @@ class VideoDatabase:
                 "watched": (e["play_count"] or 0) > 0,
                 "last_viewed_at": e["last_viewed_at"],
                 "view_offset_ms": e["view_offset_ms"] or 0,
+                "added_at": e["added_at"],   # NEW badge (freshly landed on the server)
             })
 
         # Seasons declared in the seasons table, plus any season numbers that only
@@ -4346,6 +4347,9 @@ class VideoDatabase:
             "locked_fields": sorted(self._parse_locked(show["locked_fields"])),
             "watched": (show["watched_episodes"] or 0) >= total > 0,
             "watched_episodes": show["watched_episodes"] or 0,   # raw count for "N of M watched"
+            # Enriched-but-never-surfaced facts (detail BIC P3)
+            "awards": show["awards"],
+            "mediastinger": bool(show["mediastinger"] or 0),
             "overview": show["overview"], "status": show["status"], "network": show["network"],
             "content_rating": show["content_rating"], "runtime_minutes": show["runtime_minutes"],
             "tagline": show["tagline"], "rating": show["rating"],
@@ -4431,12 +4435,19 @@ class VideoDatabase:
             if kind == "movie":
                 cur = conn.execute(
                     "UPDATE movies SET play_count=CASE WHEN ? THEN MAX(COALESCE(play_count,0),1) "
-                    "ELSE 0 END WHERE id=?", (1 if watched else 0, item_id))
+                    "ELSE 0 END, view_offset_ms=0 WHERE id=?", (1 if watched else 0, item_id))
             elif kind == "show":
                 cur = conn.execute(
                     "UPDATE shows SET watched_episodes=CASE WHEN ? THEN "
                     "(SELECT COUNT(*) FROM episodes WHERE show_id=shows.id) ELSE 0 END "
                     "WHERE id=?", (1 if watched else 0, item_id))
+                # markPlayed/markUnplayed on a SHOW hits every episode on the
+                # server — mirror that here so the per-episode watch state
+                # (checkmarks, next-up) agrees without waiting for the next scan.
+                conn.execute(
+                    "UPDATE episodes SET play_count=CASE WHEN ? THEN "
+                    "MAX(COALESCE(play_count,0),1) ELSE 0 END, view_offset_ms=0 "
+                    "WHERE show_id=?", (1 if watched else 0, item_id))
             else:
                 return False
             conn.commit()
@@ -7141,6 +7152,10 @@ class VideoDatabase:
             "play_count": m["play_count"] or 0,
             "last_viewed_at": m["last_viewed_at"],
             "view_offset_ms": m["view_offset_ms"] or 0,
+            # Enriched-but-never-surfaced facts (detail BIC P3)
+            "awards": m["awards"],
+            "mediastinger": bool(m["mediastinger"] or 0),
+            "digital_release_date": m["digital_release_date"],
             "overview": m["overview"], "status": m["status"], "studio": m["studio"],
             "release_date": m["release_date"], "runtime_minutes": m["runtime_minutes"],
             "content_rating": m["content_rating"], "tagline": m["tagline"],

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -43,7 +43,7 @@ def _publish_video_event(event_type: str, data: dict) -> None:
 
 # Bump when video_schema.sql changes in a way worth recording. Stored in
 # PRAGMA user_version as a backstop indicator (nothing gates on it yet).
-SCHEMA_VERSION = 43   # v43: shows.series_type (daily/anime, P8); v42: video_requests (in-app Overseerr, arr-parity P4); v41: one-time details_synced heal
+SCHEMA_VERSION = 44   # v44: video_wishlist.search_attempts/last_search_at (failing visibility); v43: shows.series_type (daily/anime, P8); v42: video_requests (in-app Overseerr, arr-parity P4)
 
 _DEFAULT_DB_PATH = "database/video_library.db"
 _SCHEMA_FILE = Path(__file__).resolve().parent / "video_schema.sql"
@@ -157,6 +157,10 @@ _BACKFILL_COLS = {
 
 # Columns ensured on existing DBs (ALTER TABLE ADD COLUMN; idempotent).
 _COLUMN_MIGRATIONS = [
+    # video_wishlist — consecutive fruitless drain searches per row, so the UI can
+    # mark repeatedly-failing items (#liveleak-failing-hub). Reset on a grab.
+    ("video_wishlist", "search_attempts", "INTEGER DEFAULT 0"),
+    ("video_wishlist", "last_search_at", "TEXT"),
     # video_downloads — media identity for the Downloads page cards (poster + open).
     ("video_downloads", "media_id", "TEXT"),
     ("video_downloads", "media_source", "TEXT"),
@@ -5710,6 +5714,35 @@ class VideoDatabase:
         finally:
             conn.close()
 
+    def record_wishlist_search_outcome(self, kind: str, tmdb_id, grabbed: bool,
+                                       season_number=None, episode_number=None) -> None:
+        """Track consecutive fruitless drain searches per wishlist row
+        (#liveleak-failing-hub): a grab resets the counter, a genuinely
+        fruitless search (no results / all rejected) increments it. Searches
+        that never RAN (slskd down, rate-limited) must not be recorded — the
+        caller owns that distinction. Best-effort; never raises."""
+        conn = self._get_connection()
+        try:
+            where = "kind=? AND tmdb_id=?"
+            args = [str(kind), tmdb_id]
+            if season_number is not None and episode_number is not None:
+                where += " AND season_number=? AND episode_number=?"
+                args += [int(season_number), int(episode_number)]
+            if grabbed:
+                conn.execute(
+                    "UPDATE video_wishlist SET search_attempts=0, "
+                    "last_search_at=datetime('now') WHERE " + where, args)
+            else:
+                conn.execute(
+                    "UPDATE video_wishlist SET "
+                    "search_attempts=COALESCE(search_attempts,0)+1, "
+                    "last_search_at=datetime('now') WHERE " + where, args)
+            conn.commit()
+        except sqlite3.Error:
+            logger.exception("record_wishlist_search_outcome failed")
+        finally:
+            conn.close()
+
     def query_wishlist(self, kind: str, *, search=None, sort="added", page=1, limit=60) -> dict:
         """One paged slice of the wishlist. kind='movie' → movie cards; kind='show'
         → shows grouped show→season→episode with wanted/done roll-ups. ``sort`` ∈
@@ -5732,12 +5765,15 @@ class VideoDatabase:
                          "added": "date_added DESC, id DESC"}.get(sort, "date_added DESC, id DESC")
                 total = conn.execute("SELECT COUNT(*) c FROM video_wishlist" + wsql, args).fetchone()["c"]
                 rows = conn.execute(
-                    "SELECT tmdb_id, title, poster_url, year, status, library_id, date_added "
+                    "SELECT tmdb_id, title, poster_url, year, status, library_id, date_added, "
+                    "search_attempts, last_search_at "
                     "FROM video_wishlist" + wsql + " ORDER BY " + order + " LIMIT ? OFFSET ?",
                     args + [limit, (page - 1) * limit]).fetchall()
                 items = [{"kind": "movie", "tmdb_id": r["tmdb_id"], "title": r["title"],
                           "poster_url": r["poster_url"], "year": r["year"], "status": r["status"],
-                          "library_id": r["library_id"]} for r in rows]
+                          "library_id": r["library_id"],
+                          "search_attempts": r["search_attempts"] or 0,
+                          "last_search_at": r["last_search_at"]} for r in rows]
             else:   # shows (grouped from episode rows)
                 where, args = ["kind='episode'"], []
                 if s:
@@ -5759,7 +5795,8 @@ class VideoDatabase:
                 for sr in show_rows:
                     eps = conn.execute(
                         "SELECT season_number, episode_number, episode_title, still_url, "
-                        "episode_overview, season_poster_url, air_date, status "
+                        "episode_overview, season_poster_url, air_date, status, "
+                        "search_attempts, last_search_at "
                         "FROM video_wishlist WHERE kind='episode' AND tmdb_id=? "
                         "ORDER BY season_number, episode_number", (sr["tmdb_id"],)).fetchall()
                     by_season: dict = {}
@@ -5768,7 +5805,9 @@ class VideoDatabase:
                         by_season.setdefault(e["season_number"], []).append({
                             "episode_number": e["episode_number"], "title": e["episode_title"],
                             "still_url": e["still_url"], "overview": e["episode_overview"],
-                            "air_date": e["air_date"], "status": e["status"]})
+                            "air_date": e["air_date"], "status": e["status"],
+                            "search_attempts": e["search_attempts"] or 0,
+                            "last_search_at": e["last_search_at"]})
                         if e["season_poster_url"] and e["season_number"] not in season_poster:
                             season_poster[e["season_number"]] = e["season_poster_url"]
                     seasons = [{"season_number": sn, "poster_url": season_poster.get(sn),

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -43,7 +43,7 @@ def _publish_video_event(event_type: str, data: dict) -> None:
 
 # Bump when video_schema.sql changes in a way worth recording. Stored in
 # PRAGMA user_version as a backstop indicator (nothing gates on it yet).
-SCHEMA_VERSION = 45   # v45: per-episode watch state + resume offsets (Continue Watching); v44: video_wishlist.search_attempts/last_search_at; v43: shows.series_type (daily/anime, P8)
+SCHEMA_VERSION = 46   # v46: media_files format facts (channels/HDR/Atmos badges); v45: per-episode watch state + resume offsets (Continue Watching); v44: video_wishlist.search_attempts/last_search_at
 
 _DEFAULT_DB_PATH = "database/video_library.db"
 _SCHEMA_FILE = Path(__file__).resolve().parent / "video_schema.sql"
@@ -160,6 +160,10 @@ _COLUMN_MIGRATIONS = [
     # Continue Watching (v45): per-episode watch state + resume offsets, scanned
     # from the server (Plex viewCount/viewOffset, Jellyfin UserData) — powers
     # episode checkmarks, progress bars, and the Resume/Next-Up CTA.
+    # v46: scanned format facts for the detail-page badges (4K · HDR · Atmos · 5.1)
+    ("media_files", "audio_channels", "INTEGER"),
+    ("media_files", "dynamic_range", "TEXT"),
+    ("media_files", "atmos", "INTEGER"),
     ("episodes", "play_count", "INTEGER"),
     ("episodes", "last_viewed_at", "TEXT"),
     ("episodes", "view_offset_ms", "INTEGER"),
@@ -2595,13 +2599,16 @@ class VideoDatabase:
                 continue
             conn.execute(
                 f"INSERT INTO media_files ({owner_col}, relative_path, size_bytes, resolution, "
-                "video_codec, audio_codec, release_source, quality, runtime_seconds, aspect) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "video_codec, audio_codec, release_source, quality, runtime_seconds, aspect, "
+                "audio_channels, dynamic_range, atmos) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (owner_id,
                  file.get("relative_path") or file.get("path") or "",
                  file.get("size_bytes"), file.get("resolution"), file.get("video_codec"),
                  file.get("audio_codec"), file.get("release_source"), file.get("quality"),
-                 file.get("runtime_seconds"), canonical_aspect(file.get("aspect"))),
+                 file.get("runtime_seconds"), canonical_aspect(file.get("aspect")),
+                 file.get("audio_channels"), file.get("dynamic_range"),
+                 1 if file.get("atmos") else 0),
             )
 
     @staticmethod
@@ -7137,7 +7144,8 @@ class VideoDatabase:
             genres = self._genres_for(conn, "movie_genres", "movie_id", movie_id)
             credits = self._credits_for(conn, "movie_id", movie_id)
             files = conn.execute(
-                "SELECT resolution, quality, video_codec, audio_codec, release_source, size_bytes "
+                "SELECT resolution, quality, video_codec, audio_codec, release_source, size_bytes, "
+                "audio_channels, dynamic_range, atmos "
                 "FROM media_files WHERE movie_id=? ORDER BY size_bytes DESC",
                 (movie_id,)).fetchall()
         finally:

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -2890,15 +2890,32 @@ class VideoDatabase:
             # Prune only SERVER-originated rows that vanished (server_id set) — the
             # full episode/season list now includes enrichment-added MISSING items
             # (server_id NULL), which the scan must never remove.
+            #
+            # Episodes are FACTS, only their files are server-owned. A missing
+            # (enrichment) row that later got downloaded acquires a server_id via
+            # the upsert above — if its file then disappears from the server, a
+            # hard DELETE erases the episode's very existence from the page (the
+            # Silo-E03 hole: aired episodes vanish, and nothing re-creates them
+            # because the full episode sync is one-time). So a vanished episode
+            # that carries enrichment identity (an air date or a tvdb id) is
+            # DEMOTED back to a missing row — files cleared, server_id NULL —
+            # and only identity-less server junk is actually deleted.
             for row in conn.execute(
-                "SELECT season_number, episode_number FROM episodes "
+                "SELECT id, season_number, episode_number, air_date, tvdb_id FROM episodes "
                 "WHERE show_id=? AND server_id IS NOT NULL", (show_id,)
             ).fetchall():
                 if (row["season_number"], row["episode_number"]) not in seen_eps:
-                    conn.execute(
-                        "DELETE FROM episodes WHERE show_id=? AND season_number=? AND episode_number=?",
-                        (show_id, row["season_number"], row["episode_number"]),
-                    )
+                    if row["air_date"] or row["tvdb_id"]:
+                        conn.execute("DELETE FROM media_files WHERE episode_id=?", (row["id"],))
+                        conn.execute(
+                            "UPDATE episodes SET server_id=NULL, has_file=0 WHERE id=?",
+                            (row["id"],),
+                        )
+                    else:
+                        conn.execute(
+                            "DELETE FROM episodes WHERE show_id=? AND season_number=? AND episode_number=?",
+                            (show_id, row["season_number"], row["episode_number"]),
+                        )
             for row in conn.execute(
                 "SELECT season_number FROM seasons WHERE show_id=? AND server_id IS NOT NULL", (show_id,)
             ).fetchall():

--- a/database/video_schema.sql
+++ b/database/video_schema.sql
@@ -513,7 +513,9 @@ CREATE TABLE IF NOT EXISTS video_wishlist (
     source         TEXT NOT NULL DEFAULT 'tmdb',
     source_id      TEXT,
     parent_source_id TEXT,                   -- owning channel's youtube id (video rows)
-    date_added     TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    date_added     TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    search_attempts INTEGER DEFAULT 0,       -- consecutive fruitless drain searches (reset on grab)
+    last_search_at  TEXT                     -- when the drain last searched this row
 );
 -- one row per movie, one per (show, season, episode), one per youtube video —
 -- partial uniques so the shapes don't collide and re-adding is an idempotent upsert.

--- a/database/video_schema.sql
+++ b/database/video_schema.sql
@@ -98,6 +98,7 @@ CREATE TABLE IF NOT EXISTS movies (
     updated_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     play_count       INTEGER,                         -- server watch state (viewCount)
     last_viewed_at   TEXT,                             -- server last-watched stamp (Plex lastViewedAt / JF LastPlayedDate)
+    view_offset_ms   INTEGER,                         -- resume position (Continue Watching)
     locked_fields    TEXT                             -- JSON list of user-edited (scan/enrichment-immune) fields
 );
 CREATE INDEX IF NOT EXISTS idx_movies_tmdb       ON movies(tmdb_id);
@@ -186,6 +187,9 @@ CREATE TABLE IF NOT EXISTS episodes (
     tvdb_id         INTEGER,
     monitored       INTEGER NOT NULL DEFAULT 1,
     has_file        INTEGER NOT NULL DEFAULT 0,
+    play_count      INTEGER,          -- server watch state (Plex viewCount / JF UserData.PlayCount)
+    last_viewed_at  TEXT,             -- server last-watched stamp
+    view_offset_ms  INTEGER,          -- resume position (Plex viewOffset / JF PlaybackPositionTicks→ms)
     UNIQUE (show_id, season_number, episode_number)
 );
 CREATE INDEX IF NOT EXISTS idx_episodes_show     ON episodes(show_id);

--- a/database/video_schema.sql
+++ b/database/video_schema.sql
@@ -411,6 +411,9 @@ CREATE TABLE IF NOT EXISTS media_files (
     release_source TEXT,             -- bluray | web-dl | webrip | hdtv | youtube
     quality        TEXT,             -- resolved quality name
     runtime_seconds INTEGER,
+    audio_channels INTEGER,          -- 2 | 6 (5.1) | 8 (7.1)
+    dynamic_range  TEXT,             -- HDR10 | HDR10+ | DV | HLG (NULL = SDR)
+    atmos          INTEGER,          -- Dolby Atmos audio present
     added_at       TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CHECK ((movie_id IS NOT NULL) + (episode_id IS NOT NULL) + (video_id IS NOT NULL) = 1)
 );

--- a/services/sync_service.py
+++ b/services/sync_service.py
@@ -367,7 +367,11 @@ class PlaylistSyncService:
                     spotify_track=track,
                     plex_track=plex_match,
                     confidence=confidence,
-                    match_type="robust_search" if plex_match else "no_match"
+                    match_type="robust_search" if plex_match else "no_match",
+                    # The finder accepts db matches at 0.7 (the app-wide "you
+                    # own this" bar) — is_match must agree, or the 0.70-0.79
+                    # band is wishlisted AND left off the playlist (#1047).
+                    match_threshold=0.7,
                 )
                 match_results.append(match_result)
             

--- a/services/sync_service.py
+++ b/services/sync_service.py
@@ -110,6 +110,44 @@ def reresolve_manual_match_live_plex(cache_db, media_client, m, *, profile_id,
         return None
 
 
+def rescue_stale_plex_track(media_client, db_track, artist_name):
+    """A fuzzy db match whose stored ratingKey went stale (Plex re-keys tracks
+    on a metadata refresh/optimize, and SoulSync's db id IS that old key).
+
+    Same recipe as the manual-match self-heal: search live Plex by the matched
+    track's metadata, prefer the exact file (basename of the db track's stored
+    path) when several versions exist, and return the live Plex object or
+    None. Best-effort — never raises; a miss just leaves the track unmatched
+    exactly as before (#1047)."""
+    try:
+        title = (getattr(db_track, 'title', '') or '').strip()
+        if not title:
+            return None
+        results = media_client.search_tracks(title, artist_name or '', limit=15) or []
+        if not results:
+            return None
+
+        import os as _os
+        file_path = (getattr(db_track, 'file_path', '') or '').strip()
+        want_base = _os.path.basename(file_path.replace('\\', '/')) if file_path else ''
+        chosen = None
+        if want_base:
+            for t in results:
+                live = getattr(t, '_original_plex_track', None)
+                p = _plex_track_file(live) if live is not None else ''
+                if p and _os.path.basename(p.replace('\\', '/')) == want_base:
+                    chosen = t
+                    break
+        if chosen is None:
+            chosen = results[0]   # search_tracks ranks artist→title; best effort
+        live = getattr(chosen, '_original_plex_track', None)
+        if live is None or not hasattr(live, 'ratingKey'):
+            return None
+        return live
+    except Exception:
+        return None
+
+
 @dataclass
 class SyncResult:
     playlist_name: str
@@ -839,12 +877,25 @@ class PlaylistSyncService:
                                         return actual_plex_track, confidence
                                     else:
                                         logger.warning(f"Fetched Plex track for '{db_track.title}' lacks ratingKey attribute")
+                                        rescued = rescue_stale_plex_track(media_client, db_track, artist_name)
+                                        if rescued is not None:
+                                            logger.info(f"[Stale-Key Rescue] '{db_track.title}' re-resolved live "
+                                                        f"(stored id {db_track.id} → {rescued.ratingKey})")
+                                            return rescued, confidence
                                 except ValueError:
                                     logger.warning(f"Invalid Plex track ID format for '{db_track.title}' (ID: {db_track.id}) - skipping this track")
                                     continue
-                                
+
                         except Exception as fetch_error:
+                            # Plex re-keys tracks on metadata refresh — the stored id
+                            # 404s here. The track EXISTS; find it live before giving
+                            # up, or it silently counts as missing (#1047).
                             logger.error(f"Failed to fetch actual {server_type} track for '{db_track.title}' (ID: {db_track.id}): {fetch_error}")
+                            rescued = rescue_stale_plex_track(media_client, db_track, artist_name)
+                            if rescued is not None:
+                                logger.info(f"[Stale-Key Rescue] '{db_track.title}' re-resolved live "
+                                            f"(stored id {db_track.id} → {rescued.ratingKey})")
+                                return rescued, confidence
                             # Continue to try other artists rather than fail completely
                             continue
                         

--- a/tests/imports/test_force_redownload_replace.py
+++ b/tests/imports/test_force_redownload_replace.py
@@ -1,0 +1,55 @@
+"""#1045 — Force download must actually replace the existing file.
+
+diegocade1 force-re-downloaded a track for better quality; the download
+succeeded and passed integrity, then the metadata-protection guard skipped
+the overwrite and deleted the new file as "redundant". Force download forced
+the DOWNLOAD but the import step had no concept of replace-intent.
+
+Now an explicit user force (the batch's force_download_all flag) rides the
+same replace path as a quality-enhance: the existing file is replaced —
+still behind the short-file replacement guard (a forced download can never
+swap a full track for a preview clip). No force flag → the protection
+behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.imports import pipeline
+
+
+class TestBatchForceReplace:
+    def test_true_when_batch_carries_the_force_flag(self, monkeypatch):
+        monkeypatch.setitem(pipeline.download_batches, "b1",
+                            {"force_download_all": True})
+        assert pipeline._batch_force_replace({"batch_id": "b1"}) is True
+
+    def test_false_when_batch_not_forced(self, monkeypatch):
+        monkeypatch.setitem(pipeline.download_batches, "b2",
+                            {"force_download_all": False})
+        assert pipeline._batch_force_replace({"batch_id": "b2"}) is False
+
+    def test_false_without_a_batch(self):
+        assert pipeline._batch_force_replace({}) is False
+        assert pipeline._batch_force_replace({"batch_id": "nope-unknown"}) is False
+        assert pipeline._batch_force_replace(None) is False
+
+
+def test_force_is_wired_into_the_protection_branch():
+    src = Path(pipeline.__file__).read_text(encoding="utf-8", errors="replace")
+    # the protection skip must yield to an explicit force...
+    assert "if has_metadata and not is_enhance_download and not force_replace:" in src
+    # ...and force rides the enhance replace path
+    assert "elif is_enhance_download or force_replace:" in src
+    assert "User-forced re-download" in src
+
+
+def test_force_replace_still_behind_the_length_guard():
+    # ordering contract: the short-file replacement guard runs BEFORE any
+    # branch that can os.remove(final_path) — a forced re-download can never
+    # replace a full track with a preview clip
+    src = Path(pipeline.__file__).read_text(encoding="utf-8", errors="replace")
+    guard = src.index("_replacement_length_is_safe(final_path, file_path)")
+    force_branch = src.index("elif is_enhance_download or force_replace:")
+    assert guard < force_branch

--- a/tests/imports/test_force_redownload_replace.py
+++ b/tests/imports/test_force_redownload_replace.py
@@ -5,11 +5,13 @@ succeeded and passed integrity, then the metadata-protection guard skipped
 the overwrite and deleted the new file as "redundant". Force download forced
 the DOWNLOAD but the import step had no concept of replace-intent.
 
-Now an explicit user force (the batch's force_download_all flag) rides the
-same replace path as a quality-enhance: the existing file is replaced —
-still behind the short-file replacement guard (a forced download can never
-swap a full track for a preview clip). No force flag → the protection
-behaves exactly as before.
+Replace-intent is a DISTINCT batch key (``force_replace``), set by web_server
+only for a user-checked Force toggle. It is deliberately NOT
+``force_download_all``: the wishlist sets that on every background batch
+(there it means "skip ownership checks") and Wing It auto-enables it —
+neither may ever overwrite library files. The replace still runs behind the
+short-file replacement guard (a forced download can never swap a full track
+for a preview clip).
 """
 
 from __future__ import annotations
@@ -18,22 +20,46 @@ from pathlib import Path
 
 from core.imports import pipeline
 
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
 
 class TestBatchForceReplace:
-    def test_true_when_batch_carries_the_force_flag(self, monkeypatch):
+    def test_true_when_batch_carries_replace_intent(self, monkeypatch):
         monkeypatch.setitem(pipeline.download_batches, "b1",
-                            {"force_download_all": True})
+                            {"force_replace": True})
         assert pipeline._batch_force_replace({"batch_id": "b1"}) is True
 
     def test_false_when_batch_not_forced(self, monkeypatch):
         monkeypatch.setitem(pipeline.download_batches, "b2",
-                            {"force_download_all": False})
+                            {"force_replace": False})
         assert pipeline._batch_force_replace({"batch_id": "b2"}) is False
+
+    def test_wishlist_style_batch_never_replaces(self, monkeypatch):
+        # the wishlist sets force_download_all=True on EVERY background batch
+        # (meaning "skip ownership checks") and never sets force_replace — a
+        # background download must never overwrite a library file
+        monkeypatch.setitem(pipeline.download_batches, "wl",
+                            {"force_download_all": True})
+        assert pipeline._batch_force_replace({"batch_id": "wl"}) is False
 
     def test_false_without_a_batch(self):
         assert pipeline._batch_force_replace({}) is False
         assert pipeline._batch_force_replace({"batch_id": "nope-unknown"}) is False
         assert pipeline._batch_force_replace(None) is False
+
+
+def test_web_server_sets_replace_intent_only_for_user_force():
+    # the batch key is derived as force AND NOT wing_it — Wing It auto-ors the
+    # force flag in client-side, and that must not read as replace-intent
+    src = (_ROOT / "web_server.py").read_text(encoding="utf-8", errors="replace")
+    assert "'force_replace': bool(force_download_all and not wing_it)" in src
+
+
+def test_wishlist_batches_carry_no_replace_intent():
+    src = (_ROOT / "core" / "wishlist" / "processing.py").read_text(
+        encoding="utf-8", errors="replace")
+    assert "force_replace" not in src, \
+        "wishlist batches must never carry replace-intent"
 
 
 def test_force_is_wired_into_the_protection_branch():
@@ -43,6 +69,8 @@ def test_force_is_wired_into_the_protection_branch():
     # ...and force rides the enhance replace path
     assert "elif is_enhance_download or force_replace:" in src
     assert "User-forced re-download" in src
+    # the pipeline reads the dedicated key, not the overloaded skip-checks flag
+    assert ".get('force_replace')" in src
 
 
 def test_force_replace_still_behind_the_length_guard():

--- a/tests/js/fetch_dedupe_harness.mjs
+++ b/tests/js/fetch_dedupe_harness.mjs
@@ -1,0 +1,91 @@
+// Behavioral harness for webui/static/fetch-dedupe.js — run under node 18+
+// (real Response objects, so the clone-per-consumer semantics are truly
+// exercised). Exits non-zero with a message on any failure.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, '..', '..', 'webui', 'static', 'fetch-dedupe.js'), 'utf8');
+
+let rawCalls = [];
+let nextResponse = () => new Response(JSON.stringify({ n: rawCalls.length }), {
+    status: 200, headers: { 'Content-Type': 'application/json' } });
+let failNext = false;
+
+const fakeFetch = (input, init) => {
+    rawCalls.push({ input, init });
+    if (failNext) { failNext = false; return Promise.resolve(new Response('nope', { status: 500 })); }
+    return Promise.resolve(nextResponse());
+};
+
+globalThis.window = {
+    fetch: fakeFetch,
+    location: { origin: 'http://localhost:8008' },
+};
+
+(0, eval)(src);
+const patched = globalThis.window.fetch;
+const hook = globalThis.window._apiGetDedupe;
+
+function assert(cond, msg) {
+    if (!cond) { console.error('FAIL: ' + msg); process.exit(1); }
+}
+
+const t = async () => {
+    // 1) burst dedupe: two identical /api GETs → ONE raw call, both bodies readable
+    rawCalls = [];
+    const [a, b] = await Promise.all([patched('/api/video/issues/counts'), patched('/api/video/issues/counts')]);
+    assert(rawCalls.length === 1, `burst should make 1 raw call, made ${rawCalls.length}`);
+    const [ja, jb] = await Promise.all([a.json(), b.json()]);
+    assert(ja.n === 1 && jb.n === 1, 'both consumers must read the SAME response body');
+
+    // 2) a third consumer after the originals were read still works (clone-per-consumer)
+    const c = await patched('/api/video/issues/counts');
+    assert(rawCalls.length === 1, 'third consumer within TTL must not refetch');
+    assert((await c.json()).n === 1, 'late consumer clone must still be readable');
+
+    // 3) different query string = different request
+    await patched('/api/video/issues/counts?x=1');
+    assert(rawCalls.length === 2, 'query strings must not collide');
+
+    // 4) POST bypasses entirely
+    rawCalls = [];
+    await patched('/api/video/issues/counts', { method: 'POST' });
+    await patched('/api/video/issues/counts', { method: 'POST' });
+    assert(rawCalls.length === 2, 'POSTs must never dedupe');
+
+    // 5) streams and socket.io bypass
+    rawCalls = [];
+    await patched('/api/artist/similar/311/stream');
+    await patched('/api/artist/similar/311/stream');
+    assert(rawCalls.length === 2, '/stream paths must never dedupe');
+    assert(hook.dedupeKey('/socket.io/?EIO=4') === null, 'socket.io must be excluded');
+
+    // 6) abortable requests bypass (a shared abort would kill every consumer)
+    assert(hook.dedupeKey('/api/x', { signal: {} }) === null, 'signal requests must bypass');
+
+    // 7) non-api and cross-origin bypass
+    assert(hook.dedupeKey('/static/style.css') === null, 'non-api must bypass');
+    assert(hook.dedupeKey('https://evil.example/api/x') === null, 'cross-origin must bypass');
+    assert(hook.dedupeKey('/status') === '/status', '/status is deduped');
+
+    // 8) failures are not cached — the next caller retries for real
+    rawCalls = [];
+    failNext = true;
+    const f = await patched('/api/failing/counts');
+    assert(f.status === 500, 'failure passes through');
+    await patched('/api/failing/counts');
+    assert(rawCalls.length === 2, 'a failed response must not be served from cache');
+
+    // 9) TTL expiry refetches
+    rawCalls = [];
+    await patched('/api/ttl/check');
+    hook.entries.get('/api/ttl/check').t -= (hook.ttl + 1);
+    await patched('/api/ttl/check');
+    assert(rawCalls.length === 2, 'expired entries must refetch');
+
+    console.log('fetch-dedupe harness: all assertions passed');
+};
+
+t().catch((e) => { console.error('FAIL: ' + (e && e.stack || e)); process.exit(1); });

--- a/tests/metadata/test_canonical_pin_deny.py
+++ b/tests/metadata/test_canonical_pin_deny.py
@@ -1,0 +1,124 @@
+"""Canonical pin deny (#re-releases-showing-as-owned, second layer).
+
+When a local album carries a canonical pin (the exact release its files were
+scored against), a discography card from the SAME source with a DIFFERENT id
+is a sibling edition — a name match must not credit it as owned.
+
+The deny demands proof before firing: the card's id must actually resolve in
+the pin's source (its tracklist loads), so a card that slipped in from a
+fallback source (different id-space) can never false-deny. Every missing
+piece of data → the original fuzzy behavior, untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+# Same import stubs as the sibling completion tests.
+if "spotipy" not in sys.modules:
+    spotipy = types.ModuleType("spotipy")
+    spotipy.Spotify = type("S", (), {"__init__": lambda self, *a, **k: None})
+    oauth2 = types.ModuleType("spotipy.oauth2")
+    oauth2.SpotifyOAuth = type("O", (), {"__init__": lambda self, *a, **k: None})
+    oauth2.SpotifyClientCredentials = oauth2.SpotifyOAuth
+    spotipy.oauth2 = oauth2
+    sys.modules["spotipy"] = spotipy
+    sys.modules["spotipy.oauth2"] = oauth2
+
+if "config.settings" not in sys.modules:
+    config_pkg = types.ModuleType("config")
+    settings_mod = types.ModuleType("config.settings")
+
+    class _DummyConfigManager:
+        def get_active_media_server(self):
+            return "plex"
+
+    settings_mod.config_manager = _DummyConfigManager()
+    config_pkg.settings = settings_mod
+    sys.modules["config"] = config_pkg
+    sys.modules["config.settings"] = settings_mod
+
+from core.metadata import completion as metadata_completion  # noqa: E402
+
+
+class _PinnedDB:
+    """A library where 'Album X' matched and carries a canonical pin."""
+
+    def __init__(self, canonical):
+        self.canonical = canonical
+        self.local_album = types.SimpleNamespace(id="local-1")
+
+    def check_album_exists_with_completeness(self, **kwargs):
+        return self.local_album, 0.95, 12, 12, True, ["FLAC"]
+
+    def get_album_canonical(self, album_id):
+        return self.canonical
+
+    def check_album_completeness(self, album_id, expected_track_count=None):
+        expected = expected_track_count or 12
+        return 12, expected, 12 >= expected, ["FLAC"]
+
+
+def _check(db, monkeypatch, *, card_id="rerelease-99", resolvable=True,
+           pin_tracks=12):
+    """Run check_album_completion for a spotify card against the pinned db."""
+
+    def get_tracks(source, album_id):
+        # the pin's own tracklist always loads; the card's id loads only when
+        # the test says it is resolvable in that source
+        if album_id == (db.canonical or {}).get("album_id"):
+            return {"items": [{"id": f"t{i}"} for i in range(pin_tracks)]}
+        if resolvable:
+            return {"items": [{"id": f"t{i}"} for i in range(15)]}
+        return {"items": []}
+
+    monkeypatch.setattr(metadata_completion, "get_album_tracks_for_source",
+                        get_tracks)
+    return metadata_completion.check_album_completion(
+        db,
+        {"id": card_id, "name": "Album X", "total_tracks": 15},
+        "Artist",
+        source_chain=["spotify"],
+    )
+
+
+def test_pin_denies_sibling_edition_from_same_source(monkeypatch):
+    # files pinned to spotify:original-1; the spotify re-release card must not
+    # read as owned even though the name matches
+    db = _PinnedDB({"source": "spotify", "album_id": "original-1"})
+    result = _check(db, monkeypatch, card_id="rerelease-99", resolvable=True)
+    assert result["status"] == "missing"
+    assert result["found_in_db"] is False
+    assert result["owned_tracks"] == 0
+
+
+def test_pin_confirms_its_own_card(monkeypatch):
+    # the card that IS the pinned release keeps its owned status
+    db = _PinnedDB({"source": "spotify", "album_id": "original-1"})
+    result = _check(db, monkeypatch, card_id="original-1")
+    assert result["status"] == "completed"
+    assert result["found_in_db"] is True
+
+
+def test_unresolvable_card_id_never_denies(monkeypatch):
+    # a card whose id does not load in the pin's source (e.g. it came from a
+    # fallback source with a different id-space) falls back to old behavior
+    db = _PinnedDB({"source": "spotify", "album_id": "original-1"})
+    result = _check(db, monkeypatch, card_id="itunes-12345", resolvable=False)
+    assert result["found_in_db"] is True
+    assert result["status"] in ("completed", "partial")
+
+
+def test_pin_from_other_source_never_denies(monkeypatch):
+    # pin is a musicbrainz release; a spotify card can't be compared to it
+    db = _PinnedDB({"source": "musicbrainz", "album_id": "mb-uuid-1"})
+    result = _check(db, monkeypatch, card_id="rerelease-99", resolvable=True)
+    assert result["found_in_db"] is True
+
+
+def test_no_pin_is_untouched(monkeypatch):
+    db = _PinnedDB(None)
+    result = _check(db, monkeypatch, card_id="rerelease-99", resolvable=True)
+    assert result["found_in_db"] is True
+    assert result["status"] in ("completed", "partial")

--- a/tests/metadata/test_rerelease_year_gate.py
+++ b/tests/metadata/test_rerelease_year_gate.py
@@ -1,0 +1,164 @@
+"""Re-release year gate (#re-releases-showing-as-owned).
+
+Ownership matching is name-based, so owning the ORIGINAL album lit up every
+re-release of it (different-year cards for the same title) as owned/partial —
+and switching the primary metadata source reshuffled which cards lit up.
+
+The gate: on discography surfaces (strict_discography_match=True) a candidate
+whose year and the card's year are BOTH known and differ by more than 1 year
+can never match. Every fallback keeps the original behavior byte-for-byte:
+either year missing/unparseable → no gate; non-strict callers (download
+matching, repair) → no gate; same-year edition variants (standard vs deluxe)
+→ untouched, including the intentional completeness clamp.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+# The same lightweight stubs the sibling completion tests use — keep the module
+# import from dragging in spotipy / live config.
+if "spotipy" not in sys.modules:
+    spotipy = types.ModuleType("spotipy")
+    spotipy.Spotify = type("S", (), {"__init__": lambda self, *a, **k: None})
+    oauth2 = types.ModuleType("spotipy.oauth2")
+    oauth2.SpotifyOAuth = type("O", (), {"__init__": lambda self, *a, **k: None})
+    oauth2.SpotifyClientCredentials = oauth2.SpotifyOAuth
+    spotipy.oauth2 = oauth2
+    sys.modules["spotipy"] = spotipy
+    sys.modules["spotipy.oauth2"] = oauth2
+
+from database.music_database import MusicDatabase, DatabaseAlbum  # noqa: E402
+from core.metadata import completion as metadata_completion  # noqa: E402
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return MusicDatabase(str(tmp_path / "music.db"))
+
+
+def _album(title, year, track_count=12, album_id=1):
+    a = DatabaseAlbum(id=album_id, artist_id=1, title=title, year=year,
+                      track_count=track_count)
+    # real candidates (search_albums / get_candidate_albums_for_artist) carry
+    # the joined artist name; the matcher reads it
+    a.artist_name = ARTIST
+    return a
+
+
+ARTIST = "Original Artist"
+
+
+def _match(db, title, candidates, *, year=None, strict=True, tracks=None):
+    album, confidence = db.check_album_exists_with_editions(
+        title, ARTIST, confidence_threshold=0.7,
+        expected_track_count=tracks, candidate_albums=candidates,
+        strict_discography_match=strict, expected_year=year)
+    return album
+
+
+class TestYearsConflict:
+    def test_far_apart_years_conflict(self):
+        assert MusicDatabase._release_years_conflict("2024", 2005) is True
+
+    def test_within_tolerance_do_not_conflict(self):
+        assert MusicDatabase._release_years_conflict("2006", 2005) is False
+        assert MusicDatabase._release_years_conflict("2005", 2005) is False
+
+    def test_missing_or_garbage_never_conflicts(self):
+        assert MusicDatabase._release_years_conflict(None, 2005) is False
+        assert MusicDatabase._release_years_conflict("2024", None) is False
+        assert MusicDatabase._release_years_conflict("", 2005) is False
+        assert MusicDatabase._release_years_conflict("abcd", 2005) is False
+        assert MusicDatabase._release_years_conflict("0", 2005) is False
+        assert MusicDatabase._release_years_conflict("2024-05-01", 2024) is False  # date string tolerated
+
+
+class TestMatcherYearGate:
+    def test_rerelease_card_does_not_match_owned_original(self, db):
+        # THE reported bug: own the 2005 original; the 2024 re-release card
+        # must not read as owned.
+        owned = [_album("Album X", 2005)]
+        assert _match(db, "Album X", owned, year="2024") is None
+
+    def test_original_card_still_matches_owned_original(self, db):
+        owned = [_album("Album X", 2005)]
+        assert _match(db, "Album X", owned, year="2005") is not None
+
+    def test_adjacent_year_tolerated(self, db):
+        # deluxe drops the following year — still the same release family
+        owned = [_album("Album X", 2005)]
+        assert _match(db, "Album X", owned, year="2006") is not None
+
+    def test_unknown_card_year_falls_back_to_old_behavior(self, db):
+        owned = [_album("Album X", 2005)]
+        assert _match(db, "Album X", owned, year=None) is not None
+
+    def test_unknown_local_year_falls_back_to_old_behavior(self, db):
+        owned = [_album("Album X", None)]
+        assert _match(db, "Album X", owned, year="2024") is not None
+
+    def test_non_strict_callers_unchanged(self, db):
+        # download matching / repair paths pass strict=False — the gate must
+        # never fire there even on a hard year mismatch.
+        owned = [_album("Album X", 2005)]
+        assert _match(db, "Album X", owned, year="2024", strict=False) is not None
+
+    def test_same_year_deluxe_still_matches_standard_card(self, db):
+        # the intentional standard-vs-deluxe behavior is preserved: same year,
+        # bigger owned edition, card asks for 12 → still a match
+        owned = [_album("Album X (Deluxe Edition)", 2005, track_count=15)]
+        assert _match(db, "Album X", owned, year="2005", tracks=12) is not None
+
+    def test_gate_picks_the_right_edition_from_mixed_candidates(self, db):
+        # both the original and a re-release exist locally; the 2024 card must
+        # match the 2024 local copy, not the 2005 one
+        owned = [_album("Album X", 2005, album_id=1),
+                 _album("Album X", 2024, album_id=2)]
+        got = _match(db, "Album X", owned, year="2024")
+        assert got is not None and got.id == 2
+
+
+class _WiringDB:
+    """Captures what completion passes to the matcher."""
+
+    def __init__(self):
+        self.kwargs = None
+
+    def check_album_exists_with_completeness(self, **kwargs):
+        self.kwargs = dict(kwargs)
+        return None, 0.0, 0, 0, False, []
+
+
+class TestCompletionWiring:
+    def test_album_completion_passes_card_year(self):
+        db = _WiringDB()
+        metadata_completion.check_album_completion(
+            db, {"id": "r1", "name": "Album X", "total_tracks": 12,
+                 "year": "2024"}, ARTIST, source_chain=["spotify"])
+        assert db.kwargs["expected_year"] == "2024"
+
+    def test_album_completion_falls_back_to_release_date(self):
+        db = _WiringDB()
+        metadata_completion.check_album_completion(
+            db, {"id": "r1", "name": "Album X", "total_tracks": 12,
+                 "release_date": "2019-03-08"}, ARTIST, source_chain=["spotify"])
+        assert db.kwargs["expected_year"] == "2019"
+
+    def test_album_completion_passes_none_when_no_year(self):
+        db = _WiringDB()
+        metadata_completion.check_album_completion(
+            db, {"id": "r1", "name": "Album X", "total_tracks": 12},
+            ARTIST, source_chain=["spotify"])
+        assert db.kwargs["expected_year"] is None
+
+    def test_ep_completion_passes_card_year(self):
+        db = _WiringDB()
+        metadata_completion.check_single_completion(
+            db, {"id": "r2", "name": "EP X", "total_tracks": 5,
+                 "album_type": "ep", "year": "2021"}, ARTIST,
+            source_chain=["spotify"])
+        assert db.kwargs["expected_year"] == "2021"

--- a/tests/sync/test_match_threshold_band.py
+++ b/tests/sync/test_match_threshold_band.py
@@ -1,0 +1,62 @@
+"""#1047 — the 0.70-0.79 confidence band must count as matched in playlist sync.
+
+The sync's finder accepts db matches at 0.7 (the app-wide "you own this"
+bar), but MatchResult.is_match hardcoded 0.8 — so a 0.70-0.79 match resolved
+to a LIVE server track and was still counted unmatched: sent to the wishlist
+(re-download of something owned) and left off the server playlist. That band
+is a real chunk of any large fuzzy-tagged library (part of the ~300-track
+gap in the report).
+
+MatchResult now carries its caller's threshold; the default stays 0.8 so
+every other consumer is untouched.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.matching_engine import MatchResult
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _mr(confidence, track=True, **kw):
+    return MatchResult(
+        spotify_track=SimpleNamespace(name="T"),
+        plex_track=SimpleNamespace(title="T") if track else None,
+        confidence=confidence,
+        match_type="robust_search",
+        **kw,
+    )
+
+
+class TestDefaultThresholdUnchanged:
+    def test_default_bar_is_still_08(self):
+        assert _mr(0.79).is_match is False
+        assert _mr(0.80).is_match is True
+
+    def test_no_track_never_matches(self):
+        assert _mr(0.95, track=False).is_match is False
+
+
+class TestSyncThreshold:
+    def test_band_counts_as_matched_at_07(self):
+        assert _mr(0.70, match_threshold=0.7).is_match is True
+        assert _mr(0.75, match_threshold=0.7).is_match is True
+
+    def test_below_the_finder_bar_still_unmatched(self):
+        assert _mr(0.69, match_threshold=0.7).is_match is False
+
+    def test_no_track_still_never_matches(self):
+        assert _mr(0.75, track=False, match_threshold=0.7).is_match is False
+
+
+def test_sync_service_constructs_with_the_finder_threshold():
+    src = (_ROOT / "services" / "sync_service.py").read_text(encoding="utf-8",
+                                                             errors="replace")
+    assert "match_threshold=0.7" in src
+    # and the finder really does accept 0.7 — the two must stay in agreement
+    assert re.search(r"confidence_threshold=0\.7", src)
+    assert "confidence >= 0.7" in src

--- a/tests/sync/test_playlist_write_chunking.py
+++ b/tests/sync/test_playlist_write_chunking.py
@@ -1,0 +1,86 @@
+"""#1047 P3 — playlist writes are chunked and read back.
+
+A single createPlaylist/addItems call carrying ~1000 ratingKeys builds an
+oversized request that Plex (or a reverse proxy) can reject or silently
+truncate — the sync then reports success while the server playlist is short.
+All Plex playlist writes now go through bounded chunks, and the result is
+read back so a partial add is logged honestly instead of over-reporting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from core.plex_client import PlexClient
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class _FakePlaylist:
+    def __init__(self):
+        self.batches = []
+
+    def addItems(self, items):
+        self.batches.append(list(items))
+
+    def items(self):
+        return [t for b in self.batches for t in b]
+
+
+def _tracks(n):
+    return [SimpleNamespace(ratingKey=i, title=f"T{i}") for i in range(n)]
+
+
+def _client():
+    # bare instance — chunk helpers don't touch the connection
+    return PlexClient.__new__(PlexClient)
+
+
+class TestChunkedAdds:
+    def test_large_add_is_split_into_bounded_batches(self):
+        c = _client()
+        pl = _FakePlaylist()
+        c._add_items_chunked(pl, _tracks(1000))
+        assert len(pl.batches) == 5
+        assert all(len(b) <= PlexClient._PLAYLIST_ADD_CHUNK for b in pl.batches)
+        assert len(pl.items()) == 1000
+
+    def test_small_add_is_a_single_batch(self):
+        c = _client()
+        pl = _FakePlaylist()
+        c._add_items_chunked(pl, _tracks(37))
+        assert len(pl.batches) == 1
+
+    def test_failed_chunk_raises_not_swallowed(self):
+        c = _client()
+
+        class _Boom(_FakePlaylist):
+            def addItems(self, items):
+                if len(self.batches) == 1:
+                    raise RuntimeError("plex rejected")
+                super().addItems(items)
+
+        pl = _Boom()
+        try:
+            c._add_items_chunked(pl, _tracks(500))
+            raise AssertionError("a failed chunk must raise")
+        except RuntimeError:
+            pass
+
+
+def test_all_three_write_paths_use_the_chunker():
+    src = (_ROOT / "core" / "plex_client.py").read_text(encoding="utf-8",
+                                                        errors="replace")
+    # create (rest-after-first-chunk), append, reconcile
+    assert src.count("self._add_items_chunked(") >= 4
+    # and no direct oversized addItems remains on the three sync write paths
+    assert "existing_playlist.addItems(new_tracks)" not in src
+    assert "existing.addItems(to_add)" not in src
+
+
+def test_writes_are_verified_against_the_server():
+    src = (_ROOT / "core" / "plex_client.py").read_text(encoding="utf-8",
+                                                        errors="replace")
+    assert src.count("self._verify_playlist_count(") >= 3
+    assert "partial add" in src

--- a/tests/sync/test_stale_ratingkey_rescue.py
+++ b/tests/sync/test_stale_ratingkey_rescue.py
@@ -1,0 +1,81 @@
+"""#1047 P2 — stale Plex ratingKeys must not silently unmatch owned tracks.
+
+Plex re-keys tracks on a metadata refresh/optimize, and SoulSync's db track
+id IS that old ratingKey. The sync's fetchItem then 404s and the track —
+which exists, matched at full confidence — silently became "missing":
+wishlisted and dropped from the playlist. The manual-match path already had
+a live-search self-heal; fuzzy matches now get the same rescue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from services.sync_service import rescue_stale_plex_track
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _live(rating_key, path):
+    live = SimpleNamespace(ratingKey=rating_key)
+    live.media = [SimpleNamespace(parts=[SimpleNamespace(file=path)])]
+    return live
+
+
+def _result(rating_key, path):
+    return SimpleNamespace(_original_plex_track=_live(rating_key, path))
+
+
+class _Client:
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def search_tracks(self, title, artist, limit=15):
+        self.calls.append((title, artist))
+        return self.results
+
+
+def _db_track(title="Song", file_path="/music/A/album/03 - Song.flac", tid="123"):
+    return SimpleNamespace(id=tid, title=title, file_path=file_path)
+
+
+def test_rescues_by_exact_file_basename():
+    # two versions live on plex; the one whose file matches the db track wins
+    client = _Client([
+        _result(901, "/music/A/other/Song (Live).flac"),
+        _result(902, "/music/A/album/03 - Song.flac"),
+    ])
+    live = rescue_stale_plex_track(client, _db_track(), "Artist")
+    assert live is not None and live.ratingKey == 902
+
+
+def test_falls_back_to_top_result_without_a_path_match():
+    client = _Client([_result(901, "/somewhere/else.flac")])
+    live = rescue_stale_plex_track(client, _db_track(), "Artist")
+    assert live is not None and live.ratingKey == 901
+
+
+def test_no_results_returns_none():
+    assert rescue_stale_plex_track(_Client([]), _db_track(), "Artist") is None
+
+
+def test_search_error_returns_none_never_raises():
+    class _Boom:
+        def search_tracks(self, *a, **k):
+            raise RuntimeError("plex down")
+    assert rescue_stale_plex_track(_Boom(), _db_track(), "Artist") is None
+
+
+def test_result_without_live_track_returns_none():
+    client = _Client([SimpleNamespace(_original_plex_track=None)])
+    assert rescue_stale_plex_track(client, _db_track(), "Artist") is None
+
+
+def test_rescue_is_wired_into_both_fetch_failure_branches():
+    src = (_ROOT / "services" / "sync_service.py").read_text(encoding="utf-8",
+                                                             errors="replace")
+    # once for the lacks-ratingKey branch, once for the fetchItem exception
+    assert src.count("rescued = rescue_stale_plex_track(") == 2
+    assert "[Stale-Key Rescue]" in src

--- a/tests/test_deep_scan_empty_library.py
+++ b/tests/test_deep_scan_empty_library.py
@@ -1,0 +1,187 @@
+"""Deep scan vs an empty/shrunken library selection (#stale-artists, 5BILLION).
+
+Switching the library selection (All Libraries → one) and deep-scanning used to
+fail two ways:
+  • an EMPTY selected library errored out ("No artists found") before stale
+    removal ever ran — the old selection's artists stayed forever
+  • a SMALL selected library tripped the >50%-stale safety guard, silently
+    skipping removal
+
+The fix makes the fetch verifiable: _get_all_artists marks whether the server
+actually ANSWERED (a real list) vs the fetch failing. A verified-empty answer
+is confirmed with a second fetch, then stale removal proceeds; the 50% guard
+is bypassed only for a fully-trusted scan (verified fetch + zero per-artist
+failures + not stopped). Every failure path keeps the old conservative
+behavior: error out, remove nothing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.database_update_worker import DatabaseUpdateWorker
+from database.music_database import MusicDatabase
+
+
+class _FakeClient:
+    """Media client whose get_all_artists yields scripted answers per call."""
+
+    def __init__(self, answers, connected=True):
+        self.answers = list(answers)
+        self.connected = connected
+
+    def ensure_connection(self):
+        return self.connected
+
+    def get_all_artists(self):
+        a = self.answers.pop(0) if self.answers else self.answers_default()
+        if isinstance(a, Exception):
+            raise a
+        return a
+
+    def answers_default(self):
+        return []
+
+    def set_progress_callback(self, cb):
+        pass
+
+    def clear_cache(self):
+        pass
+
+
+@pytest.fixture()
+def dbpath(tmp_path, monkeypatch):
+    p = str(tmp_path / "music.db")
+    db = MusicDatabase(p)   # create schema
+    # get_database() is a process-wide singleton bound to the FIRST path it
+    # sees — later workers would silently write to another test's db. Bind the
+    # worker to THIS test's db explicitly.
+    monkeypatch.setattr("core.database_update_worker.get_database",
+                        lambda path=None: db)
+    return p
+
+
+def _seed(dbpath, n_tracks=10, server="navidrome"):
+    db = MusicDatabase(dbpath)
+    with db._get_connection() as conn:
+        conn.execute("INSERT OR REPLACE INTO artists (id, name, server_source) VALUES ('a1', 'Old Artist', ?)", (server,))
+        conn.execute("INSERT OR REPLACE INTO albums (id, title, artist_id) VALUES (900, 'Old Album', 'a1')")
+        for i in range(n_tracks):
+            conn.execute(
+                "INSERT OR REPLACE INTO tracks (id, album_id, artist_id, title, track_number, duration, "
+                "file_path, server_source) VALUES (?, 900, 'a1', ?, 1, 100, ?, ?)",
+                (f"t{i}", f"T{i}", f"/m/t{i}.flac", server))
+        conn.commit()
+    return db
+
+
+def _worker(dbpath, client):
+    w = DatabaseUpdateWorker(media_client=client, database_path=dbpath,
+                             server_type="navidrome", force_sequential=True)
+    w.events = {"error": [], "finished": []}
+    w.callbacks["error"].append(lambda *a: w.events["error"].append(a))
+    w.callbacks["finished"].append(lambda *a: w.events["finished"].append(a))
+    return w
+
+
+def _counts(dbpath, server="navidrome"):
+    db = MusicDatabase(dbpath)
+    with db._get_connection() as conn:
+        artists = conn.execute("SELECT COUNT(*) FROM artists WHERE server_source = ?", (server,)).fetchone()[0]
+        tracks = conn.execute("SELECT COUNT(*) FROM tracks WHERE server_source = ?", (server,)).fetchone()[0]
+    return artists, tracks
+
+
+def test_verified_empty_library_removes_stale_artists(dbpath):
+    # THE reported bug: selected library is empty; the old selection's data
+    # must be removed, not left behind an error.
+    _seed(dbpath, n_tracks=10)
+    w = _worker(dbpath, _FakeClient(answers=[[], []]))   # two verified-empty answers
+    w.run_deep_scan()
+    assert not w.events["error"], f"unexpected error: {w.events['error']}"
+    assert w.events["finished"], "scan should complete"
+    artists, tracks = _counts(dbpath)
+    assert tracks == 0
+    assert artists == 0, "stale artists must be cleaned up"
+
+
+def test_failed_connection_still_errors_and_removes_nothing(dbpath):
+    _seed(dbpath, n_tracks=10)
+    w = _worker(dbpath, _FakeClient(answers=[[]], connected=False))
+    w.run_deep_scan()
+    assert w.events["error"], "a failed connection must surface as an error"
+    assert _counts(dbpath) == (1, 10)
+
+
+def test_fetch_exception_still_errors_and_removes_nothing(dbpath):
+    _seed(dbpath, n_tracks=10)
+    w = _worker(dbpath, _FakeClient(answers=[RuntimeError("api down")]))
+    w.run_deep_scan()
+    assert w.events["error"]
+    assert _counts(dbpath) == (1, 10)
+
+
+def test_none_answer_is_not_trusted_as_empty(dbpath):
+    # a client that swallowed an error into None must not wipe anything
+    _seed(dbpath, n_tracks=10)
+    w = _worker(dbpath, _FakeClient(answers=[None]))
+    w.run_deep_scan()
+    assert w.events["error"]
+    assert _counts(dbpath) == (1, 10)
+
+
+def test_transient_empty_answer_recovers_on_second_fetch(dbpath):
+    # first answer empty, second answer has the artist — scan proceeds with
+    # the real list and removes nothing it saw
+    _seed(dbpath, n_tracks=3)
+    artist = SimpleNamespace(title="Old Artist")
+    w = _worker(dbpath, _FakeClient(answers=[[], [artist]]))
+    w._deep_scan_process_all_artists = lambda artists, seen: seen.update({"t0", "t1", "t2"})
+    w.run_deep_scan()
+    assert not w.events["error"]
+    assert _counts(dbpath) == (1, 3)
+
+
+def test_trusted_scan_may_exceed_the_50pct_guard(dbpath):
+    # the shrunken-library case: >100 tracks in db, server (verified, clean)
+    # only has 2 of them → mass staleness is REAL and must be removed
+    _seed(dbpath, n_tracks=120)
+    artist = SimpleNamespace(title="Old Artist")
+    w = _worker(dbpath, _FakeClient(answers=[[artist]]))
+    w._deep_scan_process_all_artists = lambda artists, seen: seen.update({"t0", "t1"})
+    w.run_deep_scan()
+    assert not w.events["error"]
+    _, tracks = _counts(dbpath)
+    assert tracks == 2, "stale tracks beyond 50% must be removed on a trusted scan"
+
+
+def test_untrusted_scan_keeps_the_50pct_guard(dbpath):
+    # same mass staleness but one artist failed to process → guard holds
+    _seed(dbpath, n_tracks=120)
+    artist = SimpleNamespace(title="Old Artist")
+    w = _worker(dbpath, _FakeClient(answers=[[artist]]))
+
+    def _process(artists, seen):
+        seen.update({"t0", "t1"})
+        w.failed_operations = 1
+    w._deep_scan_process_all_artists = _process
+    w.run_deep_scan()
+    _, tracks = _counts(dbpath)
+    assert tracks == 120, "guard must hold when any artist failed to process"
+
+
+def test_stopped_scan_keeps_the_50pct_guard(dbpath):
+    # a scan stopped mid-run has a partial seen-set — never mass-remove
+    _seed(dbpath, n_tracks=120)
+    artist = SimpleNamespace(title="Old Artist")
+    w = _worker(dbpath, _FakeClient(answers=[[artist]]))
+
+    def _process(artists, seen):
+        seen.update({"t0", "t1"})
+        w.should_stop = True
+    w._deep_scan_process_all_artists = _process
+    w.run_deep_scan()
+    _, tracks = _counts(dbpath)
+    assert tracks == 120

--- a/tests/test_deep_scan_empty_library.py
+++ b/tests/test_deep_scan_empty_library.py
@@ -132,6 +132,31 @@ def test_none_answer_is_not_trusted_as_empty(dbpath):
     assert _counts(dbpath) == (1, 10)
 
 
+def test_client_marked_fetch_failure_is_not_trusted_as_empty(dbpath):
+    # the real clients swallow API failures into [] internally (a reachable
+    # server whose artists endpoint 500s). they mark last_fetch_failed for
+    # exactly this — an [] carrying that mark must never wipe the library.
+    _seed(dbpath, n_tracks=10)
+    client = _FakeClient(answers=[[], []])
+    client.last_fetch_failed = True
+    w = _worker(dbpath, client)
+    w.run_deep_scan()
+    assert w.events["error"], "a marked-failed fetch must surface as an error"
+    assert _counts(dbpath) == (1, 10)
+
+
+def test_all_real_clients_mark_fetch_failures():
+    # contract: every media client's get_all_artists must set last_fetch_failed
+    # (True on its swallowed-failure branches, False on a real answer) — a new
+    # client without it would reopen the wipe-on-API-failure hole.
+    from pathlib import Path
+    root = Path(__file__).resolve().parent.parent
+    for name in ("plex_client.py", "jellyfin_client.py", "navidrome_client.py"):
+        src = (root / "core" / name).read_text(encoding="utf-8")
+        assert "self.last_fetch_failed = True" in src, f"{name} missing failure mark"
+        assert "self.last_fetch_failed = False" in src, f"{name} missing success mark"
+
+
 def test_transient_empty_answer_recovers_on_second_fetch(dbpath):
     # first answer empty, second answer has the artist — scan proceeds with
     # the real list and removes nothing it saw

--- a/tests/test_enrichment_status_all.py
+++ b/tests/test_enrichment_status_all.py
@@ -1,0 +1,99 @@
+"""Bundled enrichment status hydrate (request-flood P2).
+
+Page load fired ~13 music + ~15 video per-service /status GETs; each side now
+has a /status-all bundle collected with per-service isolation (one failing
+collector degrades to its own error field, never the whole response), and the
+frontends hydrate from the bundle with per-service fallback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from core.enrichment.api import create_blueprint
+from core.enrichment.services import (
+    EnrichmentService,
+    clear_registry,
+    register_services,
+)
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+class _Worker:
+    def __init__(self, stats=None, raises=None):
+        self._stats = stats or {"enabled": True, "running": True, "paused": False}
+        self._raises = raises
+
+    def get_stats(self):
+        if self._raises:
+            raise self._raises
+        return self._stats
+
+
+@pytest.fixture()
+def client():
+    clear_registry()
+    register_services([
+        EnrichmentService(id="alpha", display_name="Alpha",
+                          worker_getter=lambda: _Worker({"enabled": True, "id": "a"})),
+        EnrichmentService(id="beta", display_name="Beta",
+                          worker_getter=lambda: _Worker({"enabled": True, "id": "b"})),
+        EnrichmentService(id="broken", display_name="Broken",
+                          worker_getter=lambda: _Worker(raises=RuntimeError("db locked"))),
+    ])
+    app = Flask(__name__)
+    app.register_blueprint(create_blueprint())
+    yield app.test_client()
+    clear_registry()
+
+
+def test_bundle_returns_every_service(client):
+    body = client.get("/api/enrichment/status-all").get_json()
+    assert set(body["services"]) == {"alpha", "beta", "broken"}
+    assert body["services"]["alpha"]["id"] == "a"
+    assert body["services"]["beta"]["id"] == "b"
+
+
+def test_one_failing_collector_never_breaks_the_bundle(client):
+    res = client.get("/api/enrichment/status-all")
+    assert res.status_code == 200
+    services = res.get_json()["services"]
+    assert "error" in services["broken"]
+    assert "error" not in services["alpha"]
+
+
+def test_bundle_agrees_with_the_per_service_route(client):
+    bundle = client.get("/api/enrichment/status-all").get_json()["services"]
+    single = client.get("/api/enrichment/alpha/status").get_json()
+    assert bundle["alpha"] == single
+
+
+# ── wiring pins ───────────────────────────────────────────────────────────────
+
+def test_music_frontend_hydrates_through_the_shim():
+    js = (_ROOT / "webui" / "static" / "enrichment.js").read_text(encoding="utf-8", errors="replace")
+    assert "function _enrichmentStatusFetch" in js
+    assert "'/api/enrichment/status-all'" in js
+    # every per-service loader was rewired — no raw per-service status fetch
+    # remains outside the shim's own fallback
+    import re
+    assert not re.search(r"fetch\('/api/enrichment/[a-z_]+/status'\)", js)
+    mgr = (_ROOT / "webui" / "static" / "enrichment-manager.js").read_text(encoding="utf-8", errors="replace")
+    assert "_enrichmentStatusFetch(w.id)" in mgr
+
+
+def test_video_backend_and_frontend_bundle():
+    api = (_ROOT / "api" / "video" / "enrichment.py").read_text(encoding="utf-8", errors="replace")
+    assert '"/enrichment/status-all"' in api
+    mgr = (_ROOT / "webui" / "static" / "video" / "video-enrichment-manager.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert "'/api/video/enrichment/status-all'" in mgr
+    dash = (_ROOT / "webui" / "static" / "video" / "video-enrichment.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert "'/api/video/enrichment/status-all'" in dash
+    # per-service fallback survives on both surfaces
+    assert "pollOne" in dash

--- a/tests/test_fetch_dedupe.py
+++ b/tests/test_fetch_dedupe.py
@@ -1,0 +1,52 @@
+"""API GET dedupe (request-flood P1).
+
+One page load fired the same GET many times from components that don't know
+about each other. fetch-dedupe.js wraps window.fetch so identical same-origin
+/api GET bursts share one wire request, with clone-per-consumer semantics.
+The behavioral contract lives in tests/js/fetch_dedupe_harness.mjs (real
+Response objects under node); this wrapper runs it and pins the wiring.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_HTML = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8", errors="replace")
+_JS = (_ROOT / "webui" / "static" / "fetch-dedupe.js").read_text(encoding="utf-8", errors="replace")
+
+
+def _node():
+    return shutil.which("node") or shutil.which("node.exe")
+
+
+@pytest.mark.skipif(_node() is None, reason="node not available")
+def test_behavioral_harness_passes():
+    # relative path + cwd: under WSL the interop node.exe can't open
+    # /mnt/... absolute paths, but resolves relative ones from the mapped cwd
+    res = subprocess.run(
+        [_node(), "tests/js/fetch_dedupe_harness.mjs"],
+        cwd=str(_ROOT), capture_output=True, text=True, timeout=120)
+    assert res.returncode == 0, f"harness failed:\n{res.stdout}\n{res.stderr}"
+    assert "all assertions passed" in res.stdout
+
+
+def test_loaded_before_every_other_script():
+    # must wrap fetch before the React bundle and all split modules run
+    dedupe_at = _HTML.index("fetch-dedupe.js")
+    assert dedupe_at < _HTML.index("vite_assets('body')")
+    assert dedupe_at < _HTML.index("filename='core.js'")
+
+
+def test_conservative_bypass_rules_present():
+    # the rules that make a global fetch patch safe
+    assert "'/stream'" in _JS or '"/stream"' in _JS      # GET SSE (similar artists)
+    assert "socket.io" in _JS
+    assert "text/event-stream" in _JS
+    assert "signal" in _JS                               # abortable → bypass
+    assert ".clone()" in _JS                             # single-use bodies
+    assert "entries.delete(key)" in _JS                  # failures not cached

--- a/tests/test_library_m3u_scan_note.py
+++ b/tests/test_library_m3u_scan_note.py
@@ -1,0 +1,63 @@
+"""#1041 — the whole-library M3U scan hook must be observable.
+
+The auto-sync fires in _db_update_finished_callback (every scan type converges
+there), but its outcome was invisible outside app.log — "never triggers"
+reports couldn't be told apart from "wrote to a folder you didn't look in"
+(default destination is the TRANSFER folder) or "toggle not actually on".
+
+Now the scan summary carries the outcome: written path + track count when it
+ran, an explicit failure note when it broke, and a skip line in the log when
+the setting is off.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+_TMP = tempfile.mkdtemp(prefix='soulsync-testdb-m3u-')
+os.environ['DATABASE_PATH'] = os.path.join(_TMP, 'm.db')
+os.environ['SOULSYNC_TEST_DB_READY'] = '1'
+
+web_server = pytest.importorskip('web_server')
+
+
+@pytest.fixture()
+def m3u_dir(tmp_path):
+    d = tmp_path / "m3u_out"
+    web_server.config_manager.set('m3u_export.library_enabled', True)
+    web_server.config_manager.set('m3u_export.library_path', str(d))
+    yield d
+    web_server.config_manager.set('m3u_export.library_enabled', False)
+    web_server.config_manager.set('m3u_export.library_path', '')
+
+
+def _phase():
+    with web_server.db_update_lock:
+        return web_server.db_update_state.get('phase', '')
+
+
+def test_scan_completion_writes_library_m3u_and_says_so(m3u_dir):
+    web_server._db_update_finished_callback(0, 0, 0, 0, 0)
+    written = m3u_dir / "soulsync_library.m3u"
+    assert written.exists(), "the library m3u must be written on scan completion"
+    assert "Library M3U" in _phase(), "the scan summary must state the m3u outcome"
+    assert str(written) in _phase()
+
+
+def test_disabled_setting_writes_nothing_and_stays_quiet(tmp_path):
+    web_server.config_manager.set('m3u_export.library_enabled', False)
+    web_server.config_manager.set('m3u_export.library_path', str(tmp_path / "off"))
+    web_server._db_update_finished_callback(0, 0, 0, 0, 0)
+    assert not (tmp_path / "off").exists()
+    assert "Library M3U" not in _phase()
+
+
+def test_write_failure_is_surfaced_in_the_summary(m3u_dir, monkeypatch):
+    import core.library.m3u_export as m3u_export
+    monkeypatch.setattr(m3u_export, "write_library_m3u",
+                        lambda *a, **k: None)
+    web_server._db_update_finished_callback(0, 0, 0, 0, 0)
+    assert "Library M3U write failed" in _phase()

--- a/tests/test_poller_cadence.py
+++ b/tests/test_poller_cadence.py
@@ -1,0 +1,47 @@
+"""Steady-state poller cadence (request-flood P3).
+
+Two provably-noisy pollers tamed:
+  • video service-status polled every 5s forever for values that change only
+    when the user edits settings — now 60s, skipped while the tab is hidden,
+    with INSTANT repaint on side-flip and tab refocus
+  • the show-detail downloads tracker polled flat 2.5s for as long as any
+    show page stayed open — now adaptive (fast only while a download for the
+    show is in flight, 10s idle) and silent while hidden
+
+The downloads PAGE poller was already adaptive (2s active / 6s idle,
+self-stopping off-page) and stays untouched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_service_status_polls_slow_and_respects_hidden():
+    js = (_ROOT / "webui" / "static" / "video" / "video-service-status.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert "60000" in js and ", 5000)" not in js
+    assert "document.hidden" in js
+    # instant repaint hooks: side-flip observer + tab refocus
+    assert "MutationObserver" in js
+    assert "visibilitychange" in js
+
+
+def test_detail_download_tracker_is_adaptive():
+    js = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert "_DL_FAST_MS = 2500" in js and "_DL_IDLE_MS = 10000" in js
+    assert "_dlHasActive ? _DL_FAST_MS : _DL_IDLE_MS" in js
+    assert "_dlHasActive = Object.keys(cur).length > 0" in js
+    # no flat interval remains for this tracker
+    assert "setInterval(pollDl" not in js
+    # hidden tab stays silent but the loop keeps rescheduling
+    assert "if (!document.hidden) pollDl()" in js
+
+
+def test_downloads_page_poller_untouched():
+    js = (_ROOT / "webui" / "static" / "video" / "video-downloads-page.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert "anyActive() ? 2000 : 6000" in js

--- a/tests/test_scan_cache_staleness.py
+++ b/tests/test_scan_cache_staleness.py
@@ -1,0 +1,107 @@
+"""Scan vs the media client's singleton caches (#torrent-album-missing, TheHomeGuy).
+
+The jellyfin/navidrome clients cache per-artist album lists and per-album track
+lists on a process-wide singleton, cache-first. Incremental scans populated
+those caches and never cleared them (the "no new content" early exit skipped
+even the end-of-run clear) — so a deep scan run after an import read a
+PRE-IMPORT view of an artist's albums and the newly imported album never
+reached the database, showing MISSING forever while the server played it fine.
+
+Contract pinned here:
+  • deep scan and full refresh clear the client cache BEFORE fetching
+  • every incremental run clears at its end — including the early "no new
+    content" exit
+  • plex is untouched (its client has no such cache contract)
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.database_update_worker import DatabaseUpdateWorker
+from database.music_database import MusicDatabase
+
+
+class _RecordingClient:
+    """Navidrome-ish client that records the order of cache/fetch calls."""
+
+    def __init__(self, artists=None):
+        self.calls = []
+        self._artists = artists if artists is not None else []
+
+    def ensure_connection(self):
+        return True
+
+    def get_all_artists(self):
+        self.calls.append("get_all_artists")
+        return list(self._artists)
+
+    def clear_cache(self):
+        self.calls.append("clear_cache")
+
+    def set_progress_callback(self, cb):
+        pass
+
+
+@pytest.fixture()
+def dbpath(tmp_path, monkeypatch):
+    p = str(tmp_path / "music.db")
+    db = MusicDatabase(p)
+    monkeypatch.setattr("core.database_update_worker.get_database",
+                        lambda path=None: db)
+    return p
+
+
+def _worker(dbpath, client, *, server="navidrome", full_refresh=False):
+    return DatabaseUpdateWorker(media_client=client, database_path=dbpath,
+                                server_type=server, full_refresh=full_refresh,
+                                force_sequential=True)
+
+
+def test_deep_scan_clears_cache_before_fetching(dbpath):
+    client = _RecordingClient()
+    w = _worker(dbpath, client)
+    w.run_deep_scan()
+    assert "clear_cache" in client.calls
+    assert client.calls.index("clear_cache") < client.calls.index("get_all_artists"), \
+        "deep scan must clear the singleton cache BEFORE reading the server"
+
+
+def test_full_refresh_clears_cache_before_fetching(dbpath):
+    client = _RecordingClient()
+    w = _worker(dbpath, client, full_refresh=True)
+    w.run()
+    assert "clear_cache" in client.calls
+    assert client.calls.index("clear_cache") < client.calls.index("get_all_artists")
+
+
+def test_incremental_no_new_content_still_clears(dbpath):
+    # the early "no new content" exit used to skip the clear — the probe's own
+    # cached listings then poisoned the next deep scan
+    client = _RecordingClient()
+    w = _worker(dbpath, client)
+    w._get_artists_for_incremental_update = lambda: []
+    w.run()
+    assert "clear_cache" in client.calls
+
+
+def test_incremental_with_content_clears_at_end(dbpath):
+    client = _RecordingClient()
+    w = _worker(dbpath, client)
+    w._get_artists_for_incremental_update = lambda: [SimpleNamespace(title="A")]
+    w._process_all_artists = lambda artists: None
+    w.run()
+    assert "clear_cache" in client.calls
+    # end-of-run clear: after processing, not before the fetch
+    assert client.calls[-1] == "clear_cache" or "clear_cache" in client.calls
+
+
+def test_plex_scans_never_touch_clear_cache(dbpath):
+    # plex has no jellyfin/navidrome-style cache contract — the worker must
+    # not call clear_cache on it
+    client = _RecordingClient(artists=[])
+    w = _worker(dbpath, client, server="plex")
+    w.run_deep_scan()
+    assert "clear_cache" not in client.calls

--- a/tests/test_video_continue_watching_ui.py
+++ b/tests/test_video_continue_watching_ui.py
@@ -1,0 +1,62 @@
+"""Continue Watching P2 — detail-page UI seams (pin tests).
+
+The backend (schema v45) ships per-episode watch state + a next_up slot; this
+pins the frontend wiring: episode rows show watched checks / progress bars /
+the Next-up highlight, the hero CTA deep-links the next episode, and the page
+opens on the season you're actually in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_JS = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+    encoding="utf-8", errors="replace")
+_CSS = (_ROOT / "webui" / "static" / "video" / "video-side.css").read_text(
+    encoding="utf-8", errors="replace")
+
+
+class TestEpisodeRows:
+    def test_watched_check_and_classes(self):
+        assert 'vd-ep-check' in _JS
+        assert "if (ep.watched) owned += ' vd-ep--watched'" in _JS
+
+    def test_progress_bar_only_for_in_progress(self):
+        # in-progress = started but NOT watched, and runtime known (else no %)
+        assert '!ep.watched && (ep.view_offset_ms || 0) > 0 && ep.runtime_minutes' in _JS
+        assert 'vd-ep-prog-fill' in _JS
+
+    def test_next_up_highlight_matches_payload_slot(self):
+        assert 'nu.season_number === selectedSeason' in _JS
+        assert 'nu.episode_number === ep.episode_number' in _JS
+        assert 'vd-ep-next-chip' in _JS
+
+
+class TestHeroCta:
+    def test_deep_links_next_episode(self):
+        assert "(snu && d.server.episode_url) ? d.server.episode_url : d.server.url" in _JS
+
+    def test_resume_labels(self):
+        assert "verb = snu.resume ? 'Resume' : 'Play'" in _JS
+        # movies: resume only when in progress and not already watched
+        assert "d.kind === 'movie' && !d.watched && (d.view_offset_ms || 0) > 0" in _JS
+
+    def test_watched_tags_in_meta(self):
+        assert _JS.count('vd-watched-tag') >= 3   # show full/partial + movie
+
+
+class TestSeasonLanding:
+    def test_initial_season_prefers_next_up(self):
+        assert 'function initialSeasonNum(d)' in _JS
+        # both load paths (initial open + the post-sync refresh) go through it
+        assert _JS.count('selectedSeason = initialSeasonNum(d)') == 2
+        # ...and never a season the payload doesn't have
+        assert 's.season_number === nu.season_number' in _JS
+
+
+def test_css_carries_the_watch_state_styles():
+    for cls in ('.vd-ep-prog', '.vd-ep-prog-fill', '.vd-ep-check',
+                '.vd-ep--watched', '.vd-ep--next', '.vd-ep-next-chip',
+                '.vd-watched-tag', '.vd-play-ep'):
+        assert cls in _CSS, f"missing style {cls}"

--- a/tests/test_video_database.py
+++ b/tests/test_video_database.py
@@ -281,13 +281,18 @@ def test_upsert_show_tree_builds_seasons_episodes_and_prunes(db):
                          (sid,)).fetchone()["has_file"] == 1
         assert c.execute("SELECT has_file FROM episodes WHERE show_id=? AND episode_number=2",
                          (sid,)).fetchone()["has_file"] == 0
-    # Re-scan with E2 removed from the server -> it gets pruned.
+    # Re-scan with E2 removed from the server -> DEMOTED, not deleted: E2 has
+    # identity (air_date), and episodes are facts — only FILES are server-owned.
+    # (The Silo E03 lesson; the full demote seams live in test_video_episode_demote.)
     item["seasons"][0]["episodes"] = item["seasons"][0]["episodes"][:1]
     assert db.upsert_show_tree("plex", item) == sid
     with db.connect() as c:
-        eps = [r["episode_number"] for r in c.execute(
-            "SELECT episode_number FROM episodes WHERE show_id=?", (sid,)).fetchall()]
-    assert eps == [1]
+        rows = {r["episode_number"]: r for r in c.execute(
+            "SELECT episode_number, server_id, has_file FROM episodes WHERE show_id=?",
+            (sid,)).fetchall()}
+    assert sorted(rows) == [1, 2]
+    assert rows[2]["server_id"] is None and rows[2]["has_file"] == 0   # demoted to MISSING
+    assert rows[1]["has_file"] == 1                                    # untouched
 
 
 def test_upsert_stores_provider_ids(db):

--- a/tests/test_video_detail_surfacing.py
+++ b/tests/test_video_detail_surfacing.py
@@ -1,0 +1,107 @@
+"""Detail BIC P3 — enriched-but-never-surfaced facts + the watched toggle UI.
+
+Awards / mediastinger / digital_release_date were already enriched (for
+overlays) but never reached the detail payloads; episodes now carry added_at
+for the NEW badge; set_watch_state on a show mirrors markPlayed down to the
+per-episode rows so the page's checkmarks agree instantly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from database.video_database import VideoDatabase
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+def _ep(e, *, plays=0, offset=0):
+    return {"server_id": "e%d" % e, "season_number": 1, "episode_number": e,
+            "title": "E%d" % e, "air_date": "2026-07-%02d" % e,
+            "play_count": plays, "view_offset_ms": offset,
+            "added_at": "2026-07-1%d 10:00:00" % (e % 10),
+            "file": {"relative_path": "/tv/s1e%d.mkv" % e, "size_bytes": 100}}
+
+
+def _tree(eps):
+    return {"server_id": "sh", "title": "Show",
+            "seasons": [{"season_number": 1, "episodes": eps}]}
+
+
+class TestPayloadSurfacing:
+    def test_movie_exposes_awards_stinger_digital_date(self, db):
+        mid = db.upsert_movie("plex", {"server_id": "m1", "title": "Film", "year": 2020,
+                                       "tmdb_id": 7})
+        with db.connect() as c:
+            c.execute("UPDATE movies SET awards=?, mediastinger=1, digital_release_date=? "
+                      "WHERE id=?", ("Won 2 Oscars. 154 wins total.", "2020-06-01", mid))
+            c.commit()
+        d = db.movie_detail(mid)
+        assert d["awards"] == "Won 2 Oscars. 154 wins total."
+        assert d["mediastinger"] is True
+        assert d["digital_release_date"] == "2020-06-01"
+
+    def test_show_exposes_awards_and_stinger(self, db):
+        sid = db.upsert_show_tree("plex", _tree([_ep(1)]))
+        with db.connect() as c:
+            c.execute("UPDATE shows SET awards=?, mediastinger=1 WHERE id=?",
+                      ("Won 3 Primetime Emmys.", sid))
+            c.commit()
+        d = db.show_detail(sid)
+        assert d["awards"] == "Won 3 Primetime Emmys."
+        assert d["mediastinger"] is True
+
+    def test_episodes_carry_added_at_for_the_new_badge(self, db):
+        sid = db.upsert_show_tree("plex", _tree([_ep(1)]))
+        eps = db.show_detail(sid)["seasons"][0]["episodes"]
+        assert eps[0]["added_at"] == "2026-07-11 10:00:00"
+
+
+class TestWatchedToggleMirror:
+    def test_show_toggle_flips_every_episode_row(self, db):
+        sid = db.upsert_show_tree("plex", _tree([
+            _ep(1, plays=1), _ep(2, offset=500_000), _ep(3)]))
+        assert db.set_watch_state("show", sid, True) is True
+        d = db.show_detail(sid)
+        assert d["watched"] is True
+        assert all(e["watched"] and e["view_offset_ms"] == 0
+                   for e in d["seasons"][0]["episodes"])
+        assert d["next_up"] is None            # nothing left to continue
+        # ...and back: unwatch clears the rows too
+        assert db.set_watch_state("show", sid, False) is True
+        d = db.show_detail(sid)
+        assert d["watched"] is False
+        assert not any(e["watched"] for e in d["seasons"][0]["episodes"])
+
+    def test_movie_toggle_clears_the_resume_offset(self, db):
+        mid = db.upsert_movie("plex", {"server_id": "m1", "title": "F", "year": 2020,
+                                       "tmdb_id": 7, "view_offset_ms": 900_000})
+        assert db.set_watch_state("movie", mid, True) is True
+        d = db.movie_detail(mid)
+        assert d["watched"] is True and d["view_offset_ms"] == 0
+
+
+class TestUiPins:
+    def test_detail_js_wires_the_toggle_and_facts(self):
+        js = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+            encoding="utf-8", errors="replace")
+        assert "data-vd-act=\"watched-toggle\"" in js
+        assert "which === 'watched-toggle') toggleWatchedState(act)" in js
+        assert "'/watched'" in js                       # hits the existing API
+        assert 'function renderAwards(d)' in js
+        assert js.count('renderAwards(d)') >= 3         # def + main + youtube-path clear
+        assert 'vd-ep-new-chip' in js
+        assert 'After-credits scene' in js
+        assert "rows.push(['Digital release', d.digital_release_date])" in js
+        assert "f.quality || mediaRes(f.resolution)" in js
+
+    def test_hero_html_has_awards_anchor_in_both_blocks(self):
+        html = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8", errors="replace")
+        assert html.count('data-vd-awards') == 2        # show + movie heroes

--- a/tests/test_video_episode_demote.py
+++ b/tests/test_video_episode_demote.py
@@ -1,0 +1,107 @@
+"""Vanished episodes demote to missing instead of being erased (the Silo-E03 hole).
+
+An enrichment-created missing episode that gets downloaded acquires a
+server_id via the scan upsert. If its file then disappears from the server,
+the old prune hard-DELETEd the row — the episode vanished from the page
+entirely (1, 2, 4, 5…), and nothing re-created it because the full episode
+sync is one-time. Episodes are facts; only files are server-owned:
+
+  • a vanished episode WITH enrichment identity (air_date or tvdb_id) is
+    demoted — files cleared, server_id NULL, row (title/air date/overview)
+    kept, so the page still shows it as missing and it stays wishlistable
+  • identity-less server junk is still deleted
+  • enrichment rows (server_id NULL) remain untouched, as before
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from database.video_database import VideoDatabase
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+def _ep(sid, e, *, air_date=None, tvdb=None, with_file=True, title=None):
+    d = {"server_id": sid, "season_number": 1, "episode_number": e,
+         "title": title or ("E%d" % e), "air_date": air_date, "tvdb_id": tvdb}
+    if with_file:
+        d["file"] = {"relative_path": "/tv/silo/s1e%d.mkv" % e,
+                     "size_bytes": 1000, "resolution": "1080p"}
+    return d
+
+
+def _tree(eps):
+    return {"server_id": "silo", "title": "Silo",
+            "seasons": [{"season_number": 1, "episodes": eps}]}
+
+
+def _rows(db, show_id):
+    conn = db._get_connection()
+    try:
+        return {r["episode_number"]: dict(r) for r in conn.execute(
+            "SELECT episode_number, server_id, has_file, title, air_date, "
+            "(SELECT COUNT(*) FROM media_files f WHERE f.episode_id=episodes.id) AS files "
+            "FROM episodes WHERE show_id=?", (show_id,))}
+    finally:
+        conn.close()
+
+
+def test_silo_e03_scenario_demotes_instead_of_erasing(db):
+    # e1..e3 on the server (e3 was downloaded after airing), then e3's file
+    # disappears — the next scan tree only carries e1, e2
+    show_id = db.upsert_show_tree("plex", _tree([
+        _ep("p1", 1, air_date="2026-07-02"),
+        _ep("p2", 2, air_date="2026-07-09"),
+        _ep("p3", 3, air_date="2026-07-16"),
+    ]))
+    db.upsert_show_tree("plex", _tree([
+        _ep("p1", 1, air_date="2026-07-02"),
+        _ep("p2", 2, air_date="2026-07-09"),
+    ]))
+    rows = _rows(db, show_id)
+    assert 3 in rows, "an aired episode must never vanish from the page"
+    assert rows[3]["has_file"] == 0 and rows[3]["server_id"] is None
+    assert rows[3]["files"] == 0
+    assert rows[3]["air_date"] == "2026-07-16"          # identity kept
+    # and the detail tree shows it as missing, not absent
+    eps = db.show_detail(show_id)["seasons"][0]["episodes"]
+    assert [e["episode_number"] for e in eps] == [1, 2, 3]
+    assert eps[2]["owned"] is False
+
+
+def test_identityless_junk_is_still_deleted(db):
+    show_id = db.upsert_show_tree("plex", _tree([
+        _ep("p1", 1, air_date="2026-07-02"),
+        _ep("p9", 9),                                    # no air_date, no tvdb id
+    ]))
+    db.upsert_show_tree("plex", _tree([_ep("p1", 1, air_date="2026-07-02")]))
+    rows = _rows(db, show_id)
+    assert 9 not in rows
+
+
+def test_tvdb_id_also_counts_as_identity(db):
+    show_id = db.upsert_show_tree("plex", _tree([
+        _ep("p1", 1, air_date="2026-07-02"),
+        _ep("p3", 3, tvdb=987654),
+    ]))
+    db.upsert_show_tree("plex", _tree([_ep("p1", 1, air_date="2026-07-02")]))
+    assert 3 in _rows(db, show_id)
+
+
+def test_demoted_episode_can_be_repromoted(db):
+    # re-download: the file comes back on the server → owned again, same row
+    show_id = db.upsert_show_tree("plex", _tree([
+        _ep("p3", 3, air_date="2026-07-16"),
+    ]))
+    db.upsert_show_tree("plex", _tree([]))               # gone → demoted
+    assert _rows(db, show_id)[3]["has_file"] == 0
+    db.upsert_show_tree("plex", _tree([
+        _ep("p3b", 3, air_date="2026-07-16"),
+    ]))
+    rows = _rows(db, show_id)
+    assert rows[3]["has_file"] == 1 and rows[3]["server_id"] == "p3b"
+    assert rows[3]["files"] == 1

--- a/tests/test_video_episode_demote.py
+++ b/tests/test_video_episode_demote.py
@@ -92,6 +92,37 @@ def test_tvdb_id_also_counts_as_identity(db):
     assert 3 in _rows(db, show_id)
 
 
+def test_backfill_restores_a_deleted_episode_row_silo_shape(db):
+    # the EXACT live shape from the report: E1/E2 server-owned, E3's row
+    # deleted (pre-demote-fix prune), E4+ enrichment rows — a TMDB season
+    # backfill must re-INSERT the hole, not just gap-fill existing rows
+    show_id = db.upsert_show_tree("plex", _tree([
+        _ep("p1", 1, air_date="2026-07-02"),
+        _ep("p2", 2, air_date="2026-07-09"),
+    ]))
+    db.backfill_episodes(show_id, 1, [
+        {"episode_number": n, "title": "E%d" % n, "air_date": "2026-07-%02d" % (2 + 7 * (n - 1))}
+        for n in range(1, 11)
+    ])
+    conn = db._get_connection()
+    conn.execute("DELETE FROM episodes WHERE show_id=? AND season_number=1 AND episode_number=3",
+                 (show_id,))
+    conn.commit()
+    conn.close()
+    assert 3 not in _rows(db, show_id)          # the hole, as on the live box
+
+    touched = db.backfill_episodes(show_id, 1, [
+        {"episode_number": n, "title": "E%d" % n, "air_date": "2026-07-%02d" % (2 + 7 * (n - 1))}
+        for n in range(1, 11)
+    ])
+    rows = _rows(db, show_id)
+    assert 3 in rows, "backfill must restore the deleted episode row"
+    assert rows[3]["has_file"] == 0
+    assert touched >= 1
+    # owned rows untouched
+    assert rows[1]["has_file"] == 1 and rows[2]["has_file"] == 1
+
+
 def test_demoted_episode_can_be_repromoted(db):
     # re-download: the file comes back on the server → owned again, same row
     show_id = db.upsert_show_tree("plex", _tree([

--- a/tests/test_video_format_badges.py
+++ b/tests/test_video_format_badges.py
@@ -1,0 +1,99 @@
+"""Detail BIC P4 — format facts on media files (4K · HDR · Atmos · 5.1 badges).
+
+media_files gains audio_channels / dynamic_range / atmos (schema v46). Plex
+gives a real channel count but stream-level HDR would be an N+1 reload, so
+HDR/Atmos come from release-name tokens (Radarr-style); Jellyfin overrides
+with real MediaStream facts (VideoRangeType, Channels, Atmos profile).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.video.sources import _format_from_name
+from database.video_database import VideoDatabase
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+class TestNameTokens:
+    def test_full_stack_release(self):
+        got = _format_from_name("/m/Dune.2021.2160p.UHD.BluRay.DV.HDR10Plus.Atmos.TrueHD.7.1.mkv")
+        assert got == {"dynamic_range": "DV HDR10+", "atmos": True}
+
+    def test_plain_hdr_and_hlg(self):
+        assert _format_from_name("/m/x.hdr.hevc.mkv") == {"dynamic_range": "HDR10"}
+        assert _format_from_name("/m/x.hlg.mkv") == {"dynamic_range": "HLG"}
+
+    def test_dolby_vision_spelled_out(self):
+        assert _format_from_name("/m/x.Dolby.Vision.mkv") == {"dynamic_range": "DV"}
+
+    def test_no_false_positives_inside_words(self):
+        # 'dv' in 'adverse', 'hdr' nowhere, 'atmos' in 'atmosphere' guarded by \b
+        assert _format_from_name("/tv/adverse.effects.s01e01.mkv") == {}
+        assert _format_from_name("/m/atmosphere.2020.mkv") == {}
+
+    def test_sdr_release_is_empty(self):
+        assert _format_from_name("/m/Oppenheimer.2023.1080p.WEB-DL.DDP5.1.H.264.mkv") == {}
+
+
+class TestIngestRoundTrip:
+    def test_schema_and_migrations(self, db):
+        conn = db._get_connection()
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(media_files)")}
+        conn.close()
+        assert {"audio_channels", "dynamic_range", "atmos"} <= cols
+        src = (_ROOT / "database" / "video_database.py").read_text(encoding="utf-8", errors="replace")
+        for entry in ('("media_files", "audio_channels", "INTEGER")',
+                      '("media_files", "dynamic_range", "TEXT")',
+                      '("media_files", "atmos", "INTEGER")'):
+            assert entry in src, f"missing migration {entry}"
+
+    def test_movie_file_carries_the_facts(self, db):
+        mid = db.upsert_movie("plex", {
+            "server_id": "m1", "title": "Dune", "year": 2021, "tmdb_id": 438631,
+            "file": {"relative_path": "/m/dune.mkv", "size_bytes": 10, "resolution": "2160p",
+                     "audio_codec": "truehd", "audio_channels": 8,
+                     "dynamic_range": "DV HDR10+", "atmos": True}})
+        f = db.movie_detail(mid)["file"]
+        assert f["audio_channels"] == 8
+        assert f["dynamic_range"] == "DV HDR10+"
+        assert f["atmos"] == 1
+
+    def test_plain_file_stays_clean(self, db):
+        mid = db.upsert_movie("plex", {
+            "server_id": "m2", "title": "F", "year": 2020, "tmdb_id": 7,
+            "file": {"relative_path": "/m/f.mkv", "size_bytes": 10, "resolution": "1080p"}})
+        f = db.movie_detail(mid)["file"]
+        assert f["audio_channels"] is None and f["dynamic_range"] is None and f["atmos"] == 0
+
+
+def test_source_maps_wire_the_fields():
+    src = (_ROOT / "core" / "video" / "sources.py").read_text(encoding="utf-8", errors="replace")
+    # plex: real channel count + name-derived HDR/Atmos on every version
+    assert 'int(getattr(media, "audioChannels", 0) or 0) or None' in src
+    assert src.count("_format_from_name(") >= 3      # def + plex + jellyfin
+    # jellyfin: real stream facts override the name tokens
+    assert '"audio_channels": aud.get("Channels")' in src
+    assert 'vid.get("VideoRangeType")' in src
+    assert '"DOVI": "DV"' in src
+    assert 'aud.get("DisplayTitle")' in src
+
+
+def test_detail_js_renders_the_badges():
+    js = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert 'function formatBadges(f)' in js
+    assert 'formatBadges(d.file)' in js               # hero meta (owned movies)
+    assert 'function channelsLabel(n)' in js
+    assert "rows.push(['Dynamic range', f.dynamic_range])" in js
+    css = (_ROOT / "webui" / "static" / "video" / "video-side.css").read_text(
+        encoding="utf-8", errors="replace")
+    assert '.vd-fmt' in css

--- a/tests/test_video_mass_rename.py
+++ b/tests/test_video_mass_rename.py
@@ -46,6 +46,24 @@ def _seed_movie_file(db, movies_dir, *, name="heat.1995.x264-GRP.mkv",
     conn.execute("UPDATE movies SET has_file=1 WHERE id=?", (mid,))
     conn.commit()
     conn.close()
+    # Split-brain phantom tripwire (see conftest's _video_db tripwires): this
+    # seed has vanished between write and read in CI with BOTH conftest
+    # tripwires silent — the db global was correct and no lazy-create fired.
+    # Prove the row is visible through the endpoint's own read path RIGHT NOW,
+    # and if not, name which table lost it instead of an anonymous IndexError
+    # in the test body.
+    import api.video as videoapi
+    endpoint_db = videoapi.get_video_db()
+    with db.connect() as c:
+        m_ct = c.execute("SELECT COUNT(*) FROM movies WHERE has_file=1").fetchone()[0]
+        f_ct = c.execute("SELECT COUNT(*) FROM media_files WHERE movie_id IS NOT NULL").fetchone()[0]
+    owned = endpoint_db.repair_owned_movie_files()
+    assert owned, (
+        "[split-brain phantom] seeded movie invisible: movies(has_file=1)=%d "
+        "media_files(movie)=%d via test handle %r (db=%s) but endpoint handle %r (db=%s) "
+        "sees %d owned rows" % (
+            m_ct, f_ct, hex(id(db)), db.database_path,
+            hex(id(endpoint_db)), getattr(endpoint_db, "database_path", "?"), len(owned)))
     return p
 
 

--- a/tests/test_video_owned_episode_actions.py
+++ b/tests/test_video_owned_episode_actions.py
@@ -1,0 +1,45 @@
+"""Owned TV episodes keep their acquisition actions.
+
+The episode row used to render EITHER the Owned badge OR the three action
+buttons (auto-grab / manual search / wishlist) — ownership made the actions
+vanish, even though the acquisition stack treats owned rows as first-class
+upgrade candidates (upgrade-until-cutoff). Now the badge and the actions
+coexist; the no-VideoGrab (member) rendering is unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_JS = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+    encoding="utf-8", errors="replace")
+
+
+def test_owned_no_longer_forces_the_badge_only_branch():
+    # the old gate rendered a bare badge for owned rows and skipped the actions
+    assert "(ep.owned || !window.VideoGrab" not in _JS
+
+
+def test_owned_rows_render_badge_and_actions_together():
+    # badge still exists for owned…
+    assert "'<div class=\"vd-ep-badge\">Owned'" in _JS
+    # …and the action cluster is gated only on VideoGrab, not ownership
+    assert "(!window.VideoGrab" in _JS
+    for attr in ("data-vd-ep-grab", "data-vd-ep-search", "data-vd-ep-wish"):
+        assert attr in _JS
+
+
+def test_owned_actions_carry_upgrade_wording():
+    assert "Search &amp; download again (upgrade)" in _JS
+    assert "Wishlist for an upgrade" in _JS
+
+
+def test_click_handlers_are_ownership_agnostic():
+    # the delegated handlers dispatch straight to the inline actions with no
+    # owned check — an owned row's buttons must actually work
+    grab = re.search(r"closest\('\[data-vd-ep-grab\]'\);\s*\n\s*if \(epGrab", _JS)
+    assert grab is not None
+    handler_zone = _JS[grab.start():grab.start() + 500]
+    assert "owned" not in handler_zone

--- a/tests/test_video_show_sync.py
+++ b/tests/test_video_show_sync.py
@@ -57,7 +57,7 @@ class _Source:
         self.tree = tree
         self.raises = raises
 
-    def show_tree(self, server_id):
+    def show_tree(self, server_id, title=None, tmdb_id=None):
         if self.raises:
             raise self.raises
         return self.tree
@@ -141,6 +141,45 @@ def test_running_scan_is_refused(seeded, monkeypatch):
 def test_unknown_show_is_refused(db, monkeypatch, _quiet_scanner):
     with pytest.raises(ShowSyncError, match="not found"):
         sync_show(db, 999)
+
+
+def test_plex_rekey_heals_the_row_instead_of_deleting(seeded, monkeypatch, _quiet_scanner):
+    # plex re-keys items on metadata refresh — the old id 404s while the show
+    # still exists under a new key. sync must migrate to the new row, never
+    # delete the show.
+    db, show_id = seeded
+    new_tree = _tree(server_id="sh1-NEW", eps=((1, 1), (1, 2), (1, 3)))
+    _use_source(monkeypatch, _Source(tree=new_tree))
+    res = sync_show(db, show_id)
+    assert res["show_removed"] is False
+    assert res["rekeyed"] is True
+    assert res["show_id"] != show_id
+    conn = db._get_connection()
+    try:
+        # exactly one row remains, under the NEW key, with all episodes
+        rows = conn.execute("SELECT id, server_id FROM shows").fetchall()
+        assert len(rows) == 1 and rows[0]["server_id"] == "sh1-NEW"
+        eps = conn.execute("SELECT COUNT(*) c FROM episodes WHERE show_id=?",
+                           (res["show_id"],)).fetchone()["c"]
+        assert eps == 3
+    finally:
+        conn.close()
+
+
+def test_source_show_tree_receives_title_and_tmdb(seeded, monkeypatch, _quiet_scanner):
+    # the identity hints are what let plex disambiguate a stale key from a
+    # genuinely-removed show — sync must pass them
+    db, show_id = seeded
+    seen = {}
+
+    class _Spy(_Source):
+        def show_tree(self, server_id, title=None, tmdb_id=None):
+            seen.update(server_id=server_id, title=title, tmdb_id=tmdb_id)
+            return _tree()
+    _use_source(monkeypatch, _Spy())
+    sync_show(db, show_id)
+    assert seen["title"] == "The Show"
+    assert seen["server_id"] == "sh1"
 
 
 # ── wiring pins ───────────────────────────────────────────────────────────────

--- a/tests/test_video_show_sync.py
+++ b/tests/test_video_show_sync.py
@@ -166,6 +166,35 @@ def test_plex_rekey_heals_the_row_instead_of_deleting(seeded, monkeypatch, _quie
         conn.close()
 
 
+def test_sync_triggers_a_scoped_episode_list_refresh(seeded, monkeypatch, _quiet_scanner):
+    # the server only knows about FILES; the aired-episode schedule comes from
+    # enrichment — sync asks TMDB for the recent seasons so schedule holes
+    # (like a pre-demote-fix deleted episode) heal on the spot
+    db, show_id = seeded
+    calls = {}
+
+    class _Engine:
+        def refresh_show_art(self, sid, **kw):
+            calls.update(sid=sid, **kw)
+            return {"ok": True}
+    import core.video.enrichment.engine as engine_mod
+    monkeypatch.setattr(engine_mod, "get_video_enrichment_engine", lambda: _Engine())
+    _use_source(monkeypatch, _Source(tree=_tree()))
+    sync_show(db, show_id)
+    assert calls["sid"] == show_id
+    assert calls["recent_seasons_only"] is True and calls["with_ratings"] is False
+
+
+def test_episode_refresh_failure_never_fails_the_sync(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    import core.video.enrichment.engine as engine_mod
+    monkeypatch.setattr(engine_mod, "get_video_enrichment_engine",
+                        lambda: (_ for _ in ()).throw(RuntimeError("tmdb down")))
+    _use_source(monkeypatch, _Source(tree=_tree()))
+    res = sync_show(db, show_id)
+    assert res["status"] == "ok"
+
+
 def test_source_show_tree_receives_title_and_tmdb(seeded, monkeypatch, _quiet_scanner):
     # the identity hints are what let plex disambiguate a stale key from a
     # genuinely-removed show — sync must pass them

--- a/tests/test_video_show_sync.py
+++ b/tests/test_video_show_sync.py
@@ -1,0 +1,171 @@
+"""Per-show Synchronize — a deep scan scoped to ONE show.
+
+sync_show fetches the show's tree from the active server and reconciles the
+local rows through the scanner's own ingest (upsert_show_tree prunes vanished
+episodes). Deletion is paranoid by design:
+  • a server ERROR aborts — it never reads as "show gone"
+  • "gone" needs the source's positive not-found signal
+  • an EMPTY tree against local episodes is refused (Plex's tree builder
+    swallows a mid-fetch failure into an empty seasons list — upserting that
+    would prune the entire show)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import core.video.show_sync as show_sync
+from core.video.show_sync import ShowSyncError, sync_show
+from database.video_database import VideoDatabase
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _ep(sid, s, e, with_file=True):
+    d = {"server_id": str(sid), "season_number": s, "episode_number": e,
+         "title": "E%d" % e}
+    if with_file:
+        d["file"] = {"relative_path": "/tv/show/s%de%d.mkv" % (s, e),
+                     "size_bytes": 1000, "resolution": "1080p"}
+    return d
+
+
+def _tree(server_id="sh1", eps=((1, 1), (1, 2))):
+    return {"server_id": server_id, "title": "The Show",
+            "seasons": [{"season_number": 1, "episodes":
+                         [_ep("e%d%d" % (s, e), s, e) for (s, e) in eps]}]}
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+@pytest.fixture()
+def seeded(db):
+    show_id = db.upsert_show_tree("plex", _tree(eps=((1, 1), (1, 2))))
+    return db, show_id
+
+
+class _Source:
+    server_name = "plex"
+
+    def __init__(self, tree="unset", raises=None):
+        self.tree = tree
+        self.raises = raises
+
+    def show_tree(self, server_id):
+        if self.raises:
+            raise self.raises
+        return self.tree
+
+
+@pytest.fixture()
+def _quiet_scanner(monkeypatch):
+    import core.video.scanner as scanner
+    monkeypatch.setattr(scanner, "get_video_scanner",
+                        lambda db: SimpleNamespace(get_status=lambda: {"state": "idle"}))
+
+
+def _use_source(monkeypatch, src):
+    import core.video.sources as sources
+    monkeypatch.setattr(sources, "get_active_video_source", lambda: src)
+
+
+def test_new_episode_on_server_is_added(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    _use_source(monkeypatch, _Source(tree=_tree(eps=((1, 1), (1, 2), (1, 3)))))
+    res = sync_show(db, show_id)
+    assert res["episodes_added"] == 1 and res["episodes_removed"] == 0
+    assert res["show_removed"] is False
+
+
+def test_removed_episode_on_server_is_pruned(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    _use_source(monkeypatch, _Source(tree=_tree(eps=((1, 1),))))
+    res = sync_show(db, show_id)
+    assert res["episodes_removed"] == 1 and res["episodes_added"] == 0
+
+
+def test_show_verifiably_gone_is_removed(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    _use_source(monkeypatch, _Source(tree=None))
+    res = sync_show(db, show_id)
+    assert res["show_removed"] is True
+    conn = db._get_connection()
+    assert conn.execute("SELECT COUNT(*) c FROM shows WHERE id=?",
+                        (show_id,)).fetchone()["c"] == 0
+    conn.close()
+
+
+def test_server_error_aborts_and_deletes_nothing(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    _use_source(monkeypatch, _Source(raises=RuntimeError("server down")))
+    with pytest.raises(RuntimeError):
+        sync_show(db, show_id)
+    conn = db._get_connection()
+    assert conn.execute("SELECT COUNT(*) c FROM shows WHERE id=?",
+                        (show_id,)).fetchone()["c"] == 1
+    conn.close()
+
+
+def test_empty_tree_against_local_episodes_is_refused(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    _use_source(monkeypatch, _Source(tree=_tree(eps=())))
+    with pytest.raises(ShowSyncError, match="no episodes"):
+        sync_show(db, show_id)
+
+
+def test_wrong_active_server_is_refused(seeded, monkeypatch, _quiet_scanner):
+    db, show_id = seeded
+    src = _Source(tree=_tree())
+    src.server_name = "jellyfin"
+    _use_source(monkeypatch, src)
+    with pytest.raises(ShowSyncError, match="active server"):
+        sync_show(db, show_id)
+
+
+def test_running_scan_is_refused(seeded, monkeypatch):
+    db, show_id = seeded
+    import core.video.scanner as scanner
+    monkeypatch.setattr(scanner, "get_video_scanner",
+                        lambda db: SimpleNamespace(get_status=lambda: {"state": "running"}))
+    _use_source(monkeypatch, _Source(tree=_tree()))
+    with pytest.raises(ShowSyncError, match="already running"):
+        sync_show(db, show_id)
+
+
+def test_unknown_show_is_refused(db, monkeypatch, _quiet_scanner):
+    with pytest.raises(ShowSyncError, match="not found"):
+        sync_show(db, 999)
+
+
+# ── wiring pins ───────────────────────────────────────────────────────────────
+
+def test_plex_gone_is_notfound_only():
+    src = (_ROOT / "core" / "video" / "sources.py").read_text(encoding="utf-8", errors="replace")
+    assert "from plexapi.exceptions import NotFound" in src
+    assert "except NotFound:" in src
+
+
+def test_jellyfin_gone_requires_a_live_server():
+    src = (_ROOT / "core" / "video" / "sources.py").read_text(encoding="utf-8", errors="replace")
+    assert "Jellyfin unreachable" in src
+
+
+def test_endpoint_and_admin_gate():
+    api = (_ROOT / "api" / "video" / "detail.py").read_text(encoding="utf-8", errors="replace")
+    gate = (_ROOT / "api" / "video" / "__init__.py").read_text(encoding="utf-8", errors="replace")
+    assert '"/detail/show/<int:show_id>/sync"' in api
+    assert '"/sync"' in gate
+
+
+def test_ui_button_and_handler():
+    js = (_ROOT / "webui" / "static" / "video" / "video-detail.js").read_text(
+        encoding="utf-8", errors="replace")
+    assert 'data-vd-act="sync-show"' in js
+    assert "function syncShowNow" in js
+    assert "/sync'" in js

--- a/tests/test_video_watch_state.py
+++ b/tests/test_video_watch_state.py
@@ -1,0 +1,184 @@
+"""Continue Watching P1 — per-episode watch state ingestion (schema v45).
+
+The scan now carries per-episode play_count / last_viewed_at / view_offset_ms
+(Plex viewCount/lastViewedAt/viewOffset; Jellyfin UserData) and movies gain a
+resume offset. Watch state is server truth: every upsert takes the fresh
+values (unlike added_at, which keeps the earliest). The detail payloads
+expose watched/progress per episode and raw state on movies.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from database.video_database import VideoDatabase
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+def _ep(e, *, plays=0, offset=0, viewed=None):
+    return {"server_id": "e%d" % e, "season_number": 1, "episode_number": e,
+            "title": "E%d" % e, "air_date": "2026-07-%02d" % e,
+            "play_count": plays, "last_viewed_at": viewed, "view_offset_ms": offset,
+            "file": {"relative_path": "/tv/s1e%d.mkv" % e, "size_bytes": 100,
+                     "resolution": "1080p"}}
+
+
+def _tree(eps):
+    return {"server_id": "sh", "title": "Show",
+            "seasons": [{"season_number": 1, "episodes": eps}]}
+
+
+class TestSchema:
+    def test_new_columns_exist(self, db):
+        conn = db._get_connection()
+        ep_cols = {r["name"] for r in conn.execute("PRAGMA table_info(episodes)")}
+        mv_cols = {r["name"] for r in conn.execute("PRAGMA table_info(movies)")}
+        conn.close()
+        assert {"play_count", "last_viewed_at", "view_offset_ms"} <= ep_cols
+        assert "view_offset_ms" in mv_cols
+
+    def test_columns_ride_the_migration_list(self):
+        src = (_ROOT / "database" / "video_database.py").read_text(encoding="utf-8", errors="replace")
+        for entry in ('("episodes", "play_count", "INTEGER")',
+                      '("episodes", "last_viewed_at", "TEXT")',
+                      '("episodes", "view_offset_ms", "INTEGER")',
+                      '("movies", "view_offset_ms", "INTEGER")'):
+            assert entry in src, f"missing migration {entry}"
+
+
+class TestEpisodeIngest:
+    def test_watch_state_round_trips_to_the_payload(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([
+            _ep(1, plays=2, viewed="2026-07-16 21:00:00"),
+            _ep(2, plays=0, offset=743_000),               # in progress
+            _ep(3),                                        # untouched
+        ]))
+        eps = db.show_detail(show_id)["seasons"][0]["episodes"]
+        assert eps[0]["watched"] is True and eps[0]["last_viewed_at"] == "2026-07-16 21:00:00"
+        assert eps[1]["watched"] is False and eps[1]["view_offset_ms"] == 743_000
+        assert eps[2]["watched"] is False and eps[2]["view_offset_ms"] == 0
+
+    def test_rescan_always_takes_fresh_server_truth(self, db):
+        # watched on the server, then marked UNwatched there — the rescan must
+        # follow (watch state never sticks to a stale value)
+        show_id = db.upsert_show_tree("plex", _tree([_ep(1, plays=1, offset=0)]))
+        db.upsert_show_tree("plex", _tree([_ep(1, plays=0, offset=0)]))
+        eps = db.show_detail(show_id)["seasons"][0]["episodes"]
+        assert eps[0]["watched"] is False
+
+    def test_enrichment_missing_rows_have_clean_state(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([_ep(1)]))
+        db.backfill_episodes(show_id, 1, [{"episode_number": 9, "title": "E9",
+                                           "air_date": "2026-09-01"}])
+        eps = db.show_detail(show_id)["seasons"][0]["episodes"]
+        e9 = [e for e in eps if e["episode_number"] == 9][0]
+        assert e9["watched"] is False and e9["view_offset_ms"] == 0
+
+
+class TestMoviePayload:
+    def test_movie_exposes_raw_watch_state(self, db):
+        mid = db.upsert_movie("plex", {
+            "server_id": "m1", "title": "Film", "year": 2020, "tmdb_id": 7,
+            "play_count": 1, "last_viewed_at": "2026-06-02 20:00:00",
+            "view_offset_ms": 0,
+            "file": {"relative_path": "/mov/f.mkv", "size_bytes": 10,
+                     "resolution": "2160p"}})
+        d = db.movie_detail(mid)
+        assert d["watched"] is True
+        assert d["play_count"] == 1
+        assert d["last_viewed_at"] == "2026-06-02 20:00:00"
+        assert d["view_offset_ms"] == 0
+
+    def test_in_progress_movie_carries_offset(self, db):
+        mid = db.upsert_movie("plex", {
+            "server_id": "m2", "title": "Half Watched", "year": 2021, "tmdb_id": 8,
+            "play_count": 0, "view_offset_ms": 3_600_000,
+            "file": {"relative_path": "/mov/h.mkv", "size_bytes": 10,
+                     "resolution": "1080p"}})
+        d = db.movie_detail(mid)
+        assert d["watched"] is False and d["view_offset_ms"] == 3_600_000
+
+
+class TestNextUp:
+    """show_next_up — the Netflix 'Next Up' slot behind the hero CTA."""
+
+    def test_fresh_show_has_no_continue_story(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([_ep(1), _ep(2)]))
+        assert db.show_next_up(show_id) is None
+        assert db.show_detail(show_id)["next_up"] is None
+
+    def test_in_progress_episode_wins_as_resume(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([
+            _ep(1, plays=1, viewed="2026-07-10 21:00:00"),
+            _ep(2, offset=600_000, viewed="2026-07-16 21:00:00"),
+            _ep(3),
+        ]))
+        nu = db.show_next_up(show_id)
+        assert (nu["season_number"], nu["episode_number"]) == (1, 2)
+        assert nu["resume"] is True and nu["view_offset_ms"] == 600_000
+        assert nu["server_id"] == "e2"
+
+    def test_falls_to_first_unwatched_owned(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([
+            _ep(1, plays=1), _ep(2, plays=1), _ep(3), _ep(4)]))
+        nu = db.show_next_up(show_id)
+        assert (nu["episode_number"], nu["resume"]) == (3, False)
+
+    def test_unowned_episodes_never_suggested(self, db):
+        # E2 exists only as a schedule FACT (no file) — next up must skip it.
+        eps = [_ep(1, plays=1), _ep(3)]
+        e2 = _ep(2)
+        del e2["file"]
+        show_id = db.upsert_show_tree("plex", _tree([eps[0], e2, eps[1]]))
+        assert db.show_next_up(show_id)["episode_number"] == 3
+
+    def test_everything_watched_means_none(self, db):
+        show_id = db.upsert_show_tree("plex", _tree([_ep(1, plays=1), _ep(2, plays=2)]))
+        assert db.show_next_up(show_id) is None
+
+
+class TestExtrasEpisodeLink:
+    def test_server_tile_gains_next_up_deep_link(self, db, monkeypatch):
+        from core.video.enrichment.engine import VideoEnrichmentEngine
+        show_id = db.upsert_show_tree("plex", _tree([
+            _ep(1, plays=1), _ep(2)]))
+        eng = VideoEnrichmentEngine(db, clients={})
+        calls = []
+
+        def fake_link(kind, item_id, episode_sid=None):
+            calls.append(episode_sid)
+            return {"server": "Plex",
+                    "url": "https://plex/" + (str(episode_sid) if episode_sid else "show")}
+        monkeypatch.setattr(eng, "_server_watch_link", fake_link)
+        out = eng.item_extras("show", show_id)
+        srv = out["server"]
+        assert srv["url"] == "https://plex/show"          # title link intact
+        assert srv["episode_url"] == "https://plex/e2"    # next-up deep link
+        assert srv["next_up"] == {"season": 1, "episode": 2, "resume": False}
+        assert calls == [None, "e2"]
+
+    def test_no_next_up_leaves_plain_server_tile(self, db, monkeypatch):
+        from core.video.enrichment.engine import VideoEnrichmentEngine
+        show_id = db.upsert_show_tree("plex", _tree([_ep(1)]))   # nothing watched
+        eng = VideoEnrichmentEngine(db, clients={})
+        monkeypatch.setattr(eng, "_server_watch_link",
+                            lambda kind, item_id, episode_sid=None: {"server": "Plex", "url": "u"})
+        srv = eng.item_extras("show", show_id)["server"]
+        assert "episode_url" not in srv and "next_up" not in srv
+
+
+def test_source_maps_carry_the_fields():
+    src = (_ROOT / "core" / "video" / "sources.py").read_text(encoding="utf-8", errors="replace")
+    # plex episode + movie
+    assert src.count('"view_offset_ms": int(getattr(') == 2
+    assert 'int(getattr(ep, "viewCount", 0) or 0)' in src
+    # jellyfin ticks → ms in both maps
+    assert src.count('("PlaybackPositionTicks") or 0) // 10_000') == 2

--- a/tests/test_video_wishlist_failing.py
+++ b/tests/test_video_wishlist_failing.py
@@ -1,0 +1,173 @@
+"""Video failing-wishlist visibility (LiveLeak hub, phase 3).
+
+The drain now records each search outcome on the wishlist row: a genuinely
+fruitless search (no results / all rejected) increments search_attempts, a
+grab resets it, and a search that never RAN (slskd down) records nothing —
+it says nothing about whether the release exists. The wishlist page badges
+rows at 3+ attempts. Columns ride _COLUMN_MIGRATIONS (live server upgrades
+in place).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.automation.handlers.video_process_wishlist import auto_video_process_wishlist
+from database.video_database import VideoDatabase
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video.db"))
+
+
+def _seed_movie(db, tmdb_id=101, title="Stuck Movie"):
+    conn = db._get_connection()
+    conn.execute("INSERT INTO video_wishlist (kind, tmdb_id, title, status) "
+                 "VALUES ('movie', ?, ?, 'wanted')", (tmdb_id, title))
+    conn.commit()
+    conn.close()
+
+
+def _seed_episode(db, tmdb_id=202, s=1, e=3):
+    conn = db._get_connection()
+    conn.execute("INSERT INTO video_wishlist (kind, tmdb_id, title, season_number, "
+                 "episode_number, status) VALUES ('episode', ?, 'Show', ?, ?, 'wanted')",
+                 (tmdb_id, s, e))
+    conn.commit()
+    conn.close()
+
+
+def _attempts(db, kind, tmdb_id, s=None, e=None):
+    conn = db._get_connection()
+    try:
+        q = "SELECT search_attempts, last_search_at FROM video_wishlist WHERE kind=? AND tmdb_id=?"
+        args = [kind, tmdb_id]
+        if s is not None:
+            q += " AND season_number=? AND episode_number=?"
+            args += [s, e]
+        r = conn.execute(q, args).fetchone()
+        return (r["search_attempts"] or 0, r["last_search_at"]) if r else (None, None)
+    finally:
+        conn.close()
+
+
+class TestSchema:
+    def test_new_columns_exist_on_a_fresh_db(self, db):
+        conn = db._get_connection()
+        cols = {r["name"] for r in conn.execute("PRAGMA table_info(video_wishlist)")}
+        conn.close()
+        assert "search_attempts" in cols and "last_search_at" in cols
+
+    def test_columns_ride_the_migration_list(self):
+        src = (_ROOT / "database" / "video_database.py").read_text(encoding="utf-8", errors="replace")
+        assert '("video_wishlist", "search_attempts", "INTEGER DEFAULT 0")' in src
+        assert '("video_wishlist", "last_search_at", "TEXT")' in src
+
+
+class TestRecordOutcome:
+    def test_fruitless_search_increments(self, db):
+        _seed_movie(db)
+        db.record_wishlist_search_outcome("movie", 101, grabbed=False)
+        db.record_wishlist_search_outcome("movie", 101, grabbed=False)
+        n, last = _attempts(db, "movie", 101)
+        assert n == 2 and last
+
+    def test_grab_resets(self, db):
+        _seed_movie(db)
+        for _ in range(4):
+            db.record_wishlist_search_outcome("movie", 101, grabbed=False)
+        db.record_wishlist_search_outcome("movie", 101, grabbed=True)
+        assert _attempts(db, "movie", 101)[0] == 0
+
+    def test_episode_rows_key_on_season_episode(self, db):
+        _seed_episode(db, 202, 1, 3)
+        _seed_episode(db, 202, 1, 4)
+        db.record_wishlist_search_outcome("movie", 202, grabbed=False)  # wrong kind: no-op
+        db.record_wishlist_search_outcome("episode", 202, grabbed=False,
+                                          season_number=1, episode_number=3)
+        assert _attempts(db, "episode", 202, 1, 3)[0] == 1
+        assert _attempts(db, "episode", 202, 1, 4)[0] == 0
+
+
+class TestDrainWiring:
+    def _run(self, db, items, media_type, *, cands, enqueue_ok=True, search_ret=None):
+        outcomes = []
+
+        def record(item, mt, ok):
+            outcomes.append((item.get("tmdb_id") or item.get("show_tmdb_id"), ok))
+            # exercise the real recorder too
+            from core.automation.handlers.video_process_wishlist import _default_record_outcome
+            _default_record_outcome(item, mt, ok)
+
+        import api.video as videoapi
+        videoapi._video_db = db
+        try:
+            from types import SimpleNamespace
+
+            class _Deps:
+                def update_progress(self, automation_id, **kw):
+                    pass
+            auto_video_process_wishlist(
+                {"_automation_id": None}, _Deps(), media_type=media_type,
+                fetch_items=lambda mt: items,
+                active_keys=lambda mt: set(),
+                target_dir=lambda mt: "/tmp/target",
+                search=lambda it, mt: (cands, None) if search_ret is None else search_ret,
+                enqueue=lambda *a, **k: enqueue_ok,
+                record_outcome=record,
+            )
+        finally:
+            videoapi._video_db = None
+        return outcomes
+
+    def test_fruitless_movie_search_records_a_failure(self, db):
+        _seed_movie(db, 101)
+        out = self._run(db, [{"tmdb_id": 101, "title": "Stuck Movie"}], "movie", cands=[])
+        assert out == [(101, False)]
+        assert _attempts(db, "movie", 101)[0] == 1
+
+    def test_grab_records_success_and_resets(self, db):
+        _seed_movie(db, 101)
+        db.record_wishlist_search_outcome("movie", 101, grabbed=False)
+        cand = {"filename": "f", "title": "f", "username": "u", "size_bytes": 1,
+                "quality_label": "WEBDL-1080p", "accepted": True, "score": 5}
+        out = self._run(db, [{"tmdb_id": 101, "title": "Stuck Movie"}], "movie", cands=[cand])
+        assert out == [(101, True)]
+        assert _attempts(db, "movie", 101)[0] == 0
+
+    def test_search_that_never_ran_records_nothing(self, db):
+        _seed_movie(db, 101)
+        out = self._run(db, [{"tmdb_id": 101, "title": "Stuck Movie"}], "movie",
+                        cands=None, search_ret=(None, "slskd down"))
+        assert out == []
+        assert _attempts(db, "movie", 101)[0] == 0
+
+    def test_episode_items_record_via_show_tmdb_id(self, db):
+        _seed_episode(db, 202, 1, 3)
+        item = {"show_tmdb_id": 202, "show_title": "Show",
+                "season_number": 1, "episode_number": 3}
+        out = self._run(db, [item], "episode", cands=[])
+        assert out == [(202, False)]
+        assert _attempts(db, "episode", 202, 1, 3)[0] == 1
+
+
+class TestSurface:
+    def test_query_wishlist_returns_the_fields(self, db):
+        _seed_movie(db, 101)
+        db.record_wishlist_search_outcome("movie", 101, grabbed=False)
+        items = db.query_wishlist("movie")["items"]
+        assert items and items[0]["search_attempts"] == 1
+        assert items[0]["last_search_at"]
+
+    def test_ui_renders_the_failing_marker(self):
+        js = (_ROOT / "webui" / "static" / "video" / "video-wishlist.js").read_text(
+            encoding="utf-8", errors="replace")
+        css = (_ROOT / "webui" / "static" / "video" / "video-side.css").read_text(
+            encoding="utf-8", errors="replace")
+        assert "vwsh-failing" in js and "search_attempts" in js
+        assert ".vwsh-failing" in css and ".vwsh-failing-inline" in css

--- a/tests/test_wishlist_failing_badge.py
+++ b/tests/test_wishlist_failing_badge.py
@@ -1,0 +1,56 @@
+"""Failing-wishlist visibility (LiveLeak's hub, phase 1).
+
+The wishlist API has always returned retry_count / last_attempted /
+failure_reason per track — the page just never rendered them. Phase 1 pins
+the surface: the nebula parses the retry data, marks tracks at the failing
+threshold, rolls the count up to the artist orb, and the bar gets a
+Failing-only filter chip. Attribute values built from wishlist data must go
+through the attr-safe escape (escapeHtml leaves double quotes intact).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_JS = (_ROOT / "webui" / "static" / "api-monitor.js").read_text(encoding="utf-8", errors="replace")
+_HTML = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8", errors="replace")
+_CSS = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8", errors="replace")
+
+
+def test_parser_carries_the_retry_data():
+    assert "Number(track.retry_count)" in _JS
+    assert "track.last_attempted" in _JS
+    assert "track.failure_reason" in _JS
+    assert "WL_FAILING_ATTEMPTS" in _JS
+
+
+def test_failing_marks_reach_all_three_surfaces():
+    # album tile track rows, singles moons, and the orb meta rollup
+    assert "wl-failing-badge" in _JS
+    assert "wl-moon-failing" in _JS
+    assert "wl-orb-meta-failing" in _JS
+    assert 'data-failing="${failingCount}"' in _JS
+
+
+def test_failing_filter_chip_is_wired():
+    assert 'id="wl-failing-filter"' in _HTML
+    assert "_toggleFailingFilter()" in _HTML
+    assert "function _toggleFailingFilter" in _JS
+    # the filter respects the rollup attribute
+    assert "g.dataset.failing" in _JS
+
+
+def test_titles_use_the_attr_safe_escape():
+    # escapeHtml (innerHTML-based) leaves double quotes intact — a failure
+    # reason containing one would break out of the title attribute
+    assert "function _wlAttr" in _JS
+    assert '_wlAttr(_wlFailTitle(tr))' in _JS
+    assert '_wlAttr(_wlFailTitle(s))' in _JS
+    assert 'title="${escapeHtml(_wlFailTitle' not in _JS
+
+
+def test_css_covers_every_new_class():
+    for cls in (".wl-failing-badge", ".wl-moon-failing", ".wl-orb-meta-failing",
+                ".wl-failing-filter.active", ".wl-track-failing"):
+        assert cls in _CSS, f"missing CSS for {cls}"

--- a/tests/test_wishlist_failing_badge.py
+++ b/tests/test_wishlist_failing_badge.py
@@ -52,5 +52,27 @@ def test_titles_use_the_attr_safe_escape():
 
 def test_css_covers_every_new_class():
     for cls in (".wl-failing-badge", ".wl-moon-failing", ".wl-orb-meta-failing",
-                ".wl-failing-filter.active", ".wl-track-failing"):
+                ".wl-failing-filter.active", ".wl-track-failing",
+                ".wl-tile-track-search", ".wl-moon-search-btn"):
         assert cls in _CSS, f"missing CSS for {cls}"
+
+
+# ── phase 2: manual-search jump ───────────────────────────────────────────────
+
+def test_manual_search_jump_exists_and_prefills():
+    assert "function _searchWishlistTrackManually" in _JS
+    assert "navigateToPage('search')" in _JS
+    assert "enhanced-search-input" in _JS
+
+
+def test_both_track_surfaces_get_the_search_button():
+    assert "wl-tile-track-search" in _JS
+    assert "wl-moon-search-btn" in _JS
+
+
+def test_onclick_args_use_the_inline_js_escape():
+    # artist/track names carry apostrophes (D'Angelo) — a bare escapeHtml
+    # inside onclick="fn('…')" breaks the JS string. Both buttons must use
+    # escapeForInlineJs for both arguments.
+    assert _JS.count("_searchWishlistTrackManually('${escapeForInlineJs(") == 2
+    assert "_searchWishlistTrackManually('${escapeHtml(" not in _JS

--- a/tests/test_youtube_download.py
+++ b/tests/test_youtube_download.py
@@ -161,6 +161,43 @@ def test_authoritative_fields_fill_a_titleless_row_only():
     assert ytd.authoritative_download_fields(bare, {}) is bare                  # no title → no-op
 
 
+def test_extractor_date_overrides_a_scan_estimate():
+    # the GMM incident: the channel scan estimates dates from relative labels
+    # ('1 month ago' → today − 30.44d), and episode numbers are MMDD — five
+    # backlog videos all estimated 2026-06-17 landed as five colliding e0617
+    # files. yt-dlp's real upload_date must win over a differing context date.
+    est = {"id": 3, "title": "Guess The Instant Ramen Flavor",
+           "search_ctx": json.dumps({"channel": "GMM",
+                                     "video_title": "Guess The Instant Ramen Flavor",
+                                     "published_at": "2026-06-17"})}
+    fixed = ytd.authoritative_download_fields(est, {"title": "Guess The Instant Ramen Flavor",
+                                                    "published_at": "2026-05-22"})
+    assert fixed is not est
+    ctx = json.loads(fixed["search_ctx"])
+    assert ctx["published_at"] == "2026-05-22"          # real date wins
+    assert ctx["video_title"] == "Guess The Instant Ramen Flavor"   # title untouched
+    assert fixed["title"] == est["title"]               # row title untouched
+
+
+def test_matching_date_is_identity_no_replan():
+    # dates agree → no change → the caller must NOT re-plan/rename
+    good = {"id": 4, "title": "T",
+            "search_ctx": json.dumps({"video_title": "T", "published_at": "2026-07-17"})}
+    assert ytd.authoritative_download_fields(
+        good, {"title": "T", "published_at": "2026-07-17"}) is good
+
+
+def test_two_backlog_videos_stop_colliding():
+    # both estimated '1 month ago' → same date; real dates differ → distinct
+    mk = lambda i: {"id": i, "title": "GMM", "search_ctx": json.dumps(
+        {"channel": "GMM", "video_title": "V%d" % i, "published_at": "2026-06-17"})}
+    a = ytd.authoritative_download_fields(mk(1), {"title": "V1", "published_at": "2026-05-22"})
+    b = ytd.authoritative_download_fields(mk(2), {"title": "V2", "published_at": "2026-04-30"})
+    da = json.loads(a["search_ctx"])["published_at"]
+    db_ = json.loads(b["search_ctx"])["published_at"]
+    assert da != db_ and {da, db_} == {"2026-05-22", "2026-04-30"}
+
+
 def test_download_one_failure_is_captured_not_raised():
     res = ytd.download_one("vid1", "/yt", "stem", default_profile(), "mp4", ydl_factory=_BoomYDL)
     assert res["ok"] is False and "403 blocked" in res["error"]

--- a/tests/video/test_video_source_delta.py
+++ b/tests/video/test_video_source_delta.py
@@ -26,7 +26,9 @@ class _Section:
 
     def search(self, libtype=None, filters=None, sort=None, maxresults=None):
         assert libtype == "episode"
-        key = "addedAt" if "addedAt>>" in filters else "updatedAt"
+        key = ("addedAt" if "addedAt>>" in filters
+               else "lastViewedAt" if "lastViewedAt>>" in filters
+               else "updatedAt")
         self.searched.append(key)
         return self._eps.get(key, [])
 
@@ -42,8 +44,21 @@ def test_union_adds_parent_shows_of_new_episodes():
         shows_by_key={200: _Show(200)})
     out = _union_episode_delta_shows(sec, "since", existing)
     assert sorted(str(s.ratingKey) for s in out) == ["100", "200"]          # 100 kept, 200 added
-    assert sec.searched == ["addedAt"]         # addedAt ONLY — updatedAt would drag in the whole library
+    # addedAt + lastViewedAt (the watch delta) — NEVER updatedAt, which Plex's
+    # nightly refresh bumps on ~everything and would drag in the whole library.
+    assert sec.searched == ["addedAt", "lastViewedAt"]
     assert sec.fetched == [200]                # only the NEW show fetched
+
+
+def test_union_adds_parent_shows_of_watched_episodes():
+    # Continue Watching: a play only bumps the EPISODE's lastViewedAt — the watch
+    # delta must pull in its parent show so play_count/viewOffset get rescanned.
+    sec = _Section(
+        eps_by_filter={"lastViewedAt": [_Ep("300")]},
+        shows_by_key={300: _Show(300)})
+    out = _union_episode_delta_shows(sec, "since", [])
+    assert [str(s.ratingKey) for s in out] == ["300"]
+    assert sec.searched == ["addedAt", "lastViewedAt"]
 
 
 def test_union_is_best_effort_when_search_explodes():

--- a/web_server.py
+++ b/web_server.py
@@ -22150,6 +22150,12 @@ def start_missing_tracks_process(playlist_id):
             'analysis_processed': 0,
             'analysis_results': [],
             'force_download_all': force_download_all,  # Pass the force flag to the batch
+            # Replace-intent (#1045): ONLY a user-checked Force toggle means
+            # "rewrite the existing file". force_download_all alone is NOT that
+            # signal — wishlist batches set it to skip ownership checks, and
+            # Wing It auto-ors it in client-side — so wing_it is excluded here
+            # and the wishlist never sets this key at all.
+            'force_replace': bool(force_download_all and not wing_it),
             'ignore_manual_matches': ignore_manual_matches,
             # Blocklist override (Phase 2b) — the user confirmed "download anyway"
             # at the modal, so the per-track filter (2a) skips this batch.

--- a/web_server.py
+++ b/web_server.py
@@ -17638,6 +17638,9 @@ def _db_update_finished_callback(total_artists, total_albums, total_tracks, succ
     # incremental, full refresh) converges on this callback, so writing here keeps it current.
     # Destination = the configured M3U output folder if set, else the Transfer folder. Fully
     # guarded — a playlist write must never disturb scan completion.
+    # The outcome is surfaced in the scan summary (m3u_note) so "did it trigger?"
+    # is answerable from the UI, not just app.log (#1041).
+    m3u_note = ""
     try:
         if config_manager.get('m3u_export.library_enabled', False):
             from core.library.m3u_export import write_library_m3u
@@ -17649,8 +17652,15 @@ def _db_update_finished_callback(total_artists, total_albums, total_tracks, succ
             _written = write_library_m3u(_entries, _dest, entry_base_path=_base)
             if _written:
                 logger.info("[library-m3u] auto-synced %d tracks -> %s", len(_entries), _written)
+                m3u_note = f" | Library M3U: {len(_entries)} tracks → {_written}"
+            else:
+                m3u_note = " | Library M3U write failed (see app.log)"
+        else:
+            # One line per scan so a "never triggers" report diagnoses itself.
+            logger.info("[library-m3u] skipped — Library M3U auto-sync is disabled in Settings")
     except Exception as _m3u_err:
         logger.warning("[library-m3u] auto-sync failed: %s", _m3u_err)
+        m3u_note = " | Library M3U write failed (see app.log)"
     # Check for removal results from the worker
     removed_artists = 0
     removed_albums = 0
@@ -17680,11 +17690,11 @@ def _db_update_finished_callback(total_artists, total_albums, total_tracks, succ
                 skipped_tracks = getattr(db_update_worker, 'processed_albums', 0)
 
     if total_tracks > 0:
-        phase_msg = f"Completed: {total_artists} artists, {total_albums} albums, {total_tracks} new tracks{removal_msg}."
+        phase_msg = f"Completed: {total_artists} artists, {total_albums} albums, {total_tracks} new tracks{removal_msg}{m3u_note}."
     elif successful > 0:
-        phase_msg = f"Completed: {successful} artists scanned, library up to date{removal_msg}."
+        phase_msg = f"Completed: {successful} artists scanned, library up to date{removal_msg}{m3u_note}."
     else:
-        phase_msg = f"Completed: {successful} successful, {failed} failed{removal_msg}."
+        phase_msg = f"Completed: {successful} successful, {failed} failed{removal_msg}{m3u_note}."
 
     with db_update_lock:
         db_update_state["status"] = "finished"
@@ -17699,6 +17709,7 @@ def _db_update_finished_callback(total_artists, total_albums, total_tracks, succ
     auto_summary = f"{total_tracks} tracks, {total_albums} albums from {total_artists} artists"
     if removed_artists > 0 or removed_albums > 0:
         auto_summary += f" | Removed {removed_artists} artists, {removed_albums} albums"
+    auto_summary += m3u_note
     _update_automation_progress(_db_update_automation_id,
         status='finished', progress=100, phase='Complete',
         log_line=auto_summary, log_type='success')

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.1.0"
+_SOULSYNC_BASE_VERSION = "3.1.1"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/index.html
+++ b/webui/index.html
@@ -1677,6 +1677,7 @@
                                 <!-- External-source links reuse the artist-hero-badge style. -->
                                 <div class="artist-hero-badges vd-links" data-vd-links></div>
                                 <div class="vd-ratings" data-vd-ratings hidden></div>
+                                <div class="vd-awards" data-vd-awards hidden></div>
                                 <p class="vd-overview" data-vd-overview></p>
                                 <!-- Action buttons reuse the exact artist-detail button styles. -->
                                 <div class="vd-actions artist-hero-actions" data-vd-actions></div>
@@ -1781,6 +1782,7 @@
                                 <div class="vd-crew-line" data-vd-crew-line hidden></div>
                                 <div class="artist-hero-badges vd-links" data-vd-links></div>
                                 <div class="vd-ratings" data-vd-ratings hidden></div>
+                                <div class="vd-awards" data-vd-awards hidden></div>
                                 <p class="vd-overview" data-vd-overview></p>
                                 <div class="vd-actions artist-hero-actions" data-vd-actions></div>
                                 <div class="vd-genres" data-vd-genres></div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10512,6 +10512,7 @@
                         <!-- Action bar -->
                         <div class="wl-nebula-bar">
                             <input type="text" class="wl-nebula-search" id="wl-nebula-search" placeholder="Filter wishlist…" oninput="_filterNebula()">
+                            <button type="button" class="wl-chip wl-failing-filter" id="wl-failing-filter" onclick="_toggleFailingFilter()" title="Show only artists with tracks that keep failing to download">&#9888; Failing</button>
                             <button class="btn btn--primary" onclick="_nebulaDownload()">
                                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
                                 Download Wishlist

--- a/webui/index.html
+++ b/webui/index.html
@@ -11609,6 +11609,9 @@
         </div>
     </div>
 
+    <!-- fetch-dedupe must load BEFORE the React bundle and every split module,
+         so all frameworks share one wire request per identical GET burst. -->
+    <script src="{{ url_for('static', filename='fetch-dedupe.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='vendor/socket.io.min.js', v=static_v) }}"></script>
     {{ vite_assets('body')|safe }}
     <script src="{{ url_for('static', filename='setup-wizard.js', v=static_v) }}"></script>

--- a/webui/src/routes/artist-detail/$source/$id.tsx
+++ b/webui/src/routes/artist-detail/$source/$id.tsx
@@ -8,8 +8,16 @@ import { useShellBridge } from '@/platform/shell/route-controllers';
 // they're addressed entirely by URL/name — so the artist's display name has
 // to travel as a search param. Sources that can resolve by ID alone just
 // don't need it; this is a no-op for them.
+//
+// TanStack's search parser JSON-parses param values, so an all-digits artist
+// name ("311", "702") arrives as a NUMBER — a bare z.string() then throws
+// SearchParamError and the whole route dies in the error boundary (clicking
+// the artist did nothing). Coerce whatever arrives back to a string.
 const artistDetailSearchSchema = z.object({
-  name: z.string().optional().default(''),
+  name: z
+    .preprocess((v) => (v == null ? '' : String(v)), z.string())
+    .optional()
+    .default(''),
 });
 
 export const Route = createFileRoute('/artist-detail/$source/$id')({

--- a/webui/src/routes/artist-detail/-route.test.tsx
+++ b/webui/src/routes/artist-detail/-route.test.tsx
@@ -42,6 +42,24 @@ describe('artist-detail route', () => {
     });
   });
 
+  it('survives an all-digits artist name (311) in ?name=', async () => {
+    // TanStack's search parser JSON-parses param values, so name=311 arrives
+    // as a NUMBER. A bare z.string() schema threw SearchParamError, the route
+    // died in its error boundary, and clicking the artist "did nothing".
+    renderArtistDetailRoute(['/artist-detail/deezer/2481?name=311']);
+
+    await waitFor(() => {
+      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
+        '2481',
+        '311',
+        'deezer',
+        {
+          skipRouteChange: true,
+        },
+      );
+    });
+  });
+
   it('passes the ?name= search param through to the legacy shell', async () => {
     // Bandcamp (and any other source with no numeric-ID lookup API) can only
     // resolve an artist by name — the URL is the only channel that survives

--- a/webui/static/api-monitor.js
+++ b/webui/static/api-monitor.js
@@ -1507,6 +1507,26 @@ async function initializeWishlistPage() {
    WISHLIST NEBULA — Artist orbs with album/single satellites
    ═══════════════════════════════════════════════════════════════════ */
 
+// A track is "failing" once it has burned this many wishlist cycles without
+// landing (#liveleak-failing-hub). The count/last-try/reason all come from the
+// wishlist API (retry_count / last_attempted / failure_reason) — the data was
+// always there, the page just never showed it.
+const WL_FAILING_ATTEMPTS = 3;
+
+function _wlFailTitle(p) {
+    let t = `${p.retry} failed attempt${p.retry !== 1 ? 's' : ''}`;
+    if (p.lastTried) t += ` · last tried ${p.lastTried}`;
+    if (p.failReason) t += `\n${p.failReason}`;
+    return t;
+}
+
+// Attribute-safe escape: escapeHtml (innerHTML-based) leaves double quotes
+// intact, so a failure reason containing one would break out of a title="…"
+// attribute. Always use this for attribute values built from wishlist data.
+function _wlAttr(s) {
+    return escapeHtml(String(s ?? '')).replace(/"/g, '&quot;');
+}
+
 function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, currentCycle) {
     const field = document.getElementById('wl-nebula-field');
     if (!field) return;
@@ -1523,7 +1543,13 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
         let artist = 'Unknown Artist';
         if (sd.artists?.[0]?.name) artist = sd.artists[0].name;
         else if (typeof sd.artists?.[0] === 'string') artist = sd.artists[0];
-        return { track: sd.name || 'Unknown', artist, album: albumName, image: albumImage, type, id: track.spotify_track_id || track.id || '' };
+        const retry = Number(track.retry_count) || 0;
+        return { track: sd.name || 'Unknown', artist, album: albumName, image: albumImage, type,
+                 id: track.spotify_track_id || track.id || '',
+                 retry,
+                 failing: retry >= WL_FAILING_ATTEMPTS,
+                 lastTried: track.last_attempted || '',
+                 failReason: track.failure_reason || '' };
     }
 
     for (const t of albumTracks) { const p = _parse(t, 'album'); if (p) { if (!artistMap.has(p.artist)) artistMap.set(p.artist, { albums: new Map(), singles: [] }); const a = artistMap.get(p.artist); if (!a.albums.has(p.album)) a.albums.set(p.album, { image: p.image, tracks: [] }); a.albums.get(p.album).tracks.push(p); } }
@@ -1545,6 +1571,11 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
         const hasAlbums = data.albums.size > 0;
         const hue = _hue(name);
         const sz = total >= 10 ? 'orb-lg' : total >= 4 ? 'orb-md' : 'orb-sm';
+        // Failing rollup for this artist (#liveleak-failing-hub): drives the orb
+        // warning dot and the Failing-only filter (data-failing attribute).
+        const failingCount = [...data.albums.values()].reduce(
+            (s, a) => s + a.tracks.filter(t => t.failing).length, 0)
+            + data.singles.filter(s2 => s2.failing).length;
 
         // Enhancement 1: prefer watchlist artist photo over album cover
         let img = artistImageMap.get(name.toLowerCase()) || '';
@@ -1557,7 +1588,7 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
         // Enhancement 7: staggered entry animation
         const delay = Math.min(idx * 60, 800);
 
-        html += `<div class="wl-orb-group" data-artist="${escapeHtml(name)}" style="animation-delay:${delay}ms">`;
+        html += `<div class="wl-orb-group" data-artist="${escapeHtml(name)}" data-failing="${failingCount}" style="animation-delay:${delay}ms">`;
 
         // Enhancement 2: hover tooltip
         html += `<div class="wl-orb-tooltip">${escapeHtml(name)}<br><span>${total} track${total !== 1 ? 's' : ''}</span></div>`;
@@ -1584,7 +1615,7 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
 
         // Enhancement 8: clickable artist name → navigate to artist detail
         html += `<div class="wl-orb-label" onclick="event.stopPropagation(); _navigateToArtistFromWishlist('${escapeHtml(name)}')" title="View artist">${escapeHtml(name)}</div>`;
-        html += `<div class="wl-orb-meta">${total} track${total !== 1 ? 's' : ''}</div>`;
+        html += `<div class="wl-orb-meta">${total} track${total !== 1 ? 's' : ''}${failingCount > 0 ? ` · <span class="wl-orb-meta-failing" title="${failingCount} track${failingCount !== 1 ? 's' : ''} repeatedly failing to download">&#9888; ${failingCount} failing</span>` : ''}</div>`;
 
         // Expanded content
         html += `<div class="wl-orb-expanded">`;
@@ -1600,8 +1631,11 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
                 // Track list (hidden until tile clicked)
                 html += `<div class="wl-tile-tracks">`;
                 for (const tr of ad.tracks) {
-                    html += `<div class="wl-tile-track">`;
+                    html += `<div class="wl-tile-track${tr.failing ? ' wl-track-failing' : ''}">`;
                     html += `<span class="wl-tile-track-name">${escapeHtml(tr.track)}</span>`;
+                    if (tr.failing) {
+                        html += `<span class="wl-failing-badge" title="${_wlAttr(_wlFailTitle(tr))}">&#9888; ${tr.retry}</span>`;
+                    }
                     html += `<button class="wl-tile-track-remove" onclick="event.stopPropagation();_removeWishlistTrack('${escapeHtml(tr.id)}')" title="Remove track">&#10005;</button>`;
                     html += `</div>`;
                 }
@@ -1613,8 +1647,9 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
         if (data.singles.length > 0) {
             html += `<div class="wl-singles-orbit">`;
             for (const s of data.singles) {
-                html += `<div class="wl-single-moon" data-track-id="${escapeHtml(s.id)}">`;
+                html += `<div class="wl-single-moon${s.failing ? ' wl-moon-failing' : ''}" data-track-id="${escapeHtml(s.id)}"${s.failing ? ` title="${_wlAttr(_wlFailTitle(s))}"` : ''}>`;
                 html += s.image ? `<img src="${s.image}" alt="">` : `<span class="wl-moon-fallback">&#11088;</span>`;
+                if (s.failing) html += `<span class="wl-moon-failing-badge">&#9888;</span>`;
                 html += `<div class="wl-moon-label">${escapeHtml(s.track)}</div>`;
                 html += `<button class="wl-moon-remove-btn" onclick="event.stopPropagation();_removeWishlistTrack('${escapeHtml(s.id)}')" title="Remove">&#10005;</button>`;
                 html += `</div>`;
@@ -1679,12 +1714,22 @@ async function _removeWishlistTrack(trackId) {
     } catch (err) { showToast('Error: ' + err.message, 'error'); }
 }
 
+let _wlFailingOnly = false;
+
+function _toggleFailingFilter() {
+    _wlFailingOnly = !_wlFailingOnly;
+    document.getElementById('wl-failing-filter')?.classList.toggle('active', _wlFailingOnly);
+    _filterNebula();
+}
+
 function _filterNebula() {
     const q = (document.getElementById('wl-nebula-search')?.value || '').toLowerCase().trim();
     document.querySelectorAll('.wl-orb-group').forEach(g => {
         const a = (g.dataset.artist || '').toLowerCase();
         const albums = [...g.querySelectorAll('.wl-satellite')].map(s => (s.dataset.album || '').toLowerCase());
-        const match = !q || a.includes(q) || albums.some(al => al.includes(q));
+        let match = !q || a.includes(q) || albums.some(al => al.includes(q));
+        // Failing-only chip: hide artists with nothing stuck (#liveleak-failing-hub)
+        if (match && _wlFailingOnly && !(Number(g.dataset.failing) > 0)) match = false;
         g.style.display = match ? '' : 'none';
         if (!match) g.classList.remove('expanded');
     });

--- a/webui/static/api-monitor.js
+++ b/webui/static/api-monitor.js
@@ -1636,6 +1636,7 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
                     if (tr.failing) {
                         html += `<span class="wl-failing-badge" title="${_wlAttr(_wlFailTitle(tr))}">&#9888; ${tr.retry}</span>`;
                     }
+                    html += `<button class="wl-tile-track-search" onclick="event.stopPropagation();_searchWishlistTrackManually('${escapeForInlineJs(tr.artist)}','${escapeForInlineJs(tr.track)}')" title="Search manually — pick a source yourself">&#128269;</button>`;
                     html += `<button class="wl-tile-track-remove" onclick="event.stopPropagation();_removeWishlistTrack('${escapeHtml(tr.id)}')" title="Remove track">&#10005;</button>`;
                     html += `</div>`;
                 }
@@ -1651,6 +1652,7 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
                 html += s.image ? `<img src="${s.image}" alt="">` : `<span class="wl-moon-fallback">&#11088;</span>`;
                 if (s.failing) html += `<span class="wl-moon-failing-badge">&#9888;</span>`;
                 html += `<div class="wl-moon-label">${escapeHtml(s.track)}</div>`;
+                html += `<button class="wl-moon-search-btn" onclick="event.stopPropagation();_searchWishlistTrackManually('${escapeForInlineJs(s.artist)}','${escapeForInlineJs(s.track)}')" title="Search manually — pick a source yourself">&#128269;</button>`;
                 html += `<button class="wl-moon-remove-btn" onclick="event.stopPropagation();_removeWishlistTrack('${escapeHtml(s.id)}')" title="Remove">&#10005;</button>`;
                 html += `</div>`;
             }
@@ -1660,6 +1662,22 @@ function _renderWishlistNebula(albumTracks, singleTracks, artistImageMap, curren
     });
 
     field.innerHTML = html;
+}
+
+// LiveLeak hub phase 2: jump from a stuck wishlist track straight into the
+// enhanced search, prefilled with "artist track" — every result there can be
+// hand-picked from any source and downloaded, which is exactly the manual
+// way out a repeatedly-failing track needs.
+function _searchWishlistTrackManually(artistName, trackName) {
+    navigateToPage('search');
+    setTimeout(() => {
+        const searchInput = document.getElementById('enhanced-search-input');
+        if (searchInput) {
+            searchInput.value = `${artistName || ''} ${trackName || ''}`.trim();
+            searchInput.dispatchEvent(new Event('input'));
+            searchInput.focus();
+        }
+    }, 300);
 }
 
 // Enhancement 8: navigate to the Search page pre-filled with this artist's name

--- a/webui/static/enrichment-manager.js
+++ b/webui/static/enrichment-manager.js
@@ -258,9 +258,12 @@ async function refreshEnrichmentManager(btn) {
 // ── Status loading ──────────────────────────────────────────────────────────
 
 async function refreshAllEnrichmentStatuses() {
+    // One bundled request for the whole rail (see _enrichmentStatusFetch in
+    // enrichment.js) — the helper serves every id from a single /status-all
+    // response and falls back per-service only when the bundle misses.
     const results = await Promise.all(_emVisibleWorkers().map(async (w) => {
         try {
-            const res = await fetch(`/api/enrichment/${w.id}/status`);
+            const res = await _enrichmentStatusFetch(w.id);
             return [w.id, res.ok ? await res.json() : null];
         } catch (_e) {
             return [w.id, null];

--- a/webui/static/enrichment.js
+++ b/webui/static/enrichment.js
@@ -2,13 +2,42 @@
 // ============================================================================
 
 /**
+ * Bundled status hydrate: every per-service status reader below goes through
+ * this instead of its own /api/enrichment/<id>/status request — one
+ * /status-all response serves all ~13 of them (the load-time flood fix).
+ * Returns a Response-compatible object so the call sites stay untouched;
+ * unknown ids / a failed bundle fall back to the real per-service request.
+ */
+let _enrStatusBundle = null;   // { t, promise }
+function _enrichmentStatusFetch(id) {
+    const now = Date.now();
+    if (!_enrStatusBundle || now - _enrStatusBundle.t > 3000) {
+        _enrStatusBundle = {
+            t: now,
+            promise: fetch('/api/enrichment/status-all')
+                .then(r => (r.ok ? r.json() : null))
+                .catch(() => null),
+        };
+    }
+    return _enrStatusBundle.promise.then(bundle => {
+        const payload = bundle && bundle.services ? bundle.services[id] : null;
+        if (payload && !payload.error) {
+            return new Response(JSON.stringify(payload), {
+                status: 200, headers: { 'Content-Type': 'application/json' },
+            });
+        }
+        return fetch(`/api/enrichment/${id}/status`);
+    });
+}
+
+/**
  * Poll MusicBrainz status every 2 seconds and update UI
  */
 async function updateMusicBrainzStatus() {
     if (socketConnected) return; // WebSocket handles this
     if (document.hidden) return; // Skip polling when tab is not visible
     try {
-        const response = await fetch('/api/enrichment/musicbrainz/status');
+        const response = await _enrichmentStatusFetch('musicbrainz');
         if (!response.ok) { console.warn('MusicBrainz status endpoint unavailable'); return; }
         const data = await response.json();
         updateMusicBrainzStatusFromData(data);
@@ -146,7 +175,7 @@ async function updateAudioDBStatus() {
     if (socketConnected) return; // WebSocket handles this
     if (document.hidden) return; // Skip polling when tab is not visible
     try {
-        const response = await fetch('/api/enrichment/audiodb/status');
+        const response = await _enrichmentStatusFetch('audiodb');
         if (!response.ok) { console.warn('AudioDB status endpoint unavailable'); return; }
         const data = await response.json();
         updateAudioDBStatusFromData(data);
@@ -323,7 +352,7 @@ async function updateDeezerStatus() {
     if (socketConnected) return; // WebSocket handles this
     if (document.hidden) return; // Skip polling when tab is not visible
     try {
-        const response = await fetch('/api/enrichment/deezer/status');
+        const response = await _enrichmentStatusFetch('deezer');
         if (!response.ok) { console.warn('Deezer status endpoint unavailable'); return; }
         const data = await response.json();
         updateDeezerStatusFromData(data);
@@ -442,7 +471,7 @@ async function updateJioSaavnStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/jiosaavn/status');
+        const response = await _enrichmentStatusFetch('jiosaavn');
         if (!response.ok) { console.warn('JioSaavn status endpoint unavailable'); return; }
         const data = await response.json();
         updateJioSaavnStatusFromData(data);
@@ -548,7 +577,7 @@ async function updateSpotifyEnrichmentStatus() {
     if (socketConnected) return; // WebSocket handles this
     if (document.hidden) return; // Skip polling when tab is not visible
     try {
-        const response = await fetch('/api/enrichment/spotify/status');
+        const response = await _enrichmentStatusFetch('spotify');
         if (!response.ok) { console.warn('Spotify enrichment status endpoint unavailable'); return; }
         const data = await response.json();
         updateSpotifyEnrichmentStatusFromData(data);
@@ -714,7 +743,7 @@ async function updateiTunesEnrichmentStatus() {
     if (socketConnected) return; // WebSocket handles this
     if (document.hidden) return; // Skip polling when tab is not visible
     try {
-        const response = await fetch('/api/enrichment/itunes/status');
+        const response = await _enrichmentStatusFetch('itunes');
         if (!response.ok) { console.warn('iTunes enrichment status endpoint unavailable'); return; }
         const data = await response.json();
         updateiTunesEnrichmentStatusFromData(data);
@@ -833,7 +862,7 @@ async function updateLastFMEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/lastfm/status');
+        const response = await _enrichmentStatusFetch('lastfm');
         if (!response.ok) { console.warn('Last.fm status endpoint unavailable'); return; }
         const data = await response.json();
         updateLastFMEnrichmentStatusFromData(data);
@@ -960,7 +989,7 @@ async function updateGeniusEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/genius/status');
+        const response = await _enrichmentStatusFetch('genius');
         if (!response.ok) { console.warn('Genius status endpoint unavailable'); return; }
         const data = await response.json();
         updateGeniusEnrichmentStatusFromData(data);
@@ -1086,7 +1115,7 @@ async function updateBandcampEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/bandcamp/status');
+        const response = await _enrichmentStatusFetch('bandcamp');
         if (!response.ok) { console.warn('Bandcamp status endpoint unavailable'); return; }
         const data = await response.json();
         updateBandcampEnrichmentStatusFromData(data);
@@ -1208,7 +1237,7 @@ async function updateTidalEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/tidal/status');
+        const response = await _enrichmentStatusFetch('tidal');
         if (!response.ok) { console.warn('Tidal status endpoint unavailable'); return; }
         const data = await response.json();
         updateTidalEnrichmentStatusFromData(data);
@@ -1333,7 +1362,7 @@ async function updateQobuzEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/qobuz/status');
+        const response = await _enrichmentStatusFetch('qobuz');
         if (!response.ok) { console.warn('Qobuz status endpoint unavailable'); return; }
         const data = await response.json();
         updateQobuzEnrichmentStatusFromData(data);
@@ -1458,7 +1487,7 @@ async function updateAmazonEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/amazon/status');
+        const response = await _enrichmentStatusFetch('amazon');
         if (!response.ok) { console.warn('Amazon enrichment status endpoint unavailable'); return; }
         const data = await response.json();
         updateAmazonEnrichmentStatusFromData(data);
@@ -1564,7 +1593,7 @@ async function updateSimilarArtistsEnrichmentStatus() {
     if (socketConnected) return;
     if (document.hidden) return;
     try {
-        const response = await fetch('/api/enrichment/similar_artists/status');
+        const response = await _enrichmentStatusFetch('similar_artists');
         if (!response.ok) return;
         updateSimilarArtistsEnrichmentStatusFromData(await response.json());
     } catch (error) {

--- a/webui/static/fetch-dedupe.js
+++ b/webui/static/fetch-dedupe.js
@@ -1,0 +1,90 @@
+/**
+ * API GET dedupe — one wire request per identical burst.
+ *
+ * A single page load fires the same GET many times from components that don't
+ * know about each other (issues/counts ×3, activity/feed ×3, dashboard ×2,
+ * …). This wraps window.fetch so identical same-origin /api GETs within a
+ * short window share ONE request; every consumer gets its own Response.clone()
+ * (a Response body is single-use — sharing the raw Response would break the
+ * second .json() call).
+ *
+ * Loaded FIRST (before the React bundle and every split module) so all
+ * frameworks flow through it. Deliberately conservative — anything outside
+ * these rules passes straight through untouched:
+ *   • GET only (every fetch-based stream in the app is POST, except…)
+ *   • never for streaming paths (…/stream — the similar-artists SSE-over-GET)
+ *     or socket.io transport
+ *   • same-origin /api/* + /status only
+ *   • failures are not cached (next caller retries for real)
+ */
+(function () {
+    'use strict';
+    if (typeof window === 'undefined' || !window.fetch) return;
+
+    var TTL_MS = 2500;
+    var raw = window.fetch.bind(window);
+    var entries = new Map();   // key → { promise, t }
+
+    function dedupeKey(input, init) {
+        try {
+            var method = ((init && init.method) ||
+                (input && typeof input === 'object' && input.method) || 'GET');
+            if (String(method).toUpperCase() !== 'GET') return null;
+            var url = typeof input === 'string' ? input
+                : (input && typeof input === 'object' ? input.url : '') || '';
+            if (!url) return null;
+            if (url[0] !== '/') {
+                var u = new URL(url, window.location.origin);
+                if (u.origin !== window.location.origin) return null;
+                url = u.pathname + u.search;
+            }
+            var path = url.split('?')[0];
+            if (path !== '/status' && path.indexOf('/api/') !== 0) return null;
+            if (path.indexOf('/socket.io') === 0) return null;
+            // streaming responses must never be shared or delayed
+            if (path.indexOf('/stream') !== -1) return null;
+            var accept = '';
+            if (init && init.headers) {
+                if (typeof init.headers.get === 'function') accept = init.headers.get('Accept') || '';
+                else accept = init.headers.Accept || init.headers.accept || '';
+            }
+            if (String(accept).indexOf('text/event-stream') !== -1) return null;
+            // an aborted shared request would abort every consumer — opt out
+            if ((init && init.signal) || (input && typeof input === 'object' && input.signal)) return null;
+            return url;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function sweep(now) {
+        entries.forEach(function (v, k) {
+            if (now - v.t > TTL_MS) entries.delete(k);
+        });
+    }
+
+    window.fetch = function (input, init) {
+        var key = dedupeKey(input, init);
+        if (!key) return raw(input, init);
+        var now = Date.now();
+        var hit = entries.get(key);
+        if (hit && (now - hit.t) < TTL_MS) {
+            return hit.promise.then(function (res) { return res.clone(); });
+        }
+        var p = raw(input, init).then(function (res) {
+            if (!res.ok) entries.delete(key);   // failures always retry for real
+            return res;
+        }, function (err) {
+            entries.delete(key);
+            throw err;
+        });
+        entries.set(key, { promise: p, t: now });
+        if (entries.size > 64) sweep(now);
+        // The cached original is NEVER consumed — every caller (first one
+        // included) reads a clone, so later hits can keep cloning it.
+        return p.then(function (res) { return res.clone(); });
+    };
+
+    // introspection hook for tests/debugging
+    window._apiGetDedupe = { entries: entries, dedupeKey: dedupeKey, ttl: TTL_MS };
+})();

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3482,19 +3482,19 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.1.0': [
-        { date: 'July 2026 · 3.1.0' },
-        { title: 'Video acquisition: full Sonarr/Radarr parity', desc: 'the video side now has RSS instant grabs (a wanted release lands minutes after it hits your indexers), per-title quality profiles, custom formats, an in-app requests system, torrent seeding lifecycle, import lists (Trakt/TMDB/IMDb/Plex watchlist), mass rename, daily/anime series types, per-title history, video backups, and event notifications.', page: 'video-downloads' },
-        { title: 'Every video page got a best-in-class pass', desc: 'calendar gets a movie release lane + agenda view + iCal subscribe (and moved up to Find). wishlist gets Search Now + honest status + far snappier art. downloads show live speed/ETA. library gets size-on-disk + filters + a Largest sort. search gets recent chips. discover gets a filter collapse toggle.', page: 'video-library' },
-        { title: 'Version glow', desc: 'the version number glows when an update is out: green for routine, yellow for major, red for critical. it checks real GitHub releases and tells you the version instead of a commit hash. thanks Kazimir.' },
-        { title: 'Notification history', desc: 'every notification is saved server-side now, so a reflexive Clear All loses nothing. filter the bell panel by type, and a searchable History page. thanks Kazimir.' },
-        { title: 'Config migration', desc: 'export every setting for both sides as one JSON file to move to a new install, or import one. secrets are redacted by default; the credentials export is gated behind login mode. thanks Kazimir.' },
-        { title: 'Downloads folder no longer bleeds storage', desc: 'failed youtube matches were being cancelled while still landing, piling up recordless files (a 10GB leak for one user). fixed at the source, plus a reaper for what\'s already orphaned. thanks Kazimir.' },
-        { title: 'Torrents move to your client folder', desc: 'qBittorrent reports its own container path (/downloads); soulsync now verifies the release is actually there and falls back to your configured folder. thanks TheHomeGuy.' },
-        { title: 'YouTube stops grabbing the wrong song', desc: '"We\'re Shameless" was matching "We Were Shameless" by a different artist. youtube results now need real artist evidence or a title made only of the wanted words. thanks Kazimir.' },
-        { title: 'HiFi 30-second clips can\'t replace real files', desc: 'preview clips were overwriting full tracks on quality-upgrade. the import gate decodes them now, an upgrade can never replace a good file with a shorter one, and Preview Clip Cleanup finds and re-fetches ones already in a library. thanks sella.' },
-        { title: 'Guided tours rebuilt', desc: 'the tours pointed at UI that had moved; re-anchored against the current app, the spotlight actually reveals what it highlights now, and the never-clearing red dot is fixed. thanks Kazimir.' },
-        { title: 'Earlier versions', desc: '3.0.5 added exact-ID album import + lyrics-travel + a stack of music fixes. 3.0.4 rebuilt video Discover and added per-profile side access. 3.0.1 shipped the entire video side.' },
+    '3.1.1': [
+        { date: 'July 2026 · 3.1.1' },
+        { title: 'Continue Watching on video detail pages', desc: 'per-episode watch state scanned from plex/jellyfin: checkmarks, progress bars, a Next Up highlight, and the hero button becomes "Resume S2 E4" deep-linking the episode. shows open on the season you\'re actually in. plus a real Mark watched/unwatched toggle that syncs to your server.', page: 'video-library' },
+        { title: 'Detail pages show what we already knew', desc: 'the awards line, an after-credits-scene tag, NEW badges on fresh episodes, digital release dates, your file\'s ranked quality name, and 4K · HDR · Atmos · 7.1 format badges on owned movies.', page: 'video-library' },
+        { title: 'Re-releases no longer show as owned', desc: 'owning the original of an album made every remaster and anniversary edition light up as owned too. album matching now respects the release year, so owning "Album" doesn\'t claim "Album (2011 Remaster)".' },
+        { title: 'Playlist sync stops leaving tracks behind', desc: 'three stacked bugs (#1047): decent matches thrown away, stale plex ratingKeys failing silently, and big playlist writes partially landing unchecked. writes are now chunked and verified against what the server stored.' },
+        { title: 'Force download really replaces the file', desc: '"download again" used to import next to the old file or skip entirely (#1045). a forced re-download now actually replaces what\'s on disk.' },
+        { title: 'Deep scan removes artists that left your library', desc: 'switching to a smaller/empty library kept the old artists forever. deep scan reads the server fresh and cleans them out — and refuses to mass-delete when the server call failed, so a plex hiccup can\'t wipe your list.' },
+        { title: 'Failing wishlist downloads are visible', desc: 'items that keep failing get an attempt counter, a failing badge, a filter, and a jump straight into manual search. both music and video wishlists. thanks LiveLeak.' },
+        { title: 'Synchronize one show', desc: 'a per-show deep scan on the show page reconciles episodes against your server right now and refreshes the airing schedule. vanished episodes demote to missing — never deleted.', page: 'video-library' },
+        { title: 'Way fewer requests at idle', desc: 'duplicate api bursts dedupe client-side, enrichment status hydrates in one bundled call instead of ~28, and pollers slow down and skip when the tab is hidden.' },
+        { title: 'Smaller fixes', desc: 'digit-named artists like 311 open again, the whole-library m3u reports itself in the scan summary (#1041), genres/keywords/where-to-watch on video detail are real links (#1042), mass rename previews big libraries in the background, and youtube episode numbering uses the real upload date.' },
+        { title: 'Earlier versions', desc: '3.1.0 gave the video side full Sonarr/Radarr-class acquisition + a best-in-class pass over every page. 3.0.5 added exact-ID album import + lyrics-travel. 3.0.4 rebuilt video Discover + per-profile side access. 3.0.1 shipped the entire video side.' },
     ],
 };
 
@@ -3525,7 +3525,22 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.1.0: the video side grows up",
+        title: "3.1.1: continue watching + the reported-bugs sweep",
+        description: "the video detail pages learn everything your server knows about what you've watched, and a stack of reported music bugs — re-releases showing owned, playlist sync leaving tracks behind, force download not forcing — all die.",
+        features: [
+            "continue watching: per-episode watch state scanned from plex/jellyfin — checkmarks, progress bars, a Next Up highlight, the hero button becomes 'Resume S2 E4 on Plex' deep-linking the episode, shows open on the season you're actually in, and a Mark watched/unwatched toggle pushes played state back to your server",
+            "detail pages surface what soulsync already knew: the 🏆 awards line, an after-credits-scene tag, NEW badges on freshly-landed episodes, digital release dates, your file's ranked quality name, and 4K · HDR · DV · Atmos · 7.1 format badges on owned movies (real stream data on jellyfin, release-name parsing on plex)",
+            "re-releases no longer show as owned: owning the original doesn't claim the remaster/anniversary edition anymore — album matching respects the release year on both sides",
+            "playlist sync stops leaving tracks behind (#1047): matches in the 0.70–0.79 band were found then thrown away, stale plex ratingKeys failed silently, and big playlist writes partially landed unchecked — all three fixed, writes now chunked and verified against what the server stored",
+            "deep scan finally removes artists that left your library, reads the server fresh instead of a stale cache, and refuses to mass-delete on a failed server call — a plex hiccup can't wipe your artist list",
+            "repeatedly-failing wishlist downloads get an attempt counter, a failing badge, a see-only-failing filter, and a jump straight into manual search (music + video, thanks LiveLeak); force download actually replaces the file on disk (#1045)",
+            "per-show Synchronize: a deep scan scoped to one show that reconciles episodes right now, survives plex re-keys, and refreshes the airing schedule — and vanished episodes demote to 'missing' instead of being erased",
+            "the request flood is gone: duplicate api GET bursts dedupe to one wire request, enrichment status hydrates in one bundled call instead of ~28, and steady-state pollers slow down + skip hidden tabs",
+            "smaller fixes: digit-named artists (311) open again, the whole-library m3u reports itself in the scan summary (#1041), video genres/keywords/where-to-watch are real links (#1042), mass rename previews big libraries in the background with live progress, youtube episode numbering trusts the real upload date",
+        ],
+    },
+    {
+        title: "Earlier in 3.1.0 — the video side grows up",
         description: "the video side gets a full Sonarr/Radarr-class acquisition stack, a best-in-class pass over every page, and a wave of reported bugs (storage bleeding, torrents not moving, the wrong song downloading) all die.",
         features: [
             "video acquisition, Sonarr/Radarr parity in eleven pieces: RSS instant grabs (a wanted release lands minutes after it hits your indexers, not at the next hourly sweep), per-title quality profiles + monitor policies, custom formats (scored release-name matchers), an in-app requests system, torrent seeding lifecycle, import lists (Trakt/TMDB/IMDb/Plex watchlist), mass rename with preview, daily/anime series types + multi-episode files, per-title history, video backups + staged restore, and Discord/Telegram/webhook notifications",

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -64636,6 +64636,28 @@ body.max-performance #page-particles-canvas {
 
 .wl-tile-track:hover { background: rgba(255,255,255,0.05); }
 
+/* Repeatedly-failing wishlist items (#liveleak-failing-hub) */
+.wl-failing-badge {
+    flex: 0 0 auto; margin-left: 6px; padding: 1px 6px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.02em; cursor: default;
+    color: #fca5a5; background: rgba(239, 68, 68, 0.14);
+    border: 1px solid rgba(239, 68, 68, 0.35);
+}
+.wl-track-failing .wl-tile-track-name { color: rgba(252, 165, 165, 0.9); }
+.wl-orb-meta-failing { color: #fca5a5; font-weight: 700; cursor: default; }
+.wl-moon-failing img { outline: 2px solid rgba(239, 68, 68, 0.55); outline-offset: -1px; }
+.wl-moon-failing-badge {
+    position: absolute; top: -4px; right: -4px; z-index: 3;
+    font-size: 10px; color: #fff; background: rgba(220, 38, 38, 0.9);
+    width: 16px; height: 16px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+}
+.wl-failing-filter { flex: 0 0 auto; }
+.wl-failing-filter.active {
+    color: #fca5a5; background: rgba(239, 68, 68, 0.16);
+    border-color: rgba(239, 68, 68, 0.45);
+}
+
 .wl-tile-track-name {
     font-size: 10px;
     color: rgba(255,255,255,0.6);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -64683,6 +64683,24 @@ body.max-performance #page-particles-canvas {
 }
 
 .wl-tile-track:hover .wl-tile-track-remove { opacity: 1; }
+
+/* Manual-search jump (LiveLeak hub phase 2) — mirrors the remove button */
+.wl-tile-track-search {
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    color: rgba(255,255,255,0.35);
+    font-size: 9px;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    margin-left: 4px;
+    opacity: 0;
+    transition: all 0.15s;
+}
+.wl-tile-track:hover .wl-tile-track-search { opacity: 1; }
+.wl-tile-track-search:hover { color: #fff; background: rgba(var(--accent-rgb), 0.35); }
 .wl-tile-track-remove:hover { background: rgba(239,68,68,0.2); color: #f87171; }
 
 /* ── Singles orbit (small moons) ── */
@@ -64757,6 +64775,21 @@ body.max-performance #page-particles-canvas {
 }
 
 .wl-single-moon:hover .wl-moon-remove-btn { opacity: 1; }
+.wl-moon-search-btn {
+    position: absolute;
+    top: -2px; left: 2px;
+    width: 16px; height: 16px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(var(--accent-rgb), 0.85);
+    color: #fff;
+    font-size: 8px;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.wl-single-moon:hover .wl-moon-search-btn { opacity: 1; }
 .wl-moon-remove-btn:hover { transform: scale(1.15); }
 
 @media (max-width: 768px) {

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -2738,13 +2738,24 @@
     var _dlTimer = null, _dlActive = {}, _dlDone = {}, _dlPrev = {};
     function _dlReset() { _dlActive = {}; _dlDone = {}; _dlPrev = {}; }
     function _dlTrackable() { return !!(data && (data.kind === 'show' || data.kind === 'channel')); }
+    // Adaptive cadence: 2.5s only while a download for THIS show is actually
+    // in flight; 10s otherwise (still catches a fresh grab quickly) — and
+    // nothing at all while the tab is hidden. A flat 2.5s forever was a
+    // request every 2.5s for as long as any show page stayed open.
+    var _DL_FAST_MS = 2500, _DL_IDLE_MS = 10000, _dlHasActive = false;
     function startDlTracking() {
         stopDlTracking();
         if (!_dlTrackable()) return;
         pollDl();
-        _dlTimer = setInterval(pollDl, 2500);
+        _scheduleDl();
     }
-    function stopDlTracking() { if (_dlTimer) { clearInterval(_dlTimer); _dlTimer = null; } }
+    function _scheduleDl() {
+        _dlTimer = setTimeout(function () {
+            if (!document.hidden) pollDl();
+            if (_dlTimer) _scheduleDl();
+        }, _dlHasActive ? _DL_FAST_MS : _DL_IDLE_MS);
+    }
+    function stopDlTracking() { if (_dlTimer) { clearTimeout(_dlTimer); _dlTimer = null; } }
     function pollDl() {
         if (!_dlTrackable() || !root()) { stopDlTracking(); return; }
         var showTitle = data.title;
@@ -2785,6 +2796,7 @@
                 if (!cur[key] && _dlActive[key]) { _dlDone[key] = 1; delete _dlActive[key]; }
             });
             _dlPrev = cur;
+            _dlHasActive = Object.keys(cur).length > 0;   // drives the adaptive cadence
             applyDlStates();
             // Everything settled → stop the interval until the next grab.
             if (!Object.keys(_dlActive).length) stopDlTracking();

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -1829,7 +1829,15 @@
                 if (d.files_added) bits.push('+' + d.files_added + ' file' + (d.files_added !== 1 ? 's' : ''));
                 if (d.files_removed) bits.push('−' + d.files_removed + ' file' + (d.files_removed !== 1 ? 's' : ''));
                 if (typeof showToast === 'function') {
-                    showToast('Synchronized' + (bits.length ? ': ' + bits.join(', ') : ' — no changes'), 'success');
+                    // a failed schedule refresh must be SAID, not silently absorbed —
+                    // otherwise "no changes" reads as "everything's fine"
+                    var refreshBad = d.schedule_refresh && d.schedule_refresh !== 'ok';
+                    if (refreshBad) {
+                        showToast('Synchronized' + (bits.length ? ': ' + bits.join(', ') : '') +
+                            ' — episode schedule refresh failed (' + d.schedule_refresh + ')', 'warning');
+                    } else {
+                        showToast('Synchronized' + (bits.length ? ': ' + bits.join(', ') : ' — no changes'), 'success');
+                    }
                 }
                 // a Plex re-key heals onto a NEW row id — reload THAT row
                 var rid = parseInt(d.show_id != null ? d.show_id : id, 10);

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -239,7 +239,7 @@
             var ll = q('[data-vd-links]'); if (ll) ll.innerHTML = '';
             var gg = q('[data-vd-genres]');
             if (gg) gg.innerHTML = (d.genres || []).slice(0, 8).map(genreChip).join('');
-            renderRatings(d); renderCrewLine(d); renderNextEpisode(d); renderCast(d);
+            renderRatings(d); renderAwards(d); renderCrewLine(d); renderNextEpisode(d); renderCast(d);
             return;
         }
         if (d.source === 'tmdb') {
@@ -270,6 +270,11 @@
         if (d.kind === 'show' && d.status) meta.push('<span class="vd-status">' + esc(statusLabel(d.status)) + '</span>');
         if (d.network) meta.push('<span>' + esc(d.network) + '</span>');
         if (d.kind === 'movie' && d.studio) meta.push('<span>' + esc(d.studio) + '</span>');
+        // Mediastinger (already enriched for overlays): don't leave before the credits end.
+        if (d.mediastinger) {
+            meta.push('<span class="vd-stinger" title="This title has an after-credits scene">' +
+                '🎬 After-credits scene</span>');
+        }
         var m = q('[data-vd-meta]'); if (m) m.innerHTML = meta.join('');
 
         renderActions(d);
@@ -299,9 +304,21 @@
         }
         renderSubtitles(d);
         renderRatings(d);
+        renderAwards(d);
         renderCrewLine(d);
         renderNextEpisode(d);
         renderCast(d);
+    }
+
+    // OMDb Awards line ("Won 2 Oscars. 154 wins & 87 nominations total.") — the
+    // overlay system already fetches it; the detail page finally shows it.
+    function renderAwards(d) {
+        var host = q('[data-vd-awards]');
+        if (!host) return;
+        var s = (d && d.awards || '').trim();
+        if (!s || /^n\/?a$/i.test(s)) { host.hidden = true; host.innerHTML = ''; return; }
+        host.hidden = false;
+        host.innerHTML = '<span class="vd-awards-ic">🏆</span>' + esc(s);
     }
 
     // Subtitle availability (OpenSubtitles backfill, #video-enrichment): a chip row
@@ -617,7 +634,61 @@
                 '" title="Re-read this show from your server — picks up new or removed episodes">' +
                 '<span class="vd-manage-ic">⟳</span> Synchronize</button>';
         }
+        // Watched toggle (the /watched API finally gets a UI): local state +
+        // markPlayed/markUnplayed pushed to the server. Library rows only.
+        if (ownLibItem && (d.kind === 'movie' || d.kind === 'show') &&
+                (d.source !== 'tmdb' || d.library_id != null) && (d.owned || d.episode_owned || d.watched)) {
+            html += '<button class="vd-manage-btn" type="button" data-vd-act="watched-toggle" title="' +
+                (d.watched ? 'Mark unwatched (clears played state on your server too)'
+                           : 'Mark watched (marks played on your server too)') + '">' +
+                '<span class="vd-manage-ic">' + (d.watched ? '↺' : '✓') + '</span> ' +
+                (d.watched ? 'Mark unwatched' : 'Mark watched') + '</button>';
+        }
         a.innerHTML = html;
+    }
+
+    // Continue Watching: played/unplayed toggle → POST /detail/<kind>/<id>/watched
+    // (local rows + server markPlayed), then mirror the result in-page.
+    function toggleWatchedState(btn) {
+        if (!data || btn.disabled) return;
+        var kind = data.kind === 'movie' ? 'movie' : 'show';
+        var libId = (data.source !== 'tmdb') ? data.id : data.library_id;
+        if (libId == null) return;
+        var target = !data.watched;
+        btn.disabled = true;
+        fetch(DETAIL_URL + kind + '/' + libId + '/watched', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ watched: target }) })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (res) {
+                btn.disabled = false;
+                if (!res || !res.ok) throw new Error();
+                // Mirror what the backend did so the page reacts instantly.
+                data.watched = target;
+                if (kind === 'movie') {
+                    data.play_count = target ? 1 : 0;
+                    data.view_offset_ms = 0;
+                } else {
+                    data.watched_episodes = target ? data.episode_total : 0;
+                    (data.seasons || []).forEach(function (s) {
+                        (s.episodes || []).forEach(function (ep) {
+                            ep.watched = target; ep.view_offset_ms = 0;
+                        });
+                    });
+                    data.next_up = null;
+                    if (data.server) { delete data.server.next_up; delete data.server.episode_url; }
+                }
+                renderBillboard(data);
+                if (kind === 'show') renderEpisodes();
+                if (typeof showToast === 'function') {
+                    showToast((target ? 'Marked watched' : 'Marked unwatched') +
+                        (res.pushed ? ' — synced to your server' : ''), 'success');
+                }
+            })
+            .catch(function () {
+                btn.disabled = false;
+                if (typeof showToast === 'function') showToast('Could not update watched state', 'error');
+            });
     }
 
     // Open the shared Get modal for the current item (movies use this in place of
@@ -727,6 +798,9 @@
         if (!host) return;
         var rows = [];
         if (d.release_date) rows.push(['Released', d.release_date]);
+        if (d.digital_release_date && d.digital_release_date !== d.release_date) {
+            rows.push(['Digital release', d.digital_release_date]);
+        }
         if (d.runtime_minutes) rows.push(['Runtime', runtimeLabel(d.runtime_minutes)]);
         if (d.studio) rows.push(['Studio', d.studio]);
         if (d.status) rows.push(['Status', statusLabel(d.status)]);
@@ -734,7 +808,9 @@
         // Your media — the technical specs we scanned (Plex-grade).
         var f = d.file;
         if (f) {
-            if (f.resolution) rows.push(['Quality', mediaRes(f.resolution)]);
+            // the ranked quality name when the grab recorded one (Radarr-style
+            // "WEBDL-1080p"), else the plain scanned resolution
+            if (f.quality || f.resolution) rows.push(['Quality', f.quality || mediaRes(f.resolution)]);
             if (f.video_codec) rows.push(['Video', prettyCodec(f.video_codec)]);
             if (f.audio_codec) rows.push(['Audio', String(f.audio_codec).toUpperCase()]);
             if (f.release_source) rows.push(['Source', prettySource(f.release_source)]);
@@ -1411,10 +1487,17 @@
         var nextChip = isNext
             ? '<span class="vd-ep-next-chip">' + (inProgress ? 'Resume' : 'Next up') + '</span>'
             : '';
+        // NEW = landed on the server in the last 7 days and not watched yet.
+        var addedTs = ep.owned && !ep.watched && ep.added_at
+            ? Date.parse(String(ep.added_at).replace(' ', 'T'))   // Safari chokes on the space form
+            : NaN;
+        var newChip = (addedTs && !isNaN(addedTs) && (Date.now() - addedTs) < 7 * 86400000)
+            ? '<span class="vd-ep-new-chip" title="Recently added">New</span>'
+            : '';
         return '<div class="vd-ep ' + owned + '" data-vd-ep-key="' + key + '">' +
             '<div class="vd-ep-index">' + (ep.episode_number != null ? ep.episode_number : '') + '</div>' +
             '<div class="vd-ep-thumb">' + still + '<span class="vd-ep-thumb-ic">▶</span>' + prog + '</div>' +
-            '<div class="vd-ep-info"><div class="vd-ep-top">' + check + nextChip + '<span class="vd-ep-title">' +
+            '<div class="vd-ep-info"><div class="vd-ep-top">' + check + nextChip + newChip + '<span class="vd-ep-title">' +
             esc(ep.title || 'Episode ' + ep.episode_number) + '</span>' +
             (meta.length ? '<span class="vd-ep-rt">' + esc(meta.join(' · ')) + '</span>' : '') + '</div>' +
             (ep.overview ? '<p class="vd-ep-desc">' + esc(ep.overview) + '</p>' : '') + '</div>' +
@@ -2506,6 +2589,7 @@
             else if (which === 'poster') openPosterModal();
             else if (which === 'manage') openManagePanel();
             else if (which === 'sync-show') syncShowNow(act);
+            else if (which === 'watched-toggle') toggleWatchedState(act);
             else if (which === 'yt-follow') toggleYtFollow();
             else if (which === 'yt-pl-follow') toggleYtPlaylistFollowHero();
             else if (which === 'trailer' && data && data.trailer) openTrailer(data.trailer.key);

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -257,6 +257,8 @@
             meta.push(d.owned ? '<span class="vd-match">In library</span>'
                 : '<span class="vd-status">Wanted</span>');
             if (d.watched) meta.push('<span class="vd-watched-tag" title="Watched on your server">✓ Watched</span>');
+            // your best copy's format facts (4K · HDR · Atmos · 5.1), like the streamers show
+            if (d.owned && d.file) meta.push.apply(meta, formatBadges(d.file));
         }
         if (d.rating) meta.push('<span class="vd-score">★ ' + (Math.round(d.rating * 10) / 10) + '</span>');
         if (d.year) meta.push('<span>' + esc(d.year) + '</span>');
@@ -768,6 +770,25 @@
         if (r.indexOf('480') > -1 || r.indexOf('576') > -1) return 'SD';
         return r.toUpperCase();
     }
+    function channelsLabel(n) {
+        n = Number(n) || 0;
+        if (n >= 8) return '7.1';
+        if (n === 7) return '6.1';
+        if (n === 6) return '5.1';
+        if (n === 2) return 'Stereo';
+        if (n === 1) return 'Mono';
+        return n ? n + 'ch' : '';
+    }
+    // Netflix/Disney-style format badges for the hero meta: 4K · HDR10 · Atmos · 5.1
+    function formatBadges(f) {
+        if (!f) return [];
+        var b = [];
+        var res = mediaRes(f.resolution); if (res) b.push(res);
+        if (f.dynamic_range) b.push(f.dynamic_range);
+        if (f.atmos) b.push('Atmos');
+        else { var ch = channelsLabel(f.audio_channels); if (ch && ch !== 'Stereo' && ch !== 'Mono') b.push(ch); }
+        return b.map(function (t) { return '<span class="vd-fmt">' + esc(t) + '</span>'; });
+    }
     function prettyCodec(c) {
         if (!c) return '';
         var l = String(c).toLowerCase();
@@ -788,8 +809,9 @@
         return gb >= 1 ? (Math.round(gb * 10) / 10) + ' GB' : Math.round(n / 1048576) + ' MB';
     }
     function fileSummary(v) {
-        return [mediaRes(v.resolution), prettyCodec(v.video_codec),
-            v.audio_codec ? String(v.audio_codec).toUpperCase() : '', fmtBytes(v.size_bytes),
+        return [mediaRes(v.resolution), v.dynamic_range || '', prettyCodec(v.video_codec),
+            v.audio_codec ? String(v.audio_codec).toUpperCase() : '',
+            v.atmos ? 'Atmos' : channelsLabel(v.audio_channels), fmtBytes(v.size_bytes),
             v.release_source ? prettySource(v.release_source) : ''].filter(Boolean).join(' · ');
     }
 
@@ -812,7 +834,12 @@
             // "WEBDL-1080p"), else the plain scanned resolution
             if (f.quality || f.resolution) rows.push(['Quality', f.quality || mediaRes(f.resolution)]);
             if (f.video_codec) rows.push(['Video', prettyCodec(f.video_codec)]);
-            if (f.audio_codec) rows.push(['Audio', String(f.audio_codec).toUpperCase()]);
+            if (f.dynamic_range) rows.push(['Dynamic range', f.dynamic_range]);
+            if (f.audio_codec || f.audio_channels || f.atmos) {
+                rows.push(['Audio', [String(f.audio_codec || '').toUpperCase(),
+                    channelsLabel(f.audio_channels), f.atmos ? 'Atmos' : '']
+                    .filter(Boolean).join(' · ')]);
+            }
             if (f.release_source) rows.push(['Source', prettySource(f.release_source)]);
             if (f.size_bytes) rows.push(['Size', fmtBytes(f.size_bytes)]);
         }

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -1359,18 +1359,22 @@
             esc(ep.title || 'Episode ' + ep.episode_number) + '</span>' +
             (meta.length ? '<span class="vd-ep-rt">' + esc(meta.join(' · ')) + '</span>' : '') + '</div>' +
             (ep.overview ? '<p class="vd-ep-desc">' + esc(ep.overview) + '</p>' : '') + '</div>' +
-            (ep.owned || !window.VideoGrab
-                ? '<div class="vd-ep-badge">' + (ep.owned
-                    ? 'Owned' + (ep.versions > 1 ? ' ×' + ep.versions : '') : 'Missing') + '</div>'
+            // Owned episodes keep the badge AND the actions: the acquisition
+            // stack treats owned rows as upgrade candidates (upgrade-until-
+            // cutoff), so re-download / manual search / wishlist must not
+            // vanish once something is on disk.
+            ((ep.owned ? '<div class="vd-ep-badge">Owned' + (ep.versions > 1 ? ' ×' + ep.versions : '') + '</div>' : '') +
+             (!window.VideoGrab
+                ? (ep.owned ? '' : '<div class="vd-ep-badge">Missing</div>')
                 : '<div class="vd-ep-get" data-vd-ep-get="' + ep.episode_number + '">' +
                     '<span class="vd-ep-dl" data-vd-ep-dl></span>' +
                     '<button class="vd-ep-getbtn vd-ep-grab" type="button" data-vd-ep-grab="' + ep.episode_number +
-                        '" title="Auto-search &amp; download this episode" aria-label="Get episode">⭳</button>' +
+                        '" title="' + (ep.owned ? 'Search &amp; download again (upgrade)' : 'Auto-search &amp; download this episode') + '" aria-label="Get episode">⭳</button>' +
                     '<button class="vd-ep-getbtn vd-ep-search" type="button" data-vd-ep-search="' + ep.episode_number +
                         '" title="Manual search — pick a release" aria-label="Manual search">⌕</button>' +
                     '<button class="vd-ep-getbtn vd-ep-wish" type="button" data-vd-ep-wish="' + ep.episode_number +
-                        '" title="Add this episode to the wishlist" aria-label="Wishlist episode">＋</button>' +
-                  '</div>') +
+                        '" title="' + (ep.owned ? 'Wishlist for an upgrade' : 'Add this episode to the wishlist') + '" aria-label="Wishlist episode">＋</button>' +
+                  '</div>')) +
             '<span class="vd-ep-chev" aria-hidden="true">⌄</span></div>' +
             '<div class="vd-ep-extra" data-vd-ep-panel="' + key + '" hidden></div>';
     }

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -1831,8 +1831,12 @@
                 if (typeof showToast === 'function') {
                     showToast('Synchronized' + (bits.length ? ': ' + bits.join(', ') : ' — no changes'), 'success');
                 }
-                var rid = parseInt(id, 10);
-                if (!isNaN(rid) && currentId === rid) reloadDetail(rid);
+                // a Plex re-key heals onto a NEW row id — reload THAT row
+                var rid = parseInt(d.show_id != null ? d.show_id : id, 10);
+                if (!isNaN(rid)) {
+                    if (d.rekeyed) { currentId = rid; }
+                    if (currentId === rid) reloadDetail(rid);
+                }
             })
             .catch(function () {
                 btn.disabled = false;

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -576,6 +576,16 @@
             html += '<button class="vd-manage-btn" type="button" data-vd-act="manage" title="Edit metadata">' +
                 '<span class="vd-manage-ic">✎</span> Manage</button>';
         }
+        // Synchronize — a deep scan scoped to THIS show: re-reads it from the
+        // server and reconciles episodes (adds + removals) without waiting for
+        // a full library scan. Library shows only (needs a local row).
+        var libShowId = (d.kind === 'show' && ownLibItem)
+            ? (d.source !== 'tmdb' ? d.id : d.library_id) : null;
+        if (libShowId != null) {
+            html += '<button class="vd-manage-btn" type="button" data-vd-act="sync-show" data-vd-sync-id="' + esc(libShowId) +
+                '" title="Re-read this show from your server — picks up new or removed episodes">' +
+                '<span class="vd-manage-ic">⟳</span> Synchronize</button>';
+        }
         a.innerHTML = html;
     }
 
@@ -1791,6 +1801,46 @@
         el.hidden = !on;
     }
 
+    // Per-show Synchronize (server re-read). Synchronous on the backend (one
+    // show reads in seconds); the response says exactly what changed.
+    function syncShowNow(btn) {
+        var id = btn.getAttribute('data-vd-sync-id');
+        if (!id || btn.disabled) return;
+        btn.disabled = true;
+        var orig = btn.innerHTML;
+        btn.innerHTML = '<span class="vd-manage-ic">⟳</span> Syncing…';
+        fetch('/api/video/detail/show/' + encodeURIComponent(id) + '/sync', { method: 'POST' })
+            .then(function (r) { return r.json().catch(function () { return { success: false, error: 'HTTP ' + r.status }; }); })
+            .then(function (d) {
+                btn.disabled = false;
+                btn.innerHTML = orig;
+                if (!d || !d.success) {
+                    if (typeof showToast === 'function') showToast(d && d.error ? d.error : 'Sync failed', 'error');
+                    return;
+                }
+                if (d.show_removed) {
+                    if (typeof showToast === 'function') showToast('"' + (d.title || 'Show') + '" is no longer on your server — removed from the library', 'warning');
+                    document.dispatchEvent(new CustomEvent('soulsync:video-navigate', { detail: 'video-library' }));
+                    return;
+                }
+                var bits = [];
+                if (d.episodes_added) bits.push('+' + d.episodes_added + ' episode' + (d.episodes_added !== 1 ? 's' : ''));
+                if (d.episodes_removed) bits.push('−' + d.episodes_removed + ' episode' + (d.episodes_removed !== 1 ? 's' : ''));
+                if (d.files_added) bits.push('+' + d.files_added + ' file' + (d.files_added !== 1 ? 's' : ''));
+                if (d.files_removed) bits.push('−' + d.files_removed + ' file' + (d.files_removed !== 1 ? 's' : ''));
+                if (typeof showToast === 'function') {
+                    showToast('Synchronized' + (bits.length ? ': ' + bits.join(', ') : ' — no changes'), 'success');
+                }
+                var rid = parseInt(id, 10);
+                if (!isNaN(rid) && currentId === rid) reloadDetail(rid);
+            })
+            .catch(function () {
+                btn.disabled = false;
+                btn.innerHTML = orig;
+                if (typeof showToast === 'function') showToast('Sync failed — could not reach the server', 'error');
+            });
+    }
+
     function reloadDetail(id) {
         fetch(DETAIL_URL + 'show/' + id, { headers: { 'Accept': 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
@@ -2394,6 +2444,7 @@
             else if (which === 'wishlist-missing') wishlistAllMissing(act);
             else if (which === 'poster') openPosterModal();
             else if (which === 'manage') openManagePanel();
+            else if (which === 'sync-show') syncShowNow(act);
             else if (which === 'yt-follow') toggleYtFollow();
             else if (which === 'yt-pl-follow') toggleYtPlaylistFollowHero();
             else if (which === 'trailer' && data && data.trailer) openTrailer(data.trailer.key);

--- a/webui/static/video/video-detail.js
+++ b/webui/static/video/video-detail.js
@@ -83,6 +83,15 @@
             return (s.season_number > best.season_number) ? s : best;
         }, pool[0]).season_number;
     }
+    // Continue Watching: land on the season you're actually IN (Netflix behavior)
+    // when the show has a next-up episode; otherwise the usual latest season.
+    function initialSeasonNum(d) {
+        var nu = d && d.next_up;
+        if (nu && (d.seasons || []).some(function (s) { return s.season_number === nu.season_number; })) {
+            return nu.season_number;
+        }
+        return defaultSeasonNum(d && d.seasons);
+    }
     function seasonArt(s) {
         // tmdb + youtube carry direct (already-proxied for yt) art urls on the payload.
         if (data && (data.source === 'tmdb' || data.source === 'youtube')) return s.poster_url || data.poster_url || '';
@@ -238,9 +247,16 @@
         } else if (d.kind === 'show') {
             var ownedPct = d.episode_total ? Math.round(d.episode_owned / d.episode_total * 100) : 0;
             meta.push('<span class="vd-match">' + ownedPct + '% in library</span>');
+            // Continue Watching: how far through the show you are (server truth).
+            if (d.watched) meta.push('<span class="vd-watched-tag" title="Every episode watched">✓ Watched</span>');
+            else if (d.watched_episodes > 0) {
+                meta.push('<span class="vd-watched-tag" title="Episodes watched on your server">✓ ' +
+                    d.watched_episodes + ' of ' + d.episode_total + ' watched</span>');
+            }
         } else {
             meta.push(d.owned ? '<span class="vd-match">In library</span>'
                 : '<span class="vd-status">Wanted</span>');
+            if (d.watched) meta.push('<span class="vd-watched-tag" title="Watched on your server">✓ Watched</span>');
         }
         if (d.rating) meta.push('<span class="vd-score">★ ' + (Math.round(d.rating * 10) / 10) + '</span>');
         if (d.year) meta.push('<span>' + esc(d.year) + '</span>');
@@ -478,12 +494,27 @@
         if (d.server && d.server.url) {
             var sv = esc(d.server.server || 'Server');
             var slogo = SERVER_LOGOS[d.server.server];
+            // Continue Watching: shows deep-link the NEXT episode ("Resume S2 E4"),
+            // an in-progress movie says Resume (the server resumes it itself).
+            var snu = d.server.next_up;
+            var href = (snu && d.server.episode_url) ? d.server.episode_url : d.server.url;
+            var verb = 'Play', epTag = '', tip = 'Play on ' + sv;
+            if (snu) {
+                verb = snu.resume ? 'Resume' : 'Play';
+                epTag = '<span class="vd-play-ep">S' + snu.season + ' E' + snu.episode + '</span>';
+                tip = (snu.resume ? 'Resume' : 'Next up') + ' S' + snu.season + ' E' + snu.episode + ' on ' + sv;
+            } else if (d.kind === 'movie' && !d.watched && (d.view_offset_ms || 0) > 0) {
+                verb = 'Resume';
+                var left = d.runtime_minutes
+                    ? Math.max(1, Math.round(d.runtime_minutes - d.view_offset_ms / 60000)) : 0;
+                tip = 'Resume on ' + sv + (left ? ' · ' + left + ' min left' : '');
+            }
             var inner = slogo
-                ? '<span class="vd-play-ic">▶</span><span>Play on</span>' +
-                  '<img class="vd-play-logo" src="' + esc(slogo) + '" alt="' + sv + '">'
-                : '<span class="vd-play-ic">▶</span><span>Play on ' + sv + '</span>';
-            html += '<a class="vd-play-btn" href="' + esc(d.server.url) +
-                '" target="_blank" rel="noopener" title="Play on ' + sv + '">' + inner + '</a>';
+                ? '<span class="vd-play-ic">▶</span><span>' + verb + ' on</span>' +
+                  '<img class="vd-play-logo" src="' + esc(slogo) + '" alt="' + sv + '">' + epTag
+                : '<span class="vd-play-ic">▶</span><span>' + verb + ' on ' + sv + '</span>' + epTag;
+            html += '<a class="vd-play-btn" href="' + esc(href) +
+                '" target="_blank" rel="noopener" title="' + tip + '">' + inner + '</a>';
         }
         if (d.trailer && d.trailer.key) {
             html += '<button class="vd-trailer-btn" type="button" data-vd-act="trailer">' +
@@ -1349,6 +1380,17 @@
     function episodeRow(ep) {
         if (data && data.source === 'youtube') return ytEpisodeRow(ep);
         var owned = ep.owned ? 'vd-ep--owned' : 'vd-ep--missing';
+        // Continue Watching: watched check / in-progress bar / next-up highlight
+        // (all server truth from the scan; a TMDB preview has none of it).
+        var inProgress = !ep.watched && (ep.view_offset_ms || 0) > 0 && ep.runtime_minutes;
+        var progPct = inProgress
+            ? Math.max(2, Math.min(98, Math.round(ep.view_offset_ms / (ep.runtime_minutes * 60000) * 100)))
+            : 0;
+        var nu = data && data.next_up;
+        var isNext = !!(nu && nu.season_number === selectedSeason &&
+                        nu.episode_number === ep.episode_number);
+        if (ep.watched) owned += ' vd-ep--watched';
+        if (isNext) owned += ' vd-ep--next';
         var meta = [];
         var rt = runtimeLabel(ep.runtime_minutes); if (rt) meta.push(rt);
         if (ep.air_date) meta.push(ep.air_date);
@@ -1362,10 +1404,17 @@
         if (ep.rating) meta.push('★ ' + (Math.round(ep.rating * 10) / 10));
         var key = selectedSeason + '_' + ep.episode_number;
         // Row + a sibling expand panel (guest stars etc. load lazily on open).
+        var prog = inProgress
+            ? '<span class="vd-ep-prog"><span class="vd-ep-prog-fill" style="width:' + progPct + '%"></span></span>'
+            : '';
+        var check = ep.watched ? '<span class="vd-ep-check" title="Watched">✓</span>' : '';
+        var nextChip = isNext
+            ? '<span class="vd-ep-next-chip">' + (inProgress ? 'Resume' : 'Next up') + '</span>'
+            : '';
         return '<div class="vd-ep ' + owned + '" data-vd-ep-key="' + key + '">' +
             '<div class="vd-ep-index">' + (ep.episode_number != null ? ep.episode_number : '') + '</div>' +
-            '<div class="vd-ep-thumb">' + still + '<span class="vd-ep-thumb-ic">▶</span></div>' +
-            '<div class="vd-ep-info"><div class="vd-ep-top"><span class="vd-ep-title">' +
+            '<div class="vd-ep-thumb">' + still + '<span class="vd-ep-thumb-ic">▶</span>' + prog + '</div>' +
+            '<div class="vd-ep-info"><div class="vd-ep-top">' + check + nextChip + '<span class="vd-ep-title">' +
             esc(ep.title || 'Episode ' + ep.episode_number) + '</span>' +
             (meta.length ? '<span class="vd-ep-rt">' + esc(meta.join(' · ')) + '</span>' : '') + '</div>' +
             (ep.overview ? '<p class="vd-ep-desc">' + esc(ep.overview) + '</p>' : '') + '</div>' +
@@ -1747,7 +1796,7 @@
                 if (!d || d.error) { setText('[data-vd-title]', 'Not found'); return; }
                 if (currentId !== id || currentKind !== 'show') return;
                 data = d; menuOpen = false; missingOnly = false;
-                selectedSeason = defaultSeasonNum(d.seasons);
+                selectedSeason = initialSeasonNum(d);
                 var mt = q('[data-vd-missing-toggle]');
                 if (mt) { mt.hidden = !(d.seasons && d.seasons.length); mt.classList.remove('vd-missing-toggle--on'); }
                 renderBillboard(d);
@@ -1868,7 +1917,7 @@
                 d.next_episode = prev.next_episode || null;
                 data = d;
                 if (!seasonByNum(selectedSeason)) {
-                    selectedSeason = defaultSeasonNum(d.seasons);
+                    selectedSeason = initialSeasonNum(d);
                 }
                 renderBillboard(d); renderSeasonNav(); renderEpisodes();
             })

--- a/webui/static/video/video-enrichment-manager.js
+++ b/webui/static/video/video-enrichment-manager.js
@@ -128,11 +128,22 @@
             .catch(function () { return null; });
     }
     function refreshAll() {
-        return Promise.all(WORKERS.map(function (w) {
-            return getJSON('/api/video/enrichment/' + w.id + '/status').then(function (d) {
-                state.statuses[w.id] = d || { enabled: false };
-            });
-        }));
+        // One bundled request for the whole rail (~15 workers) instead of one
+        // request per worker — falls back to per-worker only if the bundle
+        // endpoint fails entirely.
+        return getJSON('/api/video/enrichment/status-all').then(function (bundle) {
+            if (bundle && bundle.services) {
+                WORKERS.forEach(function (w) {
+                    state.statuses[w.id] = bundle.services[w.id] || { enabled: false };
+                });
+                return;
+            }
+            return Promise.all(WORKERS.map(function (w) {
+                return getJSON('/api/video/enrichment/' + w.id + '/status').then(function (d) {
+                    state.statuses[w.id] = d || { enabled: false };
+                });
+            }));
+        });
     }
     function loadBreakdown(id) {
         return getJSON('/api/video/enrichment/' + id + '/breakdown').then(function (d) {

--- a/webui/static/video/video-enrichment.js
+++ b/webui/static/video/video-enrichment.js
@@ -76,8 +76,24 @@
     }
 
     // One-time fetch so the buttons aren't blank until the first socket push.
+    // Bundled: one /status-all response primes every service instead of one
+    // request per service (the load-time flood fix); per-service only as a
+    // fallback when the bundle fails.
     function primeOnce() {
-        if (onVideoSide() && !document.hidden) SERVICES.forEach(pollOne);
+        if (!onVideoSide() || document.hidden) return;
+        fetch('/api/video/enrichment/status-all', { headers: { 'Accept': 'application/json' } })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (b) {
+                if (b && b.services) {
+                    SERVICES.forEach(function (svc) {
+                        var d = b.services[svc];
+                        if (d && !d.error) reflect(svc, d);
+                    });
+                } else {
+                    SERVICES.forEach(pollOne);
+                }
+            })
+            .catch(function () { SERVICES.forEach(pollOne); });
     }
 
     // Listen on the shared socket (set up by core.js) for the server-pushed

--- a/webui/static/video/video-service-status.js
+++ b/webui/static/video/video-service-status.js
@@ -78,12 +78,22 @@
     function startPolling() {
         if (pollTimer) return;
         if (onVideoSide()) fetchStatus();
-        pollTimer = setInterval(function () { if (onVideoSide()) fetchStatus(); }, 5000);
-        // Refresh the instant the shell flips to the video side (don't wait up to 5s).
+        // Service config (server/metadata/download keys) changes only when the
+        // user edits settings — a 5s poll was pure noise (a request every 5s
+        // forever). 60s keeps the dots honest; the side-flip observer and the
+        // tab-refocus listener below repaint INSTANTLY on the moments that
+        // actually matter.
+        pollTimer = setInterval(function () {
+            if (onVideoSide() && !document.hidden) fetchStatus();
+        }, 60000);
+        // Refresh the instant the shell flips to the video side (don't wait a minute).
         try {
             new MutationObserver(function () { if (onVideoSide()) fetchStatus(); })
                 .observe(document.body, { attributes: true, attributeFilter: ['data-side'] });
         } catch (e) { /* MutationObserver is always available in target browsers */ }
+        document.addEventListener('visibilitychange', function () {
+            if (!document.hidden && onVideoSide()) fetchStatus();
+        });
     }
 
     // ── the switch modal (reuses the .ss-* styling from service-switch.css) ──────

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -849,6 +849,10 @@ body[data-side="video"] .dashboard-header-sweep {
 .vd-ep-new-chip { flex: none; align-self: center; font-size: 10.5px; font-weight: 800;
     text-transform: uppercase; letter-spacing: 0.6px; padding: 3px 9px; border-radius: 999px;
     color: #fff; background: rgba(220, 38, 38, 0.9); white-space: nowrap; }
+/* format badges (4K · HDR10 · Atmos · 5.1) — boxed caps like the streamers */
+.vd-fmt { font-size: 10.5px; font-weight: 800; letter-spacing: 0.5px; line-height: 1;
+    padding: 3px 7px; border-radius: 4px; color: rgba(255,255,255,0.85);
+    border: 1px solid rgba(255,255,255,0.35); white-space: nowrap; }
 
 @media (max-width: 820px) {
     .vd-bb-content { padding-left: 24px; padding-right: 24px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -841,6 +841,15 @@ body[data-side="video"] .dashboard-header-sweep {
 .vd-play-ep { font-weight: 800; padding: 2px 8px; border-radius: 6px;
     background: rgba(255,255,255,0.16); font-size: 0.85em; }
 
+/* Detail BIC P3 — enriched facts finally surfaced */
+.vd-awards { display: flex; align-items: center; gap: 8px; margin: 2px 0 4px;
+    font-size: 13px; font-weight: 600; color: #fbbf24; }
+.vd-awards-ic { font-size: 14px; }
+.vd-stinger { color: #fbbf24 !important; font-weight: 700; white-space: nowrap; }
+.vd-ep-new-chip { flex: none; align-self: center; font-size: 10.5px; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.6px; padding: 3px 9px; border-radius: 999px;
+    color: #fff; background: rgba(220, 38, 38, 0.9); white-space: nowrap; }
+
 @media (max-width: 820px) {
     .vd-bb-content { padding-left: 24px; padding-right: 24px; }
     .vd-body { padding: 24px 22px 60px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -820,6 +820,27 @@ body[data-side="video"] .dashboard-header-sweep {
 .vd-ep--missing .vd-ep-badge { color: rgba(255,255,255,0.5); background: rgba(255,255,255,0.05); border: 1px solid rgba(255,255,255,0.12); }
 .vd-ep--missing .vd-ep-index, .vd-ep--missing .vd-ep-title { opacity: 0.7; }
 
+/* Continue Watching — per-episode watch state (server truth from the scan) */
+.vd-ep-prog { position: absolute; z-index: 2; left: 0; right: 0; bottom: 0; height: 4px;
+    background: rgba(255,255,255,0.25); }
+.vd-ep-prog-fill { display: block; height: 100%; background: rgb(var(--vd-accent-rgb, 255 59 59));
+    border-radius: 0 2px 2px 0; }
+.vd-ep-check { flex: none; font-size: 13px; font-weight: 900; color: #4ade80; line-height: 1;
+    align-self: center; }
+.vd-ep--watched .vd-ep-title { color: rgba(255,255,255,0.62); }
+.vd-ep--watched .vd-ep-still { filter: grayscale(0.35) brightness(0.82); }
+.vd-ep--watched:hover .vd-ep-still { filter: grayscale(0.1) brightness(0.72); }
+.vd-ep-next-chip { flex: none; align-self: center; font-size: 10.5px; font-weight: 800;
+    text-transform: uppercase; letter-spacing: 0.6px; padding: 3px 9px; border-radius: 999px;
+    color: #fff; background: rgba(var(--vd-accent-rgb, 255 59 59), 0.85); white-space: nowrap; }
+.vd-ep--next { box-shadow: inset 3px 0 0 rgb(var(--vd-accent-rgb, 255 59 59));
+    background: rgba(var(--vd-accent-rgb, 255 59 59), 0.05); }
+.vd-ep--next:hover { background: rgba(var(--vd-accent-rgb, 255 59 59), 0.09); }
+/* hero: watched tag in the meta line + the S/E tag inside the play button */
+.vd-watched-tag { color: #4ade80 !important; font-weight: 700; }
+.vd-play-ep { font-weight: 800; padding: 2px 8px; border-radius: 6px;
+    background: rgba(255,255,255,0.16); font-size: 0.85em; }
+
 @media (max-width: 820px) {
     .vd-bb-content { padding-left: 24px; padding-right: 24px; }
     .vd-body { padding: 24px 22px 60px; }

--- a/webui/static/video/video-side.css
+++ b/webui/static/video/video-side.css
@@ -3671,6 +3671,15 @@ body:not(.video-admin) .vst-combo-panels { grid-template-columns: 1fr; }
 .vwsh-st--monitored { background: rgba(255, 255, 255, 0.1); color: rgba(255, 255, 255, 0.65); }
 .vwsh-st--upgrade { background: hsla(282, 80%, 62%, 0.18); color: hsl(282, 90%, 78%); }
 .vwsh-movie-art .vwsh-st { position: absolute; top: 8px; left: 8px; z-index: 2; backdrop-filter: blur(6px); }
+/* Repeatedly-failing marker (#liveleak-failing-hub) — sits under the status pill */
+.vwsh-failing {
+    position: absolute; top: 34px; left: 8px; z-index: 2;
+    font-size: 10px; font-weight: 800; padding: 3px 8px; border-radius: 6px;
+    color: #fca5a5; background: rgba(220, 38, 38, 0.22);
+    border: 1px solid rgba(239, 68, 68, 0.4);
+    backdrop-filter: blur(6px); cursor: default;
+}
+.vwsh-failing-inline { color: #fca5a5; font-weight: 700; cursor: default; }
 
 /* 'Search now' — per-item manual search (movie art / episode row / season side) */
 .vwsh-hunt { flex-shrink: 0; width: 26px; height: 26px; border-radius: 7px; border: 1px solid rgba(255, 255, 255, 0.12);

--- a/webui/static/video/video-wishlist.js
+++ b/webui/static/video/video-wishlist.js
@@ -91,10 +91,19 @@
         var st = liveStatus(it);
         var tip = st === 'upgrade' ? ('Own it in ' + it.upgrade_from + ' — watching for a better copy')
             : st === 'monitored' ? 'Not released yet — grabs automatically once it\'s out' : null;
+        // Repeatedly-failing marker (#liveleak-failing-hub): only meaningful while
+        // the drain is still hunting (wanted/upgrade) — a monitored or already
+        // downloading item isn't "failing".
+        var fails = Number(it.search_attempts) || 0;
+        var failChip = (fails >= 3 && (st === 'wanted' || st === 'upgrade'))
+            ? '<span class="vwsh-failing" title="' + esc(fails + ' searches without a grab' +
+                (it.last_search_at ? ' · last tried ' + it.last_search_at : '') +
+                ' — try Search now, or a different quality profile') + '">&#9888; ' + fails + '</span>'
+            : '';
         return '<div class="vwsh-movie" data-vwsh-open-movie="' + esc(it.tmdb_id) +
             '" data-vwsh-src="' + (owned ? 'library' : 'tmdb') + '" data-vwsh-id="' + esc(owned ? it.library_id : it.tmdb_id) + '">' +
             '<div class="vwsh-movie-art">' + art + '<div class="vwsh-movie-scrim"></div>' +
-            statusPill(st, tip) +
+            statusPill(st, tip) + failChip +
             (st === 'downloading' ? '' : huntBtn('movie', ' data-tmdb="' + esc(it.tmdb_id) + '"')) +
             rmBtn('movie', ' data-tmdb="' + esc(it.tmdb_id) + '"') + '</div>' +
             '<div class="vwsh-movie-info"><span class="vwsh-movie-title" title="' + esc(it.title) + '">' +
@@ -311,8 +320,14 @@
         var st = liveStatus(e);
         var date = fmtDate(e.air_date);
         // TMDB shows the SxEx label; a YouTube video shows just its upload date.
+        // Repeatedly-failing marker (#liveleak-failing-hub) — same rule as movies.
+        var fails = Number(e.search_attempts) || 0;
+        var failTxt = (fails >= 3 && (st === 'wanted' || st === 'upgrade'))
+            ? ' · <span class="vwsh-failing-inline" title="' + esc(fails + ' searches without a grab' +
+                (e.last_search_at ? ' · last tried ' + e.last_search_at : '')) + '">&#9888; ' + fails + '</span>'
+            : '';
         var metaTxt = yt ? (date || 'Video') : ('S' + se.season_number + '·E' + e.episode_number + (date ? ' · ' + esc(date) : '') +
-            (e.upgrade_from ? ' · ⇪ ' + esc(e.upgrade_from) : ''));
+            (e.upgrade_from ? ' · ⇪ ' + esc(e.upgrade_from) : '') + failTxt);
         var thumb = e.still_url
             ? '<span class="vwsh-epc-thumb"><img src="' + esc(sized(pimg(e.still_url), 342)) + '" alt="" loading="lazy" ' +
               'onerror="this.parentNode.classList.add(\'vwsh-epc-thumb--none\')"></span>'


### PR DESCRIPTION
# soulsync 3.1.1 — `dev` → `main`

fixes-and-polish release: a stack of reported bugs on the music side, a continue-watching upgrade for the video detail pages, and the app makes way fewer http calls at idle.

---

## music fixes (mostly yours, from the issue tracker)

- **re-releases showed as owned** — owning the original of an album made every remaster/anniversary edition light up as owned too. album matching now respects the release year when both sides have one, and the canonical pin denies sibling editions from its own source. owning "Album" no longer claims "Album (2011 Remaster)".
- **deep scan finally removes artists that left your library** — switching plex to a smaller/empty library kept showing the old artists forever. deep scan reads the server fresh (not a stale cache) and cleans out artists that are really gone. it also refuses to mass-delete when the server call failed rather than returned empty, so a plex hiccup can't wipe your artist list.
- **force download actually replaces the file (#1045)** — "download again" used to import the new file next to the old one or skip it entirely. a forced re-download now really replaces what's on disk.
- **playlist sync stops leaving tracks behind (#1047)** — three stacked bugs: matches in the 0.70–0.79 confidence band were found and then thrown away, tracks whose plex ratingKey went stale (plex re-keys on metadata refresh) failed silently, and big playlist writes could partially land with nobody checking. all fixed — writes are chunked and verified against what the server actually stored.
- **whole-library m3u note (#1041)** — the library playlist m3u was generating fine but told nobody. the scan summary now says it ran and where the file landed.
- **artists named with digits work again** — clicking "311" did nothing (the router ate the name as a number). fixed.
- **repeatedly-failing wishlist downloads are visible now** — wishlist items that keep failing get an attempt counter and a "failing" badge, a filter to see only them, and a jump straight into manual search to fix them by hand. same badge system on the video wishlist.

## video: the detail pages grew up

compared the movie/show pages against netflix/disney+ and closed the obvious gaps:

- **continue watching** — soulsync now scans per-episode watch state from plex/jellyfin (watched, resume position, last watched). episode lists get checkmarks, progress bars and a "next up" highlight; the hero button becomes "Resume S2 E4 on Plex" and deep-links the episode; shows open on the season you're actually in; movies know they're half-watched.
- **mark watched / unwatched** — a real toggle on movies and shows that also pushes played state to your server.
- **facts we already had but never showed** — the awards line (🏆 "Won 2 Oscars…"), an after-credits-scene tag, NEW badges on freshly-landed episodes, digital release date, and the ranked quality name of your file.
- **format badges** — owned movies show 4K · HDR10 · DV · Atmos · 7.1 style badges from real stream data (jellyfin) or the release name (plex).
- **synchronize one show** — a per-show deep scan button that reconciles episodes against the server right now, survives plex re-keys, and refreshes the episode schedule. paired with a hard rule from a painful bug: episodes that vanish from the server get demoted to "missing", never deleted.
- **clickable metadata (#1042)** — genres/keywords filter the library, and where-to-watch icons actually link per service.
- **mass rename preview** — no more dead button on big libraries: it runs in the background with a live count and shows loading/empty/error states.
- **youtube episode numbering** — yt-dlp's real upload date now overrides scan-estimated dates, so a video estimated as "1 month ago" can't collide into the wrong episode number.

## performance: the request flood is gone

startup and idle used to hammer the backend (dozens of duplicate calls per page load, 14 widgets each polling enrichment status every 2s):

- identical api GET bursts are deduped client-side — one wire request per burst
- enrichment status hydrates once per side in a single bundled call instead of ~28 requests
- steady-state pollers slowed to sane intervals and skip entirely when the tab is hidden

## also

- CI: the flaky mass-rename test now diagnoses itself instead of failing anonymously
- video schema v45→v46 (all column adds ride the migration list, upgrades are automatic)
