### PR TITLE
Misc fixes from Library V2 work: indexer URL leak, retry-loop stalls, tag-writer false positives, track-number collisions

### DIFF
--- a/core/automation/progress.py
+++ b/core/automation/progress.py
@@ -30,6 +30,20 @@ progress_states: dict[int, dict] = {}
 progress_lock = threading.Lock()
 
 
+def _clamp_percent(value: Any) -> Any:
+    """Clamp a reported progress value to 0-100.
+
+    Callers compute `progress` from counters (processed/skipped/failed vs. a
+    precomputed grand total) that can drift past the nominal total under
+    races or double-counting, so this is the one place that guarantees the
+    polled/pushed state never shows a bar or label outside 0-100.
+    """
+    try:
+        return max(0, min(100, round(float(value))))
+    except (TypeError, ValueError):
+        return value
+
+
 def init_progress(automation_id: int, automation_name: str, action_type: str) -> None:
     """Initialize progress state when an automation starts running."""
     with progress_lock:
@@ -70,6 +84,8 @@ def update_progress(
                 state['log'].append({'type': kwargs.get('log_type', 'info'), 'text': v})
                 if len(state['log']) > 50:
                     state['log'] = state['log'][-50:]
+            elif k == 'progress':
+                state[k] = _clamp_percent(v)
             elif k != 'log_type':
                 state[k] = v
         if kwargs.get('status') in ('finished', 'error'):

--- a/core/connection_test.py
+++ b/core/connection_test.py
@@ -342,9 +342,19 @@ def run_service_test(service, test_config):
                     if client_type == "sabnzbd":
                         return False, "SABnzbd needs both URL and API key."
                     return False, "NZBGet needs URL, username, and password."
-                if run_async(adapter.check_connection()):
-                    return True, f"Connected to {client_type}"
-                return False, f"{client_type} probe failed — check URL, credentials, and that the client is running."
+                if not run_async(adapter.check_connection()):
+                    return False, f"{client_type} probe failed — check URL, credentials, and that the client is running."
+                if client_type == "sabnzbd":
+                    category = str(config_manager.get(
+                        'usenet_client.category', 'soulsync') or 'soulsync'
+                    ).strip() or 'soulsync'
+                    if not run_async(adapter.category_exists(category)):
+                        return False, (
+                            f"Connected to SABnzbd, but category '{category}' "
+                            "is not configured there. Add the same category "
+                            "in SABnzbd before enabling acquisition."
+                        )
+                return True, f"Connected to {client_type}"
             except Exception as e:
                 return False, f"Usenet client connection error: {str(e)}"
         elif service == "torrent_client":

--- a/core/download_plugins/album_bundle.py
+++ b/core/download_plugins/album_bundle.py
@@ -401,6 +401,47 @@ def snapshot_incomplete_path(path: str) -> Optional[tuple]:
         return None
 
 
+def incomplete_path_stability_check(
+    raw_path: str,
+    prior_path: Optional[str],
+    prior_snapshot: Optional[tuple],
+    *,
+    snapshot_path: Callable[[str], Optional[tuple]] = snapshot_incomplete_path,
+    resolve_path: Callable[[str], str] = lambda p: p,
+) -> tuple:
+    """P2-21 stability gate for the ``incomplete_path`` fallback, shared by
+    ``poll_album_download`` and the usenet single-track poll loop.
+
+    ``raw_path`` is the client-reported in-progress directory, which may
+    live inside the client's OWN container/mount and not be directly
+    readable here. ``resolve_path`` (typically ``resolve_reported_save_path``)
+    is applied BEFORE snapshotting so the stability check — and the path
+    returned on success — both operate on somewhere this process can
+    actually read; snapshotting the raw path meant a remote-mounted
+    directory always read as unreadable (``None``) and could never
+    stabilize, stalling the fallback until the outer poll deadline instead
+    of the intended ~120s window.
+
+    A snapshot with zero files never counts as stable either: the client
+    may have just created an empty in-progress directory a moment before
+    starting to populate it, and two empty reads in a row would otherwise
+    look identical to "writes have stopped".
+
+    Returns ``(stable, resolved_path, new_snapshot)``. Callers should
+    remember ``resolved_path``/``new_snapshot`` as ``prior_path``/
+    ``prior_snapshot`` for the next poll regardless of ``stable``.
+    """
+    resolved = resolve_path(raw_path) or raw_path
+    current = snapshot_path(resolved)
+    stable = (
+        current is not None
+        and current[1] > 0
+        and prior_path == resolved
+        and current == prior_snapshot
+    )
+    return stable, resolved, current
+
+
 def poll_album_download(
     *,
     get_status: Callable[[], Optional[Any]],
@@ -416,6 +457,7 @@ def poll_album_download(
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
     snapshot_path: Callable[[str], Optional[tuple]] = snapshot_incomplete_path,
+    resolve_path: Callable[[str], str] = lambda p: p,
     log_prefix: str = '[album_bundle]',
 ) -> Optional[str]:
     """Drive the per-poll status loop for an album-bundle download.
@@ -598,11 +640,12 @@ def poll_album_download(
                     # two consecutive polls (writes have stopped) before
                     # accepting it; otherwise keep polling, bounded by the
                     # outer deadline rather than this window (P2-21).
-                    current_snapshot = snapshot_path(last_incomplete_path)
-                    stable = (
-                        current_snapshot is not None
-                        and last_incomplete_snapshot_path == last_incomplete_path
-                        and current_snapshot == last_incomplete_snapshot
+                    stable, resolved_incomplete_path, current_snapshot = incomplete_path_stability_check(
+                        last_incomplete_path,
+                        last_incomplete_snapshot_path,
+                        last_incomplete_snapshot,
+                        snapshot_path=snapshot_path,
+                        resolve_path=resolve_path,
                     )
                     if stable:
                         logger.warning(
@@ -611,19 +654,19 @@ def poll_album_download(
                             "in-progress path %r as a last resort (its contents were "
                             "unchanged across a poll, so post-processing looks done).",
                             log_prefix, title, completed_no_path_misses.misses,
-                            last_incomplete_path,
+                            resolved_incomplete_path,
                         )
-                        return last_incomplete_path
+                        return resolved_incomplete_path
                     logger.info(
                         "%s '%s' completed on the client but save_path never landed "
                         "and the in-progress path %r is still changing (or unreadable) "
                         "— waiting for it to stabilize before treating it as final "
                         "(poll %d).",
-                        log_prefix, title, last_incomplete_path,
+                        log_prefix, title, resolved_incomplete_path,
                         completed_no_path_misses.misses,
                     )
                     last_incomplete_snapshot = current_snapshot
-                    last_incomplete_snapshot_path = last_incomplete_path
+                    last_incomplete_snapshot_path = resolved_incomplete_path
                     sleep(interval)
                     continue
                 logger.error(

--- a/core/download_plugins/album_bundle.py
+++ b/core/download_plugins/album_bundle.py
@@ -369,6 +369,38 @@ class TransientMissCounter:
         self.misses = 0
 
 
+def snapshot_incomplete_path(path: str) -> Optional[tuple]:
+    """Cheap on-disk fingerprint of a path: total size, file count, and
+    latest mtime across every file under it (or a single file's own stat).
+
+    Used as the stability gate for the ``incomplete_path`` fallback
+    (P2-21): the client reporting a terminal-success *state* does not mean
+    its post-processing (unpack/repair/move) has stopped writing into that
+    directory. Two equal snapshots taken one poll apart are the signal
+    that writes have actually stopped — a fixed wait window elapsing is
+    not. Returns ``None`` if the path doesn't exist or can't be read,
+    which the caller treats as "not yet stable"."""
+    try:
+        p = Path(path)
+        if p.is_file():
+            st = p.stat()
+            return (st.st_size, 1, st.st_mtime)
+        if not p.is_dir():
+            return None
+        total_size = 0
+        count = 0
+        latest_mtime = 0.0
+        for entry in p.rglob('*'):
+            if entry.is_file():
+                st = entry.stat()
+                total_size += st.st_size
+                count += 1
+                latest_mtime = max(latest_mtime, st.st_mtime)
+        return (total_size, count, latest_mtime)
+    except OSError:
+        return None
+
+
 def poll_album_download(
     *,
     get_status: Callable[[], Optional[Any]],
@@ -383,6 +415,7 @@ def poll_album_download(
     timeout: Optional[float] = None,
     sleep: Callable[[float], None] = time.sleep,
     monotonic: Callable[[], float] = time.monotonic,
+    snapshot_path: Callable[[str], Optional[tuple]] = snapshot_incomplete_path,
     log_prefix: str = '[album_bundle]',
 ) -> Optional[str]:
     """Drive the per-poll status loop for an album-bundle download.
@@ -419,21 +452,32 @@ def poll_album_download(
       already succeeded, so this defaults to ~120s (configurable via
       ``download_source.album_bundle_completed_no_path_seconds``) instead
       of reusing the 10s miss window — #721 showed SAB can take 2+ minutes
-      to write ``storage``. When the window is exhausted the loop falls
-      back to the adapter's ``incomplete_path`` (the on-disk in-progress
-      dir) if present, and only emits terminal ``failed`` when there's no
-      path of any kind to scan.
+      to write ``storage``. Once the window is exhausted, the loop does
+      NOT immediately trust the adapter's ``incomplete_path`` (the on-disk
+      in-progress dir) — that path can still be actively written by the
+      client's own unpack/repair/move post-processing at the exact moment
+      we'd read it (P2-21). It is only accepted once ``snapshot_path``
+      reports the SAME fingerprint (size/file-count/mtime) on two polls in
+      a row, i.e. the directory has visibly stopped changing; until then
+      the loop keeps polling (bounded by the outer ``timeout``, not by
+      this window). Terminal ``failed`` only fires when there's no path of
+      any kind to scan.
 
     Returns the adapter's reported save_path (or, as a last resort, its
-    ``incomplete_path``) on terminal success, or ``None`` on any failure
-    (timeout / disappeared / explicit failed / shutdown). On every
-    failure path emits ``'failed'`` once with an ``error`` field
-    describing why.
+    stability-confirmed ``incomplete_path``) on terminal success, or
+    ``None`` on any failure (timeout / disappeared / explicit failed /
+    shutdown). On every failure path emits ``'failed'`` once with an
+    ``error`` field describing why.
     """
     interval = poll_interval if poll_interval is not None else get_poll_interval()
     deadline = monotonic() + (timeout if timeout is not None else get_poll_timeout())
     last_save_path: Optional[str] = None
     last_incomplete_path: Optional[str] = None
+    # Stability gate for the incomplete_path fallback below (P2-21): the
+    # snapshot + path it was taken for, so a poll that returns the SAME
+    # snapshot for the SAME path counts as "stopped changing".
+    last_incomplete_snapshot: Optional[tuple] = None
+    last_incomplete_snapshot_path: Optional[str] = None
     misses = TransientMissCounter(transient_miss_threshold)
     # Separate counter for "client reports terminal-success state but no
     # save_path field has landed yet." SAB History flips ``status`` to
@@ -548,15 +592,40 @@ def poll_album_download(
                 # leaving the user stuck with a completed-in-SAB download
                 # that SoulSync never imports.
                 if last_incomplete_path:
-                    logger.warning(
-                        "%s '%s' completed on the client but never exposed a final "
-                        "save_path after %d polls — falling back to the in-progress "
-                        "path %r as a last resort. If staging fails, the SAB job "
-                        "likely needs its post-process move to finish first.",
-                        log_prefix, title, completed_no_path_misses.misses,
-                        last_incomplete_path,
+                    # Don't trust incomplete_path just because the window
+                    # elapsed — the client's own post-processing may still
+                    # be writing into it. Require the same fingerprint on
+                    # two consecutive polls (writes have stopped) before
+                    # accepting it; otherwise keep polling, bounded by the
+                    # outer deadline rather than this window (P2-21).
+                    current_snapshot = snapshot_path(last_incomplete_path)
+                    stable = (
+                        current_snapshot is not None
+                        and last_incomplete_snapshot_path == last_incomplete_path
+                        and current_snapshot == last_incomplete_snapshot
                     )
-                    return last_incomplete_path
+                    if stable:
+                        logger.warning(
+                            "%s '%s' completed on the client but never exposed a "
+                            "final save_path after %d polls — falling back to the "
+                            "in-progress path %r as a last resort (its contents were "
+                            "unchanged across a poll, so post-processing looks done).",
+                            log_prefix, title, completed_no_path_misses.misses,
+                            last_incomplete_path,
+                        )
+                        return last_incomplete_path
+                    logger.info(
+                        "%s '%s' completed on the client but save_path never landed "
+                        "and the in-progress path %r is still changing (or unreadable) "
+                        "— waiting for it to stabilize before treating it as final "
+                        "(poll %d).",
+                        log_prefix, title, last_incomplete_path,
+                        completed_no_path_misses.misses,
+                    )
+                    last_incomplete_snapshot = current_snapshot
+                    last_incomplete_snapshot_path = last_incomplete_path
+                    sleep(interval)
+                    continue
                 logger.error(
                     "%s '%s' reported terminal success but no save_path landed "
                     "after %d consecutive polls — bundle cannot stage. Adapter "

--- a/core/download_plugins/album_bundle.py
+++ b/core/download_plugins/album_bundle.py
@@ -543,6 +543,16 @@ def poll_album_download(
             int(get_completed_no_path_window_seconds() / max(interval, 0.001)) or 1,
         )
     completed_no_path_misses = TransientMissCounter(completed_no_path_threshold)
+    # Separate counter for "the in-progress path can't be read at all"
+    # (as opposed to "readable but still changing"), e.g. no
+    # download_source.usenet_path_mappings entry for a split-container /
+    # remote-mount deployment. snapshot_path returns None every single
+    # poll in that case, so `stable` can never become True — without a
+    # cap the stability gate above would poll for the full outer
+    # ``timeout`` (hours) before saying anything. A handful of
+    # consecutive unreadable polls is enough to conclude the path is
+    # genuinely unreachable from here, not just mid-write.
+    incomplete_path_unreadable_misses = TransientMissCounter(transient_miss_threshold)
 
     def _fail(reason: str) -> None:
         try:
@@ -647,6 +657,19 @@ def poll_album_download(
                         snapshot_path=snapshot_path,
                         resolve_path=resolve_path,
                     )
+                    if current_snapshot is None:
+                        if incomplete_path_unreadable_misses.record_miss():
+                            logger.error(
+                                "%s '%s' in-progress path %r could not be read for "
+                                "%d consecutive polls — giving up instead of waiting "
+                                "out the full timeout.",
+                                log_prefix, title, resolved_incomplete_path,
+                                incomplete_path_unreadable_misses.misses,
+                            )
+                            _fail('Client reported success but never provided a save_path')
+                            return None
+                    else:
+                        incomplete_path_unreadable_misses.reset()
                     if stable:
                         logger.warning(
                             "%s '%s' completed on the client but never exposed a "

--- a/core/download_plugins/candidate_store.py
+++ b/core/download_plugins/candidate_store.py
@@ -1,0 +1,107 @@
+"""Server-side TTL store for indexer download URLs (audit P0-03).
+
+Prowlarr download URLs (and magnet URIs from private trackers) can embed
+indexer API keys or signed, time-limited parameters. They must never reach
+the browser: search results carry an opaque candidate token in the
+``filename`` field instead, and the download path resolves the token back
+to the real URL server-side. A token that is unknown or expired is
+rejected — the client can no longer submit an arbitrary URL for the
+server to forward to SABnzbd/NZBGet/qBittorrent.
+
+The store is in-memory and process-local, which matches the current
+single-worker Gunicorn deployment (same assumption the plugins'
+``active_downloads`` dicts already make). Entries expire after a TTL and
+the store is size-capped so an indexer flood can't grow it unbounded.
+"""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import time
+from typing import Dict, Optional, Tuple
+
+# Recognizable, URL-unlike token prefix ("soulsync candidate, v1").
+TOKEN_PREFIX = "ssc1-"
+
+# Generous window between a search and the grab that uses its result —
+# covers a long manual browsing session and queued auto-grabs. Deliberately
+# NOT days: these URLs may be signed/short-lived on the indexer side too.
+DEFAULT_TTL_SECONDS = 6 * 60 * 60
+
+DEFAULT_MAX_ENTRIES = 5000
+
+
+class CandidateStore:
+    """Token -> download-URL map with TTL and size cap."""
+
+    def __init__(self, ttl_seconds: int = DEFAULT_TTL_SECONDS,
+                 max_entries: int = DEFAULT_MAX_ENTRIES) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._lock = threading.Lock()
+        self._by_token: Dict[str, Tuple[str, float]] = {}   # token -> (url, expires_at)
+        self._by_url: Dict[str, str] = {}                   # url -> token (dedup)
+
+    @staticmethod
+    def is_token(value: Optional[str]) -> bool:
+        return bool(value) and value.startswith(TOKEN_PREFIX)
+
+    def put(self, url: str) -> str:
+        """Register a URL; returns its opaque token. The same URL within the
+        TTL returns the same token (repeated searches don't grow the store)."""
+        now = time.monotonic()
+        with self._lock:
+            self._purge_locked(now)
+            token = self._by_url.get(url)
+            if token is not None and token in self._by_token:
+                # Refresh the TTL — the candidate was just seen again.
+                self._by_token[token] = (url, now + self._ttl)
+                return token
+            token = TOKEN_PREFIX + secrets.token_urlsafe(24)
+            self._by_token[token] = (url, now + self._ttl)
+            self._by_url[url] = token
+            if len(self._by_token) > self._max:
+                self._evict_oldest_locked()
+            return token
+
+    def resolve(self, token: str) -> Optional[str]:
+        """The URL behind a token, or None when unknown/expired."""
+        if not self.is_token(token):
+            return None
+        now = time.monotonic()
+        with self._lock:
+            entry = self._by_token.get(token)
+            if entry is None:
+                return None
+            url, expires_at = entry
+            if expires_at < now:
+                self._by_token.pop(token, None)
+                self._by_url.pop(url, None)
+                return None
+            return url
+
+    def _purge_locked(self, now: float) -> None:
+        expired = [t for t, (_u, exp) in self._by_token.items() if exp < now]
+        for token in expired:
+            url, _exp = self._by_token.pop(token)
+            self._by_url.pop(url, None)
+
+    def _evict_oldest_locked(self) -> None:
+        overflow = len(self._by_token) - self._max
+        if overflow <= 0:
+            return
+        oldest = sorted(self._by_token.items(), key=lambda kv: kv[1][1])[:overflow]
+        for token, (url, _exp) in oldest:
+            self._by_token.pop(token, None)
+            self._by_url.pop(url, None)
+
+
+_store = CandidateStore()
+
+
+def get_candidate_store() -> CandidateStore:
+    return _store
+
+
+__all__ = ["CandidateStore", "get_candidate_store", "TOKEN_PREFIX"]

--- a/core/download_plugins/candidate_store.py
+++ b/core/download_plugins/candidate_store.py
@@ -50,8 +50,14 @@ class CandidateStore:
     def put(self, url: str) -> str:
         """Register a URL; returns its opaque token. The same URL within the
         TTL returns the same token (repeated searches don't grow the store)."""
-        now = time.monotonic()
         with self._lock:
+            # Captured under the lock, not before it: expires_at must
+            # reflect actual insertion order so a call that loses the race
+            # for the lock can't record an earlier timestamp than entries
+            # inserted moments before it — otherwise the expiry-sorted
+            # eviction in _evict_oldest_locked could pick the entry this
+            # very call is about to create.
+            now = time.monotonic()
             self._purge_locked(now)
             token = self._by_url.get(url)
             if token is not None and token in self._by_token:

--- a/core/download_plugins/torrent.py
+++ b/core/download_plugins/torrent.py
@@ -688,6 +688,14 @@ class TorrentDownloadPlugin(DownloadSourcePlugin):
             # default-'error' fallback the helper treats as transient.
             failed_states=frozenset(['error']),
             is_shutdown=self.shutdown_check,
+            # P2-21: remap the client-container path before the incomplete_path
+            # stability check, not just on the final save_path — otherwise a
+            # split-container mount never resolves to a readable local path and
+            # the fallback can't stabilize. expect_name isn't known this early
+            # (fetched below only after the poll returns), so this is the
+            # weaker no-expect_name resolution; the final walk_root re-resolves
+            # with expect_name for the stricter content-checked path.
+            resolve_path=resolve_reported_save_path,
             log_prefix='[Torrent album]',
         )
         if save_path is None:

--- a/core/download_plugins/torrent.py
+++ b/core/download_plugins/torrent.py
@@ -68,6 +68,7 @@ from core.download_plugins.album_bundle import (
     resolve_reported_save_path,
 )
 from core.download_plugins.base import DownloadSourcePlugin
+from core.download_plugins.candidate_store import get_candidate_store
 from core.download_plugins.torrent_stall import (
     StallTracker,
     get_stall_action,
@@ -189,7 +190,11 @@ class TorrentDownloadPlugin(DownloadSourcePlugin):
             download_url = result.magnet_uri or result.download_url
             if not download_url:
                 continue
-            filename = f"{download_url}{_FILENAME_SEP}{result.title}"
+            # The filename crosses to the browser in search responses and
+            # comes back on grab. Indexer URLs can carry API keys / signed
+            # params, so only an opaque server-side token travels (P0-03).
+            token = get_candidate_store().put(download_url)
+            filename = f"{token}{_FILENAME_SEP}{result.title}"
             quality = _guess_quality_from_title(result.title)
             parsed_artist, parsed_title = _parse_release_title(result.title)
             tr = TrackResult(
@@ -248,9 +253,16 @@ class TorrentDownloadPlugin(DownloadSourcePlugin):
     ) -> Optional[str]:
         if not self.is_configured():
             return None
-        download_url, display_name = _decode_filename(filename)
+        token, display_name = _decode_filename(filename)
+        if not token:
+            logger.error("Torrent download missing candidate token in filename: %r", filename)
+            return None
+        # Only a token from OUR candidate store is accepted — a raw URL from
+        # the client is a trust-boundary violation, not a fallback (P0-03).
+        download_url = get_candidate_store().resolve(token)
         if not download_url:
-            logger.error("Torrent download missing URL in filename: %r", filename)
+            logger.error("Torrent download: unknown or expired candidate for %r "
+                         "— re-run the search", display_name)
             return None
 
         download_id = str(uuid.uuid4())

--- a/core/download_plugins/usenet.py
+++ b/core/download_plugins/usenet.py
@@ -25,6 +25,7 @@ from core.download_plugins.album_bundle import (
     TransientMissCounter,
     copy_audio_files_atomically,
     get_completed_no_path_window_seconds,
+    incomplete_path_stability_check,
     pick_best_album_release,
     poll_album_download,
     resolve_reported_save_path,
@@ -319,12 +320,14 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
                         # fingerprint on two consecutive polls before
                         # accepting it; otherwise keep polling, bounded by
                         # the outer deadline rather than this window
-                        # (P2-21).
-                        current_snapshot = snapshot_incomplete_path(last_incomplete_path)
-                        stable = (
-                            current_snapshot is not None
-                            and last_incomplete_snapshot_path == last_incomplete_path
-                            and current_snapshot == last_incomplete_snapshot
+                        # (P2-21). Shared with poll_album_download's
+                        # sibling logic in album_bundle.py.
+                        stable, resolved_incomplete_path, current_snapshot = incomplete_path_stability_check(
+                            last_incomplete_path,
+                            last_incomplete_snapshot_path,
+                            last_incomplete_snapshot,
+                            snapshot_path=snapshot_incomplete_path,
+                            resolve_path=resolve_reported_save_path,
                         )
                         if stable:
                             logger.warning(
@@ -333,19 +336,19 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
                                 "contents were unchanged across a poll, so "
                                 "post-processing looks done).",
                                 download_id[:8], job_id, completed_no_path_misses.misses,
-                                last_incomplete_path,
+                                resolved_incomplete_path,
                             )
-                            self._finalize_download(download_id, last_incomplete_path)
+                            self._finalize_download(download_id, resolved_incomplete_path)
                             return
                         logger.info(
                             "Usenet %s: '%s' completed but save_path never landed and "
                             "in-progress path %r is still changing (or unreadable) — "
                             "waiting for it to stabilize (poll %d).",
-                            download_id[:8], job_id, last_incomplete_path,
+                            download_id[:8], job_id, resolved_incomplete_path,
                             completed_no_path_misses.misses,
                         )
                         last_incomplete_snapshot = current_snapshot
-                        last_incomplete_snapshot_path = last_incomplete_path
+                        last_incomplete_snapshot_path = resolved_incomplete_path
                         time.sleep(_POLL_INTERVAL_SECONDS)
                         continue
                     self._mark_error(
@@ -552,6 +555,12 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
             complete_states=frozenset(['completed']),
             failed_states=frozenset(['failed']),
             is_shutdown=self.shutdown_check,
+            # P2-21: remap the client-container path before the
+            # incomplete_path stability check runs, not just on the final
+            # save_path — otherwise a split-container SAB/NZBGet mount
+            # never resolves to a locally-readable path and the stability
+            # gate can never stabilize.
+            resolve_path=resolve_reported_save_path,
             log_prefix='[Usenet album]',
         )
         if save_path is None:

--- a/core/download_plugins/usenet.py
+++ b/core/download_plugins/usenet.py
@@ -30,6 +30,7 @@ from core.download_plugins.album_bundle import (
     resolve_reported_save_path,
 )
 from core.download_plugins.base import DownloadSourcePlugin
+from core.download_plugins.candidate_store import get_candidate_store
 from core.download_plugins.torrent import (
     _adapter_state_to_display,
     _decode_filename,
@@ -121,7 +122,11 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
                 continue
             if not result.download_url:
                 continue
-            filename = f"{result.download_url}{_FILENAME_SEP}{result.title}"
+            # The filename crosses to the browser in search responses and
+            # comes back on grab. Prowlarr NZB URLs can carry API keys /
+            # signed params, so only an opaque server token travels (P0-03).
+            token = get_candidate_store().put(result.download_url)
+            filename = f"{token}{_FILENAME_SEP}{result.title}"
             quality = _guess_quality_from_title(result.title)
             parsed_artist, parsed_title = _parse_release_title(result.title)
             tr = TrackResult(
@@ -176,9 +181,16 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
     ) -> Optional[str]:
         if not self.is_configured():
             return None
-        nzb_url, display_name = _decode_filename(filename)
+        token, display_name = _decode_filename(filename)
+        if not token:
+            logger.error("Usenet download missing candidate token in filename: %r", filename)
+            return None
+        # Only a token from OUR candidate store is accepted — a raw URL from
+        # the client is a trust-boundary violation, not a fallback (P0-03).
+        nzb_url = get_candidate_store().resolve(token)
         if not nzb_url:
-            logger.error("Usenet download missing URL in filename: %r", filename)
+            logger.error("Usenet download: unknown or expired candidate for %r "
+                         "— re-run the search", display_name)
             return None
 
         download_id = str(uuid.uuid4())

--- a/core/download_plugins/usenet.py
+++ b/core/download_plugins/usenet.py
@@ -28,6 +28,7 @@ from core.download_plugins.album_bundle import (
     pick_best_album_release,
     poll_album_download,
     resolve_reported_save_path,
+    snapshot_incomplete_path,
 )
 from core.download_plugins.base import DownloadSourcePlugin
 from core.download_plugins.candidate_store import get_candidate_store
@@ -244,6 +245,12 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
         deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
         last_save_path: Optional[str] = None
         last_incomplete_path: Optional[str] = None
+        # Stability gate for the incomplete_path fallback below (P2-21,
+        # sibling of the same fix in album_bundle.poll_album_download):
+        # the snapshot + path it was taken for, so a poll returning the
+        # SAME fingerprint for the SAME path counts as "stopped changing".
+        last_incomplete_snapshot: Optional[tuple] = None
+        last_incomplete_snapshot_path: Optional[str] = None
         # Tolerate transient None / unmapped 'error' reads — SAB
         # removes a job from the queue before adding it to history,
         # and on busy servers that gap spans several polls. See
@@ -306,14 +313,41 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
                 # than erroring a download that actually succeeded.
                 if completed_no_path_misses.record_miss():
                     if last_incomplete_path:
-                        logger.warning(
-                            "Usenet %s: '%s' completed but no final save_path after "
-                            "%d polls — falling back to in-progress path %r",
-                            download_id[:8], job_id, completed_no_path_misses.misses,
-                            last_incomplete_path,
+                        # Don't trust incomplete_path just because the
+                        # window elapsed — SAB/NZBGet post-processing may
+                        # still be writing into it. Require the same
+                        # fingerprint on two consecutive polls before
+                        # accepting it; otherwise keep polling, bounded by
+                        # the outer deadline rather than this window
+                        # (P2-21).
+                        current_snapshot = snapshot_incomplete_path(last_incomplete_path)
+                        stable = (
+                            current_snapshot is not None
+                            and last_incomplete_snapshot_path == last_incomplete_path
+                            and current_snapshot == last_incomplete_snapshot
                         )
-                        self._finalize_download(download_id, last_incomplete_path)
-                        return
+                        if stable:
+                            logger.warning(
+                                "Usenet %s: '%s' completed but no final save_path after "
+                                "%d polls — falling back to in-progress path %r (its "
+                                "contents were unchanged across a poll, so "
+                                "post-processing looks done).",
+                                download_id[:8], job_id, completed_no_path_misses.misses,
+                                last_incomplete_path,
+                            )
+                            self._finalize_download(download_id, last_incomplete_path)
+                            return
+                        logger.info(
+                            "Usenet %s: '%s' completed but save_path never landed and "
+                            "in-progress path %r is still changing (or unreadable) — "
+                            "waiting for it to stabilize (poll %d).",
+                            download_id[:8], job_id, last_incomplete_path,
+                            completed_no_path_misses.misses,
+                        )
+                        last_incomplete_snapshot = current_snapshot
+                        last_incomplete_snapshot_path = last_incomplete_path
+                        time.sleep(_POLL_INTERVAL_SECONDS)
+                        continue
                     self._mark_error(
                         download_id,
                         "Usenet job completed but client never reported a save_path",

--- a/core/download_plugins/usenet.py
+++ b/core/download_plugins/usenet.py
@@ -267,6 +267,12 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
             max(misses.threshold,
                 int(get_completed_no_path_window_seconds() / max(_POLL_INTERVAL_SECONDS, 0.001)) or 1)
         )
+        # Sibling of the same counter in poll_album_download: caps how many
+        # consecutive polls tolerate an incomplete_path that can't be read
+        # at all (e.g. no usenet_path_mappings entry for a split-container
+        # deployment) — without it the stability gate below never becomes
+        # True and the thread would poll for the full outer deadline.
+        incomplete_path_unreadable_misses = TransientMissCounter(misses.threshold)
         while time.monotonic() < deadline:
             if self.shutdown_check and self.shutdown_check():
                 return
@@ -329,6 +335,22 @@ class UsenetDownloadPlugin(DownloadSourcePlugin):
                             snapshot_path=snapshot_incomplete_path,
                             resolve_path=resolve_reported_save_path,
                         )
+                        if current_snapshot is None:
+                            if incomplete_path_unreadable_misses.record_miss():
+                                logger.error(
+                                    "Usenet %s: '%s' in-progress path %r could not be "
+                                    "read for %d consecutive polls — giving up instead "
+                                    "of waiting out the full timeout.",
+                                    download_id[:8], job_id, resolved_incomplete_path,
+                                    incomplete_path_unreadable_misses.misses,
+                                )
+                                self._mark_error(
+                                    download_id,
+                                    "Usenet job completed but client never reported a save_path",
+                                )
+                                return
+                        else:
+                            incomplete_path_unreadable_misses.reset()
                         if stable:
                             logger.warning(
                                 "Usenet %s: '%s' completed but no final save_path after "

--- a/core/downloads/monitor.py
+++ b/core/downloads/monitor.py
@@ -62,6 +62,7 @@ MAX_TOTAL_QUARANTINE_RETRIES = 100
 # per-source retry budget.
 _STREAMING_SOURCE_NAMES = frozenset((
     'youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'lidarr', 'soundcloud', 'amazon',
+    'torrent', 'usenet',
 ))
 
 

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -889,7 +889,11 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
         # See ``core/imports/track_number.py`` for the resolution
         # chain — pure function, unit-tested in isolation, single
         # place to fix the rule.
-        from core.imports.track_number import resolve_track_number, read_embedded_track_number
+        from core.imports.track_number import (
+            resolve_track_number,
+            read_embedded_track_number,
+            track_number_from_directory_order,
+        )
         track_info_for_resolve = context.get('track_info') if isinstance(context, dict) else None
         # "Track 01" bug: a single Deezer track is matched via an endpoint
         # that omits track_position, so the context never carried the real
@@ -907,8 +911,23 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
             track_number,
         )
         if not isinstance(track_number, int) or track_number < 1:
-            logger.error(f"Invalid track number ({track_number}), defaulting to 1")
-            track_number = 1
+            # §16.3(a): before collapsing the WHOLE album onto track 1, fall back
+            # to this file's sorted position among its audio siblings on disk
+            # (album bundles stage all files into one directory together). This
+            # only ever replaces the constant-1 default, so it can never override
+            # a number a real source produced — it just stops every un-numbered
+            # track claiming position 1 and all-but-one showing as "missing".
+            scan_order = track_number_from_directory_order(file_path)
+            if scan_order is not None:
+                logger.warning(
+                    "No per-track number from any source; using scan-order "
+                    "position %s from directory siblings (avoids album collapse "
+                    "onto track 1)", scan_order,
+                )
+                track_number = scan_order
+            else:
+                logger.error(f"Invalid track number ({track_number}), defaulting to 1")
+                track_number = 1
 
         logger.debug(f"FINAL track_number used for filename: {track_number}")
         album_info['track_number'] = track_number

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -79,6 +79,7 @@ from core.imports.paths import (
 from core.imports.album_naming import resolve_album_group
 from core.metadata.lyrics import generate_lrc_file
 from database.music_database import get_database
+from core.tag_writer import is_placeholder_meta, write_tags_to_file
 from utils.logging_config import get_logger
 
 
@@ -149,6 +150,27 @@ def _should_skip_quarantine_check(context: dict, check_name: str) -> bool:
     if isinstance(bypass, (list, tuple, set)):
         return 'all' in bypass or check_name in bypass
     return bypass == check_name
+
+
+def _build_simple_download_tag_data(
+    search_result: dict, album_name: str | None,
+) -> dict[str, str]:
+    """Return only trustworthy metadata known by a direct/simple grab.
+
+    Simple downloads deliberately skip provider enhancement, but their request
+    still carries a title, artist and sometimes an album. Persist those values
+    without ever stamping placeholder text over useful source tags.
+    """
+    values = {
+        "title": search_result.get("title"),
+        "artist_name": search_result.get("artist"),
+        "album_title": album_name,
+    }
+    return {
+        key: str(value).strip()
+        for key, value in values.items()
+        if not is_placeholder_meta(value)
+    }
 
 
 def _resolve_context_quality_profile(context: dict) -> dict:
@@ -748,6 +770,29 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
             from core.imports.file_ops import move_companion_sidecars
             move_companion_sidecars(file_path, destination)
             cleanup_slskd_dedup_siblings(file_path)
+
+            simple_tags = _build_simple_download_tag_data(
+                search_result, album_name)
+            if simple_tags:
+                try:
+                    tag_result = write_tags_to_file(
+                        destination, simple_tags, embed_cover=False)
+                    if tag_result.get('success'):
+                        logger.info(
+                            "Embedded direct-download metadata: %s",
+                            ', '.join(simple_tags),
+                        )
+                    else:
+                        logger.warning(
+                            "[Simple Download] Could not embed metadata: %s",
+                            tag_result.get('error', 'unknown error'),
+                        )
+                except Exception as tag_error:
+                    # The file is already safely moved. Tagging is enrichment,
+                    # so a malformed/unsupported source file remains a
+                    # successful direct download with a visible warning.
+                    logger.warning(
+                        "[Simple Download] Metadata write failed: %s", tag_error)
 
             with matched_context_lock:
                 if context_key in matched_downloads_context:

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -962,7 +962,18 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
             # only ever replaces the constant-1 default, so it can never override
             # a number a real source produced — it just stops every un-numbered
             # track claiming position 1 and all-but-one showing as "missing".
-            scan_order = track_number_from_directory_order(file_path)
+            #
+            # Restricted to genuine album-bundle downloads: a plain
+            # (non-bundle) download lands in a SHARED flat directory (e.g.
+            # Soulseek's download_path) that can hold other, unrelated
+            # in-flight downloads at the same time — applying the fallback
+            # there would compute this file's position among files from a
+            # completely different download, not a real position within
+            # its own album.
+            scan_order = (
+                track_number_from_directory_order(file_path)
+                if is_album_download else None
+            )
             if scan_order is not None:
                 logger.warning(
                     "No per-track number from any source; using scan-order "

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -79,7 +79,7 @@ from core.imports.paths import (
 from core.imports.album_naming import resolve_album_group
 from core.metadata.lyrics import generate_lrc_file
 from database.music_database import get_database
-from core.tag_writer import is_placeholder_meta, write_tags_to_file
+from core.tag_writer import is_placeholder_meta, read_file_tags, write_tags_to_file
 from utils.logging_config import get_logger
 
 
@@ -170,6 +170,40 @@ def _build_simple_download_tag_data(
         key: str(value).strip()
         for key, value in values.items()
         if not is_placeholder_meta(value)
+    }
+
+
+# Maps _build_simple_download_tag_data's db_data keys to the matching
+# read_file_tags() key, so a field can be checked against the file's
+# CURRENT value before deciding to write it.
+_SIMPLE_DOWNLOAD_TAG_TO_FILE_FIELD = {
+    'title': 'title',
+    'artist_name': 'artist',
+    'album_title': 'album',
+}
+
+
+def _fill_only_simple_download_tags(destination: str, simple_tags: dict[str, str]) -> dict[str, str]:
+    """Restrict ``simple_tags`` to fields the file doesn't already have.
+
+    A simple/direct download skips provider enhancement, so its title/artist/
+    album come straight from the user's search request rather than verified
+    metadata — and Soulseek search titles are often parsed from a messy
+    filename. Unlike the enhanced-import path (which trusts DB metadata over
+    file tags), a simple download must never stamp a real existing tag with
+    a value that's merely "not a placeholder" — only fill in what's actually
+    blank or placeholder in the file today. When the file's current tags
+    can't be read at all, skip writing entirely rather than guessing.
+    """
+    if not simple_tags:
+        return {}
+    current = read_file_tags(destination)
+    if current.get('error'):
+        return {}
+    return {
+        key: value
+        for key, value in simple_tags.items()
+        if is_placeholder_meta(current.get(_SIMPLE_DOWNLOAD_TAG_TO_FILE_FIELD.get(key)))
     }
 
 
@@ -773,6 +807,7 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
 
             simple_tags = _build_simple_download_tag_data(
                 search_result, album_name)
+            simple_tags = _fill_only_simple_download_tags(destination, simple_tags)
             if simple_tags:
                 try:
                     tag_result = write_tags_to_file(

--- a/core/imports/track_number.py
+++ b/core/imports/track_number.py
@@ -31,9 +31,17 @@ real source position.
 from __future__ import annotations
 
 import json
+import os
 from typing import Any, Optional
 
 from core.imports.filename import extract_explicit_track_number
+
+# Audio extensions considered when deriving a scan-order fallback number
+# (§16.3(a)). Kept liberal so odd but real formats still count as siblings.
+_AUDIO_EXTENSIONS = frozenset({
+    ".flac", ".mp3", ".m4a", ".aac", ".ogg", ".oga", ".opus", ".wav",
+    ".aif", ".aiff", ".alac", ".ape", ".wv", ".wma", ".mpc", ".dsf",
+})
 
 
 def _coerce_positive(value: Any) -> Optional[int]:
@@ -159,6 +167,41 @@ def resolve_track_number(
     # value the pre-fix resolver would have used. A correctly-named file
     # with a stale/wrong embedded tag is therefore never regressed.
     return _coerce_positive(embedded_track_number)
+
+
+def track_number_from_directory_order(file_path: str) -> Optional[int]:
+    """Last-resort track number: this file's 1-based position among the audio
+    files that sit next to it, sorted by name (§16.3(a)).
+
+    The pipeline's final ``default to 1`` floor collapses a WHOLE album onto
+    track 1 whenever no source (metadata, filename, embedded tag) carried a
+    per-track number — every track then claims position 1 and all but one show
+    as "missing". Album-bundle downloads stage all of an album's files into one
+    directory together, so their sorted order is a stable, DISTINCT fallback:
+    a wrong-but-ordered guess is strictly better than one slot for the whole
+    album, and it can only ever replace the constant-1 default (never a number
+    a real source already produced).
+
+    Best-effort: returns None when the directory can't be listed or the file has
+    no audio siblings (a lone file needs no disambiguation), so the caller keeps
+    its own default. Never raises.
+    """
+    if not file_path:
+        return None
+    try:
+        directory = os.path.dirname(file_path)
+        base = os.path.basename(file_path)
+        if not directory or not os.path.isdir(directory):
+            return None
+        siblings = sorted(
+            name for name in os.listdir(directory)
+            if os.path.splitext(name)[1].lower() in _AUDIO_EXTENSIONS
+        )
+    except OSError:
+        return None
+    if base in siblings and len(siblings) > 1:
+        return siblings.index(base) + 1
+    return None
 
 
 def normalize_disc_number(value) -> int:

--- a/core/tag_writer.py
+++ b/core/tag_writer.py
@@ -217,6 +217,18 @@ def guard_placeholder_overwrite(db_val: Any, file_val: Any) -> Any:
     return db_val
 
 
+def _normalize_date_str(s: str) -> str:
+    """Normalize date/time strings (strip 'T', 'Z', seconds, offsets) to compare values."""
+    import re
+    if not s:
+        return ''
+    s = s.replace('T', ' ').replace('Z', '').split('+')[0].strip()
+    match = re.match(r'^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})(:\d{2})?(\.\d+)?$', s)
+    if match:
+        return match.group(1)
+    return s
+
+
 def build_tag_diff(file_tags: Dict[str, Any], db_data: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Compare file tags against DB metadata. Returns a list of diffs:
@@ -274,6 +286,20 @@ def build_tag_diff(file_tags: Dict[str, Any], db_data: Dict[str, Any]) -> List[D
         # Only mark as changed if DB has a value AND it differs from file
         # (writer skips fields where DB value is empty, so don't show them as diffs)
         changed = bool(db_str) and file_str != db_str
+
+        if changed and db_key == 'year':
+            # Check if normalized date/time matches to avoid false format-only mismatches
+            if _normalize_date_str(file_str) == _normalize_date_str(db_str):
+                changed = False
+
+        if changed and db_key == 'genres' and db_val:
+            # If the file genres contain the database genres, do not flag as changed
+            # (prevents overwriting a rich genre list with a generic parent genre like Pop)
+            import re
+            file_genres = [g.strip().lower() for g in re.split(r'[,;]+', file_str) if g.strip()]
+            db_genres = [g.strip().lower() for g in re.split(r'[,;]+', db_str) if g.strip()]
+            if all(g in file_genres for g in db_genres):
+                changed = False
 
         # #800 — if the change would replace a real file value with a
         # placeholder (Various Artists / [Unknown Album] / …), hold it back:
@@ -527,8 +553,11 @@ def _date_to_write(existing: Optional[str], year) -> str:
     year_str = str(year)
     if existing:
         existing = str(existing).strip()
-        if len(existing) > 4 and existing[:4] == year_str:
-            return existing
+        if len(existing) >= 4 and len(year_str) >= 4 and existing[:4] == year_str[:4]:
+            if _normalize_date_str(existing) == _normalize_date_str(year_str):
+                return existing
+            if len(existing) > len(year_str):
+                return existing
     return year_str
 
 

--- a/core/tag_writer.py
+++ b/core/tag_writer.py
@@ -202,6 +202,24 @@ def write_verification_status(file_path: str, status: str) -> bool:
         return False
 
 
+def genre_write_value_is_subset_of_existing(file_genre_str: Any, db_genre_str: Any) -> bool:
+    """True when every genre token in ``db_genre_str`` already appears in
+    ``file_genre_str``'s (comma/semicolon-split) list — writing the DB
+    value would only narrow a richer existing tag, not add information
+    (prevents a generic parent genre like "Pop" from overwriting a rich
+    file genre list). Shared by ``build_tag_diff`` (the preview) and
+    ``write_tags_to_file`` (the actual write) so the two never disagree
+    about whether a genre write is a real change."""
+    import re
+    if not db_genre_str or not file_genre_str:
+        return False
+    file_genres = [g.strip().lower() for g in re.split(r'[,;]+', str(file_genre_str)) if g.strip()]
+    db_genres = [g.strip().lower() for g in re.split(r'[,;]+', str(db_genre_str)) if g.strip()]
+    if not db_genres:
+        return False
+    return all(g in file_genres for g in db_genres)
+
+
 def guard_placeholder_overwrite(db_val: Any, file_val: Any) -> Any:
     """#800 guard: never replace a real file value with a placeholder.
 
@@ -218,15 +236,26 @@ def guard_placeholder_overwrite(db_val: Any, file_val: Any) -> Any:
 
 
 def _normalize_date_str(s: str) -> str:
-    """Normalize date/time strings (strip 'T', 'Z', seconds, offsets) to compare values."""
+    """Normalize date/time strings (strip 'T', 'Z', seconds, offsets, and a
+    no-information midnight time-of-day) to compare values.
+
+    A bare ``YYYY-MM-DD`` and the same date written as a full ISO timestamp
+    (``YYYY-MM-DDT00:00:00Z``, the common shape from taggers that always
+    emit a time component) must normalize to the SAME value — the time
+    portion carries no real information for a music release date."""
     import re
     if not s:
         return ''
     s = s.replace('T', ' ').replace('Z', '').split('+')[0].strip()
-    match = re.match(r'^(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})(:\d{2})?(\.\d+)?$', s)
-    if match:
-        return match.group(1)
-    return s
+    match = re.match(
+        r'^(\d{4}-\d{2}-\d{2})(?:\s+(\d{2}:\d{2}))?(?::\d{2})?(?:\.\d+)?$', s,
+    )
+    if not match:
+        return s
+    date_part, time_part = match.group(1), match.group(2)
+    if time_part and time_part != '00:00':
+        return f'{date_part} {time_part}'
+    return date_part
 
 
 def build_tag_diff(file_tags: Dict[str, Any], db_data: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -293,12 +322,12 @@ def build_tag_diff(file_tags: Dict[str, Any], db_data: Dict[str, Any]) -> List[D
                 changed = False
 
         if changed and db_key == 'genres' and db_val:
-            # If the file genres contain the database genres, do not flag as changed
-            # (prevents overwriting a rich genre list with a generic parent genre like Pop)
-            import re
-            file_genres = [g.strip().lower() for g in re.split(r'[,;]+', file_str) if g.strip()]
-            db_genres = [g.strip().lower() for g in re.split(r'[,;]+', db_str) if g.strip()]
-            if all(g in file_genres for g in db_genres):
+            # If the file genres contain the database genres, do not flag as
+            # changed (prevents overwriting a rich genre list with a generic
+            # parent genre like Pop). write_tags_to_file applies the SAME
+            # check before writing, so this preview always matches the
+            # actual write outcome.
+            if genre_write_value_is_subset_of_existing(file_str, db_str):
                 changed = False
 
         # #800 — if the change would replace a real file value with a
@@ -436,6 +465,19 @@ def write_tags_to_file(file_path: str, db_data: Dict[str, Any],
             elif isinstance(genres, str):
                 genre_str = genres
 
+        # Same guard build_tag_diff's preview applies: don't narrow a
+        # richer existing genre tag down to a DB value that's a pure
+        # subset of it (prevents a generic parent genre like "Pop" from
+        # clobbering a real multi-genre tag). Without this, a batch write
+        # (gated on build_tag_diff's verdict) would skip the file, while a
+        # single-track write — which calls this function directly — would
+        # still overwrite it, silently disagreeing with what the preview
+        # told the user.
+        if genre_str and not _current.get('error'):
+            existing_genre = _current.get('genre')
+            if genre_write_value_is_subset_of_existing(existing_genre, genre_str):
+                genre_str = existing_genre
+
         # Multi-value artist support — issue #587. Caller can pass
         # `artists_list` (per-track list of contributor names) and the
         # writer respects the user's `metadata_enhancement.tags.write_multi_artist`
@@ -553,10 +595,17 @@ def _date_to_write(existing: Optional[str], year) -> str:
     year_str = str(year)
     if existing:
         existing = str(existing).strip()
-        if len(existing) >= 4 and len(year_str) >= 4 and existing[:4] == year_str[:4]:
+        if len(existing) > 4 and len(year_str) >= 4 and existing[:4] == year_str[:4]:
             if _normalize_date_str(existing) == _normalize_date_str(year_str):
                 return existing
-            if len(existing) > len(year_str):
+            # Only keep the (longer) existing value when the new value is
+            # itself just a bare year — genuinely less specific, so it
+            # can't express a real month/day correction. Any longer new
+            # value (e.g. a full date) is a genuine correction and must
+            # win even if `existing` happens to be an even longer string
+            # (a stale full timestamp is not "more specific" than a
+            # shorter but correct date).
+            if len(year_str) <= 4:
                 return existing
     return year_str
 

--- a/core/usenet_clients/sabnzbd.py
+++ b/core/usenet_clients/sabnzbd.py
@@ -64,7 +64,9 @@ class SABnzbdAdapter:
     def _load_config(self) -> None:
         self._url = (config_manager.get('usenet_client.url', '') or '').rstrip('/')
         self._api_key = config_manager.get('usenet_client.api_key', '') or ''
-        self._category = config_manager.get('usenet_client.category', 'soulsync') or 'soulsync'
+        self._category = str(
+            config_manager.get('usenet_client.category', 'soulsync') or 'soulsync'
+        ).strip() or 'soulsync'
 
     def reload_settings(self) -> None:
         self._load_config()

--- a/core/usenet_clients/sabnzbd.py
+++ b/core/usenet_clients/sabnzbd.py
@@ -83,6 +83,33 @@ class SABnzbdAdapter:
         data = self._call_sync('version')
         return bool(data and data.get('version'))
 
+    async def category_exists(self, category: str) -> bool:
+        """Return whether SAB knows the category SoulSync will submit with.
+
+        SAB silently rewrites an unknown category to ``*``.  Normal submits
+        still retain their external job id, but a timed-out submit must be
+        adopted after restart by category and title.  Detecting the mismatch
+        during the settings connection test keeps that recovery boundary
+        reliable without broadening monitor adoption to unrelated jobs.
+        """
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(
+            None, self._category_exists_sync, category,
+        )
+
+    def _category_exists_sync(self, category: str) -> bool:
+        expected = str(category or "").strip().casefold()
+        if not expected:
+            return False
+        data = self._call_sync('get_cats')
+        categories = data.get('categories') if isinstance(data, dict) else None
+        if not isinstance(categories, list):
+            return False
+        return any(
+            str(value or "").strip().casefold() == expected
+            for value in categories
+        )
+
     def _call_sync(self, mode: str, **extra) -> Optional[dict]:
         if not self.is_configured():
             return None

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -9531,9 +9531,11 @@ class MusicDatabase:
 
         References to the deleted id are cleaned up in the same transaction
         (wishlist rows AND library tracks are re-pointed to NULL = "use the
-        default", and a matching Auto-Import override is cleared) — and even
-        a reference missed by that (or written concurrently) safely falls
-        back to the default via `core/quality/selection.py::load_profile_by_id`.
+        default"). A default is guaranteed to exist after this call even if
+        the profile table's is_default bookkeeping was ever left inconsistent
+        (e.g. by a bug or a hand-edited DB) — not just in the common case of
+        deleting the current default. A matching Auto-Import override is
+        cleared after the DB transaction commits.
 
         Returns ``(success, reason)`` — ``reason`` is empty on success.
         """
@@ -9547,12 +9549,22 @@ class MusicDatabase:
             target = next((r for r in rows if r["id"] == profile_id), None)
             if target is None:
                 return False, "Profile not found"
+            remaining = [r for r in rows if r["id"] != profile_id]
             if target["is_default"]:
-                promote_id = next(r["id"] for r in rows if r["id"] != profile_id)
+                promote_id = remaining[0]["id"]
                 conn.execute("UPDATE quality_profiles SET is_default=0 WHERE is_default=1")
                 conn.execute(
                     "UPDATE quality_profiles SET is_default=1, updated_at=CURRENT_TIMESTAMP WHERE id=?",
                     (promote_id,),
+                )
+            elif not any(r["is_default"] for r in remaining):
+                # Defensive: the surviving profiles have no default at all
+                # (inconsistent is_default state pre-dating this delete).
+                # Promote one now instead of leaving the app without one.
+                conn.execute(
+                    "UPDATE quality_profiles SET is_default=1, "
+                    "updated_at=CURRENT_TIMESTAMP WHERE id=?",
+                    (remaining[0]["id"],),
                 )
             conn.execute(
                 "UPDATE wishlist_tracks SET quality_profile_id=NULL WHERE quality_profile_id=?",

--- a/tests/automation/test_automation_progress.py
+++ b/tests/automation/test_automation_progress.py
@@ -106,6 +106,33 @@ def test_update_progress_emit_failure_swallowed():
     assert progress.progress_states[1]['finished_at'] is not None
 
 
+def test_update_progress_clamps_overflow_to_100():
+    """P2-20: counters (processed+skipped+failed vs. a precomputed grand
+    total) can exceed the nominal total under races/double-counting — the
+    shared status boundary must never surface >100%."""
+    progress.init_progress(1, 'A', 'x')
+    progress.update_progress(1, progress=143)
+    assert progress.progress_states[1]['progress'] == 100
+
+
+def test_update_progress_clamps_underflow_to_0():
+    progress.init_progress(1, 'A', 'x')
+    progress.update_progress(1, progress=-7)
+    assert progress.progress_states[1]['progress'] == 0
+
+
+def test_update_progress_rounds_fractional_progress():
+    progress.init_progress(1, 'A', 'x')
+    progress.update_progress(1, progress=33.6)
+    assert progress.progress_states[1]['progress'] == 34
+
+
+def test_update_progress_in_range_value_unchanged():
+    progress.init_progress(1, 'A', 'x')
+    progress.update_progress(1, progress=57)
+    assert progress.progress_states[1]['progress'] == 57
+
+
 def test_update_progress_none_id_is_noop():
     progress.update_progress(None, progress=99)  # no exception
 

--- a/tests/blocklist/test_blocklist_api.py
+++ b/tests/blocklist/test_blocklist_api.py
@@ -17,6 +17,11 @@ def client(monkeypatch):
     return web_server.app.test_client()
 
 
+def _skip_download(coro):
+    coro.close()
+    return None
+
+
 def test_search_proxies_active_source(client):
     with patch.object(web_server, "_search_service", return_value=[
             {"id": "drake-sp", "name": "Drake", "image": None, "extra": "", "provider": "spotify"}]):
@@ -82,18 +87,20 @@ def test_manual_download_blocked_by_artist_name(client, banned_artist):
 
 
 def test_manual_download_unrelated_artist_not_blocked(client, banned_artist):
-    # Allowed artist → guard passes (the download itself may fail offline; we
-    # only assert it wasn't blocked by the blocklist).
-    r = client.post("/api/download", json={
-        "result_type": "track", "username": "peer", "filename": "y.flac",
-        "artist": "Allowed Artist", "title": "Song"})
+    # Allowed artist -> guard passes. Keep the external download outside this
+    # guard test so an unavailable client cannot stall the suite.
+    with patch.object(web_server, "run_async", side_effect=_skip_download):
+        r = client.post("/api/download", json={
+            "result_type": "track", "username": "peer", "filename": "y.flac",
+            "artist": "Allowed Artist", "title": "Song"})
     assert not (r.get_json() or {}).get("blocked")
 
 
 def test_manual_download_override_passes_guard(client, banned_artist):
-    r = client.post("/api/download", json={
-        "result_type": "track", "username": "peer", "filename": "x.flac",
-        "artist": "Banned Guy", "title": "Song", "ignore_blocklist": True})
+    with patch.object(web_server, "run_async", side_effect=_skip_download):
+        r = client.post("/api/download", json={
+            "result_type": "track", "username": "peer", "filename": "x.flac",
+            "artist": "Banned Guy", "title": "Song", "ignore_blocklist": True})
     assert not (r.get_json() or {}).get("blocked")   # override skips the guard
 
 

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -2,6 +2,8 @@ import logging
 import sys
 import types
 
+import pytest
+
 import core.imports.pipeline as import_pipeline
 import core.imports.paths as import_paths
 import core.runtime_state as runtime_state
@@ -598,6 +600,27 @@ def test_exhaustive_soulseek_peer_resolves_to_soulseek(monkeypatch):
 
     assert task["status"] == "searching"
     assert task["quarantine_retry_counts_by_source"] == {"soulseek": 1}
+
+
+@pytest.mark.parametrize("source", ["torrent", "usenet"])
+def test_exhaustive_release_source_keeps_its_own_budget(monkeypatch, source):
+    _wire_retry_engine(monkeypatch)
+    _patch_config(monkeypatch, {
+        "post_processing.retry_exhaustive": True,
+        "post_processing.retries_per_query": 5,
+    })
+
+    task, _completion, _ = _run_wrapper_with_quarantine(
+        monkeypatch,
+        _acoustid_quarantine,
+        task_extra={
+            "username": source,
+            "filename": "release-reference",
+            "query_count": 1,
+        },
+    )
+
+    assert task["quarantine_retry_counts_by_source"] == {source: 1}
 
 
 def test_exhaustive_budget_defaults_query_count_to_one(monkeypatch):

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -232,6 +232,125 @@ def test_post_process_matched_download_forwards_separate_metadata_runtime(tmp_pa
 
 
 # ---------------------------------------------------------------------------
+# §16.3(a) scan-order track-number fallback must only fire for genuine
+# album-bundle downloads (files staged into one directory dedicated to that
+# album). A plain/non-bundle download lands in a SHARED flat directory that
+# can hold unrelated in-flight downloads at the same time — applying the
+# fallback there would compute a track's position among files from a
+# different download entirely.
+# ---------------------------------------------------------------------------
+
+def _wire_post_process_common(monkeypatch, tmp_path, target_path, *, track_number, is_album_download):
+    monkeypatch.setattr(import_pipeline, "config_manager", types.SimpleNamespace(
+        get=lambda key, default=None: {
+            "post_processing.replaygain_enabled": False,
+            "lossy_copy.enabled": False,
+            "lossy_copy.delete_original": False,
+            "import.replace_lower_quality": False,
+            "soulseek.download_path": str(tmp_path / "downloads"),
+        }.get(key, default)
+    ))
+    monkeypatch.setattr(import_pipeline, "normalize_import_context", lambda context: context)
+    monkeypatch.setattr(import_pipeline, "get_import_track_info", lambda context: {})
+    monkeypatch.setattr(import_pipeline, "get_import_original_search", lambda context: {"title": "Track", "album": "Album"})
+    monkeypatch.setattr(import_pipeline, "get_import_context_artist", lambda context: {"name": "Artist"})
+    monkeypatch.setattr(import_pipeline, "get_import_has_clean_metadata", lambda context: True)
+    monkeypatch.setattr(
+        import_pipeline,
+        "build_import_album_info",
+        lambda context, force_album=False: {
+            "is_album": is_album_download,
+            "album_name": "Album",
+            "track_number": track_number,
+            "disc_number": 1,
+            "clean_track_name": "Track",
+            "source": "unknown",
+        },
+    )
+    monkeypatch.setattr(import_pipeline, "resolve_album_group", lambda artist_context, album_info, original_album: album_info["album_name"])
+    monkeypatch.setattr(import_pipeline, "get_import_clean_title", lambda *args, **kwargs: "Track")
+    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda file_path: "")
+    monkeypatch.setattr(import_pipeline, "check_flac_bit_depth", lambda *args, **kwargs: None)
+    from core.imports.file_integrity import IntegrityResult
+    monkeypatch.setattr(import_pipeline, "check_audio_integrity",
+                        lambda *_a, **_kw: IntegrityResult(ok=True, checks={}))
+    monkeypatch.setattr(import_pipeline, "build_final_path_for_track", lambda *args, **kwargs: (str(target_path), None))
+    monkeypatch.setattr(import_pipeline, "enhance_file_metadata", lambda *args, **kwargs: True)
+    monkeypatch.setattr(import_pipeline, "safe_move_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "download_cover_art", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "generate_lrc_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "downsample_hires_flac", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "create_lossy_copy", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "cleanup_empty_directories", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "emit_track_downloaded", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "record_library_history_download", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "record_download_provenance", lambda *args, **kwargs: None)
+    monkeypatch.setattr(import_pipeline, "check_and_remove_from_wishlist", lambda *args, **kwargs: None)
+    library_calls = []
+    monkeypatch.setattr(import_pipeline, "record_soulsync_library_entry",
+                        lambda context, artist_context, album_info: library_calls.append(album_info))
+    return library_calls
+
+
+def test_scan_order_fallback_used_for_album_bundle_download(tmp_path, monkeypatch):
+    """A genuine album-bundle download (files staged into one directory
+    dedicated to this album) with no per-track number from any source
+    SHOULD use the scan-order fallback instead of collapsing to track 1."""
+    source_path = tmp_path / "source.flac"
+    source_path.write_bytes(b"audio")
+    target_path = tmp_path / "Album Folder" / "track.flac"
+
+    library_calls = _wire_post_process_common(
+        monkeypatch, tmp_path, target_path, track_number=0, is_album_download=True)
+    import core.imports.track_number as track_number_module
+    monkeypatch.setattr(track_number_module, "track_number_from_directory_order",
+                        lambda file_path: 7)
+
+    runtime = types.SimpleNamespace(automation_engine=None, on_download_completed=None,
+                                    web_scan_manager=None, repair_worker=None)
+    context = {
+        "track_info": {},
+        "original_search_result": {"title": "Track", "album": "Album"},
+        "is_album_download": True,
+    }
+    import_pipeline.post_process_matched_download("ctx-1", context, str(source_path), runtime)
+
+    assert library_calls[0]["track_number"] == 7
+
+
+def test_scan_order_fallback_not_used_for_plain_download(tmp_path, monkeypatch):
+    """A plain (non-bundle) download lands in a SHARED flat directory that
+    can hold unrelated in-flight downloads at the same time — the
+    scan-order fallback must NOT be attempted there, since it would compute
+    a position among files from a different download entirely. Falls back
+    to the old constant-1 default instead."""
+    source_path = tmp_path / "source.flac"
+    source_path.write_bytes(b"audio")
+    target_path = tmp_path / "Album Folder" / "track.flac"
+
+    library_calls = _wire_post_process_common(
+        monkeypatch, tmp_path, target_path, track_number=0, is_album_download=False)
+    import core.imports.track_number as track_number_module
+    fallback_calls = []
+    monkeypatch.setattr(
+        track_number_module, "track_number_from_directory_order",
+        lambda file_path: fallback_calls.append(file_path) or 7,
+    )
+
+    runtime = types.SimpleNamespace(automation_engine=None, on_download_completed=None,
+                                    web_scan_manager=None, repair_worker=None)
+    context = {
+        "track_info": {},
+        "original_search_result": {"title": "Track", "album": "Album"},
+        "is_album_download": False,
+    }
+    import_pipeline.post_process_matched_download("ctx-1", context, str(source_path), runtime)
+
+    assert fallback_calls == []
+    assert library_calls[0]["track_number"] == 1
+
+
+# ---------------------------------------------------------------------------
 # Quarantine entry-id propagation through the verification wrapper
 # (the wrapper pops task_id out of context, so _mark_task_quarantined can't
 # write to the task directly — it stashes on context and the wrapper applies it)

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -35,6 +35,58 @@ class _ImmediateThread:
             self._target()
 
 
+def test_fill_only_simple_download_tags_skips_fields_with_real_existing_values(monkeypatch):
+    """The simple-download tagger must FILL blank/placeholder fields, never
+    overwrite a real existing tag — search titles come straight from the
+    user's request and Soulseek filenames are often messy, so the file's
+    own tag (when present) wins."""
+    monkeypatch.setattr(
+        import_pipeline, "read_file_tags",
+        lambda path: {
+            "title": "Real Title", "artist": None, "album": "[Unknown Album]",
+            "error": None,
+        },
+    )
+    result = import_pipeline._fill_only_simple_download_tags(
+        "/fake/dest.flac",
+        {"title": "Messy Filename Title", "artist_name": "Parsed Artist", "album_title": "Real Album"},
+    )
+    # title: file already has a real value → dropped.
+    # artist_name: file has no artist at all → filled.
+    # album_title: file's album is a placeholder → filled.
+    assert result == {"artist_name": "Parsed Artist", "album_title": "Real Album"}
+
+
+def test_fill_only_simple_download_tags_keeps_all_fields_when_file_is_blank(monkeypatch):
+    monkeypatch.setattr(
+        import_pipeline, "read_file_tags",
+        lambda path: {"title": None, "artist": None, "album": None, "error": None},
+    )
+    simple_tags = {"title": "Title", "artist_name": "Artist", "album_title": "Album"}
+    result = import_pipeline._fill_only_simple_download_tags("/fake/dest.flac", simple_tags)
+    assert result == simple_tags
+
+
+def test_fill_only_simple_download_tags_skips_write_when_file_unreadable(monkeypatch):
+    """When the file's current tags can't be determined at all, don't guess
+    — skip tagging entirely rather than risk clobbering an unknown value."""
+    monkeypatch.setattr(
+        import_pipeline, "read_file_tags",
+        lambda path: {"error": "Could not read file with Mutagen"},
+    )
+    result = import_pipeline._fill_only_simple_download_tags(
+        "/fake/dest.flac", {"title": "Title", "artist_name": "Artist"},
+    )
+    assert result == {}
+
+
+def test_fill_only_simple_download_tags_empty_input_short_circuits(monkeypatch):
+    calls = []
+    monkeypatch.setattr(import_pipeline, "read_file_tags", lambda path: calls.append(path) or {})
+    assert import_pipeline._fill_only_simple_download_tags("/fake/dest.flac", {}) == {}
+    assert calls == []   # never even reads the file when there's nothing to fill
+
+
 def test_verification_wrapper_handles_simple_download(tmp_path, monkeypatch):
     transfer_root = tmp_path / "Transfer"
     transfer_root.mkdir()

--- a/tests/imports/test_track_number_resolver.py
+++ b/tests/imports/test_track_number_resolver.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from core.imports.track_number import read_embedded_track_number, resolve_track_number
+from core.imports.track_number import (
+    read_embedded_track_number,
+    resolve_track_number,
+    track_number_from_directory_order,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -336,3 +340,42 @@ def test_read_embedded_never_raises():
 
 def test_read_embedded_empty_path_returns_none():
     assert read_embedded_track_number('') is None
+
+
+# ---------------------------------------------------------------------------
+# §16.3(a): scan-order fallback — when NO source carries a per-track number,
+# the file's sorted position among its audio siblings keeps a whole album from
+# collapsing onto track 1 (album-bundle stages all files into one directory).
+# ---------------------------------------------------------------------------
+
+
+def test_directory_order_assigns_distinct_positions(tmp_path):
+    for name in ("b_song.flac", "a_song.flac", "c_song.mp3"):
+        (tmp_path / name).write_bytes(b"x")
+    assert track_number_from_directory_order(str(tmp_path / "a_song.flac")) == 1
+    assert track_number_from_directory_order(str(tmp_path / "b_song.flac")) == 2
+    assert track_number_from_directory_order(str(tmp_path / "c_song.mp3")) == 3
+
+
+def test_directory_order_ignores_non_audio_siblings(tmp_path):
+    (tmp_path / "cover.jpg").write_bytes(b"x")
+    (tmp_path / "notes.txt").write_bytes(b"x")
+    (tmp_path / "01.flac").write_bytes(b"x")
+    (tmp_path / "02.flac").write_bytes(b"x")
+    # Non-audio files never shift a track's ordinal.
+    assert track_number_from_directory_order(str(tmp_path / "02.flac")) == 2
+
+
+def test_directory_order_single_audio_file_returns_none(tmp_path):
+    (tmp_path / "cover.jpg").write_bytes(b"x")
+    (tmp_path / "only.flac").write_bytes(b"x")
+    # Nothing to disambiguate → let the caller keep its own default.
+    assert track_number_from_directory_order(str(tmp_path / "only.flac")) is None
+
+
+def test_directory_order_missing_dir_returns_none():
+    assert track_number_from_directory_order("/no/such/dir/file.flac") is None
+
+
+def test_directory_order_empty_path_returns_none():
+    assert track_number_from_directory_order("") is None

--- a/tests/test_album_bundle.py
+++ b/tests/test_album_bundle.py
@@ -1109,6 +1109,63 @@ def test_poll_gives_up_if_incomplete_path_never_stabilizes_before_deadline() -> 
     assert 'timed out' in failed_calls[0][1].get('error', '').lower()
 
 
+def test_poll_resolves_incomplete_path_before_stability_check() -> None:
+    """P2-21 follow-up: the client-reported incomplete_path can live inside
+    the client's OWN container/mount, unreadable from here directly. If the
+    stability check snapshots the raw path, it always reads None (path
+    doesn't exist locally) and can never stabilize — the download would
+    hang until the outer deadline instead of falling back within the
+    completed-no-path window. ``resolve_path`` is applied before
+    snapshotting so both the stability check and the returned path operate
+    on the locally-readable, remapped location."""
+    clock = _ScriptedClock()
+    emit, calls = _make_emit_recorder()
+    result = poll_album_download(
+        get_status=lambda: _Status(
+            state='completed', save_path=None,
+            incomplete_path='/client-container/incomplete/album', progress=1.0,
+        ),
+        title='Remote Mount Album',
+        emit=emit,
+        complete_states=frozenset(['completed']),
+        completed_no_path_threshold=2,
+        sleep=clock.sleep, monotonic=clock.monotonic,
+        poll_interval=2.0, timeout=600.0,
+        resolve_path=lambda p: '/local/incomplete/album',
+        snapshot_path=lambda p: (100, 3, 1.0) if p == '/local/incomplete/album' else None,
+    )
+    assert result == '/local/incomplete/album'
+    assert 'failed' not in [c[0] for c in calls]
+
+
+def test_poll_does_not_treat_empty_incomplete_path_as_stable() -> None:
+    """An incomplete_path that exists but is currently empty (the client
+    just created the directory and hasn't started writing into it) must
+    not satisfy the stability gate just because two empty snapshots
+    match — zero files means writes haven't started, not that they've
+    stopped. The poll should keep waiting (and eventually time out here,
+    since it never gains content) rather than hand back an empty dir."""
+    clock = _ScriptedClock()
+    emit, calls = _make_emit_recorder()
+    result = poll_album_download(
+        get_status=lambda: _Status(
+            state='completed', save_path=None,
+            incomplete_path='/sab/incomplete/album', progress=1.0,
+        ),
+        title='Empty Then Never Fills',
+        emit=emit,
+        complete_states=frozenset(['completed']),
+        completed_no_path_threshold=2,
+        sleep=clock.sleep, monotonic=clock.monotonic,
+        poll_interval=2.0, timeout=20.0,
+        snapshot_path=lambda path: (0, 0, 0.0),
+    )
+    assert result is None
+    failed_calls = [c for c in calls if c[0] == 'failed']
+    assert len(failed_calls) == 1
+    assert 'timed out' in failed_calls[0][1].get('error', '').lower()
+
+
 def test_poll_fails_when_no_path_and_no_incomplete_path() -> None:
     """Last resort only fires when there's actually a path to scan.
     With neither a final save_path nor an incomplete_path, the poll

--- a/tests/test_album_bundle.py
+++ b/tests/test_album_bundle.py
@@ -639,6 +639,7 @@ from core.download_plugins.album_bundle import (
     TransientMissCounter,
     get_transient_miss_threshold,
     poll_album_download,
+    snapshot_incomplete_path,
 )
 
 
@@ -1014,13 +1015,14 @@ def test_poll_completed_no_path_window_is_longer_than_miss_window() -> None:
     assert 'failed' not in [c[0] for c in calls]
 
 
-def test_poll_falls_back_to_incomplete_path_after_window_exhausted() -> None:
+def test_poll_falls_back_to_incomplete_path_after_window_exhausted_and_stable() -> None:
     """When SAB reports the job completed but the final save_path NEVER
     lands (some SAB versions / no post-process move), the files are
     still physically on disk in the in-progress dir. Rather than failing
     a download that actually succeeded, the poll falls back to the
     adapter's ``incomplete_path`` as a last resort once the window is
-    exhausted — no terminal 'failed' emit."""
+    exhausted AND its on-disk fingerprint has stopped changing (P2-21) —
+    no terminal 'failed' emit."""
     clock = _ScriptedClock()
     emit, calls = _make_emit_recorder()
     result = poll_album_download(
@@ -1034,9 +1036,77 @@ def test_poll_falls_back_to_incomplete_path_after_window_exhausted() -> None:
         completed_no_path_threshold=3,
         sleep=clock.sleep, monotonic=clock.monotonic,
         poll_interval=2.0, timeout=600.0,
+        snapshot_path=lambda path: ('fixed-size', 3, 100.0),
     )
     assert result == '/sab/incomplete/album'
     assert 'failed' not in [c[0] for c in calls]
+
+
+def test_poll_waits_for_incomplete_path_to_stop_changing_before_falling_back() -> None:
+    """P2-21: a fixed wait window elapsing does NOT mean the client's
+    post-processing has stopped writing into ``incomplete_path`` — it
+    could still be mid-unrar/mid-move. The poll must keep waiting past
+    the completed-no-path window while the fingerprint keeps changing,
+    and only fall back once two consecutive snapshots match."""
+    clock = _ScriptedClock()
+    emit, calls = _make_emit_recorder()
+    # Fingerprint keeps growing (still being written) for a while, then
+    # settles on a final value that repeats.
+    growing_sizes = iter([100, 200, 300, 400, 400, 400])
+
+    def _snapshot(path):
+        return (next(growing_sizes, 400), 1, 0.0)
+
+    result = poll_album_download(
+        get_status=lambda: _Status(
+            state='completed', save_path=None,
+            incomplete_path='/sab/incomplete/album', progress=1.0,
+        ),
+        title='Still Writing',
+        emit=emit,
+        complete_states=frozenset(['completed']),
+        completed_no_path_threshold=2,
+        sleep=clock.sleep, monotonic=clock.monotonic,
+        poll_interval=2.0, timeout=600.0,
+        snapshot_path=_snapshot,
+    )
+    assert result == '/sab/incomplete/album'
+    assert 'failed' not in [c[0] for c in calls]
+    # Had to poll well past the raw completed_no_path_threshold (2) while
+    # the fingerprint kept changing before it stabilized.
+    assert clock.sleep_calls > 2
+
+
+def test_poll_gives_up_if_incomplete_path_never_stabilizes_before_deadline() -> None:
+    """If the in-progress path never stops changing (or is never
+    readable), the poll must NOT silently promote it — it should run out
+    the outer deadline and fail loudly instead of importing a possibly
+    partial/corrupt directory."""
+    clock = _ScriptedClock()
+    emit, calls = _make_emit_recorder()
+    counter = {'n': 0}
+
+    def _always_changing(path):
+        counter['n'] += 1
+        return (counter['n'], 1, 0.0)  # never equal to the previous snapshot
+
+    result = poll_album_download(
+        get_status=lambda: _Status(
+            state='completed', save_path=None,
+            incomplete_path='/sab/incomplete/album', progress=1.0,
+        ),
+        title='Never Settles',
+        emit=emit,
+        complete_states=frozenset(['completed']),
+        completed_no_path_threshold=2,
+        sleep=clock.sleep, monotonic=clock.monotonic,
+        poll_interval=2.0, timeout=20.0,
+        snapshot_path=_always_changing,
+    )
+    assert result is None
+    failed_calls = [c for c in calls if c[0] == 'failed']
+    assert len(failed_calls) == 1
+    assert 'timed out' in failed_calls[0][1].get('error', '').lower()
 
 
 def test_poll_fails_when_no_path_and_no_incomplete_path() -> None:
@@ -1060,6 +1130,40 @@ def test_poll_fails_when_no_path_and_no_incomplete_path() -> None:
     assert len(failed_calls) == 1
     err = failed_calls[0][1].get('error', '').lower()
     assert 'save_path' in err or 'success but never' in err
+
+
+# ---------------------------------------------------------------------------
+# snapshot_incomplete_path — real on-disk fingerprint used by the stability
+# gate above (P2-21).
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_incomplete_path_missing_path_is_none(tmp_path: Path) -> None:
+    assert snapshot_incomplete_path(str(tmp_path / 'does-not-exist')) is None
+
+
+def test_snapshot_incomplete_path_single_file(tmp_path: Path) -> None:
+    f = tmp_path / 'track.flac'
+    f.write_bytes(b'abcd')
+    snap = snapshot_incomplete_path(str(f))
+    assert snap == (4, 1, f.stat().st_mtime)
+
+
+def test_snapshot_incomplete_path_directory_sums_all_files(tmp_path: Path) -> None:
+    (tmp_path / 'a.flac').write_bytes(b'12345')
+    (tmp_path / 'b.flac').write_bytes(b'1234567890')
+    total_size, count, _mtime = snapshot_incomplete_path(str(tmp_path))
+    assert total_size == 15
+    assert count == 2
+
+
+def test_snapshot_incomplete_path_changes_when_a_file_grows(tmp_path: Path) -> None:
+    f = tmp_path / 'a.flac'
+    f.write_bytes(b'12345')
+    before = snapshot_incomplete_path(str(tmp_path))
+    f.write_bytes(b'1234567890')
+    after = snapshot_incomplete_path(str(tmp_path))
+    assert before != after
 
 
 def test_poll_uses_save_path_from_earlier_downloading_emit_if_completed_lacks_one() -> None:

--- a/tests/test_album_bundle.py
+++ b/tests/test_album_bundle.py
@@ -1166,6 +1166,39 @@ def test_poll_does_not_treat_empty_incomplete_path_as_stable() -> None:
     assert 'timed out' in failed_calls[0][1].get('error', '').lower()
 
 
+def test_poll_gives_up_on_incomplete_path_after_repeated_unreadable_polls() -> None:
+    """If the in-progress path can never be READ AT ALL (e.g. no
+    usenet_path_mappings entry for a split-container deployment, not just
+    an unresolved-but-real path), snapshot_path returns None on every
+    single poll — `stable` can never become True, so without a cap the
+    gate would poll for the entire outer ``timeout`` (hours) before saying
+    anything. A handful of consecutive unreadable polls must be enough to
+    give up with the SAME error the pre-stability-gate code used, well
+    before the (long) outer deadline."""
+    clock = _ScriptedClock()
+    emit, calls = _make_emit_recorder()
+    result = poll_album_download(
+        get_status=lambda: _Status(
+            state='completed', save_path=None,
+            incomplete_path='/sab/incomplete/album', progress=1.0,
+        ),
+        title='Never Readable',
+        emit=emit,
+        complete_states=frozenset(['completed']),
+        transient_miss_threshold=3,
+        completed_no_path_threshold=2,
+        sleep=clock.sleep, monotonic=clock.monotonic,
+        poll_interval=2.0, timeout=6 * 3600.0,   # long outer deadline (6h)
+        snapshot_path=lambda path: None,   # truly unreadable, every poll
+    )
+    assert result is None
+    failed_calls = [c for c in calls if c[0] == 'failed']
+    assert len(failed_calls) == 1
+    assert 'never provided a save_path' in failed_calls[0][1].get('error', '').lower()
+    # Gave up long before the 6h outer deadline.
+    assert clock.monotonic() < 3600.0
+
+
 def test_poll_fails_when_no_path_and_no_incomplete_path() -> None:
     """Last resort only fires when there's actually a path to scan.
     With neither a final save_path nor an incomplete_path, the poll

--- a/tests/test_candidate_store.py
+++ b/tests/test_candidate_store.py
@@ -1,0 +1,71 @@
+"""Candidate store (audit P0-03): indexer download URLs stay server-side.
+
+Search results carry an opaque token; the download path resolves it back.
+A client-supplied raw URL or an expired/unknown token must be rejected —
+the browser can no longer make SoulSync forward arbitrary URLs to the
+download client, and Prowlarr API keys never reach the frontend.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from core.download_plugins.candidate_store import CandidateStore, TOKEN_PREFIX
+
+
+def test_put_resolve_roundtrip():
+    store = CandidateStore()
+    token = store.put("https://indexer/dl?apikey=SECRET")
+    assert token.startswith(TOKEN_PREFIX)
+    assert "SECRET" not in token
+    assert store.resolve(token) == "https://indexer/dl?apikey=SECRET"
+
+
+def test_same_url_reuses_token():
+    store = CandidateStore()
+    assert store.put("https://x/a.nzb") == store.put("https://x/a.nzb")
+    assert store.put("https://x/a.nzb") != store.put("https://x/b.nzb")
+
+
+def test_unknown_and_tampered_tokens_are_rejected():
+    store = CandidateStore()
+    store.put("https://x/a.nzb")
+    assert store.resolve(TOKEN_PREFIX + "forged") is None
+    # A raw URL is not a token — the pre-fix behaviour (client sends the
+    # URL, server fetches it) must not resolve.
+    assert store.resolve("https://evil.example/payload.nzb") is None
+    assert store.resolve("") is None
+    assert store.resolve(None) is None
+
+
+def test_expired_token_is_rejected():
+    store = CandidateStore(ttl_seconds=100)
+    with patch("core.download_plugins.candidate_store.time.monotonic", return_value=0.0):
+        token = store.put("https://x/a.nzb")
+    with patch("core.download_plugins.candidate_store.time.monotonic", return_value=50.0):
+        assert store.resolve(token) == "https://x/a.nzb"
+    with patch("core.download_plugins.candidate_store.time.monotonic", return_value=101.0):
+        assert store.resolve(token) is None
+
+
+def test_size_cap_evicts_oldest():
+    store = CandidateStore(max_entries=3)
+    tokens = [store.put(f"https://x/{i}.nzb") for i in range(5)]
+    live = [t for t in tokens if store.resolve(t) is not None]
+    assert len(live) == 3
+    # The most recent entries survive.
+    assert store.resolve(tokens[-1]) is not None
+
+
+def test_plugin_download_rejects_raw_url(monkeypatch):
+    """End-to-end guard: a client that still submits `<url>||<name>` (the
+    pre-fix wire format, or a tampered request) must be refused."""
+    from core.download_plugins.torrent import TorrentDownloadPlugin, _FILENAME_SEP
+    from utils.async_helpers import run_async
+
+    plugin = TorrentDownloadPlugin()
+    monkeypatch.setattr(plugin, "is_configured", lambda: True)
+    result = run_async(plugin.download(
+        "torrent", f"https://evil.example/x.torrent{_FILENAME_SEP}Album"))
+    assert result is None
+    assert plugin.active_downloads == {}

--- a/tests/test_candidate_store.py
+++ b/tests/test_candidate_store.py
@@ -8,6 +8,7 @@ download client, and Prowlarr API keys never reach the frontend.
 
 from __future__ import annotations
 
+import time
 from unittest.mock import patch
 
 from core.download_plugins.candidate_store import CandidateStore, TOKEN_PREFIX
@@ -55,6 +56,52 @@ def test_size_cap_evicts_oldest():
     assert len(live) == 3
     # The most recent entries survive.
     assert store.resolve(tokens[-1]) is not None
+
+
+def test_put_captures_timestamp_after_acquiring_the_lock():
+    """The eviction race (put() evicting the entry it just inserted) stems
+    from computing `now` BEFORE acquiring the lock: under contention, a
+    call whose lock acquisition happens LAST can still have captured the
+    EARLIEST timestamp, decoupling insertion order from expires_at order
+    -- so `_evict_oldest_locked`'s expiry-sort can pick the entry a put()
+    call is about to return, in that same call. Assert `now` is captured
+    only once the lock is already held, which makes that ordering
+    inversion structurally impossible (whichever call acquires the lock
+    last also necessarily reads the largest timestamp)."""
+    store = CandidateStore()
+    events: list = []
+    real_lock = store._lock
+
+    class _RecordingLock:
+        def __enter__(self):
+            real_lock.acquire()
+            events.append('acquire')
+            return self
+
+        def __exit__(self, *exc_info):
+            events.append('release')
+            real_lock.release()
+
+    store._lock = _RecordingLock()
+
+    real_monotonic = time.monotonic
+
+    def _recording_monotonic():
+        events.append('monotonic')
+        return real_monotonic()
+
+    with patch(
+        "core.download_plugins.candidate_store.time.monotonic",
+        side_effect=_recording_monotonic,
+    ):
+        store.put("https://x/a.nzb")
+
+    assert events.index('monotonic') > events.index('acquire'), (
+        "now = time.monotonic() must be captured AFTER acquiring the lock, "
+        "not before — otherwise insertion order and expires_at order can "
+        "diverge under contention, letting put() evict the entry it just "
+        f"created. Recorded order: {events}"
+    )
 
 
 def test_plugin_download_rejects_raw_url(monkeypatch):

--- a/tests/test_infer_candidate_source.py
+++ b/tests/test_infer_candidate_source.py
@@ -1,0 +1,23 @@
+"""web_server.py keeps its OWN copy of `_STREAMING_SOURCE_NAMES`, separate
+from core/downloads/monitor.py's and core/downloads/status.py's. When
+torrent/usenet acquisition sources were added to the other two copies, this
+one was left stale — `_infer_candidate_source` kept bucketing torrent/usenet
+search candidates under 'soulseek' in the UI even though their retry-budget
+bookkeeping (via monitor.py) correctly treated them as their own source.
+"""
+
+import web_server
+
+
+def test_infer_candidate_source_recognizes_torrent_and_usenet():
+    assert web_server._infer_candidate_source('torrent') == 'torrent'
+    assert web_server._infer_candidate_source('usenet') == 'usenet'
+
+
+def test_infer_candidate_source_recognizes_amazon():
+    assert web_server._infer_candidate_source('amazon') == 'amazon'
+
+
+def test_infer_candidate_source_still_buckets_soulseek_peers_as_soulseek():
+    assert web_server._infer_candidate_source('some-peer-username') == 'soulseek'
+    assert web_server._infer_candidate_source('') == 'soulseek'

--- a/tests/test_tag_writer_date_normalization.py
+++ b/tests/test_tag_writer_date_normalization.py
@@ -1,0 +1,98 @@
+"""Date/time comparison bugs in the "fix false-positive date retag
+warnings" change (commit 73ec9c7a):
+
+- ``_normalize_date_str`` only matched strings that included a
+  time-of-day component, so a bare ``YYYY-MM-DD`` never normalized
+  equal to the same date with a ``T00:00:00`` suffix — defeating the
+  false-positive suppression for the single most common shape of this
+  mismatch (a full ISO timestamp on the file vs. a plain date in the DB).
+- ``_date_to_write`` used string length as a proxy for "more specific,"
+  so a longer but genuinely WRONG existing date (same year, different
+  month/day) could permanently block a real correction from a shorter
+  but correct new value.
+"""
+
+from __future__ import annotations
+
+from core.tag_writer import _date_to_write, _normalize_date_str, build_tag_diff
+
+
+# ---------------------------------------------------------------------------
+# _normalize_date_str
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_bare_date_matches_same_date_with_midnight_timestamp():
+    assert _normalize_date_str('2023-09-01') == _normalize_date_str('2023-09-01T00:00:00')
+
+
+def test_normalize_bare_date_matches_same_date_with_zulu_midnight_timestamp():
+    assert _normalize_date_str('2023-09-01') == _normalize_date_str('2023-09-01T00:00:00Z')
+
+
+def test_normalize_still_distinguishes_different_dates():
+    assert _normalize_date_str('2023-09-01') != _normalize_date_str('2023-09-05')
+    assert _normalize_date_str('2023-01-01T00:00:00') != _normalize_date_str('2023-09-05')
+
+
+def test_normalize_empty_string_is_empty():
+    assert _normalize_date_str('') == ''
+
+
+# ---------------------------------------------------------------------------
+# _date_to_write
+# ---------------------------------------------------------------------------
+
+
+def test_date_to_write_applies_a_genuine_correction_within_the_same_year():
+    """A longer existing tag must not block a real month/day correction
+    just because it happens to be a longer string."""
+    assert _date_to_write('2023-01-01 00:00:00', '2023-09-05') == '2023-09-05'
+
+
+def test_date_to_write_applies_a_genuine_correction_across_years():
+    assert _date_to_write('2019-12-31T23:00:00+00:00', '2020-01-01') == '2020-01-01'
+
+
+def test_date_to_write_keeps_existing_full_date_when_new_value_is_a_bare_year():
+    """#824: enrichment must not downgrade a real full release date to
+    just the year when the new source only provides a bare year."""
+    assert _date_to_write('2020-03-15', 2020) == '2020-03-15'
+    assert _date_to_write('2020-03-15', '2020') == '2020-03-15'
+
+
+def test_date_to_write_writes_the_bare_year_when_years_differ():
+    assert _date_to_write('2019-03-15', 2020) == '2020'
+
+
+def test_date_to_write_recognizes_format_only_differences_as_unchanged():
+    """A file timestamp and a plain DB date for the SAME real date must
+    both resolve to keeping the (more informative) existing value."""
+    assert _date_to_write('2023-09-01T00:00:00', '2023-09-01') == '2023-09-01T00:00:00'
+
+
+def test_date_to_write_with_no_existing_value_uses_the_new_year():
+    assert _date_to_write(None, '2023-09-05') == '2023-09-05'
+    assert _date_to_write('', '2023-09-05') == '2023-09-05'
+
+
+# ---------------------------------------------------------------------------
+# build_tag_diff — integration: the year-diff suppression must not leave a
+# spurious "changed" diff for the bare-date-vs-timestamp shape.
+# ---------------------------------------------------------------------------
+
+
+def test_build_tag_diff_suppresses_bare_date_vs_midnight_timestamp_false_positive():
+    file_tags = {'year': '2023-09-01T00:00:00'}
+    db_data = {'year': 2023, 'release_date': '2023-09-01'}
+    diffs = build_tag_diff(file_tags, db_data)
+    year_diff = next(d for d in diffs if d['field'] == 'Year')
+    assert year_diff['changed'] is False
+
+
+def test_build_tag_diff_still_flags_a_genuine_year_difference():
+    file_tags = {'year': '2023-01-01T00:00:00'}
+    db_data = {'year': 2023, 'release_date': '2023-09-05'}
+    diffs = build_tag_diff(file_tags, db_data)
+    year_diff = next(d for d in diffs if d['field'] == 'Year')
+    assert year_diff['changed'] is True

--- a/tests/test_tag_writer_genre_consistency.py
+++ b/tests/test_tag_writer_genre_consistency.py
@@ -1,0 +1,91 @@
+"""Genre-diff-suppression consistency (commit 73ec9c7a):
+
+``build_tag_diff`` suppresses a genre "change" when the DB's genre value
+is a pure subset of the file's existing (richer) genre list — meant to
+stop automated enrichment from downgrading a rich file tag to a generic
+single DB genre (e.g. "Pop"). But ``write_tags_to_file`` had no matching
+guard: a batch write (gated on ``build_tag_diff``'s ``changed`` flag)
+would silently skip the file entirely, while a single-track write (which
+calls ``write_tags_to_file`` directly, bypassing the diff) would still
+overwrite the richer file value — contradicting what the diff/preview
+told the user. The same subset check must apply in both places so the
+preview and the actual write always agree.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+from mutagen.flac import FLAC
+
+from core.tag_writer import build_tag_diff, write_tags_to_file
+
+
+def _make_minimal_flac(path):
+    minimal = (
+        b'fLaC' + b'\x80\x00\x00\x22' + b'\x00\x10\x00\x10'
+        + b'\x00\x00\x00\x00\x00\x00' + b'\x0a\xc4\x42\xf0\x00\x00\x00\x00' + b'\x00' * 16
+    )
+    with open(path, 'wb') as f:
+        f.write(minimal)
+
+
+@pytest.fixture
+def flac_path():
+    fd, path = tempfile.mkstemp(suffix='.flac')
+    os.close(fd)
+    _make_minimal_flac(path)
+    yield path
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def test_write_preserves_richer_existing_genre_when_db_is_a_subset(flac_path):
+    audio = FLAC(flac_path)
+    audio['genre'] = ['Electronic; House; Techno']
+    audio.save()
+
+    result = write_tags_to_file(flac_path, {'genres': ['Electronic']}, embed_cover=False)
+    assert result['success'] is True
+    # The narrower DB genre must not clobber the richer existing tag —
+    # matches what build_tag_diff already shows as "no change" for this pair.
+    assert FLAC(flac_path).get('genre') == ['Electronic; House; Techno']
+
+
+def test_write_still_applies_a_genuinely_different_genre(flac_path):
+    audio = FLAC(flac_path)
+    audio['genre'] = ['Pop']
+    audio.save()
+
+    result = write_tags_to_file(
+        flac_path, {'genres': ['Electronic', 'House']}, embed_cover=False)
+    assert result['success'] is True
+    assert FLAC(flac_path).get('genre') == ['Electronic, House']
+
+
+def test_write_applies_genre_when_file_has_none_yet(flac_path):
+    result = write_tags_to_file(flac_path, {'genres': ['Electronic']}, embed_cover=False)
+    assert result['success'] is True
+    assert FLAC(flac_path).get('genre') == ['Electronic']
+
+
+def test_diff_and_write_agree_on_subset_genre(flac_path):
+    """The preview (build_tag_diff) and the actual writer must reach the
+    SAME verdict for the same genre pair — no silent divergence between
+    what the UI shows and what a write would actually do."""
+    audio = FLAC(flac_path)
+    audio['genre'] = ['Electronic; House; Techno']
+    audio.save()
+
+    diff = build_tag_diff(
+        {'genre': 'Electronic; House; Techno'}, {'genres': ['Electronic']})
+    genre_diff = next(d for d in diff if d['field'] == 'Genre')
+    assert genre_diff['changed'] is False
+
+    write_tags_to_file(flac_path, {'genres': ['Electronic']}, embed_cover=False)
+    # The write must match what the diff promised: no actual change.
+    assert FLAC(flac_path).get('genre') == ['Electronic; House; Techno']

--- a/tests/test_torrent_usenet_plugins.py
+++ b/tests/test_torrent_usenet_plugins.py
@@ -545,6 +545,36 @@ def test_usenet_thread_waits_for_incomplete_path_to_stop_changing() -> None:
     assert row['audio_files'] == [str(Path('/done/track1.flac'))]
 
 
+def test_usenet_thread_resolves_incomplete_path_before_stability_check() -> None:
+    """P2-21 follow-up: a client-container incomplete_path unreadable from
+    here must be remapped via resolve_reported_save_path BEFORE the
+    stability snapshot — the same fix applied to poll_album_download's
+    stability gate — otherwise a split-container SAB/NZBGet mount can
+    never stabilize and the download hangs until the outer deadline."""
+    plugin = UsenetDownloadPlugin()
+    completed_no_path = UsenetStatus(
+        id='job1', name='A', state='completed', progress=1.0,
+        size=100, downloaded=100, download_speed=0,
+        save_path=None, incomplete_path='/client-container/incomplete/A',
+    )
+    with patch(
+        'core.download_plugins.usenet.resolve_reported_save_path',
+        side_effect=lambda p, *a, **kw: (
+            '/local/incomplete/A' if p == '/client-container/incomplete/A' else p
+        ),
+    ):
+        row = _drive_download_thread(
+            plugin, [completed_no_path] * 12,
+            snapshot={
+                'side_effect': lambda path: (
+                    (100, 3, 1.0) if path == '/local/incomplete/A' else None
+                ),
+            },
+        )
+    assert row['state'] == 'Completed, Succeeded'
+    assert row['audio_files'] == [str(Path('/done/track1.flac'))]
+
+
 def test_usenet_thread_errors_when_completed_with_no_path_at_all() -> None:
     """No final save_path AND no incomplete_path → there's nothing to
     scan, so the thread errors (rather than spinning or finalizing a

--- a/tests/test_torrent_usenet_plugins.py
+++ b/tests/test_torrent_usenet_plugins.py
@@ -445,11 +445,18 @@ class _FakeClock:
         self.now += seconds
 
 
-def _drive_download_thread(plugin, statuses, *, window_seconds=10.0):
+def _drive_download_thread(plugin, statuses, *, window_seconds=10.0, snapshot=None):
     """Run ``_download_thread`` end-to-end against a scripted adapter.
 
     ``statuses`` is the sequence of ``UsenetStatus`` reads the poll loop
-    will see (one per poll). Returns the finished active_downloads row."""
+    will see (one per poll). Returns the finished active_downloads row.
+
+    ``snapshot`` stubs the P2-21 incomplete_path stability check
+    (``snapshot_incomplete_path``) — a real filesystem probe that would
+    otherwise return ``None`` for the fake ``/sab/...`` test paths and
+    make the fallback branch un-testable. Defaults to a fixed value so
+    two consecutive polls always look "stable" once reached; pass a
+    ``side_effect`` list/callable to simulate a still-changing path."""
     download_id = 'u-poll'
     plugin.active_downloads[download_id] = {
         'id': download_id, 'filename': 'x', 'username': 'usenet',
@@ -462,11 +469,14 @@ def _drive_download_thread(plugin, statuses, *, window_seconds=10.0):
     adapter.add_nzb.return_value = 'job1'
     adapter.get_status.side_effect = list(statuses)
     clock = _FakeClock()
+    snapshot_patch_kwargs = {'return_value': ('fixed', 1, 0.0)} if snapshot is None else snapshot
     with patch('core.download_plugins.usenet.get_active_usenet_adapter', return_value=adapter), \
          patch('core.download_plugins.usenet.run_async', side_effect=lambda x: x), \
          patch('core.download_plugins.usenet.get_completed_no_path_window_seconds',
                return_value=window_seconds), \
          patch('core.download_plugins.usenet.time', clock), \
+         patch('core.download_plugins.usenet.snapshot_incomplete_path',
+               **snapshot_patch_kwargs), \
          patch('core.download_plugins.usenet.collect_audio_after_extraction',
                return_value=[Path('/done/track1.flac')]):
         plugin._download_thread(download_id, 'http://x/y.nzb')
@@ -498,8 +508,9 @@ def test_usenet_thread_waits_out_completed_no_path_then_finalizes(tmp_path: Path
 
 def test_usenet_thread_falls_back_to_incomplete_path_when_storage_never_lands() -> None:
     """If ``storage`` never lands but SAB exposed an ``incomplete_path``
-    (files physically on disk), the thread recovers via the in-progress
-    dir as a last resort rather than erroring a completed download."""
+    (files physically on disk) whose fingerprint has stopped changing
+    (P2-21), the thread recovers via the in-progress dir as a last resort
+    rather than erroring a completed download."""
     plugin = UsenetDownloadPlugin()
     completed_no_path = UsenetStatus(
         id='job1', name='A', state='completed', progress=1.0,
@@ -507,8 +518,29 @@ def test_usenet_thread_falls_back_to_incomplete_path_when_storage_never_lands() 
         save_path=None, incomplete_path='/sab/incomplete/A',
     )
     # Window of 10s / 2s interval = 5 polls, floored at the miss
-    # threshold; supply plenty so the fallback fires.
+    # threshold; supply plenty so the fallback (plus one extra
+    # stability-confirmation poll) fires.
     row = _drive_download_thread(plugin, [completed_no_path] * 12)
+    assert row['state'] == 'Completed, Succeeded'
+    assert row['audio_files'] == [str(Path('/done/track1.flac'))]
+
+
+def test_usenet_thread_waits_for_incomplete_path_to_stop_changing() -> None:
+    """P2-21: the window elapsing alone must not trigger the fallback —
+    while the client is still writing into ``incomplete_path`` (fingerprint
+    keeps changing), the thread keeps polling instead of finalizing a
+    possibly-partial directory. Once it stabilizes, it recovers."""
+    plugin = UsenetDownloadPlugin()
+    completed_no_path = UsenetStatus(
+        id='job1', name='A', state='completed', progress=1.0,
+        size=100, downloaded=100, download_speed=0,
+        save_path=None, incomplete_path='/sab/incomplete/A',
+    )
+    growing = iter([1, 2, 3, 4, 4, 4, 4, 4])
+    row = _drive_download_thread(
+        plugin, [completed_no_path] * 20,
+        snapshot={'side_effect': lambda path: (next(growing, 4), 1, 0.0)},
+    )
     assert row['state'] == 'Completed, Succeeded'
     assert row['audio_files'] == [str(Path('/done/track1.flac'))]
 

--- a/tests/test_torrent_usenet_plugins.py
+++ b/tests/test_torrent_usenet_plugins.py
@@ -161,19 +161,25 @@ def test_torrent_project_results_drops_releases_without_download_url() -> None:
 
 
 def test_torrent_project_results_prefers_magnet_when_available() -> None:
+    from core.download_plugins.candidate_store import get_candidate_store
     plugin = TorrentDownloadPlugin()
     magnet = 'magnet:?xt=urn:btih:abc'
     results = [_make_torrent_result(magnet_uri=magnet, download_url='https://x/y.torrent')]
     tracks, _ = plugin._project_results(results)
-    url, _ = _decode_filename(tracks[0].filename)
-    assert url == magnet
+    token, _ = _decode_filename(tracks[0].filename)
+    assert get_candidate_store().resolve(token) == magnet
 
 
-def test_torrent_project_results_encodes_url_and_title_in_filename() -> None:
+def test_torrent_project_results_encodes_token_and_title_in_filename() -> None:
+    """P0-03: the filename that reaches the browser carries an opaque
+    candidate token — never the indexer download URL (may embed API keys)."""
+    from core.download_plugins.candidate_store import get_candidate_store
     plugin = TorrentDownloadPlugin()
     tracks, _ = plugin._project_results([_make_torrent_result()])
-    url, display = _decode_filename(tracks[0].filename)
-    assert url == 'https://x/y.torrent'
+    token, display = _decode_filename(tracks[0].filename)
+    assert 'https://x/y.torrent' not in tracks[0].filename
+    assert get_candidate_store().is_token(token)
+    assert get_candidate_store().resolve(token) == 'https://x/y.torrent'
     assert display == 'Danny Brown - Atrocity Exhibition [FLAC]'
 
 
@@ -395,11 +401,14 @@ def test_usenet_project_drops_results_without_download_url() -> None:
     assert tracks == []
 
 
-def test_usenet_project_encodes_url_in_filename() -> None:
+def test_usenet_project_encodes_token_in_filename() -> None:
+    """P0-03: the browser sees an opaque candidate token, never the NZB URL."""
+    from core.download_plugins.candidate_store import get_candidate_store
     plugin = UsenetDownloadPlugin()
     tracks, _ = plugin._project_results([_make_usenet_result()])
-    url, display = _decode_filename(tracks[0].filename)
-    assert url == 'https://x/y.nzb'
+    token, display = _decode_filename(tracks[0].filename)
+    assert 'https://x/y.nzb' not in tracks[0].filename
+    assert get_candidate_store().resolve(token) == 'https://x/y.nzb'
     assert display == 'Some Artist - Some Album'
     # Artist + title should be parsed out, not auto-extracted from filename.
     assert tracks[0].artist == 'Some Artist'

--- a/tests/test_torrent_usenet_plugins.py
+++ b/tests/test_torrent_usenet_plugins.py
@@ -575,6 +575,29 @@ def test_usenet_thread_resolves_incomplete_path_before_stability_check() -> None
     assert row['audio_files'] == [str(Path('/done/track1.flac'))]
 
 
+def test_usenet_thread_gives_up_when_incomplete_path_is_never_readable() -> None:
+    """Sibling of the same cap added to ``poll_album_download``: if
+    ``incomplete_path`` can never be read at all (e.g. no
+    ``usenet_path_mappings`` entry for a split-container deployment, not
+    just an unresolved-but-real path), the stability snapshot returns
+    ``None`` on every single poll and can never stabilize. After a
+    handful of consecutive unreadable polls the thread must give up with
+    the same error the pre-stability-gate code used, rather than quietly
+    retrying for the full outer deadline (6h)."""
+    plugin = UsenetDownloadPlugin()
+    completed_no_path = UsenetStatus(
+        id='job1', name='A', state='completed', progress=1.0,
+        size=100, downloaded=100, download_speed=0,
+        save_path=None, incomplete_path='/sab/incomplete/A',
+    )
+    row = _drive_download_thread(
+        plugin, [completed_no_path] * 30,
+        snapshot={'return_value': None},
+    )
+    assert row['state'] == 'Completed, Errored'
+    assert 'never reported a save_path' in (row['error'] or '').lower()
+
+
 def test_usenet_thread_errors_when_completed_with_no_path_at_all() -> None:
     """No final save_path AND no incomplete_path → there's nothing to
     scan, so the thread errors (rather than spinning or finalizing a

--- a/tests/test_usenet_client_adapters.py
+++ b/tests/test_usenet_client_adapters.py
@@ -70,6 +70,30 @@ def test_sab_is_configured_requires_url_and_key() -> None:
     assert _sab_with_config('http://x', 'k').is_configured() is True
 
 
+def test_sab_category_exists_uses_authenticated_category_list() -> None:
+    adapter = _sab_with_config()
+    with patch(
+        'core.usenet_clients.sabnzbd.http_requests.get',
+        return_value=_mock_response(200, {
+            'categories': ['*', 'Music', 'SoulSync'],
+        }),
+    ) as mock_get:
+        assert _run(adapter.category_exists('soulsync')) is True
+
+    params = mock_get.call_args.kwargs['params']
+    assert params['mode'] == 'get_cats'
+    assert params['apikey'] == 'k'
+
+
+def test_sab_category_exists_fails_closed_on_invalid_response() -> None:
+    adapter = _sab_with_config()
+    with patch(
+        'core.usenet_clients.sabnzbd.http_requests.get',
+        return_value=_mock_response(200, {'status': True}),
+    ):
+        assert _run(adapter.category_exists('soulsync')) is False
+
+
 def test_sab_state_mapping_covers_queue_states() -> None:
     assert sab_map('Downloading') == 'downloading'
     assert sab_map('Verifying') == 'verifying'

--- a/tests/test_usenet_client_adapters.py
+++ b/tests/test_usenet_client_adapters.py
@@ -64,6 +64,22 @@ def _sab_with_config(url='http://sab:8080', api_key='k'):
     return adapter
 
 
+def test_sab_load_config_strips_incidental_category_whitespace() -> None:
+    """The connection test validates a stripped category against SAB's
+    category list; the adapter must submit that SAME stripped value, or a
+    category configured with incidental whitespace (e.g. a copy-paste)
+    passes the check but still gets silently rewritten to '*' by SAB on
+    the real submit."""
+    with patch('core.usenet_clients.sabnzbd.config_manager') as cm:
+        cm.get.side_effect = lambda key, default=None: {
+            'usenet_client.url': 'http://sab:8080',
+            'usenet_client.api_key': 'k',
+            'usenet_client.category': 'soulsync ',
+        }.get(key, default)
+        adapter = SABnzbdAdapter()
+    assert adapter._category == 'soulsync'
+
+
 def test_sab_is_configured_requires_url_and_key() -> None:
     assert _sab_with_config('http://x', '').is_configured() is False
     assert _sab_with_config('', 'k').is_configured() is False

--- a/tests/test_usenet_connection_test.py
+++ b/tests/test_usenet_connection_test.py
@@ -1,0 +1,68 @@
+"""Settings connection checks that protect Usenet acquisition recovery."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from core import connection_test
+
+
+def _config_get(values):
+    def get(key, default=None):
+        if key == "usenet_client":
+            return {}
+        return values.get(key, default)
+
+    return get
+
+
+def _run_sab_test(*, category_exists: bool):
+    values = {
+        "usenet_client.type": "sabnzbd",
+        "usenet_client.url": "http://sab:8080",
+        "usenet_client.api_key": "secret",
+        "usenet_client.category": "soulsync",
+    }
+    adapter = MagicMock()
+    adapter.is_configured.return_value = True
+    adapter.check_connection = AsyncMock(return_value=True)
+    adapter.category_exists = AsyncMock(return_value=category_exists)
+
+    with (
+        patch.object(
+            connection_test.config_manager,
+            "get",
+            side_effect=_config_get(values),
+        ),
+        patch.object(connection_test.config_manager, "set"),
+        patch.object(connection_test, "docker_resolve_url", side_effect=lambda value: value),
+        patch("core.usenet_clients.adapter_for_type", return_value=adapter),
+    ):
+        result = connection_test.run_service_test(
+            "usenet_client",
+            {
+                "type": "sabnzbd",
+                "url": "http://sab:8080",
+                "api_key": "secret",
+                "category": "soulsync",
+            },
+        )
+    return result, adapter
+
+
+def test_sab_connection_test_rejects_missing_acquisition_category() -> None:
+    result, adapter = _run_sab_test(category_exists=False)
+
+    assert result == (
+        False,
+        "Connected to SABnzbd, but category 'soulsync' is not configured "
+        "there. Add the same category in SABnzbd before enabling acquisition.",
+    )
+    adapter.category_exists.assert_awaited_once_with("soulsync")
+
+
+def test_sab_connection_test_accepts_configured_acquisition_category() -> None:
+    result, adapter = _run_sab_test(category_exists=True)
+
+    assert result == (True, "Connected to sabnzbd")
+    adapter.category_exists.assert_awaited_once_with("soulsync")

--- a/tests/utils/test_async_helpers.py
+++ b/tests/utils/test_async_helpers.py
@@ -1,0 +1,29 @@
+"""Regression tests for the shared synchronous-to-async bridge."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_first_run_async_call_waits_for_event_loop_startup():
+    repo_root = Path(__file__).resolve().parents[2]
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import asyncio; "
+                "from utils.async_helpers import run_async; "
+                "assert run_async(asyncio.sleep(0, result='ready')) == 'ready'"
+            ),
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/utils/test_async_helpers.py
+++ b/tests/utils/test_async_helpers.py
@@ -2,9 +2,46 @@
 
 from __future__ import annotations
 
+import asyncio
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
+
+from utils.async_helpers import run_async
+
+
+def test_concurrent_run_async_calls_interleave_instead_of_serializing():
+    """Two run_async calls from different threads must run concurrently on
+    the shared loop (each yielding at its own await points) rather than
+    fully serialize one behind the other. A slow, unrelated coroutine must
+    not head-of-line-block a fast one queued shortly after it."""
+    results = {}
+
+    def slow():
+        run_async(asyncio.sleep(0.5))
+
+    def fast():
+        time.sleep(0.1)  # start once `slow` is already in flight
+        start = time.monotonic()
+        run_async(asyncio.sleep(0.01))
+        results['fast_duration'] = time.monotonic() - start
+
+    t_slow = threading.Thread(target=slow)
+    t_fast = threading.Thread(target=fast)
+    t_slow.start()
+    t_fast.start()
+    t_slow.join()
+    t_fast.join()
+
+    # Fully serialized behind `slow` would take ~0.4s (0.5 - 0.1 already
+    # elapsed); real concurrency keeps it close to its own 0.01s sleep.
+    assert results['fast_duration'] < 0.3, (
+        f"fast run_async call took {results['fast_duration']}s -- "
+        "it was serialized behind an unrelated slow call instead of "
+        "running concurrently"
+    )
 
 
 def test_first_run_async_call_waits_for_event_loop_startup():

--- a/utils/async_helpers.py
+++ b/utils/async_helpers.py
@@ -1,24 +1,41 @@
 import asyncio
+import concurrent.futures
+import queue
 import threading
 
 _loop = None
 _thread = None
+_jobs = queue.Queue()
 _lock = threading.Lock()
 
 
-def _run_loop(loop):
+def _run_loop(loop, ready):
     asyncio.set_event_loop(loop)
-    loop.run_forever()
+    ready.set()
+    while True:
+        coro, future = _jobs.get()
+        if not future.set_running_or_notify_cancel():
+            coro.close()
+            continue
+        try:
+            result = loop.run_until_complete(coro)
+        except BaseException as exc:
+            future.set_exception(exc)
+        else:
+            future.set_result(result)
 
 
 def _get_loop():
     global _loop, _thread
-    if _loop is None or _loop.is_closed():
+    if _loop is None or _loop.is_closed() or _thread is None or not _thread.is_alive():
         with _lock:
-            if _loop is None or _loop.is_closed():
+            if _loop is None or _loop.is_closed() or _thread is None or not _thread.is_alive():
                 _loop = asyncio.new_event_loop()
-                _thread = threading.Thread(target=_run_loop, args=(_loop,), daemon=True)
+                ready = threading.Event()
+                _thread = threading.Thread(target=_run_loop, args=(_loop, ready), daemon=True)
                 _thread.start()
+                if not ready.wait(timeout=5):
+                    raise RuntimeError("Async event loop thread failed to start")
     return _loop
 
 
@@ -30,6 +47,7 @@ def run_async(coro):
     This avoids creating/destroying event loops per call (FD leak)
     and works correctly with both long-lived and short-lived threads.
     """
-    loop = _get_loop()
-    future = asyncio.run_coroutine_threadsafe(coro, loop)
+    _get_loop()
+    future = concurrent.futures.Future()
+    _jobs.put((coro, future))
     return future.result()

--- a/utils/async_helpers.py
+++ b/utils/async_helpers.py
@@ -1,28 +1,20 @@
 import asyncio
-import concurrent.futures
-import queue
 import threading
 
 _loop = None
 _thread = None
-_jobs = queue.Queue()
 _lock = threading.Lock()
 
 
 def _run_loop(loop, ready):
     asyncio.set_event_loop(loop)
-    ready.set()
-    while True:
-        coro, future = _jobs.get()
-        if not future.set_running_or_notify_cancel():
-            coro.close()
-            continue
-        try:
-            result = loop.run_until_complete(coro)
-        except BaseException as exc:
-            future.set_exception(exc)
-        else:
-            future.set_result(result)
+    # Scheduled via call_soon (same-thread), not set as the first statement:
+    # this only fires once run_forever() actually starts pumping the loop's
+    # ready queue, so _get_loop() can safely hand the loop to
+    # run_coroutine_threadsafe() the instant `ready` is set, closing the
+    # startup race where a caller submits before the loop is truly running.
+    loop.call_soon(ready.set)
+    loop.run_forever()
 
 
 def _get_loop():
@@ -44,10 +36,11 @@ def run_async(coro):
 
     A dedicated daemon thread runs one event loop for the entire process.
     Callers submit coroutines and block until the result is ready.
-    This avoids creating/destroying event loops per call (FD leak)
-    and works correctly with both long-lived and short-lived threads.
+    This avoids creating/destroying event loops per call (FD leak),
+    works correctly with both long-lived and short-lived threads, and lets
+    concurrently-submitted coroutines interleave at their own await points
+    instead of fully serializing one caller behind another.
     """
-    _get_loop()
-    future = concurrent.futures.Future()
-    _jobs.put((coro, future))
+    loop = _get_loop()
+    future = asyncio.run_coroutine_threadsafe(coro, loop)
     return future.result()

--- a/web_server.py
+++ b/web_server.py
@@ -7740,7 +7740,8 @@ def clear_finished_downloads():
 # Streaming sources where the candidate's `username` field IS the source name
 # (Soulseek uses a real peer username; everything else stamps the source string).
 _STREAMING_SOURCE_NAMES = frozenset((
-    'youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'lidarr', 'soundcloud'
+    'youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'lidarr', 'soundcloud', 'amazon',
+    'torrent', 'usenet',
 ))
 
 


### PR DESCRIPTION
These are miscellaneous fixes that came out of building and stress-testing a larger library-management feature I'm working on against real libraries .. downloads, tag writing, imports, quality profiles. Every item below is a bug I actually hit (or found while reviewing the fix for one I'd hit), and I reproduced each one before touching the code. Grouped by area, each with what was broken and what's different now.

 I'm opening this separately, ahead of libary v2, these fixes stand on their own... so there's no reason to sit on them until then.

### Security — indexer URLs never reach the browser (P0-03)

**Before:** Search results for torrent/usenet candidates embedded the raw indexer download URL (magnet link or NZB link) directly in the `filename` field sent to the frontend. Some private-tracker/Prowlarr URLs carry API keys or signed, time-limited parameters — those were sitting in plain sight in the browser's network tab and local state.

**Now:** Search results carry an opaque, server-generated token instead. The download endpoint resolves the token back to the real URL server-side, in a TTL-capped in-memory store. A raw URL or a forged/expired token is rejected outright — the client can no longer make SoulSync forward an arbitrary URL to the download client.

**Follow-up fix:** the token store's `put()` captured its expiry timestamp *before* acquiring its lock, so under concurrent search traffic near the store's size cap, a `put()` call could evict the very token it just created and hand back a token that was already dead. Moved the timestamp capture inside the lock so insertion order and eviction order can't diverge.

### Downloads — stuck/failed jobs that actually succeeded

**Before (P2-21):** When a usenet/torrent client reports a completed job but never exposes the final `save_path` (SAB does this routinely — `Completed` flips in History before `storage` is populated), SoulSync fell back to the client's in-progress directory *the moment* a wait window elapsed — without checking whether the client's own post-processing (unpack, repair, move) was still writing into that directory. That could mean staging a partially-written directory.

**Now:** the fallback requires the directory's on-disk fingerprint (size/file-count/mtime) to be identical across two consecutive polls before it's trusted. If it's still changing, SoulSync keeps waiting, bounded by the overall timeout instead of the short window.

**Follow-up fix #1:** that stability check ran on the *client-reported* path — for split-container setups (SAB in a different container/host than SoulSync, using `usenet_path_mappings`), that path was never locally readable in the first place, so the fingerprint always read "unreadable" and could never stabilize. The download would then hang for the full outer timeout (6h) instead of recovering within ~2 minutes. Fixed by resolving the remote-mount path *before* fingerprinting, not just on the final return value.

**Follow-up fix #2:** an in-progress directory that exists but is currently empty (created by the client, not populated yet) fingerprints as `(0 bytes, 0 files)` on every poll — two empty reads in a row looked identical to "stopped changing." Added a floor requiring at least one file before a fingerprint counts as stable.

**Also:** torrent/usenet downloads used to fall into the same retry-budget bucket as Soulseek peers, so an exhausted torrent search could burn through budget that should've been separate from a parallel Soulseek attempt. They now get their own budgets — and a stale, separate copy of the source-name list in `web_server.py` that still bucketed them under "soulseek" for UI display got synced to match.

### Async bridge — Python 3.14 compatibility without losing concurrency

**Before:** `run_async()`, the single shared bridge every sync call site uses to run a coroutine (download status polls, search, connection tests, web request handlers — ~150+ call sites), stopped reliably starting its background event-loop thread on Python 3.14.

**The original fix's side effect:** it replaced the shared `run_forever()` event loop (which lets many coroutines from different threads run concurrently, each yielding at its own `await` points) with a single-worker queue that runs one coroutine to *full completion* before starting the next — silently serializing every `run_async()` caller in the whole process. Confirmed by timing it directly: 3 threads each doing a 1-second async sleep took ~1 second concurrently before, ~3 seconds serialized after. In practice that means one slow network call (an unresponsive indexer, a stalled client) would head-of-line-block every unrelated download's status polling, search requests, and connection tests until it finished.

**Now:** back to the concurrent `run_forever()` model, keeping only the actual startup-race fix — a readiness signal (`loop.call_soon(ready.set)`) that only fires once the loop is genuinely pumping, so the first caller can't submit before the loop is ready without giving up concurrency to get there.

### Import pipeline — track numbers

**Before (§16.3(a)):** when no source (metadata, filename, embedded tag) carried a track number, the pipeline defaulted every un-numbered track in an album to track 1 — so a whole album with missing numbers collapsed onto one slot, and the library showed one track present and the rest "missing."

**The fix:** as a last resort, use the file's sorted position among its audio siblings on disk — the reasoning being that album-bundle downloads stage all of an album's files into one directory together, so sorted order is at least a distinct, if imperfect, fallback.

**Follow-up fix:** that reasoning only holds for genuine album-bundle downloads. A plain Soulseek download instead lands in a *shared* flat directory that can hold other, unrelated in-flight downloads at the same time — so an un-numbered single track could get assigned a position among files from a completely different download. Restricted the fallback to `is_album_download` contexts, which also incidentally closes a race where concurrent import workers processing the same folder could see a shrinking sibling list (as files get moved out mid-processing) and assign colliding numbers.

### Tag writer — false-positive retag warnings, and closing the gaps in that fix

**Before:** the "Re-tag" preview flagged files as needing a rewrite purely because of formatting differences — a full ISO timestamp on the file vs. a plain date in the DB, or a rich multi-genre tag getting flagged for "changing" to a generic single genre pulled from an enrichment pass.

**The fix:** normalize dates before comparing, and don't flag a genre change when the DB's value is already contained in the file's existing genre list.

**Follow-up fix #1:** the date-normalizer's regex required a time-of-day component to match at all, so the single most common shape of this exact problem — a bare `YYYY-MM-DD` on one side vs. `YYYY-MM-DDT00:00:00` on the other — was never actually recognized as equal, leaving the false positive it was written for unfixed for that case.

**Follow-up fix #2:** the "keep the existing date" logic used string *length* as a proxy for "more specific," so a stale, genuinely wrong existing date (`2023-01-01`, same year, wrong month/day) could permanently block a real, shorter correction (`2023-09-05`) from ever being written.

**Follow-up fix #3:** the genre-diff suppression only existed in the *preview* — `write_tags_to_file` had no matching check. A batch write (which pre-filters files using the preview's verdict) would silently skip a file whose only real change was a genre narrowing, while a single-track write (which calls the writer directly, bypassing the preview) would still apply it — two different outcomes for the exact same data, depending only on which button you clicked. Extracted the subset check into a shared helper so the preview and the actual write always agree.

### Also in this batch
- SABnzbd category whitespace: the new connection-test category check strips the configured category before validating it against SAB's category list, but the adapter never stripped it before submitting — a category with incidental whitespace could pass the check and still get silently rewritten to `*` by SAB on the real download.
- `delete_quality_profile` now guarantees a default profile survives any deletion, even if `is_default` bookkeeping was ever left inconsistent by an older bug or a hand-edited DB.
- Simple/direct downloads (no provider enhancement) now get title/artist/album written into their tags instead of staying untagged.
- Automation progress is clamped to 0–100%, so a counter race under load can't show >100% in the UI.