### PR TITLE
Add strict discography provider outcomes and Library source selection

### DIFF
--- a/core/metadata/discography_providers.py
+++ b/core/metadata/discography_providers.py
@@ -1,0 +1,215 @@
+"""Provider adapters for strict artist-discography lookups.
+
+Every adapter exposes the same provider-independent request/result contract. The
+legacy metadata methods remain untouched for background and best-effort flows.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List
+
+from core.metadata.album_tracks import _extract_lookup_value, _pick_best_artist_match
+from core.metadata.discography_result import DiscographyOutcome, DiscographyRequest
+from core.metadata.provider_access import (
+    ProviderAccessError,
+    allow_provider_not_found,
+    call_discography_provider,
+)
+from utils.logging_config import get_logger
+
+logger = get_logger("metadata.discography.providers")
+
+
+class DiscographyProviderAdapter(ABC):
+    """Single responsibility: execute one provider's discography operation."""
+
+    def __init__(self, source: str, client: Any):
+        self.source = (source or "unknown").strip().lower() or "unknown"
+        self.client = client
+
+    @abstractmethod
+    def load(self, request: DiscographyRequest) -> DiscographyOutcome:
+        """Return RESULTS, EMPTY or ACCESS_ERROR for this provider only."""
+
+    def _execute(self, callback) -> DiscographyOutcome:
+        try:
+            releases = call_discography_provider(
+                self.source,
+                self.client,
+                callback,
+            ) or []
+        except ProviderAccessError as exc:
+            return DiscographyOutcome.access_error(
+                self.source,
+                str(exc),
+                operation=exc.operation,
+                status_code=exc.status_code,
+            )
+
+        if releases:
+            return DiscographyOutcome.results(self.source, releases)
+        return DiscographyOutcome.empty(self.source)
+
+
+class StandardDiscographyProviderAdapter(DiscographyProviderAdapter):
+    """Adapter for providers exposing get_artist_albums/search_artists."""
+
+    def _spotify_free_active(self, client: Any) -> bool:
+        if self.source != "spotify":
+            return False
+        try:
+            return bool(getattr(client, "_free_active", lambda: False)())
+        except Exception:
+            return False
+
+    def _search_spotify_free_artists(
+        self,
+        client: Any,
+        artist_name: str,
+        limit: int,
+    ) -> List[Any]:
+        free_client = getattr(client, "_free_meta", None)
+        if free_client is None or not hasattr(free_client, "search_artists"):
+            return []
+        return free_client.search_artists(artist_name, limit) or []
+
+    def _load_with_client(
+        self,
+        client: Any,
+        request: DiscographyRequest,
+    ) -> List[Any]:
+        if not hasattr(client, "get_artist_albums"):
+            return []
+
+        spotify_free = self._spotify_free_active(client)
+
+        def fetch_for_artist(target_artist_id: str) -> List[Any]:
+            kwargs: Dict[str, Any] = {
+                "album_type": "album,single",
+                "limit": request.limit,
+            }
+            if self.source in {"jiosaavn", "bandcamp"}:
+                kwargs["artist_name"] = request.artist_name
+            if self.source == "spotify":
+                # Spotify Free is still Spotify. Cross-provider fallbacks inside
+                # SpotifyClient remain disabled for the strict provider path.
+                kwargs["allow_fallback"] = spotify_free and not target_artist_id.isdigit()
+                kwargs["skip_cache"] = request.skip_cache
+                kwargs["max_pages"] = request.max_pages
+
+            with allow_provider_not_found(client):
+                return client.get_artist_albums(target_artist_id, **kwargs) or []
+
+        releases = fetch_for_artist(request.artist_id) if request.artist_id else []
+        if releases or not request.artist_name:
+            return releases
+
+        if spotify_free:
+            search_results = self._search_spotify_free_artists(
+                client,
+                request.artist_name,
+                5,
+            )
+        else:
+            search_artists = getattr(client, "search_artists", None)
+            if not callable(search_artists):
+                return releases
+
+            search_kwargs: Dict[str, Any] = {"limit": 5}
+            if self.source == "spotify":
+                search_kwargs["allow_fallback"] = False
+            search_results = search_artists(
+                request.artist_name,
+                **search_kwargs,
+            ) or []
+
+        best = _pick_best_artist_match(search_results, request.artist_name)
+        if not best:
+            return releases
+
+        found_artist_id = _extract_lookup_value(best, "id", "artist_id")
+        if not found_artist_id:
+            return releases
+
+        resolved = fetch_for_artist(str(found_artist_id))
+        if resolved:
+            logger.debug(
+                "Found %s artist '%s' (id=%s)",
+                self.source,
+                _extract_lookup_value(best, "name", "artist_name", "title"),
+                found_artist_id,
+            )
+        return resolved
+
+    def load(self, request: DiscographyRequest) -> DiscographyOutcome:
+        return self._execute(
+            lambda isolated: self._load_with_client(isolated, request)
+        )
+
+
+class MusicBrainzDiscographyProviderAdapter(DiscographyProviderAdapter):
+    """MusicBrainz implementation of the same discography contract."""
+
+    def _load_with_client(
+        self,
+        client: Any,
+        request: DiscographyRequest,
+    ) -> List[Any]:
+        # MusicBrainzSearchClient currently exposes its artist-discography flow
+        # through search_albums. The strict adapter owns only the operation
+        # mapping; the orchestrator remains provider-agnostic.
+        if request.artist_name and hasattr(client, "search_albums"):
+            return client.search_albums(
+                request.artist_name,
+                limit=request.limit,
+            ) or []
+
+        if request.artist_id:
+            nested = getattr(client, "_client", None)
+            browse = getattr(nested, "browse_artist_release_groups", None)
+            convert = getattr(client, "_release_group_to_album", None)
+            if callable(browse) and callable(convert):
+                release_groups = browse(
+                    request.artist_id,
+                    release_types=["album", "ep", "single", "other"],
+                    limit=request.limit,
+                ) or []
+                return [
+                    convert(group, request.artist_name)
+                    for group in release_groups
+                    if group
+                ]
+
+        return []
+
+    def load(self, request: DiscographyRequest) -> DiscographyOutcome:
+        return self._execute(
+            lambda isolated: self._load_with_client(isolated, request)
+        )
+
+
+_ADAPTERS = {
+    "musicbrainz": MusicBrainzDiscographyProviderAdapter,
+}
+
+
+def get_discography_provider_adapter(
+    source: str,
+    client: Any,
+) -> DiscographyProviderAdapter:
+    """Return the adapter implementing the common contract for ``source``."""
+
+    adapter_type = _ADAPTERS.get(
+        (source or "").strip().lower(),
+        StandardDiscographyProviderAdapter,
+    )
+    return adapter_type(source, client)
+
+
+__all__ = [
+    "DiscographyProviderAdapter",
+    "MusicBrainzDiscographyProviderAdapter",
+    "StandardDiscographyProviderAdapter",
+    "get_discography_provider_adapter",
+]

--- a/core/metadata/discography_result.py
+++ b/core/metadata/discography_result.py
@@ -1,0 +1,128 @@
+"""Typed three-state results for artist-discography provider operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Tuple
+
+
+class DiscographyStatus(str, Enum):
+    """Outcome of one provider's artist-discography operation."""
+
+    RESULTS = "results"
+    EMPTY = "empty"
+    ACCESS_ERROR = "access_error"
+
+
+@dataclass(frozen=True)
+class DiscographyRequest:
+    """Provider-independent input for one artist-discography lookup."""
+
+    artist_id: str = ""
+    artist_name: str = ""
+    limit: int = 50
+    skip_cache: bool = False
+    max_pages: int = 0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "artist_id", str(self.artist_id or "").strip())
+        object.__setattr__(self, "artist_name", str(self.artist_name or "").strip())
+        if self.limit < 1:
+            raise ValueError("DiscographyRequest.limit must be at least 1")
+        if self.max_pages < 0:
+            raise ValueError("DiscographyRequest.max_pages cannot be negative")
+
+
+@dataclass(frozen=True)
+class DiscographyOutcome:
+    """Validated result returned by every discography provider adapter."""
+
+    status: DiscographyStatus
+    source: str
+    releases: Tuple[Any, ...] = ()
+    operation: str = "artist discography"
+    message: Optional[str] = None
+    status_code: int = 200
+
+    def __post_init__(self) -> None:
+        source = str(self.source or "unknown").strip().lower() or "unknown"
+        object.__setattr__(self, "source", source)
+        object.__setattr__(self, "releases", tuple(self.releases or ()))
+
+        if self.status is DiscographyStatus.RESULTS:
+            if not self.releases:
+                raise ValueError("RESULTS requires at least one release")
+            if self.message is not None:
+                raise ValueError("RESULTS cannot contain an error message")
+            if self.status_code >= 400:
+                raise ValueError("RESULTS cannot contain an error HTTP status")
+            return
+
+        if self.releases:
+            raise ValueError(f"{self.status.name} cannot contain releases")
+
+        if self.status is DiscographyStatus.EMPTY:
+            if self.message is not None:
+                raise ValueError("EMPTY cannot contain an error message")
+            if self.status_code >= 400 and self.status_code not in {404, 410}:
+                raise ValueError("EMPTY only supports success, 404 or 410 status codes")
+            return
+
+        if self.status is DiscographyStatus.ACCESS_ERROR:
+            if not str(self.message or "").strip():
+                raise ValueError("ACCESS_ERROR requires a message")
+            if self.status_code < 400:
+                raise ValueError("ACCESS_ERROR requires an error HTTP status")
+            return
+
+        raise ValueError(f"Unsupported discography status: {self.status!r}")
+
+    @classmethod
+    def results(cls, source: str, releases: Any) -> "DiscographyOutcome":
+        values = tuple(releases or ())
+        return cls(
+            status=DiscographyStatus.RESULTS,
+            source=source,
+            releases=values,
+            status_code=200,
+        )
+
+    @classmethod
+    def empty(
+        cls,
+        source: str,
+        *,
+        operation: str = "artist discography",
+        status_code: int = 404,
+    ) -> "DiscographyOutcome":
+        return cls(
+            status=DiscographyStatus.EMPTY,
+            source=source,
+            operation=operation,
+            status_code=status_code,
+        )
+
+    @classmethod
+    def access_error(
+        cls,
+        source: str,
+        message: str,
+        *,
+        operation: str = "artist discography",
+        status_code: int = 502,
+    ) -> "DiscographyOutcome":
+        return cls(
+            status=DiscographyStatus.ACCESS_ERROR,
+            source=source,
+            operation=operation,
+            message=message,
+            status_code=status_code,
+        )
+
+
+__all__ = [
+    "DiscographyOutcome",
+    "DiscographyRequest",
+    "DiscographyStatus",
+]

--- a/core/metadata/discography_strict.py
+++ b/core/metadata/discography_strict.py
@@ -1,130 +1,80 @@
-"""Three-state artist-discography orchestration.
+"""Strict three-state artist-discography orchestration.
 
-A valid provider response with no releases is an empty catalogue and may advance
-to the next configured source. A provider-access failure is a different state:
-it stops fallback and is returned to the web layer as a visible error.
-
-The strict path is intentionally limited to artist discography. Search, import
-and enrichment keep their existing best-effort behaviour.
+The orchestrator is provider-agnostic. Provider adapters own their operation and
+return RESULTS, EMPTY or ACCESS_ERROR. Search, import and enrichment keep their
+existing best-effort behaviour.
 """
 
 from __future__ import annotations
 
-from functools import partial
 from typing import Any, Dict, List, Optional
 
 from core.metadata import registry as metadata_registry
-from core.metadata.album_tracks import (
-    _extract_lookup_value,
-    _pick_best_artist_match,
-)
 from core.metadata.discography import (
     _build_artist_detail_release_card,
     _build_discography_release_dict,
     _dedup_variant_releases,
-    _get_source_chain_for_lookup,
     _sort_discography_releases,
 )
-from core.metadata.lookup import MetadataLookupOptions
-from core.metadata.provider_access import (
-    ProviderAccessError,
-    allow_provider_not_found,
-    call_discography_provider,
+from core.metadata.discography_providers import get_discography_provider_adapter
+from core.metadata.discography_result import (
+    DiscographyRequest,
+    DiscographyStatus,
 )
+from core.metadata.lookup import MetadataLookupOptions
 from utils.logging_config import get_logger
 
 logger = get_logger("metadata.discography.strict")
 
 
-def _spotify_free_active(client: Any) -> bool:
-    try:
-        return bool(getattr(client, "_free_active", lambda: False)())
-    except Exception:
-        return False
+def _get_strict_source_chain(options: MetadataLookupOptions) -> List[str]:
+    """Return the provider chain for the user-facing strict discography path.
 
-
-def _search_spotify_free_artists(client: Any, artist_name: str, limit: int) -> List[Any]:
-    """Search Spotify Free directly without enabling cross-provider fallback."""
-
-    free_client = getattr(client, "_free_meta", None)
-    if free_client is None or not hasattr(free_client, "search_artists"):
-        return []
-    return free_client.search_artists(artist_name, limit) or []
-
-
-def _get_artist_albums_with_client(
-    source: str,
-    client: Any,
-    artist_id: str,
-    *,
-    artist_name: str,
-    limit: int,
-    skip_cache: bool,
-    max_pages: int,
-) -> List[Any]:
-    """Run the exact-ID/name-resolution flow on one isolated client.
-
-    ``400``, ``404`` and ``410`` are treated as a valid empty result only while
-    resolving an explicit artist ID. Search failures remain provider-access
-    errors and stop the fallback chain.
+    An explicit source is authoritative and therefore exclusive. Automatic mode
+    preserves the configured priority and may continue after confirmed EMPTY.
     """
 
-    if not client or not hasattr(client, "get_artist_albums"):
-        return []
+    override = (options.source_override or "").strip().lower()
+    if override:
+        return [override]
 
-    spotify_free = source == "spotify" and _spotify_free_active(client)
+    primary_source = metadata_registry.get_primary_source()
+    source_chain = list(metadata_registry.get_source_priority(primary_source))
+    if not options.allow_fallback:
+        return source_chain[:1]
+    return source_chain
 
-    def fetch_for_artist(target_artist_id: str) -> List[Any]:
-        kwargs: Dict[str, Any] = {
-            "album_type": "album,single",
-            "limit": limit,
-        }
-        if source in {"jiosaavn", "bandcamp"}:
-            kwargs["artist_name"] = artist_name
-        if source == "spotify":
-            # Spotify Free is still the Spotify catalogue. Enabling fallback is
-            # safe only for a real Spotify ID: the client's numeric-ID branch is
-            # what delegates to iTunes/Deezer, so it remains disabled here.
-            kwargs["allow_fallback"] = spotify_free and not target_artist_id.isdigit()
-            kwargs["skip_cache"] = skip_cache
-            kwargs["max_pages"] = max_pages
 
-        with allow_provider_not_found(client):
-            return client.get_artist_albums(target_artist_id, **kwargs) or []
+def _lookup_artist_id(
+    source: str,
+    artist_id: str,
+    source_artist_ids: Dict[str, str],
+) -> str:
+    source_artist_id = str(source_artist_ids.get(source) or "").strip()
+    if source_artist_id:
+        return source_artist_id
+    if source_artist_ids:
+        return ""
+    return str(artist_id or "").strip()
 
-    albums = fetch_for_artist(artist_id) if artist_id else []
-    if albums or not artist_name:
-        return albums
 
-    if spotify_free:
-        search_results = _search_spotify_free_artists(client, artist_name, 5)
-    else:
-        search_artists = getattr(client, "search_artists", None)
-        if not callable(search_artists):
-            return albums
-
-        search_kwargs: Dict[str, Any] = {"limit": 5}
-        if source == "spotify":
-            search_kwargs["allow_fallback"] = False
-        search_results = search_artists(artist_name, **search_kwargs) or []
-
-    best = _pick_best_artist_match(search_results, artist_name)
-    if not best:
-        return albums
-
-    found_artist_id = _extract_lookup_value(best, "id", "artist_id")
-    if not found_artist_id:
-        return albums
-
-    resolved = fetch_for_artist(str(found_artist_id))
-    if resolved:
-        logger.debug(
-            "Found %s artist '%s' (id=%s)",
-            source,
-            _extract_lookup_value(best, "name", "artist_name", "title"),
-            found_artist_id,
-        )
-    return resolved
+def _error_response(
+    *,
+    source: str,
+    source_priority: List[str],
+    message: str,
+    status_code: int,
+) -> Dict[str, Any]:
+    return {
+        "success": False,
+        "state": "error",
+        "albums": [],
+        "singles": [],
+        "source": source,
+        "source_priority": source_priority,
+        "error": message,
+        "status_code": status_code,
+    }
 
 
 def get_artist_discography(
@@ -132,14 +82,14 @@ def get_artist_discography(
     artist_name: str = "",
     options: Optional[MetadataLookupOptions] = None,
 ) -> Dict[str, Any]:
-    """Return an artist discography with ``results`` / ``empty`` / ``error``.
+    """Return an artist discography with results / empty / error.
 
-    Fallback continues only after a provider completed successfully and returned
-    no releases. Any outbound communication failure stops the chain immediately.
+    Automatic mode continues only after a confirmed EMPTY. An explicit source
+    never crosses into another provider, regardless of ``allow_fallback``.
     """
 
     options = options or MetadataLookupOptions()
-    source_priority = _get_source_chain_for_lookup(options)
+    source_priority = _get_strict_source_chain(options)
     source_artist_ids = options.artist_source_ids or {}
     releases: List[Any] = []
     active_source: Optional[str] = None
@@ -147,50 +97,51 @@ def get_artist_discography(
     for source in source_priority:
         client = metadata_registry.get_client_for_source(source)
         if not client:
+            if options.source_override:
+                return _error_response(
+                    source=source,
+                    source_priority=source_priority,
+                    message=(
+                        f"Could not access {source} while loading the artist "
+                        "discography: provider is unavailable"
+                    ),
+                    status_code=503,
+                )
             continue
 
-        source_artist_id = str(source_artist_ids.get(source) or "").strip()
-        lookup_artist_id = (
-            source_artist_id
-            if source_artist_id
-            else artist_id if not source_artist_ids else ""
+        request = DiscographyRequest(
+            artist_id=_lookup_artist_id(
+                source,
+                artist_id,
+                source_artist_ids,
+            ),
+            artist_name=artist_name,
+            limit=options.limit,
+            skip_cache=options.skip_cache,
+            max_pages=options.max_pages,
         )
+        outcome = get_discography_provider_adapter(source, client).load(request)
 
-        try:
-            load_discography = partial(
-                _get_artist_albums_with_client,
-                source,
-                artist_id=lookup_artist_id,
-                artist_name=artist_name,
-                limit=options.limit,
-                skip_cache=options.skip_cache,
-                max_pages=options.max_pages,
-            )
-            releases = call_discography_provider(
-                source,
-                client,
-                load_discography,
-            ) or []
-        except ProviderAccessError as exc:
+        if outcome.status is DiscographyStatus.ACCESS_ERROR:
             logger.warning(
                 "Discography access failed for %s and fallback was stopped: %s",
                 source,
-                exc,
+                outcome.message,
             )
-            return {
-                "success": False,
-                "state": "error",
-                "albums": [],
-                "singles": [],
-                "source": source,
-                "source_priority": source_priority,
-                "error": str(exc),
-                "status_code": exc.status_code,
-            }
+            return _error_response(
+                source=source,
+                source_priority=source_priority,
+                message=str(outcome.message),
+                status_code=outcome.status_code,
+            )
 
-        if releases:
+        if outcome.status is DiscographyStatus.RESULTS:
+            releases = list(outcome.releases)
             active_source = source
             break
+
+        # EMPTY is the only state that may advance in automatic mode. For an
+        # explicit source the chain contains exactly one provider, so it ends.
 
     albums: List[Dict[str, Any]] = []
     singles: List[Dict[str, Any]] = []

--- a/core/metadata/discography_strict.py
+++ b/core/metadata/discography_strict.py
@@ -26,23 +26,82 @@ from utils.logging_config import get_logger
 
 logger = get_logger("metadata.discography.strict")
 
+LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY = "primary"
+LIBRARY_DISCOGRAPHY_SOURCE_AUTOMATIC = "automatic"
+LIBRARY_DISCOGRAPHY_EXPLICIT_SOURCES = frozenset(
+    {"itunes", "deezer", "musicbrainz", "spotify"}
+)
+COMMERCIAL_DISCOGRAPHY_SOURCE_PRIORITY = ("itunes", "deezer")
 
-def _get_strict_source_chain(options: MetadataLookupOptions) -> List[str]:
-    """Return the provider chain for the user-facing strict discography path.
 
-    An explicit source is authoritative and therefore exclusive. Automatic mode
-    preserves the configured priority and may continue after confirmed EMPTY.
+def _get_configured_library_discography_source() -> str:
+    """Return the independent Library discography-source setting.
+
+    Missing or invalid values preserve the legacy behaviour: use the primary
+    metadata source and its configured fallback chain.
+    """
+
+    try:
+        from config.settings import config_manager
+
+        raw_source = config_manager.get(
+            "metadata.library_discography_source",
+            LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY,
+        )
+    except Exception:
+        raw_source = LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY
+
+    source = str(raw_source or LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY).strip().lower()
+    valid_sources = {
+        LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY,
+        LIBRARY_DISCOGRAPHY_SOURCE_AUTOMATIC,
+        *LIBRARY_DISCOGRAPHY_EXPLICIT_SOURCES,
+    }
+    if source in valid_sources:
+        return source
+
+    logger.warning(
+        "Invalid Library discography source %r; using the primary metadata source",
+        raw_source,
+    )
+    return LIBRARY_DISCOGRAPHY_SOURCE_PRIMARY
+
+
+def _get_strict_source_plan(
+    options: MetadataLookupOptions,
+) -> tuple[List[str], bool]:
+    """Return ``(source_chain, unavailable_is_error)`` for Library discography.
+
+    A per-request override remains authoritative and exclusive. The independent
+    Library setting can select one exclusive provider, the commercial automatic
+    chain (iTunes then Deezer), or the existing primary-metadata behaviour.
     """
 
     override = (options.source_override or "").strip().lower()
     if override:
-        return [override]
+        return [override], True
+
+    configured_source = _get_configured_library_discography_source()
+    if configured_source in LIBRARY_DISCOGRAPHY_EXPLICIT_SOURCES:
+        return [configured_source], True
+
+    if configured_source == LIBRARY_DISCOGRAPHY_SOURCE_AUTOMATIC:
+        source_chain = list(COMMERCIAL_DISCOGRAPHY_SOURCE_PRIORITY)
+        if not options.allow_fallback:
+            source_chain = source_chain[:1]
+        return source_chain, True
 
     primary_source = metadata_registry.get_primary_source()
     source_chain = list(metadata_registry.get_source_priority(primary_source))
     if not options.allow_fallback:
-        return source_chain[:1]
-    return source_chain
+        source_chain = source_chain[:1]
+    return source_chain, False
+
+
+def _get_strict_source_chain(options: MetadataLookupOptions) -> List[str]:
+    """Return the provider chain for the user-facing strict discography path."""
+
+    return _get_strict_source_plan(options)[0]
 
 
 def _lookup_artist_id(
@@ -84,12 +143,13 @@ def get_artist_discography(
 ) -> Dict[str, Any]:
     """Return an artist discography with results / empty / error.
 
-    Automatic mode continues only after a confirmed EMPTY. An explicit source
-    never crosses into another provider, regardless of ``allow_fallback``.
+    Automatic mode continues only after a confirmed EMPTY. An explicit request
+    or configured Library provider never crosses into another provider,
+    regardless of ``allow_fallback``.
     """
 
     options = options or MetadataLookupOptions()
-    source_priority = _get_strict_source_chain(options)
+    source_priority, unavailable_is_error = _get_strict_source_plan(options)
     source_artist_ids = options.artist_source_ids or {}
     releases: List[Any] = []
     active_source: Optional[str] = None
@@ -97,7 +157,7 @@ def get_artist_discography(
     for source in source_priority:
         client = metadata_registry.get_client_for_source(source)
         if not client:
-            if options.source_override:
+            if unavailable_is_error:
                 return _error_response(
                     source=source,
                     source_priority=source_priority,

--- a/tests/metadata/test_discography_provider_outcomes.py
+++ b/tests/metadata/test_discography_provider_outcomes.py
@@ -270,7 +270,7 @@ def test_automatic_commercial_catalogue_stops_on_access_error(monkeypatch):
 
 
 def test_invalid_library_setting_falls_back_to_primary(monkeypatch):
-    primary = _StaticClient([_album("primary-album")])
+    primary = _MusicBrainzClient([_album("primary-album")])
     _configure_sources(
         monkeypatch,
         {"musicbrainz": primary},

--- a/tests/metadata/test_discography_provider_outcomes.py
+++ b/tests/metadata/test_discography_provider_outcomes.py
@@ -1,0 +1,195 @@
+"""Tests for typed provider-owned artist-discography outcomes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.metadata import registry as metadata_registry
+from core.metadata.discography_providers import (
+    MusicBrainzDiscographyProviderAdapter,
+    StandardDiscographyProviderAdapter,
+)
+from core.metadata.discography_result import (
+    DiscographyOutcome,
+    DiscographyRequest,
+    DiscographyStatus,
+)
+from core.metadata.discography_strict import get_artist_discography
+from core.metadata.lookup import MetadataLookupOptions
+
+
+def _album(album_id: str = "album-1"):
+    return SimpleNamespace(
+        id=album_id,
+        name="Album One",
+        release_date="2024-01-01",
+        album_type="album",
+        image_url=None,
+        total_tracks=10,
+        external_urls={},
+        artist_ids=["artist-1"],
+    )
+
+
+class _StaticClient:
+    def __init__(self, albums):
+        self.albums = list(albums)
+        self.calls = []
+
+    def get_artist_albums(self, artist_id, **kwargs):
+        self.calls.append((artist_id, dict(kwargs)))
+        return list(self.albums)
+
+
+class _MusicBrainzClient:
+    def __init__(self, albums):
+        self.albums = list(albums)
+        self.calls = []
+
+    def search_albums(self, query, limit=10):
+        self.calls.append((query, limit))
+        return list(self.albums)
+
+
+def _configure_sources(monkeypatch, clients, priority):
+    monkeypatch.setattr(
+        metadata_registry,
+        "get_primary_source",
+        lambda spotify_client_factory=None: priority[0],
+    )
+    monkeypatch.setattr(
+        metadata_registry,
+        "get_source_priority",
+        lambda primary_source: list(priority),
+    )
+    monkeypatch.setattr(
+        metadata_registry,
+        "get_client_for_source",
+        lambda source, **kwargs: clients.get(source),
+    )
+
+
+def test_results_outcome_requires_releases():
+    with pytest.raises(ValueError):
+        DiscographyOutcome(
+            status=DiscographyStatus.RESULTS,
+            source="deezer",
+        )
+
+
+def test_empty_outcome_cannot_contain_releases():
+    with pytest.raises(ValueError):
+        DiscographyOutcome(
+            status=DiscographyStatus.EMPTY,
+            source="deezer",
+            releases=(_album(),),
+            status_code=404,
+        )
+
+
+def test_access_error_requires_error_status():
+    with pytest.raises(ValueError):
+        DiscographyOutcome.access_error(
+            "deezer",
+            "failure",
+            status_code=200,
+        )
+
+
+def test_standard_adapter_returns_results():
+    client = _StaticClient([_album()])
+    outcome = StandardDiscographyProviderAdapter("deezer", client).load(
+        DiscographyRequest(artist_id="artist-1")
+    )
+
+    assert outcome.status is DiscographyStatus.RESULTS
+    assert [album.id for album in outcome.releases] == ["album-1"]
+
+
+def test_standard_adapter_returns_confirmed_empty():
+    client = _StaticClient([])
+    outcome = StandardDiscographyProviderAdapter("deezer", client).load(
+        DiscographyRequest(artist_id="artist-1")
+    )
+
+    assert outcome.status is DiscographyStatus.EMPTY
+    assert outcome.releases == ()
+
+
+def test_musicbrainz_uses_same_contract():
+    client = _MusicBrainzClient([_album("mb-album")])
+    outcome = MusicBrainzDiscographyProviderAdapter(
+        "musicbrainz",
+        client,
+    ).load(
+        DiscographyRequest(
+            artist_id="mbid",
+            artist_name="Artist One",
+            limit=25,
+        )
+    )
+
+    assert outcome.status is DiscographyStatus.RESULTS
+    assert [album.id for album in outcome.releases] == ["mb-album"]
+    assert client.calls == [("Artist One", 25)]
+
+
+def test_explicit_provider_is_exclusive_even_when_fallback_allowed(monkeypatch):
+    selected = _StaticClient([])
+    fallback = _StaticClient([_album("fallback-album")])
+    _configure_sources(
+        monkeypatch,
+        {"itunes": selected, "deezer": fallback},
+        ["deezer", "itunes"],
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(
+            source_override="itunes",
+            allow_fallback=True,
+        ),
+    )
+
+    assert result["state"] == "empty"
+    assert result["source"] == "itunes"
+    assert result["source_priority"] == ["itunes"]
+    assert len(selected.calls) == 1
+    assert fallback.calls == []
+
+
+def test_automatic_mode_continues_after_confirmed_empty(monkeypatch):
+    primary = _StaticClient([])
+    fallback = _StaticClient([_album("fallback-album")])
+    _configure_sources(
+        monkeypatch,
+        {"itunes": primary, "deezer": fallback},
+        ["itunes", "deezer"],
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(),
+    )
+
+    assert result["state"] == "results"
+    assert result["source"] == "deezer"
+    assert [album["id"] for album in result["albums"]] == ["fallback-album"]
+
+
+def test_unavailable_explicit_provider_is_error(monkeypatch):
+    _configure_sources(monkeypatch, {}, ["deezer"])
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(source_override="musicbrainz"),
+    )
+
+    assert result["state"] == "error"
+    assert result["source"] == "musicbrainz"
+    assert result["status_code"] == 503

--- a/tests/metadata/test_discography_provider_outcomes.py
+++ b/tests/metadata/test_discography_provider_outcomes.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from config.settings import config_manager
 from core.metadata import registry as metadata_registry
 from core.metadata.discography_providers import (
     MusicBrainzDiscographyProviderAdapter,
@@ -53,7 +54,21 @@ class _MusicBrainzClient:
         return list(self.albums)
 
 
-def _configure_sources(monkeypatch, clients, priority):
+def _configure_sources(
+    monkeypatch,
+    clients,
+    priority,
+    *,
+    library_source="primary",
+):
+    original_get = config_manager.get
+
+    def get_config(key, default=None):
+        if key == "metadata.library_discography_source":
+            return library_source
+        return original_get(key, default)
+
+    monkeypatch.setattr(config_manager, "get", get_config)
     monkeypatch.setattr(
         metadata_registry,
         "get_primary_source",
@@ -161,13 +176,14 @@ def test_explicit_provider_is_exclusive_even_when_fallback_allowed(monkeypatch):
     assert fallback.calls == []
 
 
-def test_automatic_mode_continues_after_confirmed_empty(monkeypatch):
+def test_primary_library_setting_preserves_existing_priority(monkeypatch):
     primary = _StaticClient([])
     fallback = _StaticClient([_album("fallback-album")])
     _configure_sources(
         monkeypatch,
-        {"itunes": primary, "deezer": fallback},
-        ["itunes", "deezer"],
+        {"musicbrainz": primary, "deezer": fallback},
+        ["musicbrainz", "deezer"],
+        library_source="primary",
     )
 
     result = get_artist_discography(
@@ -178,7 +194,99 @@ def test_automatic_mode_continues_after_confirmed_empty(monkeypatch):
 
     assert result["state"] == "results"
     assert result["source"] == "deezer"
-    assert [album["id"] for album in result["albums"]] == ["fallback-album"]
+    assert result["source_priority"] == ["musicbrainz", "deezer"]
+
+
+def test_configured_library_provider_is_exclusive(monkeypatch):
+    selected = _StaticClient([])
+    fallback = _StaticClient([_album("fallback-album")])
+    _configure_sources(
+        monkeypatch,
+        {"itunes": selected, "deezer": fallback},
+        ["deezer", "itunes"],
+        library_source="itunes",
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(allow_fallback=True),
+    )
+
+    assert result["state"] == "empty"
+    assert result["source"] == "itunes"
+    assert result["source_priority"] == ["itunes"]
+    assert len(selected.calls) == 1
+    assert fallback.calls == []
+
+
+def test_automatic_commercial_catalogue_uses_itunes_then_deezer(monkeypatch):
+    itunes = _StaticClient([])
+    deezer = _StaticClient([_album("deezer-album")])
+    musicbrainz = _StaticClient([_album("mb-album")])
+    _configure_sources(
+        monkeypatch,
+        {
+            "itunes": itunes,
+            "deezer": deezer,
+            "musicbrainz": musicbrainz,
+        },
+        ["musicbrainz", "deezer", "itunes"],
+        library_source="automatic",
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(),
+    )
+
+    assert result["state"] == "results"
+    assert result["source"] == "deezer"
+    assert result["source_priority"] == ["itunes", "deezer"]
+    assert len(itunes.calls) == 1
+    assert len(deezer.calls) == 1
+    assert musicbrainz.calls == []
+
+
+def test_automatic_commercial_catalogue_stops_on_access_error(monkeypatch):
+    _configure_sources(
+        monkeypatch,
+        {"deezer": _StaticClient([_album("deezer-album")])},
+        ["musicbrainz", "deezer", "itunes"],
+        library_source="automatic",
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(),
+    )
+
+    assert result["state"] == "error"
+    assert result["source"] == "itunes"
+    assert result["source_priority"] == ["itunes", "deezer"]
+    assert result["status_code"] == 503
+
+
+def test_invalid_library_setting_falls_back_to_primary(monkeypatch):
+    primary = _StaticClient([_album("primary-album")])
+    _configure_sources(
+        monkeypatch,
+        {"musicbrainz": primary},
+        ["musicbrainz"],
+        library_source="not-a-source",
+    )
+
+    result = get_artist_discography(
+        "artist-1",
+        artist_name="Artist One",
+        options=MetadataLookupOptions(),
+    )
+
+    assert result["state"] == "results"
+    assert result["source"] == "musicbrainz"
+    assert result["source_priority"] == ["musicbrainz"]
 
 
 def test_unavailable_explicit_provider_is_error(monkeypatch):

--- a/webui/src/app/main.tsx
+++ b/webui/src/app/main.tsx
@@ -1,6 +1,7 @@
 import '@vitejs/plugin-react/preamble';
 import { createRoot } from 'react-dom/client';
 
+import { mountLibraryDiscographySourceSelector } from '@/features/settings/library-discography-source';
 import { bindWindowWebRouter } from '@/platform/shell/bridge';
 import { ROUTER_ROOT_ID } from '@/platform/shell/route-controllers';
 
@@ -20,4 +21,5 @@ export async function bootstrapApp() {
   return { queryClient, router };
 }
 
+void mountLibraryDiscographySourceSelector();
 void bootstrapApp();

--- a/webui/src/features/settings/library-discography-source.test.ts
+++ b/webui/src/features/settings/library-discography-source.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, waitFor } from '@testing-library/dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS,
@@ -7,7 +7,16 @@ import {
   normalizeLibraryDiscographySource,
 } from './library-discography-source';
 
+type SettingsWindow = Window & {
+  _settingsPayload?: unknown;
+};
+
 describe('Library discography source selector', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    delete (window as SettingsWindow)._settingsPayload;
+  });
+
   it('normalizes unknown values to the primary metadata source', () => {
     expect(normalizeLibraryDiscographySource('deezer')).toBe('deezer');
     expect(normalizeLibraryDiscographySource('not-valid')).toBe('primary');

--- a/webui/src/features/settings/library-discography-source.test.ts
+++ b/webui/src/features/settings/library-discography-source.test.ts
@@ -1,0 +1,103 @@
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS,
+  mountLibraryDiscographySourceSelector,
+  normalizeLibraryDiscographySource,
+} from './library-discography-source';
+
+describe('Library discography source selector', () => {
+  it('normalizes unknown values to the primary metadata source', () => {
+    expect(normalizeLibraryDiscographySource('deezer')).toBe('deezer');
+    expect(normalizeLibraryDiscographySource('not-valid')).toBe('primary');
+    expect(normalizeLibraryDiscographySource(undefined)).toBe('primary');
+  });
+
+  it('renders directly below the primary metadata source', async () => {
+    document.body.innerHTML = `
+      <div id="metadata-settings">
+        <div class="form-group" id="primary-group">
+          <label for="metadata-fallback-source">Primary metadata source:</label>
+          <select id="metadata-fallback-source"><option value="musicbrainz">MusicBrainz</option></select>
+        </div>
+      </div>
+    `;
+
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          metadata: {
+            fallback_source: 'musicbrainz',
+            library_discography_source: 'automatic',
+          },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const select = await mountLibraryDiscographySourceSelector({ fetchImpl });
+
+    expect(select).not.toBeNull();
+    expect(select?.value).toBe('automatic');
+    expect(select?.parentElement?.previousElementSibling?.id).toBe('primary-group');
+    expect(Array.from(select?.options ?? []).map((option) => option.value)).toEqual(
+      LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS.map((option) => option.value),
+    );
+  });
+
+  it('persists the independent setting without replacing other metadata settings', async () => {
+    document.body.innerHTML = `
+      <div class="form-group">
+        <label for="metadata-fallback-source">Primary metadata source:</label>
+        <select id="metadata-fallback-source"><option value="musicbrainz">MusicBrainz</option></select>
+      </div>
+    `;
+
+    const settings = {
+      metadata: {
+        fallback_source: 'musicbrainz',
+        spotify_free: false,
+        library_discography_source: 'primary',
+      },
+      active_media_server: 'plex',
+    };
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(settings), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(settings), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    const select = await mountLibraryDiscographySourceSelector({ fetchImpl });
+    expect(select).not.toBeNull();
+
+    if (!select) throw new Error('Selector was not mounted');
+    fireEvent.change(select, { target: { value: 'deezer' } });
+
+    await waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
+
+    const [, request] = fetchImpl.mock.calls[2];
+    const payload = JSON.parse(String(request?.body));
+    expect(payload.metadata).toEqual({
+      fallback_source: 'musicbrainz',
+      spotify_free: false,
+      library_discography_source: 'deezer',
+    });
+    expect(payload.active_media_server).toBe('plex');
+  });
+});

--- a/webui/src/features/settings/library-discography-source.test.ts
+++ b/webui/src/features/settings/library-discography-source.test.ts
@@ -101,7 +101,10 @@ describe('Library discography source selector', () => {
     await waitFor(() => expect(fetchImpl).toHaveBeenCalledTimes(3));
 
     const [, request] = fetchImpl.mock.calls[2];
-    const payload = JSON.parse(String(request?.body));
+    if (typeof request?.body !== 'string') {
+      throw new Error('Expected JSON request body');
+    }
+    const payload = JSON.parse(request.body);
     expect(payload.metadata).toEqual({
       fallback_source: 'musicbrainz',
       spotify_free: false,

--- a/webui/src/features/settings/library-discography-source.ts
+++ b/webui/src/features/settings/library-discography-source.ts
@@ -1,0 +1,167 @@
+export const LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS = [
+  { value: 'primary', label: 'Use primary metadata source' },
+  { value: 'automatic', label: 'Automatic commercial catalogue' },
+  { value: 'itunes', label: 'iTunes' },
+  { value: 'deezer', label: 'Deezer' },
+  { value: 'musicbrainz', label: 'MusicBrainz' },
+  { value: 'spotify', label: 'Spotify' },
+] as const;
+
+export type LibraryDiscographySource =
+  (typeof LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS)[number]['value'];
+
+type SettingsPayload = {
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+type SoulSyncWindow = Window & {
+  _settingsPayload?: SettingsPayload;
+  showToast?: (message: string, type?: string) => void;
+};
+
+const SELECT_ID = 'library-discography-source';
+const GROUP_ID = 'library-discography-source-group';
+const VALID_SOURCES = new Set<string>(
+  LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS.map((option) => option.value),
+);
+
+export function normalizeLibraryDiscographySource(
+  value: unknown,
+): LibraryDiscographySource {
+  const normalized = String(value ?? '').trim().toLowerCase();
+  return VALID_SOURCES.has(normalized)
+    ? (normalized as LibraryDiscographySource)
+    : 'primary';
+}
+
+async function loadSettings(fetchImpl: typeof fetch): Promise<SettingsPayload> {
+  const response = await fetchImpl('/api/settings');
+  if (!response.ok) {
+    throw new Error(`Settings request failed with HTTP ${response.status}`);
+  }
+
+  const settings = (await response.json()) as SettingsPayload;
+  if (!settings || typeof settings !== 'object') {
+    throw new Error('Settings response is invalid');
+  }
+
+  return settings;
+}
+
+async function saveLibraryDiscographySource(
+  source: LibraryDiscographySource,
+  fetchImpl: typeof fetch,
+  targetWindow: SoulSyncWindow,
+): Promise<void> {
+  const settings = await loadSettings(fetchImpl);
+  settings.metadata = {
+    ...(settings.metadata ?? {}),
+    library_discography_source: source,
+  };
+
+  const response = await fetchImpl('/api/settings', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(settings),
+  });
+
+  const result = (await response.json()) as { success?: boolean; error?: string };
+  if (!response.ok || result.success !== true) {
+    throw new Error(result.error || `Settings save failed with HTTP ${response.status}`);
+  }
+
+  targetWindow._settingsPayload = settings;
+}
+
+function createSelector(documentRef: Document): HTMLSelectElement {
+  const select = documentRef.createElement('select');
+  select.id = SELECT_ID;
+  select.className = 'form-select';
+
+  for (const optionDefinition of LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS) {
+    const option = documentRef.createElement('option');
+    option.value = optionDefinition.value;
+    option.textContent = optionDefinition.label;
+    select.append(option);
+  }
+
+  return select;
+}
+
+function insertSelector(documentRef: Document): HTMLSelectElement | null {
+  const existing = documentRef.getElementById(SELECT_ID);
+  if (existing instanceof HTMLSelectElement) return existing;
+
+  const primarySelect = documentRef.getElementById('metadata-fallback-source');
+  if (!(primarySelect instanceof HTMLSelectElement)) return null;
+
+  const primaryGroup = primarySelect.closest('.form-group') ?? primarySelect.parentElement;
+  if (!primaryGroup?.parentElement) return null;
+
+  const group = documentRef.createElement('div');
+  group.id = GROUP_ID;
+  group.className = 'form-group';
+
+  const label = documentRef.createElement('label');
+  label.htmlFor = SELECT_ID;
+  label.textContent = 'Library discography source:';
+
+  const select = createSelector(documentRef);
+
+  const hint = documentRef.createElement('small');
+  hint.className = 'settings-hint';
+  hint.textContent =
+    'Controls album, EP and single catalogues shown in Library artist views. Automatic tries iTunes, then Deezer.';
+
+  group.append(label, select, hint);
+  primaryGroup.insertAdjacentElement('afterend', group);
+  return select;
+}
+
+export async function mountLibraryDiscographySourceSelector({
+  documentRef = document,
+  targetWindow = window as SoulSyncWindow,
+  fetchImpl = fetch,
+}: {
+  documentRef?: Document;
+  targetWindow?: SoulSyncWindow;
+  fetchImpl?: typeof fetch;
+} = {}): Promise<HTMLSelectElement | null> {
+  const select = insertSelector(documentRef);
+  if (!select) return null;
+
+  try {
+    const settings = targetWindow._settingsPayload ?? (await loadSettings(fetchImpl));
+    targetWindow._settingsPayload = settings;
+    select.value = normalizeLibraryDiscographySource(
+      settings.metadata?.library_discography_source,
+    );
+  } catch (error) {
+    console.error('Failed to load Library discography source:', error);
+    select.value = 'primary';
+  }
+
+  if (select.dataset.libraryDiscographyBound === 'true') return select;
+  select.dataset.libraryDiscographyBound = 'true';
+
+  select.addEventListener('change', async () => {
+    const source = normalizeLibraryDiscographySource(select.value);
+    select.disabled = true;
+
+    try {
+      await saveLibraryDiscographySource(source, fetchImpl, targetWindow);
+      targetWindow.showToast?.('Library discography source saved', 'success');
+    } catch (error) {
+      console.error('Failed to save Library discography source:', error);
+      targetWindow.showToast?.(
+        error instanceof Error ? error.message : 'Failed to save Library discography source',
+        'error',
+      );
+    } finally {
+      select.disabled = false;
+    }
+  });
+
+  return select;
+}

--- a/webui/src/features/settings/library-discography-source.ts
+++ b/webui/src/features/settings/library-discography-source.ts
@@ -26,9 +26,7 @@ const VALID_SOURCES = new Set<string>(
 );
 
 export function normalizeLibraryDiscographySource(value: unknown): LibraryDiscographySource {
-  const normalized = String(value ?? '')
-    .trim()
-    .toLowerCase();
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
   return VALID_SOURCES.has(normalized) ? (normalized as LibraryDiscographySource) : 'primary';
 }
 
@@ -53,7 +51,7 @@ async function saveLibraryDiscographySource(
 ): Promise<void> {
   const settings = await loadSettings(fetchImpl);
   settings.metadata = {
-    ...(settings.metadata ?? {}),
+    ...settings.metadata,
     library_discography_source: source,
   };
 

--- a/webui/src/features/settings/library-discography-source.ts
+++ b/webui/src/features/settings/library-discography-source.ts
@@ -66,9 +66,14 @@ async function saveLibraryDiscographySource(
     body: JSON.stringify(settings),
   });
 
-  const result = (await response.json()) as { success?: boolean; error?: string };
+  const result = (await response.json()) as {
+    success?: boolean;
+    error?: string;
+  };
   if (!response.ok || result.success !== true) {
-    throw new Error(result.error || `Settings save failed with HTTP ${response.status}`);
+    throw new Error(
+      result.error || `Settings save failed with HTTP ${response.status}`,
+    );
   }
 
   targetWindow._settingsPayload = settings;
@@ -96,7 +101,8 @@ function insertSelector(documentRef: Document): HTMLSelectElement | null {
   const primarySelect = documentRef.getElementById('metadata-fallback-source');
   if (!(primarySelect instanceof HTMLSelectElement)) return null;
 
-  const primaryGroup = primarySelect.closest('.form-group') ?? primarySelect.parentElement;
+  const primaryGroup =
+    primarySelect.closest('.form-group') ?? primarySelect.parentElement;
   if (!primaryGroup?.parentElement) return null;
 
   const group = documentRef.createElement('div');
@@ -132,7 +138,8 @@ export async function mountLibraryDiscographySourceSelector({
   if (!select) return null;
 
   try {
-    const settings = targetWindow._settingsPayload ?? (await loadSettings(fetchImpl));
+    const settings =
+      targetWindow._settingsPayload ?? (await loadSettings(fetchImpl));
     targetWindow._settingsPayload = settings;
     select.value = normalizeLibraryDiscographySource(
       settings.metadata?.library_discography_source,
@@ -155,7 +162,9 @@ export async function mountLibraryDiscographySourceSelector({
     } catch (error) {
       console.error('Failed to save Library discography source:', error);
       targetWindow.showToast?.(
-        error instanceof Error ? error.message : 'Failed to save Library discography source',
+        error instanceof Error
+          ? error.message
+          : 'Failed to save Library discography source',
         'error',
       );
     } finally {

--- a/webui/src/features/settings/library-discography-source.ts
+++ b/webui/src/features/settings/library-discography-source.ts
@@ -7,8 +7,7 @@ export const LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS = [
   { value: 'spotify', label: 'Spotify' },
 ] as const;
 
-export type LibraryDiscographySource =
-  (typeof LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS)[number]['value'];
+export type LibraryDiscographySource = (typeof LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS)[number]['value'];
 
 type SettingsPayload = {
   metadata?: Record<string, unknown>;
@@ -26,13 +25,11 @@ const VALID_SOURCES = new Set<string>(
   LIBRARY_DISCOGRAPHY_SOURCE_OPTIONS.map((option) => option.value),
 );
 
-export function normalizeLibraryDiscographySource(
-  value: unknown,
-): LibraryDiscographySource {
-  const normalized = String(value ?? '').trim().toLowerCase();
-  return VALID_SOURCES.has(normalized)
-    ? (normalized as LibraryDiscographySource)
-    : 'primary';
+export function normalizeLibraryDiscographySource(value: unknown): LibraryDiscographySource {
+  const normalized = String(value ?? '')
+    .trim()
+    .toLowerCase();
+  return VALID_SOURCES.has(normalized) ? (normalized as LibraryDiscographySource) : 'primary';
 }
 
 async function loadSettings(fetchImpl: typeof fetch): Promise<SettingsPayload> {
@@ -71,9 +68,7 @@ async function saveLibraryDiscographySource(
     error?: string;
   };
   if (!response.ok || result.success !== true) {
-    throw new Error(
-      result.error || `Settings save failed with HTTP ${response.status}`,
-    );
+    throw new Error(result.error || `Settings save failed with HTTP ${response.status}`);
   }
 
   targetWindow._settingsPayload = settings;
@@ -101,8 +96,7 @@ function insertSelector(documentRef: Document): HTMLSelectElement | null {
   const primarySelect = documentRef.getElementById('metadata-fallback-source');
   if (!(primarySelect instanceof HTMLSelectElement)) return null;
 
-  const primaryGroup =
-    primarySelect.closest('.form-group') ?? primarySelect.parentElement;
+  const primaryGroup = primarySelect.closest('.form-group') ?? primarySelect.parentElement;
   if (!primaryGroup?.parentElement) return null;
 
   const group = documentRef.createElement('div');
@@ -138,12 +132,9 @@ export async function mountLibraryDiscographySourceSelector({
   if (!select) return null;
 
   try {
-    const settings =
-      targetWindow._settingsPayload ?? (await loadSettings(fetchImpl));
+    const settings = targetWindow._settingsPayload ?? (await loadSettings(fetchImpl));
     targetWindow._settingsPayload = settings;
-    select.value = normalizeLibraryDiscographySource(
-      settings.metadata?.library_discography_source,
-    );
+    select.value = normalizeLibraryDiscographySource(settings.metadata?.library_discography_source);
   } catch (error) {
     console.error('Failed to load Library discography source:', error);
     select.value = 'primary';
@@ -162,9 +153,7 @@ export async function mountLibraryDiscographySourceSelector({
     } catch (error) {
       console.error('Failed to save Library discography source:', error);
       targetWindow.showToast?.(
-        error instanceof Error
-          ? error.message
-          : 'Failed to save Library discography source',
+        error instanceof Error ? error.message : 'Failed to save Library discography source',
         'error',
       );
     } finally {


### PR DESCRIPTION
## Summary

- introduce typed, provider-owned artist-discography outcomes: `RESULTS`, `EMPTY`, and `ACCESS_ERROR`
- keep explicit provider requests exclusive and stop cross-provider fallback on access failures
- preserve the existing primary metadata priority behavior by default
- add an independent **Library discography source** setting with these modes:
  - primary metadata source
  - automatic commercial catalogue (`iTunes` → `Deezer`)
  - explicit iTunes, Deezer, MusicBrainz, or Spotify
- keep per-request source overrides authoritative
- expose the new setting directly below **Primary metadata source** without changing unrelated metadata workflows

## Provider behavior

- `RESULTS` stops immediately
- `EMPTY` continues only in automatic modes
- `ACCESS_ERROR` stops and is surfaced
- explicit providers never cross to another provider
- same-provider retries and partial results remain supported
- MusicBrainz uses the same orchestration contract as the other providers

## Validation

- `27` Python tests passed
- `3` Vitest selector tests passed
- `npm run check` completed with `0` errors; only two pre-existing warnings remain in unrelated route files
- `npm run build` completed successfully
- manually deployed and validated:
  - selector placement and all six options
  - setting persistence after reload
  - Library artist discography rendering and ownership checks
  - automatic commercial catalogue behavior using The Smashing Pumpkins

This change intentionally does not alter the existing per-visit Library ownership/completion recalculation; caching that flow is separate follow-up work.