### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 3.1.6)'
+        description: 'Version tag (e.g. 3.1.7)'
         required: true
-        default: '3.1.6'
+        default: '3.1.7'
 
 jobs:
   build-and-push:

--- a/api/chat.py
+++ b/api/chat.py
@@ -144,10 +144,13 @@ def _unwrap_room_messages(messages):
     their text swapped for the payload + rich=True; reply refs are validated
     and attached. REACTION carriers (empty-text envelopes with 're') are
     pulled OUT of the visible list into a {target_key: {emoji: [users]}} map.
-    Returns (messages, reactions_map)."""
+    PROTOCOL carriers (envelopes with 'p' — jukebox votes, beacons, pins) are
+    pulled out into an event list: machine coordination, never rendered,
+    never archived. Returns (messages, reactions_map, protocol_events)."""
     from core import chat_codec
     out = []
     reactions: dict = {}
+    protocol: list = []
     for m in (messages or []):
         m = dict(m)
         dec = chat_codec.decode(m.get("message"))
@@ -160,13 +163,24 @@ def _unwrap_room_messages(messages):
                 if u and u not in users:
                     users.append(u)
                 continue                     # carriers never render as messages
+            proto = chat_codec.protocol_of(dec)
+            if proto:
+                protocol.append({"username": str(m.get("username") or ""),
+                                 "timestamp": m.get("timestamp"),
+                                 "p": proto})
+                # PURE carriers (empty text) vanish like reaction carriers.
+                # A message with BOTH text and 'p' (piggybacked state, e.g.
+                # now-playing) must still render — swallowing it would let
+                # any client vanish its own text from SoulSync views.
+                if not dec.get("t"):
+                    continue
             m["message"] = dec["t"]
             m["rich"] = True
             r = chat_codec.reply_of(dec)
             if r:
                 m["reply"] = r
         out.append(m)
-    return out, reactions
+    return out, reactions, protocol
 
 
 def _attach_reactions(messages, reactions) -> list:
@@ -315,7 +329,29 @@ def create_blueprint() -> Blueprint:
                                if isinstance(v, (str, int, float, bool)) and k != "picture"}
         except Exception:
             logger.debug("chat: user info failed", exc_info=True)
+        # OUR history with this peer — the card no other Soulseek client has:
+        # download count, success rate, last pull, bytes moved. Plus the local
+        # private note. Both best-effort; the card renders without them.
+        try:
+            db = _db()
+            if db is not None:
+                out["history"] = db.get_user_download_stats(username)
+                out["note"] = db.get_chat_user_note(username)
+        except Exception:
+            logger.debug("chat: user history/note failed", exc_info=True)
         return jsonify(out)
+
+    @bp.route("/api/chat/user/<path:username>/note", methods=["POST"])
+    def chat_user_note_set(username):
+        """Save the local, private note for a user ('' clears it)."""
+        db = _db()
+        if db is None:
+            return jsonify({"error": "database unavailable"}), 503
+        payload = request.get_json(silent=True) or {}
+        note = str(payload.get("note") or "")[:2000]
+        if not db.set_chat_user_note(username, note):
+            return jsonify({"error": "could not save note"}), 500
+        return jsonify({"ok": True, "note": note.strip()})
 
     @bp.route("/api/chat/user/<path:username>/shares", methods=["GET"])
     def chat_user_shares(username):
@@ -564,7 +600,7 @@ def create_blueprint() -> Blueprint:
         except Exception as e:
             logger.exception("chat: room hydrate failed")
             return jsonify({"error": str(e)}), 502
-        live, reactions = _unwrap_room_messages(messages)
+        live, reactions, protocol_events = _unwrap_room_messages(messages)
         # Archive-first (chatbic P2): slskd forgets the room on restart, the
         # archive doesn't. Top it up from the live buffer (idempotent), then
         # serve the archive tail; live is only the fallback when the archive
@@ -587,7 +623,44 @@ def create_blueprint() -> Blueprint:
                 logger.debug("chat: archive unavailable, serving live buffer", exc_info=True)
         return jsonify({"room": room, "joined": True,
                         "messages": _attach_reactions(out, reactions),
-                        "users": users or [], "can_send": _can_send()})
+                        "users": users or [], "can_send": _can_send(),
+                        # machine coordination events (jukebox/polls/beacons)
+                        # from the live buffer — the page's protocol feed
+                        "protocol": protocol_events})
+
+    @bp.route("/api/chat/room/protocol", methods=["POST"])
+    def chat_room_protocol_send():
+        """Send a PROTOCOL carrier into the room: an empty-text envelope whose
+        'p' object coordinates SoulSync clients (a vote, a beacon, a pin).
+        Vanilla clients see one line of envelope noise; SoulSync clients
+        intercept it before render. Same send gate as talking — a client that
+        can't speak can't emit machine chatter either."""
+        from core import chat_codec
+        client = _client()
+        if client is None:
+            return jsonify({"error": "Soulseek (slskd) is not configured"}), 503
+        if not _can_send():
+            return jsonify({"error": "Sending is disabled for this profile"}), 403
+        payload = request.get_json(silent=True) or {}
+        proto = chat_codec.protocol_of({"p": payload.get("p")})
+        if proto is None:
+            return jsonify({"error": "Malformed protocol payload"}), 400
+        room = _resolve_room(payload.get("room"))
+        if room is None:
+            return jsonify({"error": "Not in that room"}), 404
+        encoded = chat_codec.encode("", {"p": proto})
+        if encoded is None:
+            return jsonify({"error": "Protocol payload too large"}), 400
+        try:
+            if not _ensure_joined(client, room):
+                return jsonify({"error": "Could not join room"}), 502
+            ok = _run_async(client.send_room_message(room, encoded))
+        except Exception as e:
+            logger.exception("chat: protocol send failed")
+            return jsonify({"error": str(e)}), 502
+        if not ok:
+            return jsonify({"error": "slskd refused the message"}), 502
+        return jsonify({"ok": True})
 
     @bp.route("/api/chat/room/history", methods=["GET"])
     def chat_room_history():

--- a/api/chat.py
+++ b/api/chat.py
@@ -465,7 +465,13 @@ def create_blueprint() -> Blueprint:
             logger.exception("chat: browse failed for %r", username)
             return jsonify({"error": str(e)}), 502
         if dirs is None:
-            return jsonify({"error": "%s is offline or not sharing right now" % username}), 502
+            # Not necessarily "offline": most browse failures are slskd being
+            # unable to open a direct/indirect peer connection (NAT/firewall).
+            # Retries often succeed once the route is warmed up.
+            return jsonify({"error": "Couldn't connect to %s — they may be "
+                            "offline, or their client couldn't accept a "
+                            "connection. Trying again often works." % username,
+                            "retryable": True}), 502
         return jsonify({"username": username, "directories": dirs})
 
     @bp.route("/api/chat/user/<path:username>/shares/files", methods=["GET"])

--- a/api/chat.py
+++ b/api/chat.py
@@ -179,6 +179,9 @@ def _unwrap_room_messages(messages):
             r = chat_codec.reply_of(dec)
             if r:
                 m["reply"] = r
+            f = chat_codec.file_of(dec)
+            if f:
+                m["file"] = f
         out.append(m)
     return out, reactions, protocol
 
@@ -206,6 +209,53 @@ def _gif_fetch(url: str, params: dict) -> dict:
     return r.json()
 
 
+def _resolve_track_path(db, track_id):
+    """A library track's on-disk path, tried at the usual roots (as-stored,
+    transfer folder, download folder). None when unreachable."""
+    import os as _os
+    conn = None
+    try:
+        conn = db._get_connection()
+        row = conn.execute("SELECT file_path FROM tracks WHERE id = ?",
+                           (str(track_id),)).fetchone()
+    except Exception:
+        return None
+    finally:
+        if conn:
+            conn.close()
+    fp = row["file_path"] if row else None
+    if not fp:
+        return None
+    candidates = [fp]
+    try:
+        base = str(_config_get("soulseek.transfer_path", "") or "")
+        if base:
+            candidates.append(_os.path.join(base, fp))
+        dl = str(_config_get("soulseek.download_path", "") or "")
+        if dl:
+            candidates.append(_os.path.join(dl, fp))
+    except Exception:
+        logger.debug("chat: path candidates from config failed", exc_info=True)
+    for c in candidates:
+        if c and _os.path.isfile(c):
+            return c
+    return None
+
+
+def _filepost_upload(api_key, name, stream, expiry=None):
+    """One seam for the filepost.dev HTTP call (monkeypatched in tests)."""
+    import requests
+    data = {}
+    if expiry:
+        data["expires_in"] = expiry
+    r = requests.post("https://filepost.dev/v1/upload",
+                      headers={"X-API-Key": api_key},
+                      files={"file": (name, stream)},
+                      data=data, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
 def create_blueprint() -> Blueprint:
     bp = Blueprint("chat_api", __name__)
 
@@ -227,6 +277,8 @@ def create_blueprint() -> Blueprint:
             "auto_join": bool(_cfg("soulseek.chat_auto_join", True)),
             "auto_prove": bool(_cfg("soulseek.chat_auto_prove", True)),
             "giphy_key_set": bool(_cfg("soulseek.chat_giphy_key", "")),
+            "filepost_key_set": bool(_cfg("soulseek.chat_filepost_key", "")),
+            "filepost_expiry": str(_cfg("soulseek.chat_filepost_expiry", "") or ""),
         })
 
     @bp.route("/api/chat/settings", methods=["POST"])
@@ -252,6 +304,12 @@ def create_blueprint() -> Blueprint:
         if "giphy_key" in body:
             # present = intentional: a value sets it, empty string clears it
             _config_set("soulseek.chat_giphy_key", str(body.get("giphy_key") or "").strip())
+        if "filepost_key" in body:
+            _config_set("soulseek.chat_filepost_key", str(body.get("filepost_key") or "").strip())
+        if "filepost_expiry" in body:
+            exp = str(body.get("filepost_expiry") or "").strip()
+            if exp in ("", "24h", "7d", "30d"):
+                _config_set("soulseek.chat_filepost_expiry", exp)
         # Renaming the room: walk slskd out of the old one, best-effort —
         # otherwise the account sits in both forever. Same for turning
         # auto-join OFF: an opt-out that leaves you sitting in the room until
@@ -460,6 +518,121 @@ def create_blueprint() -> Blueprint:
             if full:
                 gifs.append({"url": full, "preview": tiny})
         return jsonify({"gifs": gifs})
+
+    @bp.route("/api/chat/files/library-search", methods=["GET"])
+    def chat_files_library_search():
+        """Pick-a-track-from-your-library search for the share flow: title or
+        artist match, only tracks with a stored file path, 20 max."""
+        db = _db()
+        if db is None:
+            return jsonify({"tracks": []})
+        query = str(request.args.get("q") or "").strip()
+        if len(query) < 2:
+            return jsonify({"tracks": []})
+        conn = None
+        try:
+            conn = db._get_connection()
+            like = "%" + query.replace("%", "\\%") + "%"
+            rows = conn.execute(
+                """SELECT t.id, t.title, t.file_path, t.file_size,
+                          COALESCE(t.track_artist, ar.name, '') AS artist,
+                          COALESCE(al.title, '') AS album
+                   FROM tracks t
+                   LEFT JOIN artists ar ON ar.id = t.artist_id
+                   LEFT JOIN albums al ON al.id = t.album_id
+                   WHERE t.file_path IS NOT NULL AND t.file_path != ''
+                     AND (t.title LIKE ? OR ar.name LIKE ? OR t.track_artist LIKE ?)
+                   ORDER BY t.title LIMIT 20""",
+                (like, like, like)).fetchall()
+            return jsonify({"tracks": [
+                {"id": r["id"], "title": r["title"], "artist": r["artist"],
+                 "album": r["album"], "size": r["file_size"]}
+                for r in rows]})
+        except Exception as e:
+            logger.debug("chat: library search failed: %s", e)
+            return jsonify({"tracks": []})
+        finally:
+            if conn:
+                conn.close()
+
+    @bp.route("/api/chat/files/upload", methods=["POST"])
+    def chat_files_upload():
+        """Upload to filepost.dev and hand back the CDN link + metadata.
+
+        Two sources: a browser file (multipart 'file') or a LIBRARY track
+        (json {track_id} — the file path resolves server-side, so sharing a
+        track is search → click, no filesystem browsing). Requires the
+        user's filepost API key (Settings → chat cog); size-capped at 50MB
+        (filepost free tier). Same gate as talking — this SENDS content."""
+        if not _can_send():
+            return jsonify({"error": "Sending is disabled for this profile"}), 403
+        try:
+            api_key = str(_config_get("soulseek.chat_filepost_key", "") or "").strip()
+        except Exception:
+            api_key = ""
+        if not api_key:
+            return jsonify({"error": "No filepost.dev API key configured "
+                                     "(chat settings cog)"}), 503
+
+        max_bytes = 50 * 1024 * 1024
+        name = None
+        stream = None
+        size = None
+        if "file" in request.files:
+            # REVIEW CATCH: the cap must hold server-side for browser uploads
+            # too — content_length covers the whole multipart body (slightly
+            # over the file size, never under), so this rejects before any
+            # bytes stream to filepost or hang the worker.
+            if (request.content_length or 0) > max_bytes + 1024 * 1024:
+                return jsonify({"error": "File is too big — filepost.dev caps "
+                                         "uploads at 50 MB"}), 413
+            fs = request.files["file"]
+            name = str(fs.filename or "file")[:200]
+            stream = fs.stream
+        else:
+            body = request.get_json(silent=True) or {}
+            track_id = body.get("track_id")
+            if not track_id:
+                return jsonify({"error": "No file or track_id given"}), 400
+            db = _db()
+            path = _resolve_track_path(db, track_id) if db is not None else None
+            if not path:
+                return jsonify({"error": "That track's file isn't reachable "
+                                         "from SoulSync"}), 404
+            import os as _os
+            size = _os.path.getsize(path)
+            if size > max_bytes:
+                return jsonify({"error": "File is %.0f MB — filepost.dev caps "
+                                         "uploads at 50 MB" % (size / 1048576)}), 413
+            name = _os.path.basename(path)
+            stream = open(path, "rb")
+
+        try:
+            expiry = str(_config_get("soulseek.chat_filepost_expiry", "") or "").strip()
+        except Exception:
+            expiry = ""
+        try:
+            result = _filepost_upload(api_key, name, stream, expiry or None)
+        except Exception as e:
+            logger.exception("chat: filepost upload failed")
+            return jsonify({"error": "Upload failed: %s" % e}), 502
+        finally:
+            try:
+                if stream is not None and hasattr(stream, "close"):
+                    stream.close()
+            except Exception:
+                logger.debug("chat: upload stream close failed", exc_info=True)
+        url = None
+        if isinstance(result, dict):
+            url = result.get("url") or result.get("cdn_url") or result.get("link")
+            if not url and isinstance(result.get("file"), dict):
+                url = result["file"].get("url")
+        if not url:
+            return jsonify({"error": "filepost.dev returned no URL"}), 502
+        import mimetypes as _mt
+        mime = _mt.guess_type(name)[0] or ""
+        return jsonify({"ok": True, "url": url, "name": name,
+                        "size": size, "mime": mime})
 
     @bp.route("/api/chat/rooms", methods=["GET"])
     def chat_rooms():
@@ -714,6 +887,10 @@ def create_blueprint() -> Blueprint:
         rep = chat_codec.reply_of({"r": body.get("reply")})
         if rep:
             extra = {"r": rep}
+        fmeta = chat_codec.file_of({"f": body.get("file")})
+        if fmeta:
+            extra = dict(extra or {})
+            extra["f"] = fmeta
         wrapped = chat_codec.encode(msg, extra)
         if wrapped is None:
             return jsonify({"error": "message too long for Soulseek chat"}), 400

--- a/api/chat.py
+++ b/api/chat.py
@@ -19,6 +19,8 @@ when actually needed.
 
 from __future__ import annotations
 
+import re as _re
+
 from flask import Blueprint, g, jsonify, request
 
 from utils.logging_config import get_logger
@@ -49,19 +51,22 @@ def _self_username(client) -> str:
 # web_server, same pattern as core/enrichment/api.py.
 _client_getter = None      # () -> SoulseekClient | None (configured or None)
 _run_async = None          # coroutine -> result (the shared slskd event loop)
+_youtube_search = None     # (query, max_results) -> [YouTubeSearchResult] | None
 _config_get = None         # (key, default) -> value
 _config_set = None         # (key, value) -> None
 _db_getter = None          # () -> MusicDatabase (the chat archive lives there)
 
 
 def configure(*, client_getter, run_async, config_get, config_set=None,
-              db_getter=None) -> None:
-    global _client_getter, _run_async, _config_get, _config_set, _db_getter
+              db_getter=None, youtube_search=None) -> None:
+    global _client_getter, _run_async, _config_get, _config_set, _db_getter, \
+        _youtube_search
     _client_getter = client_getter
     _run_async = run_async
     _config_get = config_get
     _config_set = config_set
     _db_getter = db_getter
+    _youtube_search = youtube_search
 
 
 def _db():
@@ -252,6 +257,41 @@ def _filepost_upload(api_key, name, stream, expiry=None):
                       headers={"X-API-Key": api_key},
                       files={"file": (name, stream)},
                       data=data, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+_YT_ID_RE = _re.compile(r"^[A-Za-z0-9_-]{11}$")
+_YT_URL_RES = (
+    _re.compile(r"(?:youtube\.com/watch\?(?:[^#\s]*&)?v=)([A-Za-z0-9_-]{11})"),
+    _re.compile(r"(?:youtu\.be/)([A-Za-z0-9_-]{11})"),
+    _re.compile(r"(?:youtube\.com/(?:shorts|embed|live)/)([A-Za-z0-9_-]{11})"),
+)
+
+
+def _parse_youtube_id(q: str):
+    """Extract an 11-char video id from a URL or a bare id; None otherwise."""
+    q = (q or "").strip()
+    if _YT_ID_RE.match(q):
+        return q
+    for rx in _YT_URL_RES:
+        m = rx.search(q)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _oembed_fetch(video_id):
+    """One seam for the keyless YouTube oEmbed lookup (monkeypatched in tests).
+
+    Returns {"title", "author_name"} or raises — never called with an
+    unvalidated id (the caller regex-gates it first)."""
+    import requests
+    r = requests.get(
+        "https://www.youtube.com/oembed",
+        params={"url": f"https://www.youtube.com/watch?v={video_id}",
+                "format": "json"},
+        timeout=10)
     r.raise_for_status()
     return r.json()
 
@@ -834,6 +874,54 @@ def create_blueprint() -> Blueprint:
         if not ok:
             return jsonify({"error": "slskd refused the message"}), 502
         return jsonify({"ok": True})
+
+    @bp.route("/api/chat/jukebox/resolve", methods=["POST"])
+    def chat_jukebox_resolve():
+        """Turn a user's jukebox input into candidate tracks.
+
+        A YouTube URL or bare 11-char id resolves via keyless oEmbed (one
+        exact result); anything else goes through yt-dlp search when wired
+        (up to 5 picks). Gated like sending — submitting to the queue IS
+        sending protocol chatter, so a client that can't speak can't make
+        the server fetch on its behalf either."""
+        if not _can_send():
+            return jsonify({"error": "Sending is disabled for this profile"}), 403
+        payload = request.get_json(silent=True) or {}
+        q = str(payload.get("q") or "").strip()
+        if not q or len(q) > 200:
+            return jsonify({"error": "Give me a YouTube link or a search"}), 400
+
+        vid = _parse_youtube_id(q)
+        if vid:
+            try:
+                meta = _oembed_fetch(vid) or {}
+            except Exception:
+                return jsonify({"error": "That video could not be resolved"}), 404
+            return jsonify({"results": [{
+                "id": vid,
+                "title": str(meta.get("title") or "")[:120] or vid,
+                "channel": str(meta.get("author_name") or "")[:80],
+            }]})
+
+        if _youtube_search is None:
+            return jsonify({"error": "Search is unavailable — paste a YouTube link"}), 503
+        try:
+            found = _youtube_search(q, 5) or []
+        except Exception:
+            logger.exception("chat: jukebox search failed")
+            return jsonify({"error": "YouTube search failed"}), 502
+        results = []
+        for v in found[:5]:
+            vid2 = str(getattr(v, "video_id", "") or "")
+            if not _YT_ID_RE.match(vid2):
+                continue
+            results.append({
+                "id": vid2,
+                "title": str(getattr(v, "title", "") or "")[:120],
+                "channel": str(getattr(v, "channel", "") or "")[:80],
+                "duration": int(getattr(v, "duration", 0) or 0),
+            })
+        return jsonify({"results": results})
 
     @bp.route("/api/chat/room/history", methods=["GET"])
     def chat_room_history():

--- a/core/chat_codec.py
+++ b/core/chat_codec.py
@@ -149,6 +149,30 @@ def protocol_of(payload) -> dict | None:
     return p
 
 
+def file_of(payload) -> dict | None:
+    """The validated file-card metadata from a decoded envelope ({'n' name,
+    's' size, 'm' mime}), or None. The URL itself travels as the message
+    TEXT (so the link survives archives and copy); this object only dresses
+    the card. REMOTE input — caps everywhere."""
+    f = (payload or {}).get("f") if isinstance(payload, dict) else None
+    if not isinstance(f, dict):
+        return None
+    n = str(f.get("n") or "").strip()[:200]
+    if not n:
+        return None
+    out = {"n": n}
+    try:
+        size = int(f.get("s") or 0)
+        if 0 < size < 10 ** 12:
+            out["s"] = size
+    except (TypeError, ValueError):
+        pass
+    m = str(f.get("m") or "").strip()[:80]
+    if m:
+        out["m"] = m
+    return out
+
+
 def reply_of(payload) -> dict | None:
     """The validated reply reference from a decoded envelope, or None.
     Everything here is REMOTE input — strict shape, hard caps."""

--- a/core/chat_codec.py
+++ b/core/chat_codec.py
@@ -98,6 +98,57 @@ def reaction_of(payload) -> dict | None:
     return {"k": k, "e": e}
 
 
+import re as _re
+
+_PROTOCOL_KIND_RE = _re.compile(r"^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)?$")
+
+
+def protocol_of(payload) -> dict | None:
+    """The validated protocol object from a decoded envelope ({'k': kind, ...}),
+    or None. Protocol carriers are empty-text envelopes carrying machine
+    coordination (jukebox votes, polls, pins, presence beacons) — invisible
+    to vanilla clients, intercepted before the visible list and NEVER
+    archived. REMOTE input: kind is a short dotted identifier, ≤16 fields,
+    strings ≤512, numbers finite, one nesting level (list/dict) with the
+    same caps. Mirrors ChatProtocol.parseProtocol in chat-protocol.js —
+    the two validators must agree or clients desync."""
+    p = (payload or {}).get("p") if isinstance(payload, dict) else None
+    if not isinstance(p, dict):
+        return None
+    k = p.get("k")
+    if not isinstance(k, str) or len(k) > 24 or not _PROTOCOL_KIND_RE.match(k):
+        return None
+
+    def _scalar_ok(v):
+        if isinstance(v, str):
+            return len(v) <= 512
+        if isinstance(v, bool) or v is None:
+            return True
+        if isinstance(v, (int, float)):
+            return abs(v) < 1e15
+        return False
+
+    def _payload_ok(obj, depth):
+        if not isinstance(obj, dict) or len(obj) > 16:
+            return False
+        for v in obj.values():
+            if _scalar_ok(v):
+                continue
+            if depth > 0 and isinstance(v, list):
+                if len(v) > 32 or not all(_scalar_ok(x) for x in v):
+                    return False
+            elif depth > 0 and isinstance(v, dict):
+                if not _payload_ok(v, depth - 1):
+                    return False
+            else:
+                return False
+        return True
+
+    if not _payload_ok(p, 1):
+        return None
+    return p
+
+
 def reply_of(payload) -> dict | None:
     """The validated reply reference from a decoded envelope, or None.
     Everything here is REMOTE input — strict shape, hard caps."""

--- a/core/repair_jobs/track_number_repair.py
+++ b/core/repair_jobs/track_number_repair.py
@@ -813,8 +813,10 @@ def _plan_track_repair(file_path: str, filename: str, api_tracks: List[Dict],
     prefix_match = re.match(r'^(\d+)', basename.strip())
     prefix = prefix_match.group(1) if prefix_match else ''
 
-    file_disc, _ = _read_disc_number_tag(audio)
-    # a DDTT filename prefix reveals the disc when the tag doesn't
+    tag_disc, _tag_disc_total = _read_disc_number_tag(audio)
+    file_disc = tag_disc
+    # a DDTT filename prefix reveals the disc when the tag doesn't (matching
+    # only — an inferred disc is not a tag, so it never satisfies disc_ok)
     if not file_disc and multi_disc and len(prefix) == 4:
         file_disc = int(prefix[:2]) or None
 
@@ -843,6 +845,13 @@ def _plan_track_repair(file_path: str, filename: str, api_tracks: List[Dict],
     current_num, current_total = _read_track_number_tag(audio)
     tag_ok = (current_num == correct_num
               and current_total in (None, disc_total, len(api_tracks)))
+    # #1075: per-disc track numbers are meaningless without disc tags — a
+    # repair that writes "track 10 of 11" onto a disc-tagless file in a
+    # 3-disc folder just manufactures a duplicate track number. On multi-disc
+    # albums the DISC TAG is part of correctness; single-disc albums never
+    # get disc tags touched.
+    total_discs = _api_disc_count(api_tracks)
+    disc_ok = (not multi_disc) or (tag_disc == correct_disc)
 
     planned = _planned_prefix(prefix, correct_num, correct_disc, multi_disc)
     new_basename = None
@@ -851,7 +860,7 @@ def _plan_track_repair(file_path: str, filename: str, api_tracks: List[Dict],
         if candidate != basename:
             new_basename = candidate
 
-    if tag_ok and new_basename is None:
+    if tag_ok and disc_ok and new_basename is None:
         return None
     return {
         'matched_track': matched_track,
@@ -859,10 +868,13 @@ def _plan_track_repair(file_path: str, filename: str, api_tracks: List[Dict],
         'correct_num': correct_num,
         'correct_disc': correct_disc,
         'disc_total': disc_total,
+        'total_discs': total_discs,
         'multi_disc': multi_disc,
         'current_num': current_num,
         'current_total': current_total,
+        'current_disc': tag_disc,
         'tag_ok': tag_ok,
+        'disc_ok': disc_ok,
         'new_basename': new_basename,
         'file_title': file_title,
     }
@@ -870,22 +882,32 @@ def _plan_track_repair(file_path: str, filename: str, api_tracks: List[Dict],
 
 def _match_title_to_api_track(file_title: str, api_tracks: List[Dict],
                                threshold: float) -> Tuple[Optional[Dict], float]:
-    """Fuzzy-match a file title to an API track. Returns (track, score)."""
+    """Fuzzy-match a file title to an API track. Returns (track, score).
+
+    The primary score compares QUALIFIER-STRIPPED titles (remaster noise must
+    not break matching), but that makes every version of a song identical —
+    "Like Spinning Plates ('Why Us?' Version)" and "Like Spinning Plates"
+    both normalize to the same string, and first-in-tracklist used to win
+    (#1075: the file got renumbered to the WRONG disc's original version).
+    Ties on the stripped score are broken by the RAW title, so the version
+    whose full name actually matches the file wins."""
     norm_file = _normalize_title(file_title)
+    raw_file = file_title.lower().strip()
     best_match = None
-    best_score = 0.0
+    best_key = (-1.0, -1.0)
 
     for track in api_tracks:
         api_name = track.get('name', '')
-        norm_api = _normalize_title(api_name)
-        score = SequenceMatcher(None, norm_file, norm_api).ratio()
-        if score > best_score:
-            best_score = score
+        norm_score = SequenceMatcher(None, norm_file, _normalize_title(api_name)).ratio()
+        raw_score = SequenceMatcher(None, raw_file, api_name.lower().strip()).ratio()
+        key = (norm_score, raw_score)
+        if key > best_key:
+            best_key = key
             best_match = track
 
-    if best_score >= threshold:
-        return best_match, best_score
-    return None, best_score
+    if best_key[0] >= threshold:
+        return best_match, best_key[0]
+    return None, max(best_key[0], 0.0)
 
 
 def _normalize_title(title: str) -> str:
@@ -931,6 +953,44 @@ def _fix_track_number_tag(file_path: str, correct_num: int, total: int):
         logger.info("Fixed track tag: %s → %s", os.path.basename(file_path), track_str)
     except Exception as e:
         logger.error("Error fixing track tag in %s: %s", file_path, e, exc_info=True)
+
+
+def _fix_disc_number_tag(file_path: str, disc_num: int, total_discs: int):
+    """Update ONLY the disc number tag (multi-disc albums — #1075: per-disc
+    track numbering is only enforceable when the disc tag rides along)."""
+    from mutagen import File as MutagenFile
+    from mutagen.id3 import TPOS, ID3
+    from mutagen.flac import FLAC
+    from mutagen.oggvorbis import OggVorbis
+    from mutagen.mp4 import MP4
+
+    try:
+        audio = MutagenFile(file_path)
+        if audio is None:
+            logger.error("Cannot re-open file for disc tag fix: %s", file_path)
+            return
+
+        disc_str = f"{disc_num}/{total_discs}" if total_discs else str(disc_num)
+
+        if isinstance(audio.tags, ID3):
+            audio.tags.delall('TPOS')
+            audio.tags.add(TPOS(encoding=3, text=[disc_str]))
+        elif isinstance(audio, (FLAC, OggVorbis)):
+            audio['discnumber'] = [disc_str]
+            if total_discs:
+                audio['disctotal'] = [str(total_discs)]
+        elif isinstance(audio, MP4):
+            audio['disk'] = [(disc_num, total_discs or 0)]
+        else:
+            return
+
+        # Atomic + audio-integrity-verified save (#819/#1000)
+        from core.metadata.common import save_audio_file, get_mutagen_symbols
+        save_audio_file(audio, get_mutagen_symbols())
+
+        logger.info("Fixed disc tag: %s → %s", os.path.basename(file_path), disc_str)
+    except Exception as e:
+        logger.error("Error fixing disc tag in %s: %s", file_path, e, exc_info=True)
 
 
 def _rename_to_basename(file_path: str, filename: str, new_basename: str) -> Optional[str]:
@@ -1166,11 +1226,17 @@ def _check_single_track(file_path: str, filename: str, api_tracks: List[Dict],
     if not plan:
         return None
 
+    disc_suffix = (f" (disc {plan['correct_disc']} of {plan['total_discs']})"
+                   if plan['multi_disc'] else "")
     changes = []
     if plan['current_num'] != plan['correct_num']:
-        changes.append(f"Track number: {plan['current_num']} -> {plan['correct_num']}")
+        changes.append(f"Track number: {plan['current_num']} -> {plan['correct_num']}{disc_suffix}")
     if not plan['tag_ok'] and plan['current_total'] != plan['disc_total']:
-        changes.append(f"Total tracks: {plan['current_total']} -> {plan['disc_total']}")
+        changes.append(f"Total tracks: {plan['current_total']} -> {plan['disc_total']}"
+                       f"{' (per disc)' if plan['multi_disc'] else ''}")
+    if not plan['disc_ok']:
+        changes.append(f"Disc: {plan['current_disc'] if plan['current_disc'] else 'none'}"
+                       f" -> {plan['correct_disc']}/{plan['total_discs']}")
     if plan['new_basename']:
         changes.append(f"Filename: {filename} -> {plan['new_basename']}{os.path.splitext(filename)[1]}")
 
@@ -1187,11 +1253,13 @@ def _check_single_track(file_path: str, filename: str, api_tracks: List[Dict],
         # the rename target ride in the finding so approve can never invent a
         # different (convention-mangling) rename than the one shown (#1009)
         'tag_ok': plan['tag_ok'],
+        'disc_ok': plan['disc_ok'],
     }
     if plan['new_basename']:
         details['new_filename'] = plan['new_basename'] + os.path.splitext(filename)[1]
     if plan['multi_disc']:
         details['disc_number'] = plan['correct_disc']
+        details['total_discs'] = plan['total_discs']
     return {
         'description': f'Matched to: "{matched_track.get("name", "?")}"\n' + '\n'.join(changes),
         'details': details,
@@ -1210,6 +1278,8 @@ def _repair_single_track(file_path: str, filename: str, api_tracks: List[Dict],
 
     if not plan['tag_ok']:
         _fix_track_number_tag(file_path, plan['correct_num'], plan['disc_total'])
+    if not plan['disc_ok']:
+        _fix_disc_number_tag(file_path, plan['correct_disc'], plan['total_discs'])
 
     if plan['new_basename']:
         new_path = _rename_to_basename(file_path, filename, plan['new_basename'])

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -1943,6 +1943,16 @@ class RepairWorker:
                 total_tracks = int(total_tracks or 0)
                 _fix_track_number_tag(resolved, int(correct_num), total_tracks)
 
+            # #1075: per-disc numbering needs the disc tag written too — the
+            # scan rode disc_ok/disc_number/total_discs in the finding, so
+            # approve applies exactly the promised disc change. Legacy
+            # findings lack disc_ok (defaults True) → no disc write, exactly
+            # the old behavior.
+            if not details.get('disc_ok', True) and details.get('disc_number'):
+                from core.repair_jobs.track_number_repair import _fix_disc_number_tag
+                _fix_disc_number_tag(resolved, int(details['disc_number']),
+                                     int(details.get('total_discs') or 0))
+
             # Rename to EXACTLY what the finding promised (#1009 — the old code
             # recomputed the prefix here and mangled 4-digit disc+track names:
             # '0213 - X' became '133 - X'). Findings created before the plan

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -422,6 +422,15 @@ class MusicDatabase:
             """)
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_chat_room_messages_room "
                            "ON chat_room_messages (room, timestamp)")
+            # Local, private notes on Soulseek users ("great jazz rips") —
+            # shown on the chat user card. Never leaves this install.
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS chat_user_notes (
+                    username TEXT PRIMARY KEY,
+                    note TEXT NOT NULL DEFAULT '',
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
             # the table shipped one commit before the reply column — live dbs
             # already created it, so the column rides a tolerant ALTER
             try:
@@ -10422,6 +10431,77 @@ class MusicDatabase:
             return 0
 
     _CHAT_ARCHIVE_KEEP = 5000     # per room — plenty of scrollback, bounded disk
+
+    def get_chat_user_note(self, username: str) -> str:
+        """The local note for a Soulseek username ('' when none)."""
+        conn = None
+        try:
+            conn = self._get_connection()
+            row = conn.execute("SELECT note FROM chat_user_notes WHERE username = ?",
+                               (str(username),)).fetchone()
+            return row[0] if row else ''
+        except Exception as e:
+            logger.debug("get_chat_user_note failed: %s", e)
+            return ''
+        finally:
+            if conn:
+                conn.close()
+
+    def set_chat_user_note(self, username: str, note: str) -> bool:
+        """Upsert (empty note deletes the row — no tombstones)."""
+        conn = None
+        try:
+            conn = self._get_connection()
+            if str(note or '').strip():
+                conn.execute(
+                    "INSERT INTO chat_user_notes (username, note, updated_at) "
+                    "VALUES (?, ?, CURRENT_TIMESTAMP) "
+                    "ON CONFLICT(username) DO UPDATE SET note = excluded.note, "
+                    "updated_at = CURRENT_TIMESTAMP",
+                    (str(username), str(note).strip()))
+            else:
+                conn.execute("DELETE FROM chat_user_notes WHERE username = ?",
+                             (str(username),))
+            conn.commit()
+            return True
+        except Exception as e:
+            logger.error("set_chat_user_note failed: %s", e)
+            return False
+        finally:
+            if conn:
+                conn.close()
+
+    def get_user_download_stats(self, username: str) -> Dict[str, Any]:
+        """Our HISTORY with a Soulseek peer, from track_downloads — the user
+        card differentiator no other client has: how many tracks we've pulled
+        from them, how reliably, and when we last did."""
+        out = {'downloads': 0, 'completed': 0, 'failed': 0,
+               'success_rate': None, 'last_download': None, 'total_bytes': 0}
+        conn = None
+        try:
+            conn = self._get_connection()
+            row = conn.execute(
+                """SELECT COUNT(*) AS n,
+                           SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS ok,
+                           SUM(CASE WHEN status NOT IN ('completed') THEN 1 ELSE 0 END) AS bad,
+                           MAX(created_at) AS last,
+                           COALESCE(SUM(CASE WHEN status = 'completed'
+                                             THEN COALESCE(source_size, 0) ELSE 0 END), 0) AS bytes
+                    FROM track_downloads WHERE source_username = ?""",
+                (str(username),)).fetchone()
+            if row and row['n']:
+                out['downloads'] = row['n']
+                out['completed'] = row['ok'] or 0
+                out['failed'] = row['bad'] or 0
+                out['success_rate'] = round(100.0 * (row['ok'] or 0) / row['n'], 1)
+                out['last_download'] = row['last']
+                out['total_bytes'] = row['bytes'] or 0
+        except Exception as e:
+            logger.debug("get_user_download_stats failed: %s", e)
+        finally:
+            if conn:
+                conn.close()
+        return out
 
     def add_chat_messages(self, room: str, messages) -> int:
         """Archive a batch of DECODED room messages ({username, message, rich,

--- a/tests/static/test_chat_protocol.mjs
+++ b/tests/static/test_chat_protocol.mjs
@@ -213,6 +213,19 @@ describe('reduceJukebox — the pure fold every client agrees on', () => {
         shapeEqual(st.history.map(h => h.id), ['bbbbbbbbbbb', 'aaaaaaaaaaa']);
     });
 
+    test('radio toggle: latest wins, auto flag rides submissions', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.radio', on: 1 }),
+            ev('b', { k: 'jbx.radio', on: 0 }),
+            ev('a', { k: 'jbx.radio', on: 1 }),
+            ev('dj', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'Auto pick', a: 1 }),
+            ev('x', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'Human pick' }),
+        ]);
+        assert.equal(st.radio, true);
+        assert.equal(st.queue[0].auto, true);
+        assert.equal(st.queue[1].auto, undefined);
+    });
+
     test('queue cap holds at 25', () => {
         const evs = [];
         for (let i = 0; i < 30; i++) {

--- a/tests/static/test_chat_protocol.mjs
+++ b/tests/static/test_chat_protocol.mjs
@@ -185,3 +185,109 @@ describe('reduceJukebox — the pure fold every client agrees on', () => {
         assert.equal(P.reduceJukebox(evs).queue.length, 25);
     });
 });
+
+describe('reducePins — the shared pin board', () => {
+    const ev = (user, p) => ({ username: user, timestamp: 't', p });
+    const add = (by, u, ts, x) => ev(by, { k: 'pin.add', u, ts, x });
+
+    test('add, dedupe (re-pin moves to newest), delete', () => {
+        const pins = P.reducePins([
+            add('a', 'bob', 't1', 'first'),
+            add('a', 'sue', 't2', 'second'),
+            add('b', 'bob', 't1', 'again'),          // re-pin same message
+            ev('c', { k: 'pin.del', u: 'sue', ts: 't2' }),
+        ]);
+        assert.equal(pins.length, 1);
+        assert.equal(pins[0].u, 'bob');
+        assert.equal(pins[0].by, 'b');               // latest pinner wins
+    });
+
+    test('board caps at 8 — oldest falls off', () => {
+        const evs = [];
+        for (let i = 0; i < 10; i++) evs.push(add('a', 'u' + i, 't' + i, 'x'));
+        const pins = P.reducePins(evs);
+        assert.equal(pins.length, 8);
+        assert.equal(pins[0].u, 'u2');
+    });
+
+    test('garbage never lands', () => {
+        assert.equal(P.reducePins([ev('a', { k: 'pin.add', u: '', ts: 't' })]).length, 0);
+        assert.equal(P.reducePins([ev('a', { k: 'pin.add', u: 'x'.repeat(99), ts: 't' })]).length, 0);
+    });
+});
+
+describe('reducePoll — one active poll, latest start wins', () => {
+    const ev = (user, p, ts) => ({ username: user, timestamp: ts || 't', p });
+
+    test('start + votes + tally, latest vote per user', () => {
+        const poll = P.reducePoll([
+            ev('op', { k: 'poll.start', q: 'best daft punk album?', o1: 'Discovery', o2: 'RAM' }),
+            ev('x', { k: 'poll.vote', o: '1' }),
+            ev('y', { k: 'poll.vote', o: '2' }),
+            ev('x', { k: 'poll.vote', o: '2' }),
+        ]);
+        assert.equal(poll.q, 'best daft punk album?');
+        shapeEqual(poll.tally.counts, { '2': 2 });
+        assert.equal(poll.closed, false);
+    });
+
+    test('a new start resets everything', () => {
+        const poll = P.reducePoll([
+            ev('op', { k: 'poll.start', q: 'old?', o1: 'a', o2: 'b' }),
+            ev('x', { k: 'poll.vote', o: '1' }),
+            ev('op2', { k: 'poll.start', q: 'new?', o1: 'c', o2: 'd' }),
+        ]);
+        assert.equal(poll.q, 'new?');
+        assert.equal(poll.tally.total, 0);
+    });
+
+    test('only the starter can end it; votes stop after close', () => {
+        const poll = P.reducePoll([
+            ev('op', { k: 'poll.start', q: 'q?', o1: 'a', o2: 'b' }),
+            ev('mallory', { k: 'poll.end' }),
+            ev('x', { k: 'poll.vote', o: '1' }),
+            ev('op', { k: 'poll.end' }),
+            ev('y', { k: 'poll.vote', o: '2' }),      // too late
+        ]);
+        assert.equal(poll.closed, true);
+        shapeEqual(poll.tally.counts, { '1': 1 });
+    });
+
+    test('out-of-range and hostile votes are ignored', () => {
+        const poll = P.reducePoll([
+            ev('op', { k: 'poll.start', q: 'q?', o1: 'a', o2: 'b' }),
+            ev('x', { k: 'poll.vote', o: '3' }),      // only 2 options exist
+            ev('y', { k: 'poll.vote', o: 'zz' }),
+        ]);
+        assert.equal(poll.tally.total, 0);
+    });
+
+    test('degenerate starts are refused', () => {
+        assert.equal(P.reducePoll([ev('op', { k: 'poll.start', q: 'q?', o1: 'only' })]), null);
+        assert.equal(P.reducePoll([ev('op', { k: 'poll.start', q: '', o1: 'a', o2: 'b' })]), null);
+        assert.equal(P.reducePoll([]), null);
+    });
+});
+
+describe('reduceTopic + reduceTuned', () => {
+    const ev = (user, p) => ({ username: user, timestamp: 't', p });
+
+    test('latest topic wins, empty clears', () => {
+        shapeEqual(P.reduceTopic([
+            ev('a', { k: 'topic.set', t: 'share your vinyl finds' }),
+            ev('b', { k: 'topic.set', t: 'friday listening party' }),
+        ]), { t: 'friday listening party', by: 'b' });
+        assert.equal(P.reduceTopic([
+            ev('a', { k: 'topic.set', t: 'x' }),
+            ev('b', { k: 'topic.set', t: '' }),
+        ]), null);
+    });
+
+    test('tuned presence follows the latest on/off per user', () => {
+        shapeEqual(P.reduceTuned([
+            ev('a', { k: 'jbx.tune', on: 1 }),
+            ev('b', { k: 'jbx.tune', on: 1 }),
+            ev('a', { k: 'jbx.tune', on: 0 }),
+        ]), { b: 1 });
+    });
+});

--- a/tests/static/test_chat_protocol.mjs
+++ b/tests/static/test_chat_protocol.mjs
@@ -106,3 +106,82 @@ describe('electCoordinator — chatter-free agreement', () => {
         assert.equal(P.electCoordinator(null), null);
     });
 });
+
+describe('reduceJukebox — the pure fold every client agrees on', () => {
+    const ev = (user, p) => ({ username: user, timestamp: 't', p });
+
+    test('submissions queue, dedupe, and keep first attribution', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: 'dQw4w9WgXcQ', ti: 'Song A' }),
+            ev('b', { k: 'jbx.sub', id: 'dQw4w9WgXcQ', ti: 'Dupe' }),
+            ev('b', { k: 'jbx.sub', id: 'oHg5SJYRHA0', ti: 'Song B' }),
+        ]);
+        assert.equal(st.queue.length, 2);
+        assert.equal(st.queue[0].by, 'a');
+        assert.equal(st.queue[0].ti, 'Song A');
+    });
+
+    test('votes count only for queued ids, latest per user', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'A' }),
+            ev('b', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'B' }),
+            ev('x', { k: 'jbx.vote', o: 'aaaaaaaaaaa' }),
+            ev('x', { k: 'jbx.vote', o: 'bbbbbbbbbbb' }),   // changed mind
+            ev('y', { k: 'jbx.vote', o: 'zzzzzzzzzzz' }),   // not queued → ignored
+        ]);
+        assert.equal(st.queue.find(e => e.id === 'bbbbbbbbbbb').votes, 1);
+        assert.equal(st.queue.find(e => e.id === 'aaaaaaaaaaa').votes, 0);
+    });
+
+    test('now removes the track from the queue and resets the round', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'A' }),
+            ev('b', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'B' }),
+            ev('x', { k: 'jbx.vote', o: 'bbbbbbbbbbb' }),
+            ev('dj', { k: 'jbx.now', id: 'bbbbbbbbbbb', ti: 'B', at: 1000 }),
+        ]);
+        assert.equal(st.now.id, 'bbbbbbbbbbb');
+        assert.equal(st.now.at, 1000);
+        assert.equal(st.queue.length, 1);
+        assert.equal(st.tally.total, 0);                    // votes reset
+    });
+
+    test('nextTrack: winner beats FIFO, FIFO when no votes', () => {
+        const base = [
+            ev('a', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'A' }),
+            ev('b', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'B' }),
+        ];
+        assert.equal(P.nextTrack(P.reduceJukebox(base)).id, 'aaaaaaaaaaa');
+        const voted = base.concat([ev('x', { k: 'jbx.vote', o: 'bbbbbbbbbbb' })]);
+        assert.equal(P.nextTrack(P.reduceJukebox(voted)).id, 'bbbbbbbbbbb');
+        assert.equal(P.nextTrack(P.reduceJukebox([])), null);
+    });
+
+    test('hostile ids never enter state', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: '<script>', ti: 'x' }),
+            ev('a', { k: 'jbx.now', id: 'javascript:x', ti: 'x' }),
+        ]);
+        assert.equal(st.queue.length, 0);
+        assert.equal(st.now, null);
+    });
+
+    test('duration rides sub and now, hostile durations dropped', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'A', d: 213 }),
+            ev('b', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'B', d: -5 }),
+            ev('dj', { k: 'jbx.now', id: 'ccccccccccc', ti: 'C', at: 1, d: 1e9 }),
+        ]);
+        assert.equal(st.queue[0].d, 213);
+        assert.equal(st.queue[1].d, null);
+        assert.equal(st.now.d, 7200);                       // capped, not trusted
+    });
+
+    test('queue cap holds at 25', () => {
+        const evs = [];
+        for (let i = 0; i < 30; i++) {
+            evs.push(ev('u' + i, { k: 'jbx.sub', id: 'id' + String(i).padStart(9, '0'), ti: 'T' + i }));
+        }
+        assert.equal(P.reduceJukebox(evs).queue.length, 25);
+    });
+});

--- a/tests/static/test_chat_protocol.mjs
+++ b/tests/static/test_chat_protocol.mjs
@@ -177,6 +177,42 @@ describe('reduceJukebox — the pure fold every client agrees on', () => {
         assert.equal(st.now.d, 7200);                       // capped, not trusted
     });
 
+    test('unsub: only the submitter can pull a track, and its votes die', () => {
+        const st = P.reduceJukebox([
+            ev('a', { k: 'jbx.sub', id: 'aaaaaaaaaaa', ti: 'A' }),
+            ev('b', { k: 'jbx.sub', id: 'bbbbbbbbbbb', ti: 'B' }),
+            ev('x', { k: 'jbx.vote', o: 'aaaaaaaaaaa' }),
+            ev('mallory', { k: 'jbx.unsub', id: 'aaaaaaaaaaa' }),   // not the submitter
+            ev('a', { k: 'jbx.unsub', id: 'aaaaaaaaaaa' }),         // the submitter
+        ]);
+        assert.equal(st.queue.length, 1);
+        assert.equal(st.queue[0].id, 'bbbbbbbbbbb');
+        assert.equal(st.tally.winner, null);            // the pulled track's vote vanished
+    });
+
+    test('skip votes count unique users for the CURRENT track and reset on handoff', () => {
+        const base = [
+            ev('dj', { k: 'jbx.now', id: 'aaaaaaaaaaa', ti: 'A', at: 1 }),
+            ev('x', { k: 'jbx.skip', o: 'aaaaaaaaaaa' }),
+            ev('x', { k: 'jbx.skip', o: 'aaaaaaaaaaa' }),           // same user twice = 1
+            ev('y', { k: 'jbx.skip', o: 'zzzzzzzzzzz' }),           // wrong target ignored
+        ];
+        assert.equal(P.reduceJukebox(base).skips, 1);
+        const after = base.concat([ev('dj', { k: 'jbx.now', id: 'bbbbbbbbbbb', ti: 'B', at: 2 })]);
+        assert.equal(P.reduceJukebox(after).skips, 0);              // skips die with the track
+    });
+
+    test('history keeps the last plays newest-first, double-starts excluded', () => {
+        const st = P.reduceJukebox([
+            ev('dj', { k: 'jbx.now', id: 'aaaaaaaaaaa', ti: 'A', at: 1 }),
+            ev('dj', { k: 'jbx.now', id: 'aaaaaaaaaaa', ti: 'A', at: 2 }),  // double-start
+            ev('dj', { k: 'jbx.now', id: 'bbbbbbbbbbb', ti: 'B', at: 3 }),
+            ev('dj', { k: 'jbx.now', id: 'ccccccccccc', ti: 'C', at: 4 }),
+        ]);
+        assert.equal(st.now.id, 'ccccccccccc');
+        shapeEqual(st.history.map(h => h.id), ['bbbbbbbbbbb', 'aaaaaaaaaaa']);
+    });
+
     test('queue cap holds at 25', () => {
         const evs = [];
         for (let i = 0; i < 30; i++) {

--- a/tests/static/test_chat_protocol.mjs
+++ b/tests/static/test_chat_protocol.mjs
@@ -1,0 +1,108 @@
+// Deterministic core of the SoulSync chat protocol (chat-protocol.js).
+// Run via: node --test tests/static/test_chat_protocol.mjs
+// (pytest wrapper: tests/test_chat_protocol_js.py)
+//
+// These functions must agree across every client observing the same message
+// stream — determinism IS the feature, so the tests hammer ordering, ties,
+// and hostile input.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, '../../webui/static/chat-protocol.js'), 'utf-8');
+const ctx = { window: {} };
+vm.createContext(ctx);
+vm.runInContext(src, ctx);
+const P = ctx.window.ChatProtocol;
+
+// VM-created objects are cross-realm (different prototype chain) — compare
+// shapes via JSON round-trip, same pattern as test_auto_sync.mjs.
+function shapeEqual(actual, expected, msg) {
+    assert.deepEqual(JSON.parse(JSON.stringify(actual)), expected, msg);
+}
+
+describe('classifyUser — the assume-SoulSync flip', () => {
+    test('unknown user stays capable until proven vanilla', () => {
+        assert.equal(P.classifyUser(undefined, false), 'vanilla');
+        assert.equal(P.classifyUser('assumed', false), 'vanilla');
+    });
+    test('an envelope is conclusive, forever', () => {
+        assert.equal(P.classifyUser('assumed', true), 'soulsync');
+        assert.equal(P.classifyUser('vanilla', true), 'soulsync');   // mid-session upgrade
+        assert.equal(P.classifyUser('soulsync', false), 'soulsync'); // plain text never demotes
+    });
+});
+
+describe('parseProtocol — hostile input', () => {
+    test('valid kinds parse', () => {
+        shapeEqual(P.parseProtocol({ p: { k: 'jbx.vote', o: 'abc' } }),
+                   { k: 'jbx.vote', o: 'abc' });
+        assert.equal(P.parseProtocol({ p: { k: 'np', t: 'song' } }).k, 'np');
+    });
+    test('garbage is rejected, never throws', () => {
+        for (const bad of [null, {}, { p: null }, { p: [] }, { p: { k: 42 } },
+                           { p: { k: 'UPPER' } }, { p: { k: 'a'.repeat(30) } },
+                           { p: { k: 'x.y', blob: { deep: { deeper: 1 } } } },
+                           { p: { k: 'x', s: 'y'.repeat(600) } },
+                           { p: { k: 'x', fn: () => 1 } }]) {
+            assert.equal(P.parseProtocol(bad), null, JSON.stringify(String(bad)));
+        }
+    });
+    test('field-count bomb rejected', () => {
+        const p = { k: 'x' };
+        for (let i = 0; i < 20; i++) p['f' + i] = i;
+        assert.equal(P.parseProtocol({ p }), null);
+    });
+});
+
+describe('tallyVotes — determinism', () => {
+    test('latest vote per user wins', () => {
+        const r = P.tallyVotes([
+            { username: 'a', option: 'song1' },
+            { username: 'b', option: 'song2' },
+            { username: 'a', option: 'song2' },   // a changed their mind
+        ]);
+        shapeEqual(r.counts, { song2: 2 });
+        assert.equal(r.winner, 'song2');
+        assert.equal(r.total, 2);
+    });
+    test('ties break lexicographically — stable everywhere', () => {
+        const r = P.tallyVotes([
+            { username: 'a', option: 'zed' },
+            { username: 'b', option: 'alpha' },
+        ]);
+        assert.equal(r.winner, 'alpha');
+    });
+    test('malformed votes are ignored', () => {
+        const r = P.tallyVotes([
+            { username: 'a', option: 'ok' },
+            { username: '', option: 'x' },
+            { username: 'b' },
+            null,
+            { username: 'c', option: 'y'.repeat(200) },
+        ]);
+        shapeEqual(r.counts, { ok: 1 });
+    });
+    test('empty stream → no winner', () => {
+        assert.equal(P.tallyVotes([]).winner, null);
+    });
+});
+
+describe('electCoordinator — chatter-free agreement', () => {
+    test('lexicographically-smallest wins, case-insensitive', () => {
+        assert.equal(P.electCoordinator(['zeta', 'Alpha', 'beta']), 'Alpha');
+    });
+    test('case tiebreak is deterministic', () => {
+        assert.equal(P.electCoordinator(['Bob', 'bob']), 'Bob');
+        assert.equal(P.electCoordinator(['bob', 'Bob']), 'Bob');   // order-independent
+    });
+    test('empty pool → null', () => {
+        assert.equal(P.electCoordinator([]), null);
+        assert.equal(P.electCoordinator(null), null);
+    });
+});

--- a/tests/test_chat_bus_p1.py
+++ b/tests/test_chat_bus_p1.py
@@ -1,0 +1,226 @@
+"""Chat next-level P1 — the protocol bus foundation + user card overhaul.
+
+The room is plain text; SoulSync envelopes can carry a protocol object under
+'p' (machine coordination: beacons, votes, pins). P1 pins the whole path:
+codec validation (hostile input), unwrap interception (protocol carriers are
+never visible and never archived), the send endpoint (same gate as talking),
+the enriched user card (download history + private notes), and the frontend
+flip (assume-SoulSync presence).
+
+Hermetic throughout — fake slskd client, temp DB, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from flask import Flask, g
+
+import api.chat as chat_api
+from core import chat_codec
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── codec: protocol_of ──────────────────────────────────────────────────────
+
+def test_protocol_roundtrip():
+    env = chat_codec.encode("", {"p": {"k": "jbx.vote", "o": "abc123"}})
+    dec = chat_codec.decode(env)
+    assert chat_codec.protocol_of(dec) == {"k": "jbx.vote", "o": "abc123"}
+
+
+@pytest.mark.parametrize("bad", [
+    None, {}, {"p": None}, {"p": []}, {"p": {"k": 42}},
+    {"p": {"k": "UPPER"}}, {"p": {"k": "a" * 30}},
+    {"p": {"k": "x", "s": "y" * 600}},
+    {"p": {"k": "x.y", "blob": {"deep": {"deeper": 1}}}},
+    {"p": {"k": "x", "huge": 1e20}},
+])
+def test_protocol_rejects_hostile_shapes(bad):
+    assert chat_codec.protocol_of(bad) is None
+
+
+def test_protocol_field_count_bomb():
+    p = {"k": "x"}
+    p.update({f"f{i}": i for i in range(20)})
+    assert chat_codec.protocol_of({"p": p}) is None
+
+
+# ── unwrap: carriers intercepted, never visible ─────────────────────────────
+
+def _msg(text, user="peer", ts="2026-07-24T10:00:00Z"):
+    return {"username": user, "message": text, "timestamp": ts}
+
+
+def test_unwrap_pulls_protocol_out_of_the_visible_list():
+    proto_env = chat_codec.encode("", {"p": {"k": "hello"}})
+    rich_env = chat_codec.encode("hey there")
+    msgs = [_msg("plain text", "vanilla_user"),
+            _msg(proto_env, "app_user"),
+            _msg(rich_env, "app_user")]
+    out, reactions, protocol = chat_api._unwrap_room_messages(msgs)
+    assert len(out) == 2                              # protocol carrier gone
+    assert all(chat_codec.MARKER not in m["message"] for m in out)
+    assert protocol == [{"username": "app_user",
+                         "timestamp": "2026-07-24T10:00:00Z",
+                         "p": {"k": "hello"}}]
+    assert reactions == {}
+
+
+def test_reaction_carriers_still_work_alongside():
+    react = chat_codec.encode("", {"re": {"k": "peer|deadbeef", "e": "🔥"}})
+    out, reactions, protocol = chat_api._unwrap_room_messages([_msg(react, "fan")])
+    assert out == [] and protocol == []
+    assert "peer|deadbeef" in reactions
+
+
+# ── endpoints (fake client harness, mirrors test_chat_api.py) ───────────────
+
+class _FakeClient:
+    base_url = "http://slskd"
+
+    def __init__(self):
+        self.joined = ["SoulSync"]
+        self.sent_room = []
+
+    def get_joined_rooms(self):
+        return list(self.joined)
+
+    def join_room(self, room):
+        self.joined.append(room)
+        return True
+
+    def get_room_messages(self, room):
+        return [
+            {"username": "vanilla_user", "message": "yo", "timestamp": "t1"},
+            {"username": "app_user",
+             "message": chat_codec.encode("", {"p": {"k": "hello"}}), "timestamp": "t2"},
+        ]
+
+    def get_room_users(self, room):
+        return [{"username": "vanilla_user"}, {"username": "app_user"}]
+
+    def send_room_message(self, room, message):
+        self.sent_room.append((room, message))
+        return True
+
+    def get_conversations(self):
+        return []
+
+
+@pytest.fixture()
+def bus_app():
+    client = _FakeClient()
+    state = {"client": client, "admin": True, "config": {}}
+    chat_api.configure(
+        client_getter=lambda: state["client"],
+        run_async=lambda v: v,
+        config_get=lambda key, default=None: state["config"].get(key, default),
+        config_set=lambda key, value: state["config"].__setitem__(key, value),
+    )
+    app = Flask(__name__)
+
+    @app.before_request
+    def _fake_profile():
+        g.is_admin = state["admin"]
+
+    app.register_blueprint(chat_api.create_blueprint())
+    yield app.test_client(), state, client
+    chat_api.configure(client_getter=lambda: None, run_async=lambda v: v,
+                       config_get=lambda k, d=None: d)
+
+
+def test_room_response_carries_protocol_feed(bus_app):
+    http, state, client = bus_app
+    body = http.get("/api/chat/room").get_json()
+    assert body["joined"] is True
+    assert body["protocol"] == [{"username": "app_user", "timestamp": "t2",
+                                 "p": {"k": "hello"}}]
+    # the carrier never appears as a visible message
+    assert all("!SS1!" not in m["message"] for m in body["messages"])
+
+
+def test_protocol_send_encodes_a_carrier(bus_app):
+    http, state, client = bus_app
+    r = http.post("/api/chat/room/protocol",
+                  json={"room": "SoulSync", "p": {"k": "jbx.vote", "o": "x1"}})
+    assert r.get_json()["ok"] is True
+    room, wire = client.sent_room[-1]
+    dec = chat_codec.decode(wire)
+    assert chat_codec.protocol_of(dec) == {"k": "jbx.vote", "o": "x1"}
+    assert dec["t"] == ""                             # empty-text carrier
+
+
+def test_protocol_send_respects_the_send_gate(bus_app):
+    http, state, client = bus_app
+    state["admin"] = False                            # default: only admin talks
+    r = http.post("/api/chat/room/protocol",
+                  json={"room": "SoulSync", "p": {"k": "hello"}})
+    assert r.status_code == 403
+    assert not any("hello" in w for _, w in client.sent_room)
+
+
+def test_protocol_send_rejects_garbage(bus_app):
+    http, state, client = bus_app
+    r = http.post("/api/chat/room/protocol",
+                  json={"room": "SoulSync", "p": {"k": "NOPE!"}})
+    assert r.status_code == 400
+
+
+# ── user card: history + notes (temp DB) ────────────────────────────────────
+
+def test_user_download_stats_and_notes(tmp_path):
+    from database.music_database import MusicDatabase
+    db = MusicDatabase(str(tmp_path / "m.db"))
+    with db._get_connection() as conn:
+        for i, status in enumerate(["completed", "completed", "failed"]):
+            conn.execute(
+                "INSERT INTO track_downloads (source_service, source_username, "
+                "source_filename, source_size, status) VALUES "
+                "('soulseek', 'goodpeer', ?, 1000, ?)", (f"f{i}.flac", status))
+        conn.commit()
+
+    stats = db.get_user_download_stats("goodpeer")
+    assert stats["downloads"] == 3 and stats["completed"] == 2
+    assert stats["success_rate"] == 66.7
+    assert stats["total_bytes"] == 2000               # completed only
+    assert db.get_user_download_stats("stranger")["downloads"] == 0
+
+    assert db.set_chat_user_note("goodpeer", "  great jazz rips  ")
+    assert db.get_chat_user_note("goodpeer") == "great jazz rips"
+    assert db.set_chat_user_note("goodpeer", "")      # empty clears
+    assert db.get_chat_user_note("goodpeer") == ""
+
+
+# ── frontend pins ───────────────────────────────────────────────────────────
+
+def test_frontend_flip_and_bus_wiring():
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    assert "_userClassification" in js
+    assert "cls[n] !== 'vanilla'" in js               # assumed users bucket as SoulSync
+    assert "Other clients" in js                      # the renamed vanilla bucket
+    assert "_ingestProtocol(res.body.protocol)" in js
+    assert "_sendJoinBeacon()" in js
+    assert "onRoomProtocol: onRoomProtocol" in js
+    assert "data-chat-card-note" in js                # note editor on the card
+
+    core = (_ROOT / "webui" / "static" / "core.js").read_text(encoding="utf-8")
+    assert "chat:room_protocol" in core
+
+    html = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+    assert "chat-protocol.js" in html
+    assert html.index("chat-protocol.js") < html.index("filename='chat.js'") \
+        or html.index("chat-protocol.js") < html.index('chat.js')
+
+
+def test_piggybacked_text_still_renders():
+    """REVIEW CATCH: a message with BOTH text and 'p' must render its text
+    (only pure empty-text carriers vanish) — otherwise any client can vanish
+    its own text from SoulSync views, and piggybacked state (now-playing on a
+    real message) would eat the message."""
+    env = chat_codec.encode("check this song out", {"p": {"k": "np", "t2": "Song"}})
+    out, _reactions, protocol = chat_api._unwrap_room_messages([_msg(env, "dj")])
+    assert len(out) == 1 and out[0]["message"] == "check this song out"
+    assert protocol and protocol[0]["p"]["k"] == "np"

--- a/tests/test_chat_files_p2.py
+++ b/tests/test_chat_files_p2.py
@@ -1,0 +1,226 @@
+"""Chat next-level P2 — file sharing via filepost.dev.
+
+Upload (browser file OR a library track resolved server-side), get a CDN
+link, send it dressed as a rich file card (the URL travels as message TEXT
+so links survive archives; the 'f' envelope key only dresses the card).
+Hermetic: the filepost HTTP call is a monkeypatched seam, temp DBs, fake
+slskd client.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from flask import Flask, g
+
+import api.chat as chat_api
+from core import chat_codec
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── codec: file_of ──────────────────────────────────────────────────────────
+
+def test_file_of_roundtrip():
+    env = chat_codec.encode("https://cdn.filepost.dev/x.flac",
+                            {"f": {"n": "song.flac", "s": 12345, "m": "audio/flac"}})
+    dec = chat_codec.decode(env)
+    assert chat_codec.file_of(dec) == {"n": "song.flac", "s": 12345, "m": "audio/flac"}
+    assert dec["t"] == "https://cdn.filepost.dev/x.flac"
+
+
+@pytest.mark.parametrize("bad", [
+    None, {}, {"f": None}, {"f": []}, {"f": {"s": 5}},         # no name
+    {"f": {"n": ""}},
+])
+def test_file_of_rejects_garbage(bad):
+    assert chat_codec.file_of(bad) is None
+
+
+def test_file_of_caps_and_coerces():
+    f = chat_codec.file_of({"f": {"n": "x" * 500, "s": "not-a-number", "m": "y" * 200}})
+    assert len(f["n"]) == 200
+    assert "s" not in f
+    assert len(f["m"]) == 80
+
+
+# ── unwrap: the card rides the visible message ──────────────────────────────
+
+def test_unwrap_attaches_file_card():
+    env = chat_codec.encode("https://cdn.filepost.dev/a.flac",
+                            {"f": {"n": "a.flac", "s": 100}})
+    out, _r, _p = chat_api._unwrap_room_messages(
+        [{"username": "dj", "message": env, "timestamp": "t1"}])
+    assert out[0]["message"] == "https://cdn.filepost.dev/a.flac"
+    assert out[0]["file"] == {"n": "a.flac", "s": 100}
+
+
+# ── endpoints ───────────────────────────────────────────────────────────────
+
+class _FakeClient:
+    base_url = "http://slskd"
+
+    def __init__(self):
+        self.joined = ["SoulSync"]
+        self.sent_room = []
+
+    def get_joined_rooms(self):
+        return list(self.joined)
+
+    def join_room(self, room):
+        self.joined.append(room)
+        return True
+
+    def send_room_message(self, room, message):
+        self.sent_room.append((room, message))
+        return True
+
+
+@pytest.fixture()
+def files_app(tmp_path, monkeypatch):
+    from database.music_database import MusicDatabase
+    db = MusicDatabase(str(tmp_path / "m.db"))
+    media = tmp_path / "media"
+    media.mkdir()
+    track_file = media / "song.flac"
+    track_file.write_bytes(b"x" * 4096)
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, server_source) VALUES ('AR1', 'Muse', 'test')")
+        conn.execute("INSERT INTO albums (id, artist_id, title, server_source) "
+                     "VALUES ('AL1', 'AR1', 'The Resistance', 'test')")
+        conn.execute("INSERT INTO tracks (id, album_id, artist_id, title, file_path, file_size, server_source) "
+                     "VALUES ('T1', 'AL1', 'AR1', 'Uprising', ?, 4096, 'test')", (str(track_file),))
+        conn.execute("INSERT INTO tracks (id, album_id, artist_id, title, file_path, server_source) "
+                     "VALUES ('T2', 'AL1', 'AR1', 'Ghost Track', '/nowhere/gone.flac', 'test')")
+        conn.commit()
+
+    client = _FakeClient()
+    state = {"client": client, "admin": True,
+             "config": {"soulseek.chat_filepost_key": "K123"}}
+    uploads = []
+
+    def fake_upload(api_key, name, stream, expiry=None):
+        uploads.append({"key": api_key, "name": name,
+                        "bytes": len(stream.read()), "expiry": expiry})
+        return {"url": "https://cdn.filepost.dev/abc/" + name}
+
+    monkeypatch.setattr(chat_api, "_filepost_upload", fake_upload)
+    monkeypatch.setattr(chat_api, "_db", lambda: db)
+    chat_api.configure(
+        client_getter=lambda: state["client"],
+        run_async=lambda v: v,
+        config_get=lambda key, default=None: state["config"].get(key, default),
+        config_set=lambda key, value: state["config"].__setitem__(key, value),
+    )
+    app = Flask(__name__)
+
+    @app.before_request
+    def _fake_profile():
+        g.is_admin = state["admin"]
+
+    app.register_blueprint(chat_api.create_blueprint())
+    yield app.test_client(), state, client, uploads
+    chat_api.configure(client_getter=lambda: None, run_async=lambda v: v,
+                       config_get=lambda k, d=None: d)
+
+
+def test_library_track_upload_resolves_path(files_app):
+    http, state, client, uploads = files_app
+    r = http.post("/api/chat/files/upload", json={"track_id": "T1"})
+    body = r.get_json()
+    assert body["ok"] is True
+    assert body["url"].endswith("song.flac")
+    assert body["name"] == "song.flac" and body["size"] == 4096
+    assert uploads[0]["key"] == "K123" and uploads[0]["bytes"] == 4096
+
+
+def test_unreachable_track_404s_without_uploading(files_app):
+    http, state, client, uploads = files_app
+    r = http.post("/api/chat/files/upload", json={"track_id": "T2"})
+    assert r.status_code == 404
+    assert uploads == []
+
+
+def test_browser_file_upload(files_app):
+    import io
+    http, state, client, uploads = files_app
+    r = http.post("/api/chat/files/upload",
+                  data={"file": (io.BytesIO(b"imgdata"), "cover.png")},
+                  content_type="multipart/form-data")
+    body = r.get_json()
+    assert body["ok"] is True and body["name"] == "cover.png"
+    assert body["mime"] == "image/png"
+
+
+def test_no_key_means_503(files_app):
+    http, state, client, uploads = files_app
+    state["config"]["soulseek.chat_filepost_key"] = ""
+    r = http.post("/api/chat/files/upload", json={"track_id": "T1"})
+    assert r.status_code == 503
+    assert uploads == []
+
+
+def test_expiry_setting_travels(files_app):
+    http, state, client, uploads = files_app
+    state["config"]["soulseek.chat_filepost_expiry"] = "7d"
+    http.post("/api/chat/files/upload", json={"track_id": "T1"})
+    assert uploads[0]["expiry"] == "7d"
+
+
+def test_library_search_only_tracks_with_files(files_app):
+    http, state, client, uploads = files_app
+    body = http.get("/api/chat/files/library-search?q=upri").get_json()
+    assert [t["title"] for t in body["tracks"]] == ["Uprising"]
+    assert http.get("/api/chat/files/library-search?q=x").get_json()["tracks"] == []
+
+
+def test_room_send_dresses_the_file_card(files_app):
+    http, state, client, uploads = files_app
+    r = http.post("/api/chat/room/message",
+                  json={"room": "SoulSync", "message": "https://cdn.filepost.dev/a.flac",
+                        "file": {"n": "a.flac", "s": 100, "m": "audio/flac"}})
+    assert r.get_json()["ok"] is True
+    dec = chat_codec.decode(client.sent_room[-1][1])
+    assert dec["t"] == "https://cdn.filepost.dev/a.flac"
+    assert chat_codec.file_of(dec) == {"n": "a.flac", "s": 100, "m": "audio/flac"}
+
+
+def test_settings_round_trip(files_app):
+    http, state, client, uploads = files_app
+    http.post("/api/chat/settings", json={"filepost_key": "NEWKEY", "filepost_expiry": "24h"})
+    assert state["config"]["soulseek.chat_filepost_key"] == "NEWKEY"
+    assert state["config"]["soulseek.chat_filepost_expiry"] == "24h"
+    body = http.get("/api/chat/settings").get_json()
+    assert body["filepost_key_set"] is True and body["filepost_expiry"] == "24h"
+    # bogus expiry values never save
+    http.post("/api/chat/settings", json={"filepost_expiry": "99y"})
+    assert state["config"]["soulseek.chat_filepost_expiry"] == "24h"
+
+
+# ── frontend pins ───────────────────────────────────────────────────────────
+
+def test_frontend_file_wiring():
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    assert "_fileCardHtml" in js
+    assert "data-chat-file-audio" in js and "data-chat-file-video" in js
+    assert "toggleAttachPanel" in js and "attachSendTrack" in js
+    assert "'/api/chat/files/upload'" in js
+    assert "^https:\\/\\//i" in js or "https:" in js   # non-https cards degrade to text
+    html = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+    assert "data-chat-attach-btn" in html and "data-chat-attach-pop" in html
+    assert "data-chat-set-filepost" in html
+
+
+def test_browser_upload_size_cap_holds_server_side(files_app):
+    """REVIEW CATCH: the 50MB cap must reject oversized BROWSER uploads
+    before anything streams to filepost (the library branch already
+    checked; the multipart branch didn't)."""
+    import io
+    http, state, client, uploads = files_app
+    big = io.BytesIO(b"0" * (52 * 1024 * 1024))
+    r = http.post("/api/chat/files/upload",
+                  data={"file": (big, "huge.bin")},
+                  content_type="multipart/form-data")
+    assert r.status_code == 413
+    assert uploads == []

--- a/tests/test_chat_jukebox_p3.py
+++ b/tests/test_chat_jukebox_p3.py
@@ -242,3 +242,22 @@ def test_jukebox_level_up_wiring():
     assert "chat_jbx_vol" in js and "setVolume" in js
     proto = (_ROOT / "webui" / "static" / "chat-protocol.js").read_text(encoding="utf-8")
     assert "skipVotes" in proto and "history" in proto
+
+
+def test_auto_dj_radio_wiring():
+    """Radio mode: shared jbx.radio toggle (latest wins, reduced like all
+    bus state); when the queue runs dry the DJ searches something related
+    to the last-heard track and queues it marked auto — vote/skippable
+    like any human pick, 25s cooldown, never fights the paste-only 503."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    assert "_jbxAutoQueue" in js and "'jbx.radio'" in js
+    wd = js[js.index("function _jbxWatchdog"):js.index("function _jbxAutoQueue")]
+    assert "st.radio && _jbxIsDj()" in wd            # only the DJ tops up
+    auto = js[js.index("function _jbxAutoQueue"):js.index("function _jbxAdvance")]
+    assert "25000" in auto                            # cooldown
+    assert "avoid[h.id] = 1" in auto                  # history never replays
+    assert "a: 1" in auto                             # marked auto
+    proto = (_ROOT / "webui" / "static" / "chat-protocol.js").read_text(encoding="utf-8")
+    assert "jbx.radio" in proto and "entry.auto = true" in proto
+    html = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+    assert "data-chat-jbx-radio" in html

--- a/tests/test_chat_jukebox_p3.py
+++ b/tests/test_chat_jukebox_p3.py
@@ -1,0 +1,199 @@
+"""Chat next-level P3 — the room jukebox.
+
+Queue/votes/now-playing live entirely in the protocol stream (jbx.sub /
+jbx.vote / jbx.now — reduced client-side by chat-protocol.js, covered in
+tests/static/test_chat_protocol.mjs). The server's only new surface is the
+resolve endpoint: YouTube URL/id → keyless oEmbed lookup, free text →
+yt-dlp search through an injected seam. Hermetic — both lookups are
+monkeypatched, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g
+
+import api.chat as chat_api
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ── URL/id parsing ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("q,vid", [
+    ("dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/watch?list=PL123&v=dQw4w9WgXcQ&t=42", "dQw4w9WgXcQ"),
+    ("https://youtu.be/dQw4w9WgXcQ?si=xyz", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://music.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+])
+def test_parse_youtube_id_accepts(q, vid):
+    assert chat_api._parse_youtube_id(q) == vid
+
+
+@pytest.mark.parametrize("q", [
+    "", "daft punk around the world", "https://vimeo.com/12345",
+    "shortid", "x" * 11 + "!",   # 11 chars but bad alphabet
+])
+def test_parse_youtube_id_rejects(q):
+    assert chat_api._parse_youtube_id(q) is None
+
+
+# ── resolve endpoint ────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def jbx_app(monkeypatch):
+    state = {"admin": True, "config": {}, "search_calls": [], "oembed_calls": [],
+             "search_results": [], "oembed_fail": False}
+
+    def fake_search(query, max_results):
+        state["search_calls"].append((query, max_results))
+        return state["search_results"]
+
+    def fake_oembed(video_id):
+        state["oembed_calls"].append(video_id)
+        if state["oembed_fail"]:
+            raise RuntimeError("404")
+        return {"title": "Never Gonna Give You Up", "author_name": "Rick Astley"}
+
+    monkeypatch.setattr(chat_api, "_oembed_fetch", fake_oembed)
+    chat_api.configure(
+        client_getter=lambda: None,
+        run_async=lambda v: v,
+        config_get=lambda key, default=None: state["config"].get(key, default),
+        youtube_search=fake_search,
+    )
+    app = Flask(__name__)
+
+    @app.before_request
+    def _fake_profile():
+        g.is_admin = state["admin"]
+
+    app.register_blueprint(chat_api.create_blueprint())
+    yield app.test_client(), state
+    chat_api.configure(client_getter=lambda: None, run_async=lambda v: v,
+                       config_get=lambda k, d=None: d)
+
+
+def test_url_resolves_via_oembed_exactly_once(jbx_app):
+    http, state = jbx_app
+    body = http.post("/api/chat/jukebox/resolve",
+                     json={"q": "https://youtu.be/dQw4w9WgXcQ"}).get_json()
+    assert body["results"] == [{"id": "dQw4w9WgXcQ",
+                                "title": "Never Gonna Give You Up",
+                                "channel": "Rick Astley"}]
+    assert state["oembed_calls"] == ["dQw4w9WgXcQ"]
+    assert state["search_calls"] == []            # a link never hits yt-dlp
+
+
+def test_free_text_goes_through_search_seam(jbx_app):
+    http, state = jbx_app
+    state["search_results"] = [
+        SimpleNamespace(video_id="aaaaaaaaaaa", title="Around the World",
+                        channel="Daft Punk", duration=429),
+        SimpleNamespace(video_id="not a vid!!", title="hostile", channel="x",
+                        duration=1),              # bad id → filtered
+    ]
+    body = http.post("/api/chat/jukebox/resolve",
+                     json={"q": "daft punk around the world"}).get_json()
+    assert state["search_calls"] == [("daft punk around the world", 5)]
+    assert body["results"] == [{"id": "aaaaaaaaaaa", "title": "Around the World",
+                                "channel": "Daft Punk", "duration": 429}]
+
+
+def test_unresolvable_video_404s(jbx_app):
+    http, state = jbx_app
+    state["oembed_fail"] = True
+    r = http.post("/api/chat/jukebox/resolve", json={"q": "dQw4w9WgXcQ"})
+    assert r.status_code == 404
+
+
+def test_resolve_respects_the_send_gate(jbx_app):
+    """Submitting to the queue is sending — a read-only profile must not be
+    able to make the server fetch YouTube on its behalf either."""
+    http, state = jbx_app
+    state["admin"] = False
+    r = http.post("/api/chat/jukebox/resolve", json={"q": "dQw4w9WgXcQ"})
+    assert r.status_code == 403
+    assert state["oembed_calls"] == [] and state["search_calls"] == []
+
+
+def test_garbage_input_400s_without_lookups(jbx_app):
+    http, state = jbx_app
+    assert http.post("/api/chat/jukebox/resolve", json={}).status_code == 400
+    assert http.post("/api/chat/jukebox/resolve",
+                     json={"q": "x" * 300}).status_code == 400
+    assert state["oembed_calls"] == [] and state["search_calls"] == []
+
+
+def test_no_search_seam_means_paste_only(jbx_app):
+    http, state = jbx_app
+    chat_api.configure(client_getter=lambda: None, run_async=lambda v: v,
+                       config_get=lambda k, d=None: d)   # no youtube_search
+    r = http.post("/api/chat/jukebox/resolve", json={"q": "some song"})
+    assert r.status_code == 503
+    # links still work without the seam
+    body = http.post("/api/chat/jukebox/resolve", json={"q": "dQw4w9WgXcQ"})
+    assert body.get_json()["results"][0]["id"] == "dQw4w9WgXcQ"
+
+
+# ── frontend pins ───────────────────────────────────────────────────────────
+
+def test_frontend_jukebox_wiring():
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    # the reducer is the single source of truth — no shadow queue state
+    assert "reduceJukebox" in js and "nextTrack" in js
+    # room-tagged protocol log: jukebox events must never mix rooms
+    assert "e.room === room" in js
+    assert "room: room, p: p" in js
+    # DJ pool = PROVEN SoulSync users only (assumed could be vanilla)
+    assert "cls[n] === 'soulsync'" in js
+    # playback is opt-in (autoplay-with-sound needs the tune-in gesture)
+    assert "data-chat-jbx-tunein" in js and "_jbxTuneOut" in js
+    # DJ double-fire guard + watchdog for stale/absent now-playing
+    assert "lastAdvanceAt" in js and "_jbxWatchdog" in js
+    assert "'/api/chat/jukebox/resolve'" in js
+
+    proto = (_ROOT / "webui" / "static" / "chat-protocol.js").read_text(encoding="utf-8")
+    assert "reduceJukebox" in proto and "_saneDuration" in proto
+
+    html = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+    assert "data-chat-jukebox" in html and "data-chat-jbx-form" in html
+    assert "data-chat-jbx-player" in html
+
+    css = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8")
+    assert ".chat-jukebox" in css and ".chat-jbx-vote" in css
+
+
+def test_switching_rooms_tunes_out():
+    """Playing room A's track while looking at room B would be chaos — the
+    room switch must destroy the player."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    open_room = js[js.index("function openRoom"):js.index("function loadRooms")]
+    assert "_jbxTuneOut()" in open_room
+
+
+def test_review_catches_pinned():
+    """P3 adversarial review — the four catches must stay fixed:
+    (1) the player follows the ROOM, not the panel (a tuned-in listener in
+    PM view must still hear DJ advances); (2) a transient null now-playing
+    between tracks must never destroy the player; (3) onReady re-syncs so a
+    now-change during iframe boot isn't skipped; (4) the DJ double-fire
+    guard outlasts a slow slskd roundtrip (a duplicate jbx.now restarts the
+    track for the whole room)."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    render = js[js.index("function renderJukebox"):js.index("function toggleJukebox")]
+    # (1) sync happens BEFORE the panel-visibility early return
+    assert render.index("_jbxSyncPlayer") < render.index("if (!show) return;")
+    # (2) between tracks: keep the player
+    sync = js[js.index("function _jbxSyncPlayer"):js.index("function _jbxOnPlayerState")]
+    assert "if (!now) return;" in sync
+    assert "_jbxTuneOut(); return;" not in sync
+    # (3) onReady catches a now-change during boot
+    assert "_jbxSyncPlayer(_jbxState().now)" in sync
+    # (4) roundtrip-proof guard
+    assert "15000" in js[js.index("function _jbxAdvance"):js.index("function _jbxLoadYT")]

--- a/tests/test_chat_jukebox_p3.py
+++ b/tests/test_chat_jukebox_p3.py
@@ -150,8 +150,13 @@ def test_frontend_jukebox_wiring():
     # room-tagged protocol log: jukebox events must never mix rooms
     assert "e.room === room" in js
     assert "room: room, p: p" in js
-    # DJ pool = PROVEN SoulSync users only (assumed could be vanilla)
-    assert "cls[n] === 'soulsync'" in js
+    # DJ pool = PROTOCOL-CAPABLE clients only (live-test catch: envelope
+    # messages also come from pre-jukebox versions — electing one of those
+    # gets a DJ that can never press play, and the queue starves forever)
+    assert "emitters[e.username] = 1" in js
+    assert "cls[n] === 'soulsync'" not in js
+    # starvation fallback: any capable client kicks a DJ-less queue
+    assert "starvedAt" in js and "45000" in js
     # playback is opt-in (autoplay-with-sound needs the tune-in gesture)
     assert "data-chat-jbx-tunein" in js and "_jbxTuneOut" in js
     # DJ double-fire guard + watchdog for stale/absent now-playing

--- a/tests/test_chat_jukebox_p3.py
+++ b/tests/test_chat_jukebox_p3.py
@@ -213,5 +213,32 @@ def test_watchdog_polls_the_player_not_just_the_event():
     js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
     wd = js[js.index("function _jbxWatchdog"):js.index("function _jbxAdvance")]
     assert "getPlayerState() === 0" in wd
-    assert "getDuration()" in wd
     assert "playerEnded" in wd
+    # the player-truth duration lives in the shared helper the watchdog calls
+    assert "_jbxEffDuration(st.now)" in wd
+    eff = js[js.index("function _jbxEffDuration"):js.index("function _jbxSkipNeeded")]
+    assert "getDuration()" in eff
+
+
+def test_jukebox_level_up_wiring():
+    """The polish pass: thumbnails, progress bar, skip votes, pull-your-own,
+    history with replay, audio-only, local volume — all reduced from the
+    same stream (three new verbs: jbx.skip / jbx.unsub, history from
+    jbx.now handoffs), still zero server surface."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    # free YouTube thumbnails, no API
+    assert "i.ytimg.com/vi/" in js
+    # skip is majority-of-listeners, deterministic from the tuned set
+    assert "_jbxSkipNeeded" in js and "Math.ceil(n / 2)" in js
+    assert "'jbx.skip'" in js and "'jbx.unsub'" in js
+    # the watchdog treats a skip majority as end-of-track
+    wd = js[js.index("function _jbxWatchdog"):js.index("function _jbxAdvance")]
+    assert "st.skips >= _jbxSkipNeeded()" in wd
+    # audio-only collapses the container but never kills the iframe
+    assert "chat-jbx-player--audio" in js
+    css = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8")
+    assert "height: 0 !important" in css.split(".chat-jbx-player--audio", 1)[1][:120]
+    # volume is local-only (player.setVolume, persisted, never a protocol event)
+    assert "chat_jbx_vol" in js and "setVolume" in js
+    proto = (_ROOT / "webui" / "static" / "chat-protocol.js").read_text(encoding="utf-8")
+    assert "skipVotes" in proto and "history" in proto

--- a/tests/test_chat_jukebox_p3.py
+++ b/tests/test_chat_jukebox_p3.py
@@ -202,3 +202,16 @@ def test_review_catches_pinned():
     assert "_jbxSyncPlayer(_jbxState().now)" in sync
     # (4) roundtrip-proof guard
     assert "15000" in js[js.index("function _jbxAdvance"):js.index("function _jbxLoadYT")]
+
+
+def test_watchdog_polls_the_player_not_just_the_event():
+    """Live-test catch #2 (Boulder): a pasted-link track has NO duration
+    (oEmbed doesn't provide one), so when the iframe's ENDED event goes
+    missing the queue sat until the 15-minute unknown-length cap. The
+    watchdog must ask a tuned-in player directly — getPlayerState() for
+    ended, getDuration() for the real length."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    wd = js[js.index("function _jbxWatchdog"):js.index("function _jbxAdvance")]
+    assert "getPlayerState() === 0" in wd
+    assert "getDuration()" in wd
+    assert "playerEnded" in wd

--- a/tests/test_chat_p4_surfaces.py
+++ b/tests/test_chat_p4_surfaces.py
@@ -1,0 +1,92 @@
+"""Chat next-level P4 — polls, pins, room topic, tuned-in presence.
+
+Zero new server surface: all four features are pure folds over the P1
+protocol bus (reducePins / reducePoll / reduceTopic / reduceTuned in
+chat-protocol.js — determinism covered in tests/static/test_chat_protocol.mjs).
+These tests pin the frontend wiring contracts so a refactor can't quietly
+detach a surface from the bus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_JS = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+_PROTO = (_ROOT / "webui" / "static" / "chat-protocol.js").read_text(encoding="utf-8")
+_HTML = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+_CSS = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8")
+
+
+def test_reducers_exist_and_are_exported():
+    for name in ("reducePins", "reducePoll", "reduceTopic", "reduceTuned"):
+        assert name in _PROTO
+        assert (name + ": " + name) in _PROTO       # exported on window.ChatProtocol
+
+
+def test_pin_wiring():
+    # pin action on room messages + the board renders from the bus
+    assert "data-chat-pin-user" in _JS and "data-chat-pin-ts" in _JS
+    assert "reducePins(_roomEvents())" in _JS
+    assert "data-chat-pins-toggle" in _JS
+    assert "pin.del" in _JS
+    assert "data-chat-pinbar" in _HTML
+    assert ".chat-pinbar" in _CSS
+
+
+def test_poll_wiring():
+    assert "reducePoll(_roomEvents())" in _JS
+    assert "'poll.start'" in _JS and "'poll.vote'" in _JS and "'poll.end'" in _JS
+    # only the starter sees End poll (reducer enforces it too — belt & braces)
+    assert "poll.by === state.selfName" in _JS
+    assert "data-chat-poll-pop" in _HTML and "data-chat-poll-btn" in _HTML
+    assert ".chat-poll-bar" in _CSS
+
+
+def test_topic_wiring():
+    assert "reduceTopic(_roomEvents())" in _JS
+    assert "'topic.set'" in _JS
+    assert "data-chat-topic-input" in _JS
+    # the open topic input must survive the 4s poll's renderHead
+    assert "if (state.topicEditing) return;" in _JS
+
+
+def test_tuned_presence_wiring():
+    assert "reduceTuned(_roomEvents())" in _JS
+    assert "'jbx.tune'" in _JS
+    assert "chat-user-tuned" in _JS and ".chat-user-tuned" in _CSS
+
+
+def test_bus_surfaces_paint_together():
+    """One ingest → every reduced surface repaints (a fresh event may touch
+    any of them; painting piecemeal is how surfaces drift stale)."""
+    assert "renderBusUI()" in _JS
+    ingest = _JS[_JS.index("function _ingestProtocol"):_JS.index("function sendProtocol")]
+    assert "renderBusUI()" in ingest
+    bus_ui = _JS[_JS.index("function renderBusUI"):_JS.index("function renderPinbar")]
+    for call in ("renderJukebox()", "renderPinbar()", "renderPoll()", "renderHead()"):
+        assert call in bus_ui
+
+
+def test_polls_are_room_only():
+    """Bus events mean nothing in a PM — the poll button must hide there."""
+    composer = _JS[_JS.index("function renderComposer"):_JS.index("var _FMT")]
+    assert "data-chat-poll-btn" in composer
+
+
+def test_p4_review_catches_pinned():
+    """P4 adversarial review — three catches must stay fixed:
+    (1) a socket protocol event during history-search must not rebuild the
+    head (it would clobber the search input mid-typing); (2) the room switch
+    tunes out BEFORE state.room flips so the jbx.tune off event reaches the
+    OLD room — otherwise you show as listening there forever; (3) the tuned
+    map reduces once per user-list render, not once per user."""
+    js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8")
+    bus_ui = js[js.index("function renderBusUI"):js.index("function renderPinbar")]
+    assert "if (!state.searchMode) renderHead();" in bus_ui
+    open_room = js[js.index("function openRoom"):js.index("function loadRooms")]
+    assert open_room.index("_jbxTuneOut()") < open_room.index("state.room = nextRoom")
+    users_list = js[js.index("function renderUsersList"):js.index("function renderSide")]
+    assert "reduceTuned(_roomEvents())" in users_list
+    user_btn = js[js.index("function _userBtn"):js.index("function renderUsers(")]
+    assert "reduceTuned" not in user_btn

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -160,5 +160,25 @@ class TestChatModalStandard:
         for hook in ("data-chat-jbx-headbar", "data-chat-jbx-form",
                      "data-chat-jbx-listeners", "data-chat-jbx-results"):
             assert hook in header, hook
-        panel = _HTML[_HTML.index('data-chat-jukebox hidden'):_HTML.index('data-chat-pinbar')]
-        assert "data-chat-jbx-form" not in panel
+        rail = _HTML[_HTML.index('class="chat-rail"'):_HTML.index('data-chat-users')]
+        assert "data-chat-jukebox" in rail             # queue/player card in the right rail
+        assert "data-chat-jbx-form" not in rail        # ...without a second add-song form
+
+
+class TestBusSurfacePlacement:
+    """Boulder's layout round 2: jukebox queue/player = right-rail card,
+    pins = head-button popover (zero standing height), poll stays inline."""
+
+    def test_pins_are_a_popover_not_a_bar(self):
+        css = (_ROOT / "webui" / "static" / "style.css").read_text(
+            encoding="utf-8", errors="replace")
+        bar = css[css.index(".chat-pinbar {"):css.index(".chat-pins-title")]
+        assert "position: absolute" in bar
+        # the head button carries the count; outside clicks close the popover
+        assert "data-chat-pins-toggle" in _CHAT_JS
+        assert "state.pinsOpen && !e.target.closest('[data-chat-pins-toggle]')" in _CHAT_JS
+
+    def test_poll_card_stays_inline_in_the_main_column(self):
+        main = _HTML[_HTML.index('class="chat-main"'):_HTML.index('class="chat-rail"')]
+        assert "data-chat-poll" in main
+        assert "data-chat-jukebox" not in main         # the panel left the main column

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -201,3 +201,24 @@ class TestTypingIndicators:
         assert "data-chat-typing" in _HTML
         css = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8", errors="replace")
         assert ".chat-typing" in css
+
+
+class TestSlashCommands:
+    """/play /skip /tune /topic /poll /pin /gif /shrug — power-user glue
+    over existing features. Autocomplete shares the mention pop; unknown
+    /words fall through as plain messages (never eaten)."""
+
+    def test_wiring(self):
+        js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8", errors="replace")
+        assert "SLASH_COMMANDS" in js and "_runSlash" in js
+        for cmd in ("'play'", "'skip'", "'tune'", "'topic'", "'poll'", "'pin'", "'gif'", "'shrug'"):
+            assert "cmd === " + cmd in js, cmd
+        # unknown commands are sent as text, not swallowed
+        run = js[js.index("function _runSlash"):js.index("function pickMention")]
+        assert run.rstrip().endswith("// unknown /word → plain message\n    }") or "return false;" in run[-200:]
+        # Tab completes the first hit; commands never emit typing noise
+        assert "data-chat-slash-pick" in js
+        assert "=== '/') return;" in js.split("_maybeSendTyping", 2)[2][:600]
+        # send() intercepts before posting
+        send_fn = js[js.index("function send()"):js.index("function send()") + 3000]
+        assert "_runSlash(text)" in send_fn

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -152,7 +152,13 @@ class TestChatModalStandard:
         assert "Trying again often works" in py
         assert "offline or not sharing" not in py      # the victim-blaming line
 
-    def test_jukebox_add_song_lives_in_the_panel_head(self):
-        head = _HTML[_HTML.index('class="chat-jbx-head"'):_HTML.index('data-chat-jbx-results')]
-        assert "data-chat-jbx-form" in head            # add-song docked in the head row
-        assert "data-chat-jbx-listeners" in head
+    def test_jukebox_controls_live_in_the_page_header(self):
+        # Boulder: the jukebox bar (brand + listeners + add-a-song) rides
+        # tools-page-header, not the panel; the panel below is queue-only
+        header = _HTML[_HTML.index('class="tools-page-header chat-page-head"'):
+                       _HTML.index('class="chat-shell"')]
+        for hook in ("data-chat-jbx-headbar", "data-chat-jbx-form",
+                     "data-chat-jbx-listeners", "data-chat-jbx-results"):
+            assert hook in header, hook
+        panel = _HTML[_HTML.index('data-chat-jukebox hidden'):_HTML.index('data-chat-pinbar')]
+        assert "data-chat-jbx-form" not in panel

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -182,3 +182,22 @@ class TestBusSurfacePlacement:
         main = _HTML[_HTML.index('class="chat-main"'):_HTML.index('class="chat-rail"')]
         assert "data-chat-poll" in main
         assert "data-chat-jukebox" not in main         # the panel left the main column
+
+
+class TestTypingIndicators:
+    """typ events on the bus — deliberately frugal (every carrier is a
+    visible noise line for vanilla clients): composition start + at most
+    one refresh per 20s, 25s TTL, cleared instantly when the typer's
+    message lands, and archive replay on room open never ghost-types."""
+
+    def test_wiring(self):
+        js = (_ROOT / "webui" / "static" / "chat.js").read_text(encoding="utf-8", errors="replace")
+        assert "_maybeSendTyping" in js and "sendProtocol('typ', {})" in js
+        assert "< 20000) return;" in js                        # the frugality throttle
+        assert "_TYP_TTL = 25000" in js
+        assert "_clearTypingFor(res.body.messages)" in js      # message beats indicator
+        assert "typingArmedAt" in js                           # archive replay guard
+        assert "!== state.selfName" in js.split("p.k === 'typ'", 1)[1][:200]
+        assert "data-chat-typing" in _HTML
+        css = (_ROOT / "webui" / "static" / "style.css").read_text(encoding="utf-8", errors="replace")
+        assert ".chat-typing" in css

--- a/tests/test_chat_page.py
+++ b/tests/test_chat_page.py
@@ -123,3 +123,36 @@ class TestMessageUserHooks:
         assert dl.count("escapeHtml(result.username || '').replace(/\"/g, '&quot;')") == 2
         # candidates: only SOULSEEK peers are messageable (torrent rows aren't users)
         assert "/soulseek/i.test(String(c.source))" in dl
+
+
+class TestChatModalStandard:
+    """Boulder's design feedback (Jul 24): chat modals must follow the app's
+    modal standard — accent-var chrome + modal-button actions, no hardcoded
+    Spotify green — and browse failures must be honest + retryable."""
+
+    def test_modal_actions_use_the_standard_buttons(self):
+        # all four chat modals' action rows ride modal-button, not chat-*-btn
+        import re
+        for anchor in ("data-chat-card-message", "data-chat-browse-dl",
+                       "data-chat-rooms-close", "data-chat-settings-save"):
+            btn = re.search(r'<button[^>]*' + anchor + r'[^>]*>', _HTML)
+            assert btn and 'modal-button' in btn.group(0), anchor
+
+    def test_modal_css_is_accent_var_not_green(self):
+        css = (_ROOT / "webui" / "static" / "style.css").read_text(
+            encoding="utf-8", errors="replace")
+        block = css[css.index(".chat-settings-overlay {"):css.index(".chat-input--area")]
+        assert "#1db954" not in block                  # the green is gone
+        assert "var(--accent-rgb)" in block            # themeable accent chrome
+        assert "linear-gradient(135deg, #1a1a1a" in block   # the standard card
+
+    def test_browse_failure_offers_retry(self):
+        assert "data-chat-browse-retry" in _CHAT_JS
+        py = (_ROOT / "api" / "chat.py").read_text(encoding="utf-8", errors="replace")
+        assert "Trying again often works" in py
+        assert "offline or not sharing" not in py      # the victim-blaming line
+
+    def test_jukebox_add_song_lives_in_the_panel_head(self):
+        head = _HTML[_HTML.index('class="chat-jbx-head"'):_HTML.index('data-chat-jbx-results')]
+        assert "data-chat-jbx-form" in head            # add-song docked in the head row
+        assert "data-chat-jbx-listeners" in head

--- a/tests/test_chat_protocol_js.py
+++ b/tests/test_chat_protocol_js.py
@@ -1,0 +1,52 @@
+"""Run the JS tests for `webui/static/chat-protocol.js` under pytest.
+
+The contract tests live in `tests/static/test_chat_protocol.mjs` and run via
+Node's built-in test runner. Determinism across clients IS the feature the
+protocol library exists for, so a regression here breaks room coordination
+(jukebox votes, coordinator election, the assume-SoulSync presence flip).
+
+Skipped when node isn't available or is older than 22 — same policy as
+tests/test_auto_sync_js.py.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TEST_FILE = _REPO_ROOT / "tests" / "static" / "test_chat_protocol.mjs"
+
+
+def _node_available() -> bool:
+    if not shutil.which("node"):
+        return False
+    try:
+        result = subprocess.run(
+            ["node", "--version"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    if result.returncode != 0:
+        return False
+    raw = (result.stdout or "").strip().lstrip("v")
+    try:
+        major = int(raw.split(".")[0])
+    except (ValueError, IndexError):
+        return False
+    return major >= 22
+
+
+@pytest.mark.skipif(not _node_available(), reason="node >= 22 not available")
+def test_chat_protocol_js_suite():
+    result = subprocess.run(
+        ["node", "--test", str(_TEST_FILE)],
+        capture_output=True, text=True, timeout=120, cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        "chat-protocol JS tests failed:\n" + (result.stdout or "") + (result.stderr or "")
+    )

--- a/tests/test_track_repair_disc_1075.py
+++ b/tests/test_track_repair_disc_1075.py
@@ -1,0 +1,178 @@
+"""Track Number Repair vs album versions + disc tags (#1075, Lain2077).
+
+KID A MNESIA: 3 discs, and disc 3 opens with "Like Spinning Plates
+('Why Us?' Version)" while disc 2 closes with the original "Like Spinning
+Plates". The matcher strips parentheses before comparing, so BOTH candidates
+normalized to the same string, both scored 100%, and first-in-tracklist won:
+the file was matched to the wrong disc's original version and renumbered
+1 → 10. On top of that the repair wrote per-disc track numbers but never the
+disc tag — on a disc-tagless file that just manufactures a duplicate track
+number — and the finding never said the numbering was disc-relative.
+
+Pins: raw-title tiebreak on stripped-score ties, disc-tag enforcement on
+multi-disc albums (never on single-disc), explicit disc wording in the
+changes, and approve-path parity for the disc write.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+from mutagen.flac import FLAC
+
+from core.repair_jobs.track_number_repair import (
+    _fix_disc_number_tag,
+    _match_title_to_api_track,
+    _check_single_track,
+    _plan_track_repair,
+)
+
+
+def _make_flac(path: Path, tags: dict | None = None) -> None:
+    fLaC = b'fLaC'
+    streaminfo = bytearray(34)
+    streaminfo[0:2] = struct.pack('>H', 4096)
+    streaminfo[2:4] = struct.pack('>H', 4096)
+    streaminfo[10] = 0x0A
+    streaminfo[12] = 0x70
+    block_header = bytes([0x80, 0x00, 0x00, 0x22])
+    path.write_bytes(fLaC + block_header + bytes(streaminfo))
+    audio = FLAC(str(path))
+    if tags:
+        for k, v in tags.items():
+            audio[k] = [v]
+    audio.save()
+
+
+def _kid_a_mnesia():
+    """The reporter's album shape: 3 discs; disc 2 ends with the original
+    'Like Spinning Plates' (#10 of 11), disc 3 opens with the 'Why Us?'
+    version (#1 of 12)."""
+    tracks = []
+    for n in range(1, 12):
+        name = 'Like Spinning Plates' if n == 10 else f'D2 Song {n:02d}'
+        tracks.append({'name': name, 'track_number': n, 'disc_number': 2})
+    tracks.append({'name': "Like Spinning Plates ('Why Us?' Version)",
+                   'track_number': 1, 'disc_number': 3})
+    for n in range(2, 13):
+        tracks.append({'name': f'D3 Song {n:02d}', 'track_number': n, 'disc_number': 3})
+    for n in range(1, 12):
+        tracks.insert(n - 1, {'name': f'D1 Song {n:02d}', 'track_number': n,
+                              'disc_number': 1})
+    return tracks
+
+
+# ── the version tiebreak ─────────────────────────────────────────────────────
+
+def test_version_qualifier_breaks_normalized_ties():
+    """The reporter's exact case: the 'Why Us?' version file must match the
+    'Why Us?' API track (D3 #1), not the original (D2 #10) that used to win
+    by tracklist order."""
+    m, score = _match_title_to_api_track(
+        "Like Spinning Plates ('Why Us?' Version)", _kid_a_mnesia(), 0.8)
+    assert m['disc_number'] == 3 and m['track_number'] == 1
+    assert score == 1.0
+
+    # and the mirror: the plain original still matches the original
+    m2, _ = _match_title_to_api_track('Like Spinning Plates', _kid_a_mnesia(), 0.8)
+    assert m2['disc_number'] == 2 and m2['track_number'] == 10
+
+
+def test_tiebreak_never_outranks_a_better_stripped_score():
+    """The raw title only breaks TIES — a clearly better stripped match must
+    still win even when its raw similarity is lower."""
+    tracks = [
+        {'name': 'Karma Police (Live at Oxford)', 'track_number': 1, 'disc_number': 1},
+        {'name': 'Karma Poliz', 'track_number': 2, 'disc_number': 1},
+    ]
+    m, _ = _match_title_to_api_track('Karma Police', tracks, 0.5)
+    assert m['track_number'] == 1          # stripped: exact; raw penalty ignored
+
+
+def test_full_plan_lands_on_the_right_disc(tmp_path):
+    """End to end on the reporter's file: no disc tag, track #1 — the plan
+    must match D3 #1 (already-correct number) and propose ONLY the missing
+    disc tag, not a renumber to 10."""
+    f = tmp_path / "Radiohead - Like Spinning Plates ('Why Us_' Version).flac"
+    _make_flac(f, {'title': "Like Spinning Plates ('Why Us?' Version)",
+                   'tracknumber': '1'})
+    plan = _plan_track_repair(str(f), f.name, _kid_a_mnesia(), 0.8)
+    assert plan is not None
+    assert plan['correct_disc'] == 3 and plan['correct_num'] == 1
+    assert plan['tag_ok'] is True          # 1 was right all along
+    assert plan['disc_ok'] is False        # the missing disc tag IS the finding
+    assert plan['total_discs'] == 3
+
+
+# ── disc-tag enforcement ─────────────────────────────────────────────────────
+
+def test_multi_disc_file_without_disc_tag_is_flagged(tmp_path):
+    f = tmp_path / "10 - Like Spinning Plates.flac"
+    _make_flac(f, {'title': 'Like Spinning Plates', 'tracknumber': '10/11'})
+    finding = _check_single_track(str(f), f.name, _kid_a_mnesia(), 0.8)
+    assert finding is not None
+    assert any(c == 'Disc: none -> 2/3' for c in finding['details']['changes'])
+    assert finding['details']['disc_ok'] is False
+    assert finding['details']['disc_number'] == 2
+    assert finding['details']['total_discs'] == 3
+
+
+def test_wrong_disc_tag_is_corrected(tmp_path):
+    f = tmp_path / "10 - Like Spinning Plates.flac"
+    _make_flac(f, {'title': 'Like Spinning Plates', 'tracknumber': '10/11',
+                   'discnumber': '1'})
+    plan = _plan_track_repair(str(f), f.name, _kid_a_mnesia(), 0.8)
+    # NB: a wrong disc tag steers disc-aware matching first, but the full-
+    # tracklist fallback still finds the right track; the disc gets fixed
+    assert plan is not None and plan['disc_ok'] is False
+    assert plan['correct_disc'] == 2
+
+
+def test_correct_multi_disc_file_stays_quiet(tmp_path):
+    f = tmp_path / "10 - Like Spinning Plates.flac"
+    _make_flac(f, {'title': 'Like Spinning Plates', 'tracknumber': '10/11',
+                   'discnumber': '2/3'})
+    assert _plan_track_repair(str(f), f.name, _kid_a_mnesia(), 0.8) is None
+
+
+def test_single_disc_albums_never_get_disc_findings(tmp_path):
+    tracks = [{'name': f'Song {n}', 'track_number': n, 'disc_number': 1}
+              for n in range(1, 11)]
+    f = tmp_path / "03 - Song 3.flac"
+    _make_flac(f, {'title': 'Song 3', 'tracknumber': '3/10'})   # no disc tag
+    assert _plan_track_repair(str(f), f.name, tracks, 0.8) is None
+
+
+def test_track_change_wording_is_disc_relative(tmp_path):
+    """The confusion in #1075: '1 -> 10' with no hint the 10 is disc-local.
+    Multi-disc changes must say the disc."""
+    f = tmp_path / "Radiohead - Like Spinning Plates.flac"
+    _make_flac(f, {'title': 'Like Spinning Plates', 'tracknumber': '1'})
+    finding = _check_single_track(str(f), f.name, _kid_a_mnesia(), 0.8)
+    assert finding is not None
+    changes = finding['details']['changes']
+    assert any(c.startswith('Track number: 1 -> 10 (disc 2 of 3)') for c in changes)
+    assert any('per disc' in c for c in changes if c.startswith('Total tracks'))
+
+
+# ── the disc writer + approve-path parity ────────────────────────────────────
+
+def test_fix_disc_number_tag_writes_flac_tags(tmp_path):
+    f = tmp_path / "x.flac"
+    _make_flac(f, {'title': 'X'})
+    _fix_disc_number_tag(str(f), 2, 3)
+    audio = FLAC(str(f))
+    assert audio['discnumber'] == ['2/3']
+    assert audio['disctotal'] == ['3']
+
+
+def test_approve_path_honors_disc_ok():
+    """The worker's approval fixer must (a) write the disc tag when the
+    finding says disc_ok False, and (b) never disc-write on legacy findings
+    that predate the field."""
+    import inspect
+    from core import repair_worker
+    src = inspect.getsource(repair_worker)
+    assert "details.get('disc_ok', True)" in src
+    assert '_fix_disc_number_tag' in src

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.1.6"
+_SOULSYNC_BASE_VERSION = "3.1.7"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/web_server.py
+++ b/web_server.py
@@ -40396,10 +40396,23 @@ def _emit_chat_push_loop():
                 if fresh:
                     # live pushes carry the same DECODED view the API serves
                     from core import chat_codec
-                    def _unwrap(m):
+                    proto_events = []
+                    def _unwrap(m, _sink=proto_events):   # bound at def (B023)
                         dec = chat_codec.decode(m.get('message'))
                         if dec is not None and chat_codec.reaction_of(dec):
                             return None      # reaction carriers never render/badge
+                        if dec is not None:
+                            _p = chat_codec.protocol_of(dec)
+                            if _p:
+                                # machine coordination: never archived, pushed
+                                # on its own channel for real-time handling.
+                                # Only PURE carriers (empty text) vanish —
+                                # piggybacked text still renders/archives.
+                                _sink.append({
+                                    'username': m.get('username'),
+                                    'timestamp': m.get('timestamp'), 'p': _p})
+                                if not dec.get('t'):
+                                    return None
                         out = {'username': m.get('username'),
                                'message': dec['t'] if dec else m.get('message'),
                                'timestamp': m.get('timestamp')}
@@ -40410,6 +40423,9 @@ def _emit_chat_push_loop():
                                 out['reply'] = rep
                         return out
                     decoded = [x for x in (_unwrap(m) for m in fresh) if x]
+                    if proto_events:
+                        socketio.emit('chat:room_protocol', {
+                            'room': room, 'events': proto_events[-40:]})
                     if decoded:      # a reaction-only tick still tracks PMs below
                         try:
                             get_database().add_chat_messages(room, decoded)

--- a/web_server.py
+++ b/web_server.py
@@ -40892,12 +40892,21 @@ app.register_blueprint(_create_enrichment_blueprint())
 # Soulseek chat (rooms + PMs through slskd) — side-neutral, absolute /api/chat
 # paths, mounted OUTSIDE the video blueprint so music-only profiles reach it.
 from api.chat import configure as _configure_chat_api, create_blueprint as _create_chat_blueprint
+def _chat_youtube_search(query, max_results):
+    """Jukebox search seam: the shared yt-dlp client, or None → paste-only."""
+    yt = download_orchestrator.client("youtube")
+    if yt is None:
+        return []
+    return run_async(yt.search_videos(query, max_results=max_results))
+
+
 _configure_chat_api(
     client_getter=lambda: download_orchestrator.client("soulseek"),
     run_async=run_async,
     config_get=lambda key, default=None: config_manager.get(key, default),
     config_set=lambda key, value: config_manager.set(key, value),
     db_getter=get_database,
+    youtube_search=_chat_youtube_search,
 )
 app.register_blueprint(_create_chat_blueprint())
 

--- a/web_server.py
+++ b/web_server.py
@@ -40421,6 +40421,9 @@ def _emit_chat_push_loop():
                             rep = chat_codec.reply_of(dec)
                             if rep:
                                 out['reply'] = rep
+                            _f = chat_codec.file_of(dec)
+                            if _f:
+                                out['file'] = _f
                         return out
                     decoded = [x for x in (_unwrap(m) for m in fresh) if x]
                     if proto_events:

--- a/webui/index.html
+++ b/webui/index.html
@@ -10060,6 +10060,20 @@
                         </aside>
                         <main class="chat-main">
                             <div class="chat-head" data-chat-head></div>
+                            <!-- room jukebox: shared YouTube listening, votes pick what's next.
+                                 Static skeleton — the submit input and the player iframe must
+                                 survive the 4s poll (renderJukebox only rewrites now/queue). -->
+                            <div class="chat-jukebox" data-chat-jukebox hidden>
+                                <div class="chat-jbx-now" data-chat-jbx-now></div>
+                                <div class="chat-jbx-player" data-chat-jbx-player hidden></div>
+                                <div class="chat-jbx-queue" data-chat-jbx-queue></div>
+                                <form class="chat-jbx-form" data-chat-jbx-form>
+                                    <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
+                                           placeholder="Add a song — paste a YouTube link or search…" autocomplete="off">
+                                    <button type="submit" class="chat-fmt-btn chat-jbx-add">Add</button>
+                                </form>
+                                <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
+                            </div>
                             <!-- user popover card (click any username) -->
                             <div class="chat-settings-overlay" data-chat-user-card hidden>
                                 <div class="chat-settings-modal chat-user-card">

--- a/webui/index.html
+++ b/webui/index.html
@@ -10042,13 +10042,25 @@
                  via SHARED_PAGES (video-side.js). All content driven by chat.js. -->
             <div class="page" id="chat-page">
                 <div class="page-shell chat-page-container">
-                    <div class="tools-page-header">
+                    <div class="tools-page-header chat-page-head">
                         <div class="tools-page-header-left">
                             <h2 class="tools-page-title">
                                 <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
                                 Chat
                             </h2>
                             <p class="tools-page-subtitle" data-chat-subtitle>Soulseek rooms &amp; private messages</p>
+                        </div>
+                        <!-- the jukebox lives up here (Boulder): brand + listeners +
+                             add-a-song; the queue/player panel opens below in the room -->
+                        <div class="chat-jbx-headbar" data-chat-jbx-headbar hidden>
+                            <span class="chat-jbx-brand">♫ Jukebox</span>
+                            <span class="chat-jbx-listeners" data-chat-jbx-listeners></span>
+                            <form class="chat-jbx-form" data-chat-jbx-form>
+                                <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
+                                       placeholder="Add a song or paste a YouTube link…" autocomplete="off">
+                                <button type="submit" class="chat-fmt-btn chat-jbx-add">Add</button>
+                            </form>
+                            <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
                         </div>
                     </div>
                     <div class="chat-shell">
@@ -10064,16 +10076,6 @@
                                  Static skeleton — the submit input and the player iframe must
                                  survive the 4s poll (renderJukebox only rewrites now/queue). -->
                             <div class="chat-jukebox" data-chat-jukebox hidden>
-                                <div class="chat-jbx-head">
-                                    <span class="chat-jbx-brand">♫ Jukebox</span>
-                                    <span class="chat-jbx-listeners" data-chat-jbx-listeners></span>
-                                    <form class="chat-jbx-form" data-chat-jbx-form>
-                                        <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
-                                               placeholder="Add a song or paste a YouTube link…" autocomplete="off">
-                                        <button type="submit" class="chat-fmt-btn chat-jbx-add">Add</button>
-                                    </form>
-                                </div>
-                                <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
                                 <div class="chat-jbx-now" data-chat-jbx-now></div>
                                 <div class="chat-jbx-player" data-chat-jbx-player hidden></div>
                                 <div class="chat-jbx-queue" data-chat-jbx-queue></div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10064,15 +10064,19 @@
                                  Static skeleton — the submit input and the player iframe must
                                  survive the 4s poll (renderJukebox only rewrites now/queue). -->
                             <div class="chat-jukebox" data-chat-jukebox hidden>
+                                <div class="chat-jbx-head">
+                                    <span class="chat-jbx-brand">♫ Jukebox</span>
+                                    <span class="chat-jbx-listeners" data-chat-jbx-listeners></span>
+                                    <form class="chat-jbx-form" data-chat-jbx-form>
+                                        <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
+                                               placeholder="Add a song or paste a YouTube link…" autocomplete="off">
+                                        <button type="submit" class="chat-fmt-btn chat-jbx-add">Add</button>
+                                    </form>
+                                </div>
+                                <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
                                 <div class="chat-jbx-now" data-chat-jbx-now></div>
                                 <div class="chat-jbx-player" data-chat-jbx-player hidden></div>
                                 <div class="chat-jbx-queue" data-chat-jbx-queue></div>
-                                <form class="chat-jbx-form" data-chat-jbx-form>
-                                    <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
-                                           placeholder="Add a song — paste a YouTube link or search…" autocomplete="off">
-                                    <button type="submit" class="chat-fmt-btn chat-jbx-add">Add</button>
-                                </form>
-                                <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
                             </div>
                             <!-- pinned messages + the room poll: pure folds over the protocol bus -->
                             <div class="chat-pinbar" data-chat-pinbar hidden></div>
@@ -10082,10 +10086,10 @@
                                 <div class="chat-settings-modal chat-user-card">
                                     <div data-chat-user-card-body></div>
                                     <div class="chat-settings-actions">
-                                        <button type="button" class="chat-fmt-btn" data-chat-card-close>Close</button>
-                                        <button type="button" class="chat-fmt-btn" data-chat-card-ignore>Mute</button>
-                                        <button type="button" class="chat-fmt-btn" data-chat-card-browse>Browse files</button>
-                                        <button type="button" class="chat-send-btn" data-chat-card-message>Message</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-card-close>Close</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-card-ignore>Mute</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-card-browse>Browse files</button>
+                                        <button type="button" class="modal-button modal-button--primary" data-chat-card-message>Message</button>
                                     </div>
                                 </div>
                             </div>
@@ -10097,9 +10101,9 @@
                                            placeholder="Filter folders…" autocomplete="off">
                                     <div class="chat-browse-body" data-chat-browse-body></div>
                                     <div class="chat-settings-actions">
-                                        <button type="button" class="chat-fmt-btn" data-chat-browse-back hidden>&larr; Folders</button>
-                                        <button type="button" class="chat-fmt-btn" data-chat-browse-close>Close</button>
-                                        <button type="button" class="chat-send-btn" data-chat-browse-dl hidden>Download selected</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-browse-back hidden>&larr; Folders</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-browse-close>Close</button>
+                                        <button type="button" class="modal-button modal-button--primary" data-chat-browse-dl hidden>Download selected</button>
                                     </div>
                                 </div>
                             </div>
@@ -10111,7 +10115,7 @@
                                            placeholder="Search rooms…" autocomplete="off">
                                     <div class="chat-rooms-list" data-chat-rooms-list></div>
                                     <div class="chat-settings-actions">
-                                        <button type="button" class="chat-fmt-btn" data-chat-rooms-close>Close</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-rooms-close>Close</button>
                                     </div>
                                 </div>
                             </div>
@@ -10149,8 +10153,8 @@
                                     <label class="chat-settings-check"><input type="checkbox" data-chat-set-autoprove>
                                         Auto-answer "prove you're human" download challenges</label>
                                     <div class="chat-settings-actions">
-                                        <button type="button" class="chat-fmt-btn" data-chat-settings-cancel>Cancel</button>
-                                        <button type="button" class="chat-send-btn" data-chat-settings-save>Save</button>
+                                        <button type="button" class="modal-button modal-button--secondary" data-chat-settings-cancel>Cancel</button>
+                                        <button type="button" class="modal-button modal-button--primary" data-chat-settings-save>Save</button>
                                     </div>
                                 </div>
                             </div>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10055,6 +10055,8 @@
                         <div class="chat-jbx-headbar" data-chat-jbx-headbar hidden>
                             <span class="chat-jbx-brand">♫ Jukebox</span>
                             <span class="chat-jbx-listeners" data-chat-jbx-listeners></span>
+                            <button type="button" class="chat-fmt-btn chat-jbx-radiobtn" data-chat-jbx-radio hidden
+                                    title="Auto-DJ: when the queue runs dry, keep the music going with related tracks">📻 Auto-DJ</button>
                             <form class="chat-jbx-form" data-chat-jbx-form>
                                 <input class="chat-input chat-jbx-input" data-chat-jbx-input type="text" maxlength="200"
                                        placeholder="Add a song or paste a YouTube link…" autocomplete="off">

--- a/webui/index.html
+++ b/webui/index.html
@@ -11972,6 +11972,7 @@
     <script src="{{ url_for('static', filename='stats-automations.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='auto-sync.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='pages-extra.js', v=static_v) }}"></script>
+    <script src="{{ url_for('static', filename='chat-protocol.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='chat.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='label-detail.js', v=static_v) }}"></script>
     <script src="{{ url_for('static', filename='init.js', v=static_v) }}"></script>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10074,6 +10074,9 @@
                                 </form>
                                 <div class="chat-jbx-results" data-chat-jbx-results hidden></div>
                             </div>
+                            <!-- pinned messages + the room poll: pure folds over the protocol bus -->
+                            <div class="chat-pinbar" data-chat-pinbar hidden></div>
+                            <div class="chat-pollcard" data-chat-poll hidden></div>
                             <!-- user popover card (click any username) -->
                             <div class="chat-settings-overlay" data-chat-user-card hidden>
                                 <div class="chat-settings-modal chat-user-card">
@@ -10190,6 +10193,21 @@
                                             <div class="chat-attach-results" data-chat-attach-results></div>
                                             <div class="chat-attach-status" data-chat-attach-status hidden></div>
                                         </div>
+                                        <div class="chat-gif-pop chat-poll-pop" data-chat-poll-pop hidden>
+                                            <input class="chat-input" data-chat-poll-q type="text" maxlength="160"
+                                                   placeholder="Ask the room something…" autocomplete="off">
+                                            <input class="chat-input" data-chat-poll-o1 type="text" maxlength="80"
+                                                   placeholder="Option 1" autocomplete="off">
+                                            <input class="chat-input" data-chat-poll-o2 type="text" maxlength="80"
+                                                   placeholder="Option 2" autocomplete="off">
+                                            <input class="chat-input" data-chat-poll-o3 type="text" maxlength="80"
+                                                   placeholder="Option 3 (optional)" autocomplete="off">
+                                            <input class="chat-input" data-chat-poll-o4 type="text" maxlength="80"
+                                                   placeholder="Option 4 (optional)" autocomplete="off">
+                                            <div class="chat-settings-actions">
+                                                <button type="button" class="chat-send-btn" data-chat-poll-start>Start poll</button>
+                                            </div>
+                                        </div>
                                         <div class="chat-gif-pop" data-chat-gif-pop hidden>
                                             <input class="chat-input chat-gif-search" data-chat-gif-search type="text"
                                                    placeholder="Search GIPHY…" autocomplete="off">
@@ -10203,6 +10221,8 @@
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg></button>
                                         <button type="button" class="chat-tbtn chat-tbtn--side" data-chat-attach-btn title="Share a file (filepost.dev)">
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button>
+                                        <button type="button" class="chat-tbtn chat-tbtn--side" data-chat-poll-btn title="Start a room poll">
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="20" x2="6" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="18" y1="20" x2="18" y2="14"/></svg></button>
                                         <button type="button" class="chat-tbtn chat-tbtn--side chat-gif-btn" data-chat-gif-btn title="Send a GIF">GIF</button>
                                         <button class="chat-send-fab" type="submit" title="Send">
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10112,6 +10112,19 @@
                                                placeholder="" autocomplete="off">
                                         <span class="chat-settings-hint">free at developers.giphy.com — enables GIF search; leave blank to keep the current key</span>
                                     </label>
+                                    <label class="chat-settings-label">filepost.dev API key
+                                        <input class="chat-input" data-chat-set-filepost type="password"
+                                               placeholder="" autocomplete="off">
+                                        <span class="chat-settings-hint">free at filepost.dev — enables file sharing in chat; leave blank to keep the current key</span>
+                                    </label>
+                                    <label class="chat-settings-label">Shared files expire after
+                                        <select class="chat-input" data-chat-set-filepost-expiry>
+                                            <option value="">Never (permanent link)</option>
+                                            <option value="24h">24 hours</option>
+                                            <option value="7d">7 days</option>
+                                            <option value="30d">30 days</option>
+                                        </select>
+                                    </label>
                                     <label class="chat-settings-check"><input type="checkbox" data-chat-set-autojoin>
                                         Auto-join the community room</label>
                                     <label class="chat-settings-check"><input type="checkbox" data-chat-set-membersend>
@@ -10152,6 +10165,17 @@
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/><path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/><line x1="1" y1="1" x2="23" y2="23"/></svg></button>
                                         <span class="chat-toolbar-hint">**bold** · *italic* · `code` · ||spoiler||</span>
                                         <div class="chat-emoji-pop" data-chat-emoji-pop hidden></div>
+                                        <div class="chat-gif-pop chat-attach-pop" data-chat-attach-pop hidden>
+                                            <div class="chat-attach-tabs">
+                                                <button type="button" class="chat-fmt-btn" data-chat-attach-upload>Upload a file</button>
+                                                <span class="chat-attach-or">or share from your library:</span>
+                                            </div>
+                                            <input type="file" data-chat-attach-file hidden>
+                                            <input class="chat-input chat-gif-search" data-chat-attach-search type="text"
+                                                   placeholder="Search your library…" autocomplete="off">
+                                            <div class="chat-attach-results" data-chat-attach-results></div>
+                                            <div class="chat-attach-status" data-chat-attach-status hidden></div>
+                                        </div>
                                         <div class="chat-gif-pop" data-chat-gif-pop hidden>
                                             <input class="chat-input chat-gif-search" data-chat-gif-search type="text"
                                                    placeholder="Search GIPHY…" autocomplete="off">
@@ -10163,6 +10187,8 @@
                                                   placeholder="Message…" autocomplete="off" rows="1"></textarea>
                                         <button type="button" class="chat-tbtn chat-tbtn--side" data-chat-emoji-btn title="Emoji">
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg></button>
+                                        <button type="button" class="chat-tbtn chat-tbtn--side" data-chat-attach-btn title="Share a file (filepost.dev)">
+                                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></button>
                                         <button type="button" class="chat-tbtn chat-tbtn--side chat-gif-btn" data-chat-gif-btn title="Send a GIF">GIF</button>
                                         <button class="chat-send-fab" type="submit" title="Send">
                                             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg></button>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10158,6 +10158,7 @@
                             <button class="chat-jump-pill" type="button" data-chat-jump hidden>New messages ↓</button>
                             <div class="chat-mention-pop" data-chat-mention-pop hidden></div>
                             <form class="chat-composer" data-chat-composer>
+                                <div class="chat-typing" data-chat-typing hidden></div>
                                 <div class="chat-reply-bar" data-chat-reply-bar hidden>
                                     <span class="chat-reply-bar-label">↩ Replying to <b data-chat-reply-who></b>
                                         <span class="chat-reply-bar-x" data-chat-reply-excerpt></span></span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -10072,15 +10072,9 @@
                         </aside>
                         <main class="chat-main">
                             <div class="chat-head" data-chat-head></div>
-                            <!-- room jukebox: shared YouTube listening, votes pick what's next.
-                                 Static skeleton — the submit input and the player iframe must
-                                 survive the 4s poll (renderJukebox only rewrites now/queue). -->
-                            <div class="chat-jukebox" data-chat-jukebox hidden>
-                                <div class="chat-jbx-now" data-chat-jbx-now></div>
-                                <div class="chat-jbx-player" data-chat-jbx-player hidden></div>
-                                <div class="chat-jbx-queue" data-chat-jbx-queue></div>
-                            </div>
-                            <!-- pinned messages + the room poll: pure folds over the protocol bus -->
+                            <!-- pinned messages popover (📌 in the room head) + the room
+                                 poll — both pure folds over the protocol bus. The poll stays
+                                 inline: a live poll SHOULD interrupt the room's attention. -->
                             <div class="chat-pinbar" data-chat-pinbar hidden></div>
                             <div class="chat-pollcard" data-chat-poll hidden></div>
                             <!-- user popover card (click any username) -->
@@ -10236,7 +10230,18 @@
                                 </div>
                             </form>
                         </main>
-                        <aside class="chat-users" data-chat-users></aside>
+                        <div class="chat-rail">
+                            <!-- room jukebox (queue/player) — a rail card above the user
+                                 list, Discord-activity style. Static skeleton: the player
+                                 iframe must survive the 4s poll (renderJukebox only
+                                 rewrites now/queue). -->
+                            <div class="chat-jukebox" data-chat-jukebox hidden>
+                                <div class="chat-jbx-now" data-chat-jbx-now></div>
+                                <div class="chat-jbx-player" data-chat-jbx-player hidden></div>
+                                <div class="chat-jbx-queue" data-chat-jbx-queue></div>
+                            </div>
+                            <aside class="chat-users" data-chat-users></aside>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/webui/static/chat-protocol.js
+++ b/webui/static/chat-protocol.js
@@ -110,10 +110,81 @@
         return pool[0];
     }
 
+    // ── Jukebox reducer ─────────────────────────────────────────────────
+    // The whole room jukebox is a PURE FOLD over the protocol event stream:
+    // every client reduces the same events to the same state — queue, votes,
+    // now-playing — with zero coordination chatter. Rules:
+    //   jbx.sub  {id, ti}      → append to queue (dedupe by id, cap 25,
+    //                            first submitter keeps attribution)
+    //   jbx.vote {o: id}       → latest vote per user among CURRENTLY queued
+    //   jbx.now  {id, ti, at}  → becomes now-playing; its id leaves the queue
+    //                            and ALL votes reset (new round)
+    // Event order is the slskd stream order — identical on every client.
+    var _YT_ID_RE = /^[A-Za-z0-9_-]{6,16}$/;
+
+    function _saneDuration(v) {
+        return (typeof v === 'number' && isFinite(v) && v > 0)
+            ? Math.min(Math.floor(v), 7200) : null;
+    }
+
+    function reduceJukebox(events) {
+        var queue = [];          // [{id, ti, by}]
+        var inQueue = {};        // id → queue entry
+        var votes = [];          // raw votes since last round
+        var now = null;
+
+        (events || []).forEach(function (ev) {
+            if (!ev || !ev.p || typeof ev.username !== 'string') return;
+            var p = ev.p;
+            if (p.k === 'jbx.sub') {
+                var id = String(p.id || '');
+                if (!_YT_ID_RE.test(id) || inQueue[id]) return;
+                if (now && now.id === id) return;          // already playing
+                if (queue.length >= 25) return;            // cap: no queue bombs
+                var entry = { id: id, ti: String(p.ti || '').slice(0, 120),
+                              d: _saneDuration(p.d), by: ev.username };
+                queue.push(entry);
+                inQueue[id] = entry;
+            } else if (p.k === 'jbx.vote') {
+                var o = String(p.o || '');
+                if (inQueue[o]) votes.push({ username: ev.username, option: o });
+            } else if (p.k === 'jbx.now') {
+                var nid = String(p.id || '');
+                if (!_YT_ID_RE.test(nid)) return;
+                now = { id: nid, ti: String(p.ti || '').slice(0, 120),
+                        at: (typeof p.at === 'number' && isFinite(p.at)) ? p.at : null,
+                        d: _saneDuration(p.d), by: ev.username };
+                if (inQueue[nid]) {
+                    queue = queue.filter(function (e) { return e.id !== nid; });
+                    delete inQueue[nid];
+                }
+                votes = [];                                // new round
+            }
+        });
+
+        var tally = tallyVotes(votes);
+        queue.forEach(function (e) { e.votes = tally.counts[e.id] || 0; });
+        return { queue: queue, now: now, tally: tally };
+    }
+
+    // The next track every client agrees on: most votes (lexicographic tie),
+    // FIFO head when nobody voted. Null when the queue is empty.
+    function nextTrack(state) {
+        if (!state || !state.queue || !state.queue.length) return null;
+        if (state.tally && state.tally.winner) {
+            for (var i = 0; i < state.queue.length; i++) {
+                if (state.queue[i].id === state.tally.winner) return state.queue[i];
+            }
+        }
+        return state.queue[0];
+    }
+
     window.ChatProtocol = {
         classifyUser: classifyUser,
         parseProtocol: parseProtocol,
         tallyVotes: tallyVotes,
         electCoordinator: electCoordinator,
+        reduceJukebox: reduceJukebox,
+        nextTrack: nextTrack,
     };
 })();

--- a/webui/static/chat-protocol.js
+++ b/webui/static/chat-protocol.js
@@ -131,6 +131,8 @@
         var queue = [];          // [{id, ti, by}]
         var inQueue = {};        // id → queue entry
         var votes = [];          // raw votes since last round
+        var skipVotes = [];      // votes to skip the CURRENT track
+        var history = [];        // previously played, newest first (cap 10)
         var now = null;
 
         (events || []).forEach(function (ev) {
@@ -148,9 +150,24 @@
             } else if (p.k === 'jbx.vote') {
                 var o = String(p.o || '');
                 if (inQueue[o]) votes.push({ username: ev.username, option: o });
+            } else if (p.k === 'jbx.unsub') {
+                // only the submitter can pull their own track
+                var uid = String(p.id || '');
+                var ent = inQueue[uid];
+                if (ent && ent.by === ev.username) {
+                    queue = queue.filter(function (e) { return e.id !== uid; });
+                    delete inQueue[uid];
+                }
+            } else if (p.k === 'jbx.skip') {
+                var so = String(p.o || '');
+                if (now && so === now.id) skipVotes.push({ username: ev.username, option: so });
             } else if (p.k === 'jbx.now') {
                 var nid = String(p.id || '');
                 if (!_YT_ID_RE.test(nid)) return;
+                if (now && now.id !== nid) {          // a real handoff, not a double-start
+                    history.unshift(now);
+                    if (history.length > 10) history.pop();
+                }
                 now = { id: nid, ti: String(p.ti || '').slice(0, 120),
                         at: (typeof p.at === 'number' && isFinite(p.at)) ? p.at : null,
                         d: _saneDuration(p.d), by: ev.username };
@@ -159,12 +176,15 @@
                     delete inQueue[nid];
                 }
                 votes = [];                                // new round
+                skipVotes = [];                            // skips die with the track
             }
         });
 
+        votes = votes.filter(function (v) { return inQueue[v.option]; });   // unsub'd ids drop out
         var tally = tallyVotes(votes);
         queue.forEach(function (e) { e.votes = tally.counts[e.id] || 0; });
-        return { queue: queue, now: now, tally: tally };
+        return { queue: queue, now: now, tally: tally,
+                 skips: tallyVotes(skipVotes).total, history: history };
     }
 
     // ── Pins / poll / topic / tuned-presence reducers ───────────────────

--- a/webui/static/chat-protocol.js
+++ b/webui/static/chat-protocol.js
@@ -133,6 +133,7 @@
         var votes = [];          // raw votes since last round
         var skipVotes = [];      // votes to skip the CURRENT track
         var history = [];        // previously played, newest first (cap 10)
+        var radio = false;       // auto-DJ: DJ tops up an empty queue (shared toggle)
         var now = null;
 
         (events || []).forEach(function (ev) {
@@ -145,6 +146,7 @@
                 if (queue.length >= 25) return;            // cap: no queue bombs
                 var entry = { id: id, ti: String(p.ti || '').slice(0, 120),
                               d: _saneDuration(p.d), by: ev.username };
+                if (p.a) entry.auto = true;        // queued by the auto-DJ
                 queue.push(entry);
                 inQueue[id] = entry;
             } else if (p.k === 'jbx.vote') {
@@ -158,6 +160,8 @@
                     queue = queue.filter(function (e) { return e.id !== uid; });
                     delete inQueue[uid];
                 }
+            } else if (p.k === 'jbx.radio') {
+                radio = !!p.on;                    // latest toggle wins, any sender
             } else if (p.k === 'jbx.skip') {
                 var so = String(p.o || '');
                 if (now && so === now.id) skipVotes.push({ username: ev.username, option: so });
@@ -184,7 +188,7 @@
         var tally = tallyVotes(votes);
         queue.forEach(function (e) { e.votes = tally.counts[e.id] || 0; });
         return { queue: queue, now: now, tally: tally,
-                 skips: tallyVotes(skipVotes).total, history: history };
+                 skips: tallyVotes(skipVotes).total, history: history, radio: radio };
     }
 
     // ── Pins / poll / topic / tuned-presence reducers ───────────────────

--- a/webui/static/chat-protocol.js
+++ b/webui/static/chat-protocol.js
@@ -167,6 +167,90 @@
         return { queue: queue, now: now, tally: tally };
     }
 
+    // ── Pins / poll / topic / tuned-presence reducers ───────────────────
+    // Same discipline as the jukebox: each is a pure fold over the room's
+    // protocol events, so every SoulSync client shows the same board.
+
+    // pin.add {u, ts, x} / pin.del {u, ts} → rolling board of pinned
+    // messages (dedupe by author|timestamp, cap 8 — oldest falls off).
+    function reducePins(events) {
+        var pins = [];
+        (events || []).forEach(function (ev) {
+            if (!ev || !ev.p || typeof ev.username !== 'string') return;
+            var p = ev.p;
+            if (p.k !== 'pin.add' && p.k !== 'pin.del') return;
+            var u = String(p.u || ''), ts = String(p.ts || '');
+            if (!u || !ts || u.length > 64 || ts.length > 64) return;
+            var key = u + '|' + ts;
+            pins = pins.filter(function (e) { return e.key !== key; });
+            if (p.k === 'pin.add') {
+                pins.push({ key: key, u: u, ts: ts,
+                            x: String(p.x || '').slice(0, 140), by: ev.username });
+                if (pins.length > 8) pins.shift();
+            }
+        });
+        return pins;
+    }
+
+    // poll.start {q, o1..o4} / poll.vote {o: '1'..'4'} / poll.end {} →
+    // ONE active poll per room, latest start wins and resets votes; only
+    // the starter's poll.end closes it. Votes ride tallyVotes (latest per
+    // user), restricted to the poll's real option indices.
+    function reducePoll(events) {
+        var poll = null;
+        var votes = [];
+        (events || []).forEach(function (ev) {
+            if (!ev || !ev.p || typeof ev.username !== 'string') return;
+            var p = ev.p;
+            if (p.k === 'poll.start') {
+                var opts = [];
+                for (var i = 1; i <= 4; i++) {
+                    var o = p['o' + i];
+                    if (typeof o === 'string' && o.trim()) opts.push(o.trim().slice(0, 80));
+                }
+                var qq = String(p.q || '').trim().slice(0, 160);
+                if (!qq || opts.length < 2) return;
+                poll = { q: qq, options: opts, by: ev.username,
+                         at: ev.timestamp, closed: false };
+                votes = [];
+            } else if (p.k === 'poll.vote' && poll && !poll.closed) {
+                var idx = String(p.o || '');
+                if (/^[1-4]$/.test(idx) && parseInt(idx, 10) <= poll.options.length) {
+                    votes.push({ username: ev.username, option: idx });
+                }
+            } else if (p.k === 'poll.end' && poll && ev.username === poll.by) {
+                poll.closed = true;
+            }
+        });
+        if (!poll) return null;
+        poll.tally = tallyVotes(votes);
+        return poll;
+    }
+
+    // topic.set {t} → latest wins; empty clears.
+    function reduceTopic(events) {
+        var topic = null;
+        (events || []).forEach(function (ev) {
+            if (!ev || !ev.p || typeof ev.username !== 'string') return;
+            if (ev.p.k !== 'topic.set') return;
+            var t = String(ev.p.t || '').trim().slice(0, 160);
+            topic = t ? { t: t, by: ev.username } : null;
+        });
+        return topic;
+    }
+
+    // jbx.tune {on: 1|0} → who is listening right now (latest per user).
+    function reduceTuned(events) {
+        var tuned = {};
+        (events || []).forEach(function (ev) {
+            if (!ev || !ev.p || typeof ev.username !== 'string') return;
+            if (ev.p.k !== 'jbx.tune') return;
+            if (ev.p.on) tuned[ev.username] = 1;
+            else delete tuned[ev.username];
+        });
+        return tuned;
+    }
+
     // The next track every client agrees on: most votes (lexicographic tie),
     // FIFO head when nobody voted. Null when the queue is empty.
     function nextTrack(state) {
@@ -186,5 +270,9 @@
         electCoordinator: electCoordinator,
         reduceJukebox: reduceJukebox,
         nextTrack: nextTrack,
+        reducePins: reducePins,
+        reducePoll: reducePoll,
+        reduceTopic: reduceTopic,
+        reduceTuned: reduceTuned,
     };
 })();

--- a/webui/static/chat-protocol.js
+++ b/webui/static/chat-protocol.js
@@ -1,0 +1,119 @@
+// SoulSync chat protocol — the pure logic under the room's hidden message bus.
+//
+// The Soulseek room is plain text, but every SoulSync message carries the
+// !SS1! envelope (see core/chat_codec.py). Envelopes can carry a protocol
+// object under "p" ({k: "<kind>", ...}) invisible to vanilla clients. This
+// file is the DETERMINISTIC core those features share: user classification,
+// protocol parsing (hostile input!), vote tallying, and coordinator election.
+// Every client sees the same message stream, so pure functions over that
+// stream agree everywhere without any server or coordination chatter.
+//
+// Zero DOM, zero fetch — loaded before chat.js, unit-tested in isolation
+// (tests/static/test_chat_protocol.mjs).
+
+(function () {
+    'use strict';
+
+    // ── User classification ─────────────────────────────────────────────
+    // The FLIP (Boulder): assume everyone is a SoulSync user until they
+    // demonstrate otherwise. An envelope message proves SoulSync — forever
+    // (clients always wrap, so one envelope is conclusive). A bare-text
+    // message from a user who has NEVER sent an envelope marks them vanilla;
+    // a later envelope promotes them (client upgrade mid-session).
+    //   states: 'assumed' (never spoke) → 'soulsync' | 'vanilla'
+    function classifyUser(current, messageIsRich) {
+        if (messageIsRich) return 'soulsync';
+        return current === 'soulsync' ? 'soulsync' : 'vanilla';
+    }
+
+    // ── Protocol payload parsing (REMOTE data — trust nothing) ──────────
+    // {k: kind, ...} where kind is a short dotted identifier ('jbx.vote').
+    // Caps: kind ≤ 24 chars, ≤ 16 fields, strings ≤ 512 chars, numbers
+    // finite, one level of nesting for plain-object/array values with the
+    // same caps. Anything else → null (callers drop it silently).
+    var KIND_RE = /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)?$/;
+
+    function _saneScalar(v) {
+        if (typeof v === 'string') return v.length <= 512;
+        if (typeof v === 'number') return isFinite(v);
+        return typeof v === 'boolean' || v === null;
+    }
+
+    function _sanePayload(obj, depth) {
+        if (obj === null || typeof obj !== 'object') return false;
+        var keys = Object.keys(obj);
+        if (keys.length > 16) return false;
+        for (var i = 0; i < keys.length; i++) {
+            var v = obj[keys[i]];
+            if (_saneScalar(v)) continue;
+            if (depth > 0 && Array.isArray(v)) {
+                if (v.length > 32 || !v.every(function (x) { return _saneScalar(x); })) return false;
+            } else if (depth > 0 && typeof v === 'object') {
+                if (!_sanePayload(v, depth - 1)) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function parseProtocol(envelope) {
+        try {
+            if (!envelope || typeof envelope !== 'object') return null;
+            var p = envelope.p;
+            if (!p || typeof p !== 'object' || Array.isArray(p)) return null;
+            if (typeof p.k !== 'string' || p.k.length > 24 || !KIND_RE.test(p.k)) return null;
+            if (!_sanePayload(p, 1)) return null;
+            return p;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // ── Deterministic vote tally ────────────────────────────────────────
+    // votes: [{username, option, timestamp}] in stream order. Rules every
+    // client applies identically: a user's LATEST vote wins (stream order —
+    // same stream everywhere); winner = most votes, ties broken by
+    // lexicographically-smallest option id (stable, no randomness).
+    function tallyVotes(votes) {
+        var byUser = {};
+        (votes || []).forEach(function (v) {
+            if (!v || typeof v.username !== 'string' || typeof v.option !== 'string') return;
+            if (!v.username || !v.option || v.option.length > 128) return;
+            byUser[v.username] = v.option;
+        });
+        var counts = {};
+        Object.keys(byUser).forEach(function (u) {
+            counts[byUser[u]] = (counts[byUser[u]] || 0) + 1;
+        });
+        var winner = null, best = -1;
+        Object.keys(counts).sort().forEach(function (opt) {   // lexicographic walk = stable ties
+            if (counts[opt] > best) { best = counts[opt]; winner = opt; }
+        });
+        return { counts: counts, winner: winner, total: Object.keys(byUser).length };
+    }
+
+    // ── Coordinator ("DJ") election ─────────────────────────────────────
+    // Deterministic and chatter-free: everyone computes the same coordinator
+    // from the same participant set — lexicographically-smallest active
+    // SoulSync username (case-insensitive, then case-sensitive tiebreak).
+    function electCoordinator(usernames) {
+        var pool = (usernames || []).filter(function (u) {
+            return typeof u === 'string' && u.length > 0;
+        });
+        if (!pool.length) return null;
+        pool.sort(function (a, b) {
+            var al = a.toLowerCase(), bl = b.toLowerCase();
+            if (al !== bl) return al < bl ? -1 : 1;
+            return a < b ? -1 : (a > b ? 1 : 0);
+        });
+        return pool[0];
+    }
+
+    window.ChatProtocol = {
+        classifyUser: classifyUser,
+        parseProtocol: parseProtocol,
+        tallyVotes: tallyVotes,
+        electCoordinator: electCoordinator,
+    };
+})();

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -2502,9 +2502,23 @@
         if (!state.jukebox.open) return;
         var st = _jbxState();
         var elapsed = _jbxElapsed(st.now);
-        var stale = !st.now ||
-            (st.now.d && elapsed !== null && elapsed > st.now.d + 8) ||
-            (!st.now.d && elapsed !== null && elapsed > 900);   // unknown length: 15-min cap
+        // A tuned-in client asks the PLAYER for the truth — pasted links have
+        // no duration (oEmbed doesn't give one), and the iframe's ENDED event
+        // is best-effort, so poll instead of trusting either.
+        var effD = st.now ? st.now.d : null;
+        var playerEnded = false;
+        if (state.jukebox.tunedIn && state.jukebox.playerAlive && state.jukebox.player) {
+            try {
+                if (!effD) {
+                    var pd = state.jukebox.player.getDuration();
+                    if (pd > 0) effD = pd;
+                }
+                playerEnded = state.jukebox.player.getPlayerState() === 0;   // YT ENDED
+            } catch (e) { /* player mid-teardown */ }
+        }
+        var stale = !st.now || playerEnded ||
+            (effD && elapsed !== null && elapsed > effD + 8) ||
+            (!effD && elapsed !== null && elapsed > 900);   // untuned + unknown length: 15-min cap
         if (!st.queue.length || !stale) { state.jukebox.starvedAt = 0; return; }
         if (_jbxIsDj()) { _jbxAdvance(st); return; }
         if (!state.jukebox.starvedAt) {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -47,6 +47,7 @@
             lastAdvanceAt: 0,    //   DJ double-fire guard (ms)
             starvedAt: 0,        //   queue-waiting-with-no-DJ clock (ms)
             histOpen: false,     //   recently-played list expanded
+            lastAutoAt: 0,       //   auto-DJ top-up cooldown (ms)
             videoHidden: false,  //   audio-only mode (iframe hidden, audio plays)
             vol: 100,            //   local player volume (persisted)
             timer: null,         //   elapsed clock + DJ watchdog while open
@@ -2077,6 +2078,15 @@
                 renderJukebox();
                 return;
             }
+            t = e.target.closest('[data-chat-jbx-radio]');
+            if (t) {
+                var rSt = _jbxState();
+                sendProtocol('jbx.radio', { on: rSt.radio ? 0 : 1 });
+                if (typeof showToast === 'function') {
+                    showToast(rSt.radio ? '📻 Auto-DJ off' : '📻 Auto-DJ on — the queue keeps itself fed', 'info');
+                }
+                return;
+            }
             t = e.target.closest('[data-chat-jbx-video]');
             if (t) {
                 state.jukebox.videoHidden = !state.jukebox.videoHidden;
@@ -2706,6 +2716,12 @@
                 var nTuned = Object.keys(window.ChatProtocol.reduceTuned(_roomEvents())).length;
                 lc.textContent = nTuned ? '♪ ' + nTuned + ' listening' : '';
             }
+            var rb = q('[data-chat-jbx-radio]');
+            if (rb) {
+                rb.hidden = !state.canSend;
+                rb.classList.toggle('chat-filter-btn--on', !!st.radio);
+                rb.classList.toggle('chat-jbx-radiobtn--on', !!st.radio);
+            }
         }
         var show = state.jukebox.open && inRoom;
         panel.hidden = !show;
@@ -2719,7 +2735,7 @@
                                  state.canSend, st.skips, needed, nextId,
                                  state.jukebox.histOpen, st.history.length,
                                  st.history[0] && st.history[0].id,   // cap rotation changes content, not length
-                                 state.jukebox.videoHidden]);
+                                 state.jukebox.videoHidden, st.radio]);
         if (fp !== state.jukebox.lastRendered) {
             state.jukebox.lastRendered = fp;
             var nowHost = q('[data-chat-jbx-now]');
@@ -2780,6 +2796,7 @@
                             '<span class="chat-jbx-title" title="' + attr(e.ti || e.id) + '">' + esc(e.ti || e.id) + '</span>' +
                             '<span class="chat-jbx-meta">' +
                                 (e.id === nextId ? '<b class="chat-jbx-next">up next</b> · ' : '') +
+                                (e.auto ? '📻 auto · ' : '') +
                                 (e.d ? _fmtSecs(e.d) + ' · ' : '') + esc(e.by) + '</span>' +
                         '</div>' +
                         '<button class="chat-jbx-vote" type="button" data-chat-jbx-vote="' + attr(e.id) + '"' +
@@ -2860,6 +2877,7 @@
         var stale = !st.now || playerEnded || skipped ||
             (effD && elapsed !== null && elapsed > effD + 8) ||
             (!effD && elapsed !== null && elapsed > 900);   // untuned + unknown length: 15-min cap
+        if (!st.queue.length && st.radio && _jbxIsDj()) _jbxAutoQueue(st);
         if (!st.queue.length || !stale) { state.jukebox.starvedAt = 0; return; }
         if (_jbxIsDj()) { _jbxAdvance(st); return; }
         if (!state.jukebox.starvedAt) {
@@ -2868,6 +2886,32 @@
             state.jukebox.starvedAt = 0;
             _jbxAdvance(st);
         }
+    }
+
+    function _jbxAutoQueue(st) {
+        // Radio mode: the queue ran dry — find something related to what the
+        // room just heard and queue it (marked auto, still vote/skippable).
+        if (Date.now() - (state.jukebox.lastAutoAt || 0) < 25000) return;
+        var seed = st.now || (st.history && st.history[0]);
+        if (!seed || !seed.ti) return;
+        state.jukebox.lastAutoAt = Date.now();
+        // strip (Official Video)-style noise so the search finds neighbors
+        var qtext = seed.ti.replace(/[\(\[][^)\]]*[\)\]]/g, ' ')
+            .replace(/\s+/g, ' ').trim().slice(0, 150);
+        if (!qtext) return;
+        var avoid = {};
+        if (st.now) avoid[st.now.id] = 1;
+        (st.history || []).forEach(function (h) { avoid[h.id] = 1; });
+        postJSON('/api/chat/jukebox/resolve', { q: qtext }).then(function (res) {
+            if (!res.ok) return;                   // paste-only servers: radio just idles
+            var pick = (res.body.results || []).filter(function (r) {
+                return r && r.id && !avoid[r.id];
+            })[0];
+            if (!pick) return;
+            var p = { id: pick.id, ti: pick.title, a: 1 };
+            if (pick.duration) p.d = pick.duration;
+            sendProtocol('jbx.sub', p);
+        });
     }
 
     function _jbxAdvance(st) {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -52,6 +52,10 @@
             timer: null,         //   elapsed clock + DJ watchdog while open
             ytLoading: false, ytCbs: [],
         },
+        typing: {},              // username → last typ-event receipt (ms, local clock)
+        typingArmedAt: 0,        // ignore typ events replayed from the archive on room open
+        lastTypSentAt: 0,        // our own typ throttle
+        typingTimer: null,       // pending expiry repaint
         pinsOpen: false,         // pin board expanded
         topicEditing: false,     // head shows the topic input (renderHead pauses)
         pollDismissedAt: null,   // locally-dismissed closed poll (its start ts)
@@ -1520,6 +1524,7 @@
                 }
                 renderHead(); renderComposer();
                 mergeMessages(res.body.messages);
+                _clearTypingFor(res.body.messages);
                 renderMessages(state.msgs);
                 renderUsers(res.body.users);
                 _ingestProtocol(res.body.protocol);
@@ -1565,6 +1570,9 @@
         }
         state.room = nextRoom;
         state.topicEditing = false;
+        state.typing = {};
+        state.typingArmedAt = Date.now() + 2000;   // archive replay isn't live typing
+        renderTyping();
         renderBusUI();
         state.msgs = []; state.loadingOlder = false; state.historyDone = false;
         cancelReply();
@@ -1703,6 +1711,7 @@
         if (!input) return;
         var text = (input.value || '').trim();
         if (!text || !state.canSend) return;
+        state.lastTypSentAt = 0;
         input.value = '';
         input.style.height = 'auto';
         var url = state.view === 'room'
@@ -2065,6 +2074,7 @@
                 inputEl.style.height = 'auto';
                 inputEl.style.height = Math.min(inputEl.scrollHeight, 132) + 'px';
                 updateMentionPop(inputEl);
+                _maybeSendTyping(inputEl);
             });
         }
 
@@ -2267,6 +2277,11 @@
                           room: room, p: p };
             log.push(entry);
             fresh.push(entry);
+            if (p.k === 'typ' && entry.username && entry.username !== state.selfName &&
+                    state.typingArmedAt && Date.now() > state.typingArmedAt) {
+                state.typing[entry.username] = Date.now();
+                renderTyping();
+            }
         });
         if (log.length > 300) state.protocolLog = log.slice(-300);
         if (fresh.length) {
@@ -2300,6 +2315,52 @@
     function onRoomProtocol(d) {
         if (!d || d.room !== state.room) return;
         _ingestProtocol(d.events || []);
+    }
+
+    // ── typing indicators (typ events on the bus, deliberately frugal:
+    // every carrier is a visible noise line for vanilla clients, so we emit
+    // on composition start + at most one refresh per 20s, never per-key) ──
+    var _TYP_TTL = 25000;      // matches the ≤20s re-emit cadence + slack
+
+    function _maybeSendTyping(input) {
+        if (state.view !== 'room' || !state.canSend) return;
+        if (!input || !(input.value || '').trim()) return;
+        if ((input.value || '')[0] === '/') return;      // commands aren't messages
+        if (Date.now() - state.lastTypSentAt < 20000) return;
+        state.lastTypSentAt = Date.now();
+        sendProtocol('typ', {});
+    }
+
+    function renderTyping() {
+        var host = q('[data-chat-typing]');
+        if (!host) return;
+        var cut = Date.now() - _TYP_TTL;
+        var names = [];
+        Object.keys(state.typing).forEach(function (n) {
+            if (state.typing[n] < cut) delete state.typing[n];
+            else names.push(n);
+        });
+        if (!names.length || state.view !== 'room') { host.hidden = true; host.innerHTML = ''; return; }
+        names.sort();
+        var who = names.length === 1 ? '<b>' + esc(names[0]) + '</b> is'
+            : names.length === 2 ? '<b>' + esc(names[0]) + '</b> and <b>' + esc(names[1]) + '</b> are'
+            : names.length + ' people are';
+        host.innerHTML = '<span class="chat-typing-dots"><i></i><i></i><i></i></span> ' + who + ' typing…';
+        host.hidden = false;
+        if (state.typingTimer) clearTimeout(state.typingTimer);
+        state.typingTimer = setTimeout(renderTyping, 5000);
+    }
+
+    function _clearTypingFor(messages) {
+        // an arriving message from a typer means they sent it — clear now
+        var changed = false;
+        (messages || []).forEach(function (m) {
+            if (m && m.username && state.typing[m.username]) {
+                delete state.typing[m.username];
+                changed = true;
+            }
+        });
+        if (changed) renderTyping();
     }
 
     // Every surface reduced from the protocol bus, painted together.

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -45,6 +45,7 @@
             resolving: false,
             lastRendered: '',    //   reduced-state fingerprint (skip no-op renders)
             lastAdvanceAt: 0,    //   DJ double-fire guard (ms)
+            starvedAt: 0,        //   queue-waiting-with-no-DJ clock (ms)
             timer: null,         //   elapsed clock + DJ watchdog while open
             ytLoading: false, ytCbs: [],
         },
@@ -2376,13 +2377,16 @@
     }
 
     function _jbxIsDj() {
-        // Only PROVEN SoulSync users (they beaconed / spoke enveloped) are DJ
-        // candidates — electing an assumed user could elect a vanilla client
-        // that will never advance the queue. We're always in our own pool.
+        // DJ candidates are PROTOCOL-CAPABLE clients only: users who have
+        // emitted protocol events (hello beacon, jukebox chatter) in this
+        // room. Envelope messages are NOT enough — every pre-jukebox
+        // SoulSync version speaks envelopes, and electing one of those gets
+        // a DJ that can never press play. We're always in our own pool.
         var CP = window.ChatProtocol;
         if (!CP || !state.canSend || !state.selfName) return false;
-        var cls = _userClassification();
-        var pool = (state.users || []).filter(function (n) { return cls[n] === 'soulsync'; });
+        var emitters = {};
+        _roomEvents().forEach(function (e) { emitters[e.username] = 1; });
+        var pool = (state.users || []).filter(function (n) { return emitters[n]; });
         if (pool.indexOf(state.selfName) === -1) pool.push(state.selfName);
         return CP.electCoordinator(pool) === state.selfName;
     }
@@ -2491,15 +2495,24 @@
 
     // DJ duties: kick the queue when nothing is playing, or when the current
     // track has provably run out (duration known) and nobody advanced it.
+    // Starvation fallback: if the elected DJ went away mid-session (closed
+    // tab, network), ANY capable client kicks the queue after 45s — a rare
+    // double-start converges (latest now wins, same track either way).
     function _jbxWatchdog() {
-        if (!state.jukebox.open || !_jbxIsDj()) return;
+        if (!state.jukebox.open) return;
         var st = _jbxState();
-        if (!st.queue.length) return;
         var elapsed = _jbxElapsed(st.now);
         var stale = !st.now ||
             (st.now.d && elapsed !== null && elapsed > st.now.d + 8) ||
             (!st.now.d && elapsed !== null && elapsed > 900);   // unknown length: 15-min cap
-        if (stale) _jbxAdvance(st);
+        if (!st.queue.length || !stale) { state.jukebox.starvedAt = 0; return; }
+        if (_jbxIsDj()) { _jbxAdvance(st); return; }
+        if (!state.jukebox.starvedAt) {
+            state.jukebox.starvedAt = Date.now();
+        } else if (Date.now() - state.jukebox.starvedAt > 45000) {
+            state.jukebox.starvedAt = 0;
+            _jbxAdvance(st);
+        }
     }
 
     function _jbxAdvance(st) {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -35,6 +35,19 @@
         selfName: '',            // our slskd username (@mention highlighting)
         users: [],               // room user names (mention autocomplete)
         replyTo: null,           // {u, x} while composing a reply
+        jukebox: {               // shared room listening (reduced from protocolLog)
+            open: false,         //   panel visible
+            tunedIn: false,      //   player exists (requires a user gesture)
+            player: null,        //   YT.Player instance while tuned in
+            playingId: null,     //   video id the player was last pointed at
+            playerAlive: false,  //   iframe API fired onReady (safe to call methods)
+            results: [],         //   resolve results awaiting a pick
+            resolving: false,
+            lastRendered: '',    //   reduced-state fingerprint (skip no-op renders)
+            lastAdvanceAt: 0,    //   DJ double-fire guard (ms)
+            timer: null,         //   elapsed clock + DJ watchdog while open
+            ytLoading: false, ytCbs: [],
+        },
     };
     try { state.ssOnly = localStorage.getItem('chat_ss_only') === '1'; } catch (e) { /* ignore */ }
 
@@ -671,6 +684,8 @@
                       'placeholder="Search history…" autocomplete="off"' +
                       (state.searchMode ? '' : ' hidden') + '>' +
               '</span>' +
+              '<button class="chat-filter-btn' + (state.jukebox.open ? ' chat-filter-btn--on' : '') +
+              '" type="button" data-chat-jukebox-btn title="Room jukebox — listen together, vote on what plays next">♫ Jukebox</button>' +
               '<button class="chat-filter-btn' + (state.ssOnly ? ' chat-filter-btn--on' : '') +
               '" type="button" data-chat-filter title="' +
               (state.ssOnly ? 'Showing SoulSync app messages only — click for everything'
@@ -1496,7 +1511,13 @@
     function openRoom(name) {
         state.view = 'room'; state.pmUser = null; state.lastStamp = null; state.stickBottom = true;
         state.renderedCount = 0; hideJumpPill();
+        var prevRoom = state.room;
         state.room = name || state.room || state.homeRoom || 'SoulSync';
+        if (prevRoom && prevRoom !== state.room) {
+            _jbxTuneOut();               // never keep playing another room's track
+            state.jukebox.lastRendered = '';
+        }
+        renderJukebox();
         state.msgs = []; state.loadingOlder = false; state.historyDone = false;
         cancelReply();
         try {
@@ -1622,7 +1643,7 @@
         state.searchMode = false;
         state.renderedCount = 0; hideJumpPill(); state.newMarker = null;
         cancelReply();
-        renderHead(); renderComposer();
+        renderHead(); renderComposer(); renderJukebox();   // hides the panel (audio keeps playing)
         var host = q('[data-chat-messages]');
         if (host) host.innerHTML = '<div class="chat-empty">Loading…</div>';
         refresh();
@@ -1771,6 +1792,16 @@
                 renderHead(); refresh();
                 return;
             }
+            t = e.target.closest('[data-chat-jukebox-btn]');
+            if (t) { toggleJukebox(); return; }
+            t = e.target.closest('[data-chat-jbx-tunein]');
+            if (t) { _jbxTuneIn(); return; }
+            t = e.target.closest('[data-chat-jbx-tuneout]');
+            if (t) { _jbxTuneOut(); renderJukebox(); return; }
+            t = e.target.closest('[data-chat-jbx-vote]');
+            if (t) { sendProtocol('jbx.vote', { o: t.getAttribute('data-chat-jbx-vote') }); return; }
+            t = e.target.closest('[data-chat-jbx-pick]');
+            if (t) { _jbxPick(state.jukebox.results[parseInt(t.getAttribute('data-chat-jbx-pick'), 10)]); return; }
             t = e.target.closest('[data-chat-search-btn]');
             if (t) { state.searchMode ? exitSearch() : enterSearch(); return; }
             t = e.target.closest('[data-chat-search-exit]');
@@ -1867,6 +1898,8 @@
 
         var form = q('[data-chat-composer]');
         if (form) form.addEventListener('submit', function (e) { e.preventDefault(); send(); });
+        var jbxForm = q('[data-chat-jbx-form]');
+        if (jbxForm) jbxForm.addEventListener('submit', function (e) { e.preventDefault(); _jbxSubmit(); });
 
         var inputEl = q('[data-chat-input]');
         if (inputEl) {
@@ -2057,17 +2090,20 @@
     function _ingestProtocol(events) {
         if (!events || !events.length) return;
         var log = state.protocolLog;
+        var room = state.room || '';
         var seen = {};
-        log.forEach(function (e) { seen[e.username + '|' + e.timestamp + '|' + (e.p && e.p.k)] = 1; });
+        log.forEach(function (e) { seen[e.room + '|' + e.username + '|' + e.timestamp + '|' + (e.p && e.p.k)] = 1; });
         var fresh = [];
         events.forEach(function (ev) {
             if (!ev || !ev.p || !window.ChatProtocol) return;
             var p = window.ChatProtocol.parseProtocol({ p: ev.p });
             if (!p) return;
-            var key = ev.username + '|' + ev.timestamp + '|' + p.k;
+            var key = room + '|' + ev.username + '|' + ev.timestamp + '|' + p.k;
             if (seen[key]) return;
             seen[key] = 1;
-            var entry = { username: String(ev.username || ''), timestamp: ev.timestamp, p: p };
+            // room-tagged: reducers (jukebox) must never mix rooms' events
+            var entry = { username: String(ev.username || ''), timestamp: ev.timestamp,
+                          room: room, p: p };
             log.push(entry);
             fresh.push(entry);
         });
@@ -2075,6 +2111,7 @@
         if (fresh.length) {
             // presence: a protocol event proves SoulSync — refresh buckets
             renderUsersList();
+            renderJukebox();
             try {
                 document.dispatchEvent(new CustomEvent('soulsync:chat-protocol',
                     { detail: { events: fresh } }));
@@ -2102,6 +2139,278 @@
     function onRoomProtocol(d) {
         if (!d || d.room !== state.room) return;
         _ingestProtocol(d.events || []);
+    }
+
+    // ── jukebox (shared room listening — a pure fold over the bus) ──────
+    // State lives in the protocol stream (jbx.sub / jbx.vote / jbx.now);
+    // every client reduces the same events to the same queue + now-playing.
+    // Playback is an OPT-IN YouTube embed ("Tune in" = the user gesture
+    // browsers require for audible autoplay); joiners seek to the live
+    // position from now.at. The DJ (deterministic election, no chatter) is
+    // the one client that emits jbx.now when a track ends or the queue waits.
+    function _jbxState() {
+        var CP = window.ChatProtocol;
+        if (!CP) return { queue: [], now: null, tally: { counts: {}, winner: null, total: 0 } };
+        var room = state.room || '';
+        return CP.reduceJukebox((state.protocolLog || []).filter(function (e) {
+            return e.room === room;
+        }));
+    }
+
+    function _jbxIsDj() {
+        // Only PROVEN SoulSync users (they beaconed / spoke enveloped) are DJ
+        // candidates — electing an assumed user could elect a vanilla client
+        // that will never advance the queue. We're always in our own pool.
+        var CP = window.ChatProtocol;
+        if (!CP || !state.canSend || !state.selfName) return false;
+        var cls = _userClassification();
+        var pool = (state.users || []).filter(function (n) { return cls[n] === 'soulsync'; });
+        if (pool.indexOf(state.selfName) === -1) pool.push(state.selfName);
+        return CP.electCoordinator(pool) === state.selfName;
+    }
+
+    function _jbxElapsed(now) {
+        if (!now || typeof now.at !== 'number') return null;
+        var s = Math.floor(Date.now() / 1000 - now.at);
+        return (s >= 0 && s < 86400) ? s : null;
+    }
+
+    function _fmtSecs(s) {
+        if (s === null || isNaN(s)) return '';
+        var m = Math.floor(s / 60), r = s % 60;
+        return m + ':' + (r < 10 ? '0' : '') + r;
+    }
+
+    function renderJukebox() {
+        var panel = q('[data-chat-jukebox]');
+        if (!panel) return;
+        var st = _jbxState();
+        var now = st.now;
+        var elapsed = _jbxElapsed(now);
+        var ended = !!(now && now.d && elapsed !== null && elapsed > now.d + 5);
+        // the player follows the ROOM, not the panel — a tuned-in listener
+        // reading PMs must still hear the DJ's advances (panel merely hides)
+        _jbxSyncPlayer(now && !ended ? now : null);
+        var show = state.jukebox.open && state.view === 'room';
+        panel.hidden = !show;
+        if (!show) return;
+        // fingerprint: skip DOM writes when nothing visible changed (the
+        // elapsed clock ticks via its own cheap textContent update below)
+        var fp = JSON.stringify([now && now.id, ended, st.queue, state.jukebox.tunedIn, state.canSend]);
+        if (fp !== state.jukebox.lastRendered) {
+            state.jukebox.lastRendered = fp;
+            var nowHost = q('[data-chat-jbx-now]');
+            if (nowHost) {
+                if (now && !ended) {
+                    nowHost.innerHTML =
+                        '<span class="chat-jbx-live">▶</span>' +
+                        '<span class="chat-jbx-title" title="' + attr(now.ti || now.id) + '">' +
+                            esc(now.ti || now.id) + '</span>' +
+                        '<span class="chat-jbx-meta">added by ' + esc(now.by || '?') +
+                            (elapsed !== null ? ' · <span data-chat-jbx-clock>' + _fmtSecs(elapsed) + '</span>' +
+                                (now.d ? ' / ' + _fmtSecs(now.d) : '') : '') + '</span>' +
+                        (state.jukebox.tunedIn
+                            ? '<button class="chat-fmt-btn chat-jbx-tune" type="button" data-chat-jbx-tuneout>Tune out</button>'
+                            : '<button class="chat-send-btn chat-jbx-tune" type="button" data-chat-jbx-tunein>▶ Tune in</button>');
+                } else {
+                    // tuned-in users keep their exit even between tracks
+                    nowHost.innerHTML = '<span class="chat-jbx-meta">' +
+                        (st.queue.length ? 'Waiting for the next track…'
+                                         : 'Nothing playing — add a song below and get the room voting.') +
+                        '</span>' +
+                        (state.jukebox.tunedIn
+                            ? '<button class="chat-fmt-btn chat-jbx-tune" type="button" data-chat-jbx-tuneout>Tune out</button>' : '');
+                }
+            }
+            var qHost = q('[data-chat-jbx-queue]');
+            if (qHost) {
+                qHost.innerHTML = st.queue.map(function (e) {
+                    return '<div class="chat-jbx-row">' +
+                        '<button class="chat-jbx-vote" type="button" data-chat-jbx-vote="' + attr(e.id) + '"' +
+                            (state.canSend ? '' : ' disabled') + ' title="Vote to play this next">▲ ' +
+                            (e.votes || 0) + '</button>' +
+                        '<span class="chat-jbx-title" title="' + attr(e.ti || e.id) + '">' + esc(e.ti || e.id) + '</span>' +
+                        '<span class="chat-jbx-meta">' + (e.d ? _fmtSecs(e.d) + ' · ' : '') + esc(e.by) + '</span>' +
+                    '</div>';
+                }).join('') || '';
+            }
+            var form = q('[data-chat-jbx-form]');
+            if (form) form.hidden = !state.canSend;
+        } else if (elapsed !== null) {
+            var clock = q('[data-chat-jbx-clock]');
+            if (clock) clock.textContent = _fmtSecs(elapsed);
+        }
+    }
+
+    function toggleJukebox() {
+        state.jukebox.open = !state.jukebox.open;
+        if (!state.jukebox.open) _jbxTuneOut();
+        state.jukebox.lastRendered = '';
+        renderHead();
+        renderJukebox();
+        if (state.jukebox.open && !state.jukebox.timer) {
+            state.jukebox.timer = setInterval(function () {
+                renderJukebox();
+                _jbxWatchdog();
+            }, 5000);
+        } else if (!state.jukebox.open && state.jukebox.timer) {
+            clearInterval(state.jukebox.timer);
+            state.jukebox.timer = null;
+        }
+    }
+
+    // DJ duties: kick the queue when nothing is playing, or when the current
+    // track has provably run out (duration known) and nobody advanced it.
+    function _jbxWatchdog() {
+        if (!state.jukebox.open || !_jbxIsDj()) return;
+        var st = _jbxState();
+        if (!st.queue.length) return;
+        var elapsed = _jbxElapsed(st.now);
+        var stale = !st.now ||
+            (st.now.d && elapsed !== null && elapsed > st.now.d + 8) ||
+            (!st.now.d && elapsed !== null && elapsed > 900);   // unknown length: 15-min cap
+        if (stale) _jbxAdvance(st);
+    }
+
+    function _jbxAdvance(st) {
+        var CP = window.ChatProtocol;
+        if (!CP || !state.canSend) return;
+        if (Date.now() - state.jukebox.lastAdvanceAt < 15000) return;  // outlast a slow slskd roundtrip
+        var next = CP.nextTrack(st || _jbxState());
+        if (!next) return;
+        state.jukebox.lastAdvanceAt = Date.now();
+        var p = { id: next.id, ti: next.ti, at: Math.floor(Date.now() / 1000) };
+        if (next.d) p.d = next.d;
+        sendProtocol('jbx.now', p);
+    }
+
+    // ── jukebox playback (YouTube iframe API, loaded on first tune-in) ──
+    function _jbxLoadYT(cb) {
+        if (window.YT && window.YT.Player) { cb(); return; }
+        state.jukebox.ytCbs.push(cb);
+        if (state.jukebox.ytLoading) return;
+        state.jukebox.ytLoading = true;
+        var prev = window.onYouTubeIframeAPIReady;
+        window.onYouTubeIframeAPIReady = function () {
+            if (typeof prev === 'function') { try { prev(); } catch (e) { /* theirs */ } }
+            var cbs = state.jukebox.ytCbs;
+            state.jukebox.ytCbs = [];
+            cbs.forEach(function (f) { try { f(); } catch (e) { /* one bad cb */ } });
+        };
+        var s = document.createElement('script');
+        s.src = 'https://www.youtube.com/iframe_api';
+        document.head.appendChild(s);
+    }
+
+    function _jbxTuneIn() {
+        var st = _jbxState();
+        if (!st.now) return;
+        state.jukebox.tunedIn = true;
+        state.jukebox.lastRendered = '';
+        renderJukebox();
+        _jbxLoadYT(function () {
+            if (!state.jukebox.tunedIn) return;        // tuned out while loading
+            _jbxSyncPlayer(_jbxState().now);
+        });
+    }
+
+    function _jbxTuneOut() {
+        state.jukebox.tunedIn = false;
+        if (state.jukebox.player) {
+            try { state.jukebox.player.destroy(); } catch (e) { /* already gone */ }
+        }
+        state.jukebox.player = null;
+        state.jukebox.playingId = null;
+        state.jukebox.playerAlive = false;
+        var host = q('[data-chat-jbx-player]');
+        if (host) { host.innerHTML = ''; host.hidden = true; }
+        state.jukebox.lastRendered = '';
+    }
+
+    function _jbxSyncPlayer(now) {
+        // Point the player at `now`, seeking to the live position. Never
+        // touches the DOM outside [data-chat-jbx-player] — renderJukebox
+        // depends on that so the iframe survives queue re-renders.
+        if (!state.jukebox.tunedIn) return;
+        if (!now) return;   // between tracks: keep the player, never kick the listener
+        if (!(window.YT && window.YT.Player)) return;  // tune-in cb will land here again
+        var host = q('[data-chat-jbx-player]');
+        if (!host) return;
+        var offset = Math.max(0, _jbxElapsed(now) || 0);
+        if (!state.jukebox.player) {
+            host.hidden = false;
+            host.innerHTML = '<div data-chat-jbx-yt></div>';
+            state.jukebox.playingId = now.id;
+            state.jukebox.player = new window.YT.Player(host.firstChild, {
+                width: '100%', height: '180', videoId: now.id,
+                playerVars: { autoplay: 1, start: offset, rel: 0, playsinline: 1 },
+                events: {
+                    onReady: function () {
+                        state.jukebox.playerAlive = true;
+                        _jbxSyncPlayer(_jbxState().now);   // catch a now-change during boot
+                    },
+                    onStateChange: _jbxOnPlayerState,
+                },
+            });
+        } else if (state.jukebox.playingId !== now.id && state.jukebox.playerAlive) {
+            state.jukebox.playingId = now.id;
+            try {
+                state.jukebox.player.loadVideoById({ videoId: now.id, startSeconds: offset });
+            } catch (e) { _jbxTuneOut(); }
+        }
+    }
+
+    function _jbxOnPlayerState(e) {
+        // ENDED (0): the tuned-in DJ advances the room. Non-DJs just wait —
+        // their player moves when the DJ's jbx.now arrives.
+        if (e && e.data === 0 && _jbxIsDj()) _jbxAdvance(null);
+    }
+
+    function _jbxSubmit() {
+        var input = q('[data-chat-jbx-input]');
+        var resHost = q('[data-chat-jbx-results]');
+        if (!input || state.jukebox.resolving) return;
+        var qtext = String(input.value || '').trim();
+        if (!qtext) return;
+        state.jukebox.resolving = true;
+        if (resHost) { resHost.hidden = false; resHost.innerHTML = '<div class="chat-jbx-meta">Looking that up…</div>'; }
+        postJSON('/api/chat/jukebox/resolve', { q: qtext }).then(function (res) {
+            state.jukebox.resolving = false;
+            if (!res.ok || !(res.body.results || []).length) {
+                if (resHost) resHost.innerHTML = '<div class="chat-jbx-meta">' +
+                    esc((res.body && res.body.error) || 'Nothing found — try a link or a different search.') + '</div>';
+                return;
+            }
+            var results = res.body.results;
+            if (results.length === 1) {                 // pasted link → straight in
+                _jbxPick(results[0]);
+                return;
+            }
+            state.jukebox.results = results;
+            if (resHost) resHost.innerHTML = results.map(function (r, i) {
+                return '<button class="chat-jbx-result" type="button" data-chat-jbx-pick="' + i + '">' +
+                    '<span class="chat-jbx-title">' + esc(r.title || r.id) + '</span>' +
+                    '<span class="chat-jbx-meta">' + esc(r.channel || '') +
+                        (r.duration ? ' · ' + _fmtSecs(r.duration) : '') + '</span>' +
+                '</button>';
+            }).join('');
+        }).catch(function () {
+            state.jukebox.resolving = false;
+            if (resHost) resHost.innerHTML = '<div class="chat-jbx-meta">Lookup failed — try again.</div>';
+        });
+    }
+
+    function _jbxPick(r) {
+        if (!r || !r.id) return;
+        var p = { id: r.id, ti: String(r.title || '').slice(0, 120) };
+        if (r.duration) p.d = r.duration;
+        sendProtocol('jbx.sub', p);
+        var input = q('[data-chat-jbx-input]');
+        if (input) input.value = '';
+        var resHost = q('[data-chat-jbx-results]');
+        if (resHost) { resHost.hidden = true; resHost.innerHTML = ''; }
+        state.jukebox.results = [];
+        if (typeof showToast === 'function') showToast('♫ Added to the room queue', 'success');
     }
 
     function onRoomMessages(d) {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -341,10 +341,53 @@
                     (r.n > 1 ? ' <b>' + r.n + '</b>' : '') + '</span>';
             }).join('') + '</div>';
         }
+        var bodyHtml = (m.file && m.file.n)
+            ? _fileCardHtml(m)
+            : (m.rich ? renderRich(m.message) : renderPlain(m.message));
         return '<div class="chat-line' + (me ? ' chat-line--me' : '') + '" title="' +
             attr(_fullTs(m.timestamp)) + '">' + replyRef +
-            (m.rich ? renderRich(m.message) : renderPlain(m.message)) +
-            actions + chips + '</div>';
+            bodyHtml + actions + chips + '</div>';
+    }
+
+    // ── shared file card (filepost.dev links dressed by envelope 'f') ────
+    var _AUDIO_EXT = /\.(flac|mp3|m4a|ogg|opus|wav|aiff?)$/i;
+    var _VIDEO_EXT = /\.(mp4|mkv|webm|mov)$/i;
+    var _IMAGE_EXT = /\.(jpe?g|png|gif|webp)$/i;
+
+    function _fileCardHtml(m) {
+        var url = String(m.message || '').trim();
+        var f = m.file || {};
+        var name = String(f.n || 'file');
+        var mime = String(f.m || '');
+        var isAudio = mime.indexOf('audio/') === 0 || _AUDIO_EXT.test(name);
+        var isVideo = mime.indexOf('video/') === 0 || _VIDEO_EXT.test(name);
+        var isImage = mime.indexOf('image/') === 0 || _IMAGE_EXT.test(name);
+        if (!/^https:\/\//i.test(url)) {
+            // hostile envelope: card metadata on a non-https 'link' — render
+            // as plain text instead of a clickable trap
+            return m.rich ? renderRich(m.message) : renderPlain(m.message);
+        }
+        var icon = isAudio ? '🎵' : isVideo ? '🎬' : isImage ? '🖼' : '📄';
+        var preview = '';
+        if (isAudio) {
+            preview = '<button type="button" class="chat-embed-chip" data-chat-file-audio="' +
+                attr(url) + '">▶ preview</button>';
+        } else if (isVideo) {
+            preview = '<button type="button" class="chat-embed-chip" data-chat-file-video="' +
+                attr(url) + '">▶ preview</button>';
+        } else if (isImage) {
+            preview = '<button type="button" class="chat-embed-chip" data-chat-embed-img="' +
+                attr(url) + '">🖼 show</button>';
+        }
+        return '<div class="chat-file-card">' +
+            '<span class="chat-file-icon">' + icon + '</span>' +
+            '<span class="chat-file-meta"><b class="chat-file-name">' + esc(name) + '</b>' +
+            (f.s ? '<span class="chat-file-size">' + esc(_fmtBytes(f.s)) + '</span>' : '') +
+            '</span>' +
+            preview +
+            '<a class="chat-embed-chip chat-file-dl" href="' + attr(url) +
+                '" target="_blank" rel="noopener noreferrer" download>⬇ download</a>' +
+            '<div class="chat-file-slot"></div></div>';
     }
 
     // Consecutive messages from the same sender (same app-ness, <5 min apart)
@@ -1060,6 +1103,9 @@
             if (el) el.value = b.room || '';
             el = q('[data-chat-set-giphy]');
             if (el) { el.value = ''; el.placeholder = b.giphy_key_set ? '••••••••  (configured)' : 'not set'; }
+            el = q('[data-chat-set-filepost]');
+            if (el) { el.value = ''; el.placeholder = b.filepost_key_set ? '••••••••  (configured)' : 'not set'; }
+            el = q('[data-chat-set-filepost-expiry]'); if (el) el.value = b.filepost_expiry || '';
             el = q('[data-chat-set-autojoin]'); if (el) el.checked = !!b.auto_join;
             el = q('[data-chat-set-membersend]'); if (el) el.checked = !!b.member_send;
             el = q('[data-chat-set-autoprove]'); if (el) el.checked = !!b.auto_prove;
@@ -1079,6 +1125,10 @@
         // blank must never clear a configured key
         var kEl = q('[data-chat-set-giphy]');
         if (kEl && kEl.value.trim()) payload.giphy_key = kEl.value.trim();
+        var fEl = q('[data-chat-set-filepost]');
+        if (fEl && fEl.value.trim()) payload.filepost_key = fEl.value.trim();
+        var xEl = q('[data-chat-set-filepost-expiry]');
+        if (xEl) payload.filepost_expiry = xEl.value || '';
         postJSON('/api/chat/settings', payload).then(function (res) {
             if (!res.ok) {
                 if (typeof showToast === 'function') {
@@ -1098,6 +1148,104 @@
             refresh();
             if (typeof showToast === 'function') showToast('Chat settings saved', 'success');
         });
+    }
+
+    // ── file sharing (filepost.dev) ─────────────────────────────────────
+    function toggleAttachPanel(forceClose) {
+        var pop = q('[data-chat-attach-pop]');
+        if (!pop) return;
+        if (forceClose === true) { pop.hidden = true; return; }
+        pop.hidden = !pop.hidden;
+        if (!pop.hidden) {
+            toggleGifPicker(true); toggleEmojiPicker(true);
+            var inp = q('[data-chat-attach-search]');
+            if (inp) inp.focus();
+        }
+    }
+
+    function _attachStatus(text, isError) {
+        var el = q('[data-chat-attach-status]');
+        if (!el) return;
+        el.hidden = !text;
+        el.textContent = text || '';
+        el.classList.toggle('chat-attach-status--err', !!isError);
+    }
+
+    function _sendFileMessage(meta) {
+        var url = String(meta.url || '');
+        if (!url) return;
+        var done = function (res) {
+            _attachStatus('');
+            toggleAttachPanel(true);
+            if (res.ok) refresh();
+            else if (typeof showToast === 'function') {
+                showToast(res.body && res.body.error || 'Could not send the file link', 'error');
+            }
+        };
+        if (state.view === 'room') {
+            postJSON('/api/chat/room/message', {
+                message: url, room: state.room,
+                file: { n: meta.name || 'file', s: meta.size || 0, m: meta.mime || '' },
+            }).then(done);
+        } else if (state.pmUser) {
+            // PMs are plaintext by design — the recipient gets a usable URL
+            postJSON('/api/chat/conversations/' + encodeURIComponent(state.pmUser),
+                     { message: url }).then(done);
+        }
+    }
+
+    function attachUploadFile(file) {
+        if (!file) return;
+        if (file.size > 50 * 1024 * 1024) {
+            _attachStatus('Too big — filepost.dev caps uploads at 50 MB', true);
+            return;
+        }
+        _attachStatus('Uploading ' + file.name + '\u2026');
+        var fd = new FormData();
+        fd.append('file', file, file.name);
+        fetch('/api/chat/files/upload', { method: 'POST', body: fd })
+            .then(function (r) { return r.json().then(function (b) { return { ok: r.ok, body: b }; }); })
+            .then(function (res) {
+                if (!res.ok || !res.body.ok) {
+                    _attachStatus(res.body && res.body.error || 'Upload failed', true);
+                    return;
+                }
+                _sendFileMessage(res.body);
+            })
+            .catch(function () { _attachStatus('Upload failed', true); });
+    }
+
+    function attachSendTrack(trackId, label) {
+        _attachStatus('Uploading ' + (label || 'track') + '\u2026');
+        postJSON('/api/chat/files/upload', { track_id: trackId }).then(function (res) {
+            if (!res.ok || !res.body.ok) {
+                _attachStatus(res.body && res.body.error || 'Upload failed', true);
+                return;
+            }
+            _sendFileMessage(res.body);
+        });
+    }
+
+    var _attachSearchTimer = null;
+    function attachLibrarySearch(qstr) {
+        var host = q('[data-chat-attach-results]');
+        if (!host) return;
+        if (!qstr || qstr.length < 2) { host.innerHTML = ''; return; }
+        getJSON('/api/chat/files/library-search?q=' + encodeURIComponent(qstr))
+            .then(function (res) {
+                if (!res.ok) return;
+                var tracks = res.body.tracks || [];
+                host.innerHTML = tracks.length ? tracks.map(function (t) {
+                    var label = (t.artist ? t.artist + ' — ' : '') + t.title;
+                    return '<button type="button" class="chat-browse-row" ' +
+                        'data-chat-attach-track="' + attr(String(t.id)) + '" ' +
+                        'data-chat-attach-label="' + attr(label) + '">' +
+                        '<span class="chat-browse-icon">🎵</span>' +
+                        '<span class="chat-browse-name">' + esc(label) + '</span>' +
+                        (t.size ? '<span class="chat-browse-meta">' + esc(_fmtBytes(t.size)) + '</span>' : '') +
+                        '</button>';
+                }).join('') : '<div class="chat-side-none">No matches with files on disk</div>';
+            });
     }
 
     function toggleGifPicker(forceClose) {
@@ -1563,6 +1711,31 @@
                     'onerror="this.replaceWith(document.createTextNode(\'(image failed to load)\'))">';
                 return;
             }
+            t = e.target.closest('[data-chat-file-audio]');
+            if (t) {
+                var card = t.closest('.chat-file-card');
+                var slot = card && card.querySelector('.chat-file-slot');
+                if (slot) {
+                    slot.innerHTML = '<audio class="chat-file-player" controls preload="none" src="' +
+                        t.getAttribute('data-chat-file-audio').replace(/"/g, '&quot;') + '"></audio>';
+                    slot.querySelector('audio').play().catch(function () {});
+                    t.remove();
+                }
+                return;
+            }
+            t = e.target.closest('[data-chat-file-video]');
+            if (t) {
+                var vcard = t.closest('.chat-file-card');
+                var vslot = vcard && vcard.querySelector('.chat-file-slot');
+                if (vslot) {
+                    vslot.innerHTML = '<video class="chat-file-player chat-file-player--video" controls preload="metadata" src="' +
+                        t.getAttribute('data-chat-file-video').replace(/"/g, '&quot;') + '"></video>';
+                    t.remove();
+                }
+                return;
+            }
+            t = e.target.closest('[data-chat-attach-btn]');
+            if (t) { toggleAttachPanel(); return; }
             t = e.target.closest('[data-chat-spoiler]');
             if (t) { t.classList.add('chat-spoiler--shown'); return; }
             t = e.target.closest('[data-chat-fmt]');
@@ -1756,6 +1929,32 @@
                 _gifTimer = setTimeout(function () { gifSearch(gifIn.value.trim()); }, 400);
             });
         }
+
+        var attIn = q('[data-chat-attach-search]');
+        if (attIn) {
+            attIn.addEventListener('input', function () {
+                if (_attachSearchTimer) clearTimeout(_attachSearchTimer);
+                _attachSearchTimer = setTimeout(function () {
+                    attachLibrarySearch(attIn.value.trim());
+                }, 350);
+            });
+        }
+        var attFile = q('[data-chat-attach-file]');
+        if (attFile) {
+            attFile.addEventListener('change', function () {
+                if (attFile.files && attFile.files[0]) attachUploadFile(attFile.files[0]);
+                attFile.value = '';
+            });
+        }
+        document.addEventListener('click', function (e) {
+            var up = e.target.closest('[data-chat-attach-upload]');
+            if (up) { var fi = q('[data-chat-attach-file]'); if (fi) fi.click(); return; }
+            var tr = e.target.closest('[data-chat-attach-track]');
+            if (tr) {
+                attachSendTrack(tr.getAttribute('data-chat-attach-track'),
+                                tr.getAttribute('data-chat-attach-label'));
+            }
+        });
 
         var scroller = q('[data-chat-messages]');
         if (scroller) {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -2392,14 +2392,23 @@
         // the player follows the ROOM, not the panel — a tuned-in listener
         // reading PMs must still hear the DJ's advances (panel merely hides)
         _jbxSyncPlayer(now && !ended ? now : null);
-        var show = state.jukebox.open && state.view === 'room';
+        // the header bar (brand + listeners + add-a-song) lives in the page
+        // header and shows whenever a room is on screen — panel open or not
+        var inRoom = state.view === 'room';
+        var headbar = q('[data-chat-jbx-headbar]');
+        if (headbar) {
+            headbar.hidden = !inRoom;
+            var form = q('[data-chat-jbx-form]');
+            if (form) form.hidden = !state.canSend;
+            var lc = q('[data-chat-jbx-listeners]');
+            if (lc && window.ChatProtocol) {
+                var nTuned = Object.keys(window.ChatProtocol.reduceTuned(_roomEvents())).length;
+                lc.textContent = nTuned ? '♪ ' + nTuned + ' listening' : '';
+            }
+        }
+        var show = state.jukebox.open && inRoom;
         panel.hidden = !show;
         if (!show) return;
-        var lc = q('[data-chat-jbx-listeners]');
-        if (lc && window.ChatProtocol) {
-            var nTuned = Object.keys(window.ChatProtocol.reduceTuned(_roomEvents())).length;
-            lc.textContent = nTuned ? '♪ ' + nTuned + ' listening' : '';
-        }
         // fingerprint: skip DOM writes when nothing visible changed (the
         // elapsed clock ticks via its own cheap textContent update below)
         var fp = JSON.stringify([now && now.id, ended, st.queue, state.jukebox.tunedIn, state.canSend]);
@@ -2440,8 +2449,6 @@
                     '</div>';
                 }).join('') || '';
             }
-            var form = q('[data-chat-jbx-form]');
-            if (form) form.hidden = !state.canSend;
         } else if (elapsed !== null) {
             var clock = q('[data-chat-jbx-clock]');
             if (clock) clock.textContent = _fmtSecs(elapsed);
@@ -2613,6 +2620,7 @@
         var p = { id: r.id, ti: String(r.title || '').slice(0, 120) };
         if (r.duration) p.d = r.duration;
         sendProtocol('jbx.sub', p);
+        if (!state.jukebox.open && state.view === 'room') toggleJukebox();
         var input = q('[data-chat-jbx-input]');
         if (input) input.value = '';
         var resHost = q('[data-chat-jbx-results]');

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -708,6 +708,12 @@
                       'placeholder="Search history…" autocomplete="off"' +
                       (state.searchMode ? '' : ' hidden') + '>' +
               '</span>' +
+              '<button class="chat-filter-btn' + (state.pinsOpen ? ' chat-filter-btn--on' : '') +
+              '" type="button" data-chat-pins-toggle title="Pinned messages">📌' +
+              (function () {
+                  var n = window.ChatProtocol ? window.ChatProtocol.reducePins(_roomEvents()).length : 0;
+                  return n ? ' ' + n : '';
+              })() + '</button>' +
               '<button class="chat-filter-btn' + (state.jukebox.open ? ' chat-filter-btn--on' : '') +
               '" type="button" data-chat-jukebox-btn title="Room jukebox — listen together, vote on what plays next">♫ Jukebox</button>' +
               '<button class="chat-filter-btn' + (state.ssOnly ? ' chat-filter-btn--on' : '') +
@@ -1747,6 +1753,12 @@
                     !e.target.closest('[data-chat-poll-pop]')) {
                 togglePollPop(true);
             }
+            if (state.pinsOpen && !e.target.closest('[data-chat-pins-toggle]') &&
+                    !e.target.closest('[data-chat-pinbar]')) {
+                state.pinsOpen = false;
+                renderPinbar();
+                if (!state.searchMode) renderHead();
+            }
             if (!e.target.closest('[data-chat-gif-btn]') &&
                     !e.target.closest('[data-chat-gif-pop]')) {
                 toggleGifPicker(true);
@@ -1833,7 +1845,12 @@
             t = e.target.closest('[data-chat-browse-retry]');
             if (t) { if (_browse.user) openBrowse(_browse.user); return; }
             t = e.target.closest('[data-chat-pins-toggle]');
-            if (t) { state.pinsOpen = !state.pinsOpen; renderPinbar(); return; }
+            if (t) {
+                state.pinsOpen = !state.pinsOpen;
+                renderPinbar();
+                if (!state.searchMode) renderHead();
+                return;
+            }
             t = e.target.closest('[data-chat-pin-del-u]');
             if (t) {
                 sendProtocol('pin.del', { u: t.getAttribute('data-chat-pin-del-u'),
@@ -2248,28 +2265,28 @@
 
     // ── pinned messages (pin.add / pin.del on the bus) ──────────────────
     function renderPinbar() {
+        // A POPOVER, not a standing bar (Boulder): pins are look-up-occasionally,
+        // so they cost zero message height until the head 📌 button opens them.
         var host = q('[data-chat-pinbar]');
         if (!host) return;
+        var show = state.pinsOpen && state.view === 'room';
+        host.hidden = !show;
+        if (!show) { host.innerHTML = ''; return; }
         var CP = window.ChatProtocol;
-        var pins = (CP && state.view === 'room') ? CP.reducePins(_roomEvents()) : [];
-        if (!pins.length) { host.hidden = true; host.innerHTML = ''; return; }
-        host.hidden = false;
-        var head = '<button class="chat-pinbar-head" type="button" data-chat-pins-toggle>📌 ' +
-            pins.length + ' pinned' + (state.pinsOpen ? ' ▾' : ' ▸') + '</button>';
-        var rows = '';
-        if (state.pinsOpen) {
-            rows = pins.slice().reverse().map(function (pin) {
-                return '<div class="chat-pin-row">' +
-                    '<span class="chat-pin-text"><b>' + esc(pin.u) + '</b> ' + esc(pin.x) + '</span>' +
-                    '<span class="chat-pin-by">pinned by ' + esc(pin.by) + '</span>' +
-                    (state.canSend
-                        ? '<button class="chat-pin-del" type="button" title="Unpin" ' +
-                          'data-chat-pin-del-u="' + attr(pin.u) + '" data-chat-pin-del-ts="' + attr(pin.ts) + '">×</button>'
-                        : '') +
-                '</div>';
-            }).join('');
-        }
-        host.innerHTML = head + rows;
+        var pins = CP ? CP.reducePins(_roomEvents()) : [];
+        host.innerHTML = '<div class="chat-pins-title">📌 Pinned messages</div>' +
+            (pins.length
+                ? pins.slice().reverse().map(function (pin) {
+                    return '<div class="chat-pin-row">' +
+                        '<span class="chat-pin-text"><b>' + esc(pin.u) + '</b> ' + esc(pin.x) + '</span>' +
+                        '<span class="chat-pin-by">pinned by ' + esc(pin.by) + '</span>' +
+                        (state.canSend
+                            ? '<button class="chat-pin-del" type="button" title="Unpin" ' +
+                              'data-chat-pin-del-u="' + attr(pin.u) + '" data-chat-pin-del-ts="' + attr(pin.ts) + '">×</button>'
+                            : '') +
+                    '</div>';
+                }).join('')
+                : '<div class="chat-side-none">Nothing pinned yet — hover a message and hit 📌</div>');
     }
 
     // ── the room poll (poll.start / poll.vote / poll.end on the bus) ────
@@ -2557,7 +2574,7 @@
             host.innerHTML = '<div data-chat-jbx-yt></div>';
             state.jukebox.playingId = now.id;
             state.jukebox.player = new window.YT.Player(host.firstChild, {
-                width: '100%', height: '180', videoId: now.id,
+                width: '100%', height: '158', videoId: now.id,
                 playerVars: { autoplay: 1, start: offset, rel: 0, playsinline: 1 },
                 events: {
                     onReady: function () {

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -24,6 +24,8 @@
         stickBottom: true,       // autoscroll unless the user scrolled up
         started: false,
         ssOnly: false,           // room filter: show only SoulSync-app messages
+        protocolLog: [],         // recent machine-coordination events (bounded)
+        beaconed: {},            // rooms we've announced ourselves in this session
         isAdmin: false,          // shows the settings cog (from /status)
         newMarker: null,         // frozen last-seen ts for the NEW divider (per room open)
         renderedCount: 0,        // for the new-messages pill delta
@@ -500,12 +502,22 @@
     // Users who spoke through SoulSync (the envelope is the app signature) —
     // sourced from the loaded messages, so it's an approximation of "runs
     // SoulSync", not a directory.
-    function _soulsyncUsers() {
-        var set = {};
+    function _userClassification() {
+        // {name: 'soulsync'|'vanilla'} — the assume-SoulSync flip: names
+        // absent from this map never spoke and are treated as SoulSync.
+        // Built with ChatProtocol.classifyUser (envelope conclusive forever,
+        // protocol events count as envelopes; only bare text marks vanilla).
+        var cls = {};
+        var CP = window.ChatProtocol;
         (state.msgs || []).forEach(function (m) {
-            if (m.rich && m.username) set[m.username] = 1;
+            if (!m.username) return;
+            cls[m.username] = CP ? CP.classifyUser(cls[m.username], !!m.rich)
+                                 : (m.rich ? 'soulsync' : (cls[m.username] || 'vanilla'));
         });
-        return set;
+        (state.protocolLog || []).forEach(function (ev) {
+            if (ev && ev.username) cls[ev.username] = 'soulsync';
+        });
+        return cls;
     }
 
     function _userBtn(n, extraClass) {
@@ -542,11 +554,12 @@
             return a.toLowerCase().localeCompare(b.toLowerCase());
         });
         if (f) names = names.filter(function (n) { return n.toLowerCase().indexOf(f) > -1; });
-        var ss = _soulsyncUsers();
+        var cls = _userClassification();
         var self = [], apps = [], rest = [];
         names.forEach(function (n) {
             if (state.selfName && n === state.selfName) self.push(n);
-            else if (ss[n]) apps.push(n);
+            // the flip: unknown (never spoke) = assumed SoulSync
+            else if (cls[n] !== 'vanilla') apps.push(n);
             else rest.push(n);
         });
         var html = '<div class="chat-users-label">' + state.users.length + ' online</div>';
@@ -557,7 +570,7 @@
         }
         if (rest.length) {
             html += (apps.length || self.length
-                        ? '<div class="chat-users-label chat-users-label--sub">Everyone</div>' : '') +
+                        ? '<div class="chat-users-label chat-users-label--sub">Other clients</div>' : '') +
                 rest.map(function (n) { return _userBtn(n); }).join('');
         }
         if (!self.length && !apps.length && !rest.length) {
@@ -757,6 +770,8 @@
             if (overlay.getAttribute('data-chat-user-card-for') !== name) return;
             var info = (res.ok && res.body.info) || {};
             var status = (res.ok && res.body.status) || {};
+            var hist = (res.ok && res.body.history) || null;
+            var note = (res.ok && typeof res.body.note === 'string') ? res.body.note : '';
             var rows = [];
             var pres = status.presence || status.status ||
                 (status.isOnline === true ? 'Online' : (status.isOnline === false ? 'Offline' : null));
@@ -769,14 +784,62 @@
             }
             var infoHost = overlay.querySelector('.chat-card-info');
             if (infoHost) {
-                infoHost.innerHTML = rows.length
+                var html = rows.length
                     ? rows.map(function (r) {
                         return '<div class="chat-card-row"><span>' + esc(r[0]) +
                             '</span><b>' + esc(r[1]) + '</b></div>';
                     }).join('')
                     : '<div class="chat-card-row chat-card-none">No info available</div>';
+                // OUR history with this peer — the card no other client has
+                if (hist && hist.downloads > 0) {
+                    html += '<div class="chat-card-hist">' +
+                        '<div class="chat-card-row"><span>Downloads from them</span><b>' +
+                            esc(String(hist.downloads)) + '</b></div>' +
+                        (hist.success_rate != null
+                            ? '<div class="chat-card-row"><span>Success rate</span><b>' +
+                                esc(String(hist.success_rate)) + '%</b></div>' : '') +
+                        (hist.total_bytes > 0
+                            ? '<div class="chat-card-row"><span>Data pulled</span><b>' +
+                                esc(_fmtBytes(hist.total_bytes)) + '</b></div>' : '') +
+                        (hist.last_download
+                            ? '<div class="chat-card-row"><span>Last download</span><b>' +
+                                esc(String(hist.last_download).slice(0, 16)) + '</b></div>' : '') +
+                        '</div>';
+                }
+                // private local note ("great jazz rips") — never leaves this install
+                html += '<div class="chat-card-note">' +
+                    '<textarea class="chat-card-note-input" data-chat-card-note ' +
+                        'placeholder="Private note about ' + attr(name) + '\u2026" ' +
+                        'maxlength="2000" rows="2">' + esc(note) + '</textarea>' +
+                    '<button class="chat-fmt-btn chat-card-note-save" type="button" ' +
+                        'data-chat-card-note-save hidden>Save note</button></div>';
+                infoHost.innerHTML = html;
+                var ta = infoHost.querySelector('[data-chat-card-note]');
+                var saveBtn = infoHost.querySelector('[data-chat-card-note-save]');
+                if (ta && saveBtn) {
+                    ta.addEventListener('input', function () { saveBtn.hidden = false; });
+                    saveBtn.addEventListener('click', function () {
+                        postJSON('/api/chat/user/' + encodeURIComponent(name) + '/note',
+                                 { note: ta.value }).then(function (r2) {
+                            if (r2.ok) {
+                                saveBtn.hidden = true;
+                                if (typeof showToast === 'function') showToast('Note saved', 'success');
+                            } else if (typeof showToast === 'function') {
+                                showToast('Could not save note', 'error');
+                            }
+                        });
+                    });
+                }
             }
         });
+    }
+
+    function _fmtBytes(n) {
+        n = Number(n) || 0;
+        if (n >= 1024 * 1024 * 1024) return (n / (1024 * 1024 * 1024)).toFixed(1) + ' GB';
+        if (n >= 1024 * 1024) return (n / (1024 * 1024)).toFixed(1) + ' MB';
+        if (n >= 1024) return (n / 1024).toFixed(0) + ' KB';
+        return n + ' B';
     }
 
     function closeUserCard() {
@@ -1251,6 +1314,8 @@
                 mergeMessages(res.body.messages);
                 renderMessages(state.msgs);
                 renderUsers(res.body.users);
+                _ingestProtocol(res.body.protocol);
+                _sendJoinBeacon();
             });
         } else {
             work = getJSON('/api/chat/conversations/' + encodeURIComponent(state.pmUser))
@@ -1789,6 +1854,57 @@
         });
     }
 
+    // ── protocol bus (the hidden coordination channel) ──────────────────
+    function _ingestProtocol(events) {
+        if (!events || !events.length) return;
+        var log = state.protocolLog;
+        var seen = {};
+        log.forEach(function (e) { seen[e.username + '|' + e.timestamp + '|' + (e.p && e.p.k)] = 1; });
+        var fresh = [];
+        events.forEach(function (ev) {
+            if (!ev || !ev.p || !window.ChatProtocol) return;
+            var p = window.ChatProtocol.parseProtocol({ p: ev.p });
+            if (!p) return;
+            var key = ev.username + '|' + ev.timestamp + '|' + p.k;
+            if (seen[key]) return;
+            seen[key] = 1;
+            var entry = { username: String(ev.username || ''), timestamp: ev.timestamp, p: p };
+            log.push(entry);
+            fresh.push(entry);
+        });
+        if (log.length > 300) state.protocolLog = log.slice(-300);
+        if (fresh.length) {
+            // presence: a protocol event proves SoulSync — refresh buckets
+            renderUsersList();
+            try {
+                document.dispatchEvent(new CustomEvent('soulsync:chat-protocol',
+                    { detail: { events: fresh } }));
+            } catch (e) { /* older browsers: features just poll the log */ }
+        }
+    }
+
+    function sendProtocol(kind, fields) {
+        // One-liner for features: fire a coordination event into the room.
+        // Respects the send gate server-side; failures are silent (fun-grade).
+        var p = Object.assign({ k: kind }, fields || {});
+        return postJSON('/api/chat/room/protocol', { room: state.room, p: p });
+    }
+
+    function _sendJoinBeacon() {
+        // Announce capability ONCE per room per session — powers the
+        // assume-SoulSync presence for users who haven't typed anything.
+        if (!state.canSend || !state.room || state.beaconed[state.room]) return;
+        state.beaconed[state.room] = 1;
+        sendProtocol('hello', {}).then(function (r) {
+            if (!r.ok) state.beaconed[state.room] = 0;   // retry next refresh
+        });
+    }
+
+    function onRoomProtocol(d) {
+        if (!d || d.room !== state.room) return;
+        _ingestProtocol(d.events || []);
+    }
+
     function onRoomMessages(d) {
         _ensureSelf();
         // a mention pings you wherever you are in the app (Discord behavior)
@@ -1856,6 +1972,7 @@
 
     window.ChatPage = { open: open, openPm: openPm, messageUser: messageUser,
                         onRoomMessages: onRoomMessages, onUnread: onUnread,
+                        onRoomProtocol: onRoomProtocol, sendProtocol: sendProtocol,
                         // exported for the node render harness (XSS contract tests)
                         renderRich: renderRich, renderPlain: renderPlain,
                         renderGroups: renderGroups,

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -48,6 +48,9 @@
             timer: null,         //   elapsed clock + DJ watchdog while open
             ytLoading: false, ytCbs: [],
         },
+        pinsOpen: false,         // pin board expanded
+        topicEditing: false,     // head shows the topic input (renderHead pauses)
+        pollDismissedAt: null,   // locally-dismissed closed poll (its start ts)
     };
     try { state.ssOnly = localStorage.getItem('chat_ss_only') === '1'; } catch (e) { /* ignore */ }
 
@@ -345,6 +348,12 @@
                 'data-chat-reply-user="' + attr(m.username || '') + '" ' +
                 'data-chat-reply-x="' + attr(String(m.message || '').slice(0, 100)) + '">↩</button>' + acts;
         }
+        if (state.view === 'room' && state.canSend) {
+            acts += '<button type="button" class="chat-line-reply" title="Pin to the room board" ' +
+                'data-chat-pin-user="' + attr(m.username || '') + '" ' +
+                'data-chat-pin-ts="' + attr(String(m.timestamp || '')) + '" ' +
+                'data-chat-pin-x="' + attr(String(m.message || '').slice(0, 140)) + '">📌</button>';
+        }
         var actions = '<span class="chat-line-acts">' + acts + '</span>';
         var chips = '';
         if (m.reactions && m.reactions.length) {
@@ -576,11 +585,14 @@
         return cls;
     }
 
-    function _userBtn(n, extraClass) {
+    function _userBtn(n, extraClass, tunedMap) {
         var ign = isIgnored(n);
+        var tuned = tunedMap && tunedMap[n];
         return '<button class="chat-user' + (extraClass || '') + (ign ? ' chat-user--ignored' : '') +
-            '" type="button" data-chat-user="' + attr(n) + '" title="' + attr(n) + '">' +
+            '" type="button" data-chat-user="' + attr(n) + '" title="' + attr(n) +
+            (tuned ? ' — listening to the room jukebox' : '') + '">' +
             '<span class="chat-user-dot"></span>' + esc(n) +
+            (tuned ? '<span class="chat-user-tuned">♫</span>' : '') +
             (ign ? '<span class="chat-user-mute">muted</span>' : '') + '</button>';
     }
 
@@ -618,16 +630,18 @@
             else if (cls[n] !== 'vanilla') apps.push(n);
             else rest.push(n);
         });
+        var tunedMap = window.ChatProtocol
+            ? window.ChatProtocol.reduceTuned(_roomEvents()) : {};   // once, not per user
         var html = '<div class="chat-users-label">' + state.users.length + ' online</div>';
-        if (self.length) html += self.map(function (n) { return _userBtn(n, ' chat-user--self'); }).join('');
+        if (self.length) html += self.map(function (n) { return _userBtn(n, ' chat-user--self', tunedMap); }).join('');
         if (apps.length) {
             html += '<div class="chat-users-label chat-users-label--sub">SoulSync users</div>' +
-                apps.map(function (n) { return _userBtn(n); }).join('');
+                apps.map(function (n) { return _userBtn(n, '', tunedMap); }).join('');
         }
         if (rest.length) {
             html += (apps.length || self.length
                         ? '<div class="chat-users-label chat-users-label--sub">Other clients</div>' : '') +
-                rest.map(function (n) { return _userBtn(n); }).join('');
+                rest.map(function (n) { return _userBtn(n, '', tunedMap); }).join('');
         }
         if (!self.length && !apps.length && !rest.length) {
             html += '<div class="chat-side-none">No users match</div>';
@@ -672,12 +686,22 @@
     function renderHead() {
         var head = q('[data-chat-head]');
         if (!head) return;
+        if (state.topicEditing) return;   // don't clobber the open topic input
         var isHome = !state.homeRoom || state.room === state.homeRoom;
+        var topic = (window.ChatProtocol && state.view === 'room')
+            ? window.ChatProtocol.reduceTopic(_roomEvents()) : null;
+        var subText = topic
+            ? esc(topic.t)
+            : (isHome ? 'the SoulSync community room on Soulseek'
+                      : 'a public Soulseek room');
         head.innerHTML = state.view === 'room'
             ? '<span class="chat-head-title"># ' + esc(state.room || '') + '</span>' +
-              '<span class="chat-head-sub">' + (isHome
-                  ? 'the SoulSync community room on Soulseek'
-                  : 'a public Soulseek room') + '</span>' +
+              '<span class="chat-head-sub' + (topic ? ' chat-head-sub--topic' : '') + '"' +
+                  (topic ? ' title="topic set by ' + attr(topic.by) + '"' : '') + '>' + subText +
+                  (state.canSend
+                      ? ' <button class="chat-topic-edit" type="button" data-chat-topic-edit ' +
+                        'title="Set the room topic (SoulSync clients only)">✎</button>'
+                      : '') + '</span>' +
               '<span class="chat-head-search' + (state.searchMode ? ' chat-head-search--on' : '') + '">' +
                   '<button class="chat-filter-btn" type="button" data-chat-search-btn title="Search this room\'s history">🔍</button>' +
                   '<input class="chat-head-search-in" data-chat-search-input type="text" ' +
@@ -716,7 +740,10 @@
         // emoji button stays everywhere (plain unicode is fine in PMs).
         var gifBtn = q('[data-chat-gif-btn]');
         if (gifBtn) gifBtn.hidden = !(state.view === 'room' && state.canSend);
-        if (state.view !== 'room') { toggleEmojiPicker(true); toggleGifPicker(true); }
+        // polls are a room thing (bus events mean nothing in a PM)
+        var pollBtn = q('[data-chat-poll-btn]');
+        if (pollBtn) pollBtn.hidden = !(state.view === 'room' && state.canSend);
+        if (state.view !== 'room') { toggleEmojiPicker(true); toggleGifPicker(true); togglePollPop(true); }
     }
 
     // ── composer toolbar (room only) ─────────────────────────────────────────
@@ -1511,13 +1538,16 @@
     function openRoom(name) {
         state.view = 'room'; state.pmUser = null; state.lastStamp = null; state.stickBottom = true;
         state.renderedCount = 0; hideJumpPill();
-        var prevRoom = state.room;
-        state.room = name || state.room || state.homeRoom || 'SoulSync';
-        if (prevRoom && prevRoom !== state.room) {
-            _jbxTuneOut();               // never keep playing another room's track
+        var nextRoom = name || state.room || state.homeRoom || 'SoulSync';
+        if (state.room && state.room !== nextRoom) {
+            _jbxTuneOut();               // BEFORE the flip: the off event goes to the OLD room
             state.jukebox.lastRendered = '';
+            state.pinsOpen = false;
+            state.pollDismissedAt = null;
         }
-        renderJukebox();
+        state.room = nextRoom;
+        state.topicEditing = false;
+        renderBusUI();
         state.msgs = []; state.loadingOlder = false; state.historyDone = false;
         cancelReply();
         try {
@@ -1643,7 +1673,8 @@
         state.searchMode = false;
         state.renderedCount = 0; hideJumpPill(); state.newMarker = null;
         cancelReply();
-        renderHead(); renderComposer(); renderJukebox();   // hides the panel (audio keeps playing)
+        state.topicEditing = false;
+        renderHead(); renderComposer(); renderBusUI();   // hides the panels (audio keeps playing)
         var host = q('[data-chat-messages]');
         if (host) host.innerHTML = '<div class="chat-empty">Loading…</div>';
         refresh();
@@ -1708,6 +1739,10 @@
             if (!e.target.closest('[data-chat-emoji-btn]') &&
                     !e.target.closest('[data-chat-emoji-pop]')) {
                 toggleEmojiPicker(true);
+            }
+            if (!e.target.closest('[data-chat-poll-btn]') &&
+                    !e.target.closest('[data-chat-poll-pop]')) {
+                togglePollPop(true);
             }
             if (!e.target.closest('[data-chat-gif-btn]') &&
                     !e.target.closest('[data-chat-gif-pop]')) {
@@ -1790,6 +1825,52 @@
                 state.lastStamp = null;
                 state.renderedCount = 0; hideJumpPill();   // a filter flip isn't 'new messages'
                 renderHead(); refresh();
+                return;
+            }
+            t = e.target.closest('[data-chat-pins-toggle]');
+            if (t) { state.pinsOpen = !state.pinsOpen; renderPinbar(); return; }
+            t = e.target.closest('[data-chat-pin-del-u]');
+            if (t) {
+                sendProtocol('pin.del', { u: t.getAttribute('data-chat-pin-del-u'),
+                                          ts: t.getAttribute('data-chat-pin-del-ts') });
+                return;
+            }
+            t = e.target.closest('[data-chat-pin-user]');
+            if (t) {
+                sendProtocol('pin.add', { u: t.getAttribute('data-chat-pin-user'),
+                                          ts: t.getAttribute('data-chat-pin-ts'),
+                                          x: t.getAttribute('data-chat-pin-x') });
+                if (typeof showToast === 'function') showToast('📌 Pinned for the room', 'success');
+                return;
+            }
+            t = e.target.closest('[data-chat-poll-btn]');
+            if (t) { togglePollPop(); return; }
+            t = e.target.closest('[data-chat-poll-start]');
+            if (t) { _pollStart(); return; }
+            t = e.target.closest('[data-chat-poll-vote]');
+            if (t) { sendProtocol('poll.vote', { o: t.getAttribute('data-chat-poll-vote') }); return; }
+            t = e.target.closest('[data-chat-poll-end]');
+            if (t) { sendProtocol('poll.end', {}); return; }
+            t = e.target.closest('[data-chat-poll-dismiss]');
+            if (t) {
+                var pd = window.ChatProtocol ? window.ChatProtocol.reducePoll(_roomEvents()) : null;
+                state.pollDismissedAt = pd ? pd.at : null;
+                renderPoll();
+                return;
+            }
+            t = e.target.closest('[data-chat-topic-edit]');
+            if (t) {
+                state.topicEditing = true;
+                var headEl = q('[data-chat-head]');
+                var cur = (window.ChatProtocol ? window.ChatProtocol.reduceTopic(_roomEvents()) : null);
+                if (headEl) {
+                    headEl.innerHTML = '<span class="chat-head-title"># ' + esc(state.room || '') + '</span>' +
+                        '<input class="chat-input chat-topic-in" data-chat-topic-input type="text" maxlength="160" ' +
+                        'placeholder="Set a room topic… (Enter to save, Esc to cancel)" autocomplete="off" value="' +
+                        attr(cur ? cur.t : '') + '">';
+                    var ti = q('[data-chat-topic-input]');
+                    if (ti) { ti.focus(); ti.select(); }
+                }
                 return;
             }
             t = e.target.closest('[data-chat-jukebox-btn]');
@@ -1933,6 +2014,15 @@
             if (e.target && e.target.matches('[data-chat-search-input]')) {
                 if (e.key === 'Enter') { e.preventDefault(); runSearch(e.target.value); }
                 if (e.key === 'Escape') exitSearch();
+            }
+            if (e.target && e.target.matches('[data-chat-topic-input]')) {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    sendProtocol('topic.set', { t: String(e.target.value || '').trim() });
+                    state.topicEditing = false;
+                    renderHead();
+                }
+                if (e.key === 'Escape') { state.topicEditing = false; renderHead(); }
             }
         });
 
@@ -2111,7 +2201,7 @@
         if (fresh.length) {
             // presence: a protocol event proves SoulSync — refresh buckets
             renderUsersList();
-            renderJukebox();
+            renderBusUI();
             try {
                 document.dispatchEvent(new CustomEvent('soulsync:chat-protocol',
                     { detail: { events: fresh } }));
@@ -2141,6 +2231,110 @@
         _ingestProtocol(d.events || []);
     }
 
+    // Every surface reduced from the protocol bus, painted together.
+    function renderBusUI() {
+        renderJukebox();
+        renderPinbar();
+        renderPoll();
+        // topic lives in the head sub-line — but search mode freezes the
+        // head (its input would be clobbered mid-typing by a socket event)
+        if (!state.searchMode) renderHead();
+    }
+
+    // ── pinned messages (pin.add / pin.del on the bus) ──────────────────
+    function renderPinbar() {
+        var host = q('[data-chat-pinbar]');
+        if (!host) return;
+        var CP = window.ChatProtocol;
+        var pins = (CP && state.view === 'room') ? CP.reducePins(_roomEvents()) : [];
+        if (!pins.length) { host.hidden = true; host.innerHTML = ''; return; }
+        host.hidden = false;
+        var head = '<button class="chat-pinbar-head" type="button" data-chat-pins-toggle>📌 ' +
+            pins.length + ' pinned' + (state.pinsOpen ? ' ▾' : ' ▸') + '</button>';
+        var rows = '';
+        if (state.pinsOpen) {
+            rows = pins.slice().reverse().map(function (pin) {
+                return '<div class="chat-pin-row">' +
+                    '<span class="chat-pin-text"><b>' + esc(pin.u) + '</b> ' + esc(pin.x) + '</span>' +
+                    '<span class="chat-pin-by">pinned by ' + esc(pin.by) + '</span>' +
+                    (state.canSend
+                        ? '<button class="chat-pin-del" type="button" title="Unpin" ' +
+                          'data-chat-pin-del-u="' + attr(pin.u) + '" data-chat-pin-del-ts="' + attr(pin.ts) + '">×</button>'
+                        : '') +
+                '</div>';
+            }).join('');
+        }
+        host.innerHTML = head + rows;
+    }
+
+    // ── the room poll (poll.start / poll.vote / poll.end on the bus) ────
+    function renderPoll() {
+        var host = q('[data-chat-poll]');
+        if (!host) return;
+        var CP = window.ChatProtocol;
+        var poll = (CP && state.view === 'room') ? CP.reducePoll(_roomEvents()) : null;
+        if (!poll || (poll.closed && state.pollDismissedAt === poll.at)) {
+            host.hidden = true; host.innerHTML = ''; return;
+        }
+        host.hidden = false;
+        var total = poll.tally.total;
+        var rows = poll.options.map(function (opt, i) {
+            var idx = String(i + 1);
+            var n = poll.tally.counts[idx] || 0;
+            var pct = total ? Math.round(n * 100 / total) : 0;
+            var winner = poll.closed && poll.tally.winner === idx;
+            return '<div class="chat-poll-opt' + (winner ? ' chat-poll-opt--win' : '') + '">' +
+                (poll.closed || !state.canSend
+                    ? '<span class="chat-poll-label">' + esc(opt) + '</span>'
+                    : '<button class="chat-poll-vote" type="button" data-chat-poll-vote="' + idx + '">' +
+                          esc(opt) + '</button>') +
+                '<span class="chat-poll-n">' + n + (total ? ' · ' + pct + '%' : '') + '</span>' +
+                '<span class="chat-poll-bar" style="width:' + pct + '%"></span>' +
+            '</div>';
+        }).join('');
+        host.innerHTML =
+            '<div class="chat-poll-head">📊 <b>' + esc(poll.q) + '</b>' +
+                '<span class="chat-jbx-meta">' + (poll.closed ? 'final — ' : '') +
+                    total + ' vote' + (total === 1 ? '' : 's') + ' · by ' + esc(poll.by) + '</span>' +
+                (!poll.closed && state.selfName && poll.by === state.selfName
+                    ? '<button class="chat-fmt-btn" type="button" data-chat-poll-end>End poll</button>' : '') +
+                (poll.closed
+                    ? '<button class="chat-pin-del" type="button" title="Dismiss" data-chat-poll-dismiss>×</button>' : '') +
+            '</div>' + rows;
+    }
+
+    function _pollStart() {
+        var qEl = q('[data-chat-poll-q]');
+        if (!qEl) return;
+        var fields = { q: String(qEl.value || '').trim() };
+        var opts = 0;
+        for (var i = 1; i <= 4; i++) {
+            var o = q('[data-chat-poll-o' + i + ']');
+            var v = o ? String(o.value || '').trim() : '';
+            if (v) { opts += 1; fields['o' + opts] = v; }   // compact gaps
+        }
+        if (!fields.q || opts < 2) {
+            if (typeof showToast === 'function') showToast('A poll needs a question and at least 2 options', 'error');
+            return;
+        }
+        sendProtocol('poll.start', fields);
+        [qEl].concat([1, 2, 3, 4].map(function (i2) { return q('[data-chat-poll-o' + i2 + ']'); }))
+            .forEach(function (el) { if (el) el.value = ''; });
+        togglePollPop(true);
+        state.pollDismissedAt = null;
+    }
+
+    function togglePollPop(forceClose) {
+        var pop = q('[data-chat-poll-pop]');
+        if (!pop) return;
+        pop.hidden = forceClose === true ? true : !pop.hidden;
+        if (!pop.hidden) {
+            toggleEmojiPicker(true); toggleGifPicker(true); toggleAttachPanel(true);
+            var qEl = q('[data-chat-poll-q]');
+            if (qEl) qEl.focus();
+        }
+    }
+
     // ── jukebox (shared room listening — a pure fold over the bus) ──────
     // State lives in the protocol stream (jbx.sub / jbx.vote / jbx.now);
     // every client reduces the same events to the same queue + now-playing.
@@ -2148,13 +2342,15 @@
     // browsers require for audible autoplay); joiners seek to the live
     // position from now.at. The DJ (deterministic election, no chatter) is
     // the one client that emits jbx.now when a track ends or the queue waits.
+    function _roomEvents() {
+        var room = state.room || '';
+        return (state.protocolLog || []).filter(function (e) { return e.room === room; });
+    }
+
     function _jbxState() {
         var CP = window.ChatProtocol;
         if (!CP) return { queue: [], now: null, tally: { counts: {}, winner: null, total: 0 } };
-        var room = state.room || '';
-        return CP.reduceJukebox((state.protocolLog || []).filter(function (e) {
-            return e.room === room;
-        }));
+        return CP.reduceJukebox(_roomEvents());
     }
 
     function _jbxIsDj() {
@@ -2306,6 +2502,7 @@
         var st = _jbxState();
         if (!st.now) return;
         state.jukebox.tunedIn = true;
+        sendProtocol('jbx.tune', { on: 1 });
         state.jukebox.lastRendered = '';
         renderJukebox();
         _jbxLoadYT(function () {
@@ -2315,6 +2512,7 @@
     }
 
     function _jbxTuneOut() {
+        if (state.jukebox.tunedIn) sendProtocol('jbx.tune', { on: 0 });
         state.jukebox.tunedIn = false;
         if (state.jukebox.player) {
             try { state.jukebox.player.destroy(); } catch (e) { /* already gone */ }

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -46,6 +46,9 @@
             lastRendered: '',    //   reduced-state fingerprint (skip no-op renders)
             lastAdvanceAt: 0,    //   DJ double-fire guard (ms)
             starvedAt: 0,        //   queue-waiting-with-no-DJ clock (ms)
+            histOpen: false,     //   recently-played list expanded
+            videoHidden: false,  //   audio-only mode (iframe hidden, audio plays)
+            vol: 100,            //   local player volume (persisted)
             timer: null,         //   elapsed clock + DJ watchdog while open
             ytLoading: false, ytCbs: [],
         },
@@ -54,6 +57,11 @@
         pollDismissedAt: null,   // locally-dismissed closed poll (its start ts)
     };
     try { state.ssOnly = localStorage.getItem('chat_ss_only') === '1'; } catch (e) { /* ignore */ }
+    try {
+        state.jukebox.videoHidden = localStorage.getItem('chat_jbx_audio') === '1';
+        var _v = parseInt(localStorage.getItem('chat_jbx_vol') || '100', 10);
+        if (_v >= 0 && _v <= 100) state.jukebox.vol = _v;
+    } catch (e) { /* ignore */ }
 
     function q(sel) {
         var page = document.getElementById('chat-page');
@@ -1906,6 +1914,36 @@
             if (t) { sendProtocol('jbx.vote', { o: t.getAttribute('data-chat-jbx-vote') }); return; }
             t = e.target.closest('[data-chat-jbx-pick]');
             if (t) { _jbxPick(state.jukebox.results[parseInt(t.getAttribute('data-chat-jbx-pick'), 10)]); return; }
+            t = e.target.closest('[data-chat-jbx-skip]');
+            if (t) { sendProtocol('jbx.skip', { o: t.getAttribute('data-chat-jbx-skip') }); return; }
+            t = e.target.closest('[data-chat-jbx-unsub]');
+            if (t) { sendProtocol('jbx.unsub', { id: t.getAttribute('data-chat-jbx-unsub') }); return; }
+            t = e.target.closest('[data-chat-jbx-resub]');
+            if (t) {
+                var rp = { id: t.getAttribute('data-chat-jbx-resub'),
+                           title: t.getAttribute('data-chat-jbx-resub-ti') || '' };
+                var rd = parseInt(t.getAttribute('data-chat-jbx-resub-d') || '', 10);
+                if (rd > 0) rp.duration = rd;
+                _jbxPick(rp);
+                return;
+            }
+            t = e.target.closest('[data-chat-jbx-hist]');
+            if (t) {
+                state.jukebox.histOpen = !state.jukebox.histOpen;
+                state.jukebox.lastRendered = '';
+                renderJukebox();
+                return;
+            }
+            t = e.target.closest('[data-chat-jbx-video]');
+            if (t) {
+                state.jukebox.videoHidden = !state.jukebox.videoHidden;
+                try { localStorage.setItem('chat_jbx_audio', state.jukebox.videoHidden ? '1' : '0'); } catch (err) { /* ignore */ }
+                var ph = q('[data-chat-jbx-player]');
+                if (ph) ph.classList.toggle('chat-jbx-player--audio', state.jukebox.videoHidden);
+                state.jukebox.lastRendered = '';
+                renderJukebox();
+                return;
+            }
             t = e.target.closest('[data-chat-search-btn]');
             if (t) { state.searchMode ? exitSearch() : enterSearch(); return; }
             t = e.target.closest('[data-chat-search-exit]');
@@ -2053,6 +2091,16 @@
             if (e.target && e.target.matches('[data-chat-user-search]')) {
                 state.userFilter = e.target.value.trim();
                 renderUsersList();
+            }
+            if (e.target && e.target.matches('[data-chat-jbx-vol]')) {
+                var vv = parseInt(e.target.value, 10);
+                if (vv >= 0 && vv <= 100) {
+                    state.jukebox.vol = vv;
+                    try { localStorage.setItem('chat_jbx_vol', String(vv)); } catch (err) { /* ignore */ }
+                    if (state.jukebox.player && state.jukebox.playerAlive) {
+                        try { state.jukebox.player.setVolume(vv); } catch (err) { /* gone */ }
+                    }
+                }
             }
             if (e.target && e.target.matches('[data-chat-browse-search]')) {
                 var v = e.target.value.trim();
@@ -2403,13 +2451,41 @@
         return m + ':' + (r < 10 ? '0' : '') + r;
     }
 
+    function _jbxThumb(id) {
+        return 'https://i.ytimg.com/vi/' + id + '/mqdefault.jpg';
+    }
+
+    function _jbxEffDuration(now) {
+        // the protocol event's duration when it has one, else a live player's
+        // truth (pasted links resolve via oEmbed, which has no duration)
+        if (!now) return null;
+        if (now.d) return now.d;
+        if (state.jukebox.tunedIn && state.jukebox.playerAlive &&
+                state.jukebox.player && state.jukebox.playingId === now.id) {
+            try {
+                var pd = state.jukebox.player.getDuration();
+                if (pd > 0) return Math.floor(pd);
+            } catch (e) { /* mid-teardown */ }
+        }
+        return null;
+    }
+
+    function _jbxSkipNeeded() {
+        // majority of tuned-in listeners (deterministic — derived from the
+        // same event stream everywhere); floor of 1 when nobody's tuned
+        var CP = window.ChatProtocol;
+        var n = CP ? Object.keys(CP.reduceTuned(_roomEvents())).length : 0;
+        return Math.max(1, Math.ceil(n / 2));
+    }
+
     function renderJukebox() {
         var panel = q('[data-chat-jukebox]');
         if (!panel) return;
         var st = _jbxState();
         var now = st.now;
         var elapsed = _jbxElapsed(now);
-        var ended = !!(now && now.d && elapsed !== null && elapsed > now.d + 5);
+        var effD = _jbxEffDuration(now);
+        var ended = !!(now && effD && elapsed !== null && elapsed > effD + 5);
         // the player follows the ROOM, not the panel — a tuned-in listener
         // reading PMs must still hear the DJ's advances (panel merely hides)
         _jbxSyncPlayer(now && !ended ? now : null);
@@ -2430,49 +2506,113 @@
         var show = state.jukebox.open && inRoom;
         panel.hidden = !show;
         if (!show) return;
+        var needed = _jbxSkipNeeded();
+        var nextId = (st.queue.length > 1 && window.ChatProtocol)
+            ? (window.ChatProtocol.nextTrack(st) || {}).id : null;
         // fingerprint: skip DOM writes when nothing visible changed (the
-        // elapsed clock ticks via its own cheap textContent update below)
-        var fp = JSON.stringify([now && now.id, ended, st.queue, state.jukebox.tunedIn, state.canSend]);
+        // clock + progress bar tick via cheap updates below)
+        var fp = JSON.stringify([now && now.id, ended, st.queue, state.jukebox.tunedIn,
+                                 state.canSend, st.skips, needed, nextId,
+                                 state.jukebox.histOpen, st.history.length,
+                                 st.history[0] && st.history[0].id,   // cap rotation changes content, not length
+                                 state.jukebox.videoHidden]);
         if (fp !== state.jukebox.lastRendered) {
             state.jukebox.lastRendered = fp;
             var nowHost = q('[data-chat-jbx-now]');
             if (nowHost) {
                 if (now && !ended) {
+                    var pct = (effD && elapsed !== null)
+                        ? Math.min(100, 100 * elapsed / effD) : 0;
                     nowHost.innerHTML =
-                        '<span class="chat-jbx-live">▶</span>' +
-                        '<span class="chat-jbx-title" title="' + attr(now.ti || now.id) + '">' +
-                            esc(now.ti || now.id) + '</span>' +
-                        '<span class="chat-jbx-meta">added by ' + esc(now.by || '?') +
-                            (elapsed !== null ? ' · <span data-chat-jbx-clock>' + _fmtSecs(elapsed) + '</span>' +
-                                (now.d ? ' / ' + _fmtSecs(now.d) : '') : '') + '</span>' +
-                        (state.jukebox.tunedIn
-                            ? '<button class="chat-fmt-btn chat-jbx-tune" type="button" data-chat-jbx-tuneout>Tune out</button>'
-                            : '<button class="chat-send-btn chat-jbx-tune" type="button" data-chat-jbx-tunein>▶ Tune in</button>');
+                        '<div class="chat-jbx-nowcard">' +
+                            '<img class="chat-jbx-art" src="' + attr(_jbxThumb(now.id)) + '" alt="">' +
+                            '<div class="chat-jbx-nowmain">' +
+                                '<div class="chat-jbx-titlerow">' +
+                                    '<span class="chat-jbx-eq"><i></i><i></i><i></i></span>' +
+                                    '<a class="chat-jbx-title" href="https://youtu.be/' + attr(now.id) +
+                                        '" target="_blank" rel="noopener" title="' + attr(now.ti || now.id) + '">' +
+                                        esc(now.ti || now.id) + '</a>' +
+                                '</div>' +
+                                '<div class="chat-jbx-meta">added by ' + esc(now.by || '?') +
+                                    (elapsed !== null ? ' · <span data-chat-jbx-clock>' + _fmtSecs(elapsed) + '</span>' +
+                                        (effD ? ' / ' + _fmtSecs(effD) : '') : '') + '</div>' +
+                                '<div class="chat-jbx-progress"><span class="chat-jbx-progbar" ' +
+                                    'data-chat-jbx-bar style="width:' + pct.toFixed(1) + '%"></span></div>' +
+                            '</div>' +
+                        '</div>' +
+                        '<div class="chat-jbx-controls">' +
+                            (state.jukebox.tunedIn
+                                ? '<button class="chat-fmt-btn chat-jbx-tune" type="button" data-chat-jbx-tuneout>Tune out</button>'
+                                : '<button class="chat-send-btn chat-jbx-tune" type="button" data-chat-jbx-tunein>▶ Tune in</button>') +
+                            '<button class="chat-fmt-btn" type="button" data-chat-jbx-skip="' + attr(now.id) + '"' +
+                                (state.canSend ? '' : ' disabled') +
+                                ' title="Vote to skip this track (majority of listeners)">⏭ Skip' +
+                                (st.skips ? ' ' + st.skips + '/' + needed : '') + '</button>' +
+                            (state.jukebox.tunedIn
+                                ? '<button class="chat-fmt-btn" type="button" data-chat-jbx-video title="' +
+                                      (state.jukebox.videoHidden ? 'Show the video' : 'Audio only — hide the video') + '">' +
+                                      (state.jukebox.videoHidden ? '🎬 Video' : '🎧 Audio only') + '</button>' +
+                                  '<input class="chat-jbx-vol" data-chat-jbx-vol type="range" min="0" max="100" ' +
+                                      'value="' + state.jukebox.vol + '" title="Volume (just yours)">'
+                                : '') +
+                        '</div>';
                 } else {
                     // tuned-in users keep their exit even between tracks
-                    nowHost.innerHTML = '<span class="chat-jbx-meta">' +
+                    nowHost.innerHTML = '<div class="chat-jbx-meta chat-jbx-idle">' +
                         (st.queue.length ? 'Waiting for the next track…'
-                                         : 'Nothing playing — add a song below and get the room voting.') +
-                        '</span>' +
+                                         : 'Nothing playing — add a song above and get the room voting.') +
+                        '</div>' +
                         (state.jukebox.tunedIn
                             ? '<button class="chat-fmt-btn chat-jbx-tune" type="button" data-chat-jbx-tuneout>Tune out</button>' : '');
                 }
             }
             var qHost = q('[data-chat-jbx-queue]');
             if (qHost) {
-                qHost.innerHTML = st.queue.map(function (e) {
-                    return '<div class="chat-jbx-row">' +
+                var rows = st.queue.map(function (e) {
+                    var mine = state.selfName && e.by === state.selfName;
+                    return '<div class="chat-jbx-row' + (e.id === nextId ? ' chat-jbx-row--next' : '') + '">' +
+                        '<img class="chat-jbx-qthumb" src="' + attr(_jbxThumb(e.id)) + '" alt="" loading="lazy">' +
+                        '<div class="chat-jbx-qmain">' +
+                            '<span class="chat-jbx-title" title="' + attr(e.ti || e.id) + '">' + esc(e.ti || e.id) + '</span>' +
+                            '<span class="chat-jbx-meta">' +
+                                (e.id === nextId ? '<b class="chat-jbx-next">up next</b> · ' : '') +
+                                (e.d ? _fmtSecs(e.d) + ' · ' : '') + esc(e.by) + '</span>' +
+                        '</div>' +
                         '<button class="chat-jbx-vote" type="button" data-chat-jbx-vote="' + attr(e.id) + '"' +
                             (state.canSend ? '' : ' disabled') + ' title="Vote to play this next">▲ ' +
                             (e.votes || 0) + '</button>' +
-                        '<span class="chat-jbx-title" title="' + attr(e.ti || e.id) + '">' + esc(e.ti || e.id) + '</span>' +
-                        '<span class="chat-jbx-meta">' + (e.d ? _fmtSecs(e.d) + ' · ' : '') + esc(e.by) + '</span>' +
+                        (mine && state.canSend
+                            ? '<button class="chat-jbx-unsub" type="button" data-chat-jbx-unsub="' + attr(e.id) +
+                              '" title="Remove your submission">×</button>' : '') +
                     '</div>';
-                }).join('') || '';
+                }).join('');
+                if (st.history.length) {
+                    rows += '<button class="chat-jbx-histbtn" type="button" data-chat-jbx-hist>' +
+                        (state.jukebox.histOpen ? '▾' : '▸') + ' Recently played (' + st.history.length + ')</button>';
+                    if (state.jukebox.histOpen) {
+                        rows += st.history.map(function (h) {
+                            return '<div class="chat-jbx-row chat-jbx-row--hist">' +
+                                '<img class="chat-jbx-qthumb" src="' + attr(_jbxThumb(h.id)) + '" alt="" loading="lazy">' +
+                                '<div class="chat-jbx-qmain">' +
+                                    '<span class="chat-jbx-title" title="' + attr(h.ti || h.id) + '">' + esc(h.ti || h.id) + '</span>' +
+                                    '<span class="chat-jbx-meta">' + esc(h.by || '') + '</span>' +
+                                '</div>' +
+                                (state.canSend
+                                    ? '<button class="chat-jbx-vote" type="button" data-chat-jbx-resub="' + attr(h.id) +
+                                      '" data-chat-jbx-resub-ti="' + attr(h.ti || '') + '"' +
+                                      (h.d ? ' data-chat-jbx-resub-d="' + attr(String(h.d)) + '"' : '') +
+                                      ' title="Queue it again">↻</button>' : '') +
+                            '</div>';
+                        }).join('');
+                    }
+                }
+                qHost.innerHTML = rows;
             }
         } else if (elapsed !== null) {
             var clock = q('[data-chat-jbx-clock]');
             if (clock) clock.textContent = _fmtSecs(elapsed);
+            var bar = q('[data-chat-jbx-bar]');
+            if (bar && effD) bar.style.width = Math.min(100, 100 * elapsed / effD).toFixed(1) + '%';
         }
     }
 
@@ -2505,18 +2645,15 @@
         // A tuned-in client asks the PLAYER for the truth — pasted links have
         // no duration (oEmbed doesn't give one), and the iframe's ENDED event
         // is best-effort, so poll instead of trusting either.
-        var effD = st.now ? st.now.d : null;
+        var effD = _jbxEffDuration(st.now);
         var playerEnded = false;
         if (state.jukebox.tunedIn && state.jukebox.playerAlive && state.jukebox.player) {
             try {
-                if (!effD) {
-                    var pd = state.jukebox.player.getDuration();
-                    if (pd > 0) effD = pd;
-                }
                 playerEnded = state.jukebox.player.getPlayerState() === 0;   // YT ENDED
             } catch (e) { /* player mid-teardown */ }
         }
-        var stale = !st.now || playerEnded ||
+        var skipped = !!(st.now && st.skips >= _jbxSkipNeeded());
+        var stale = !st.now || playerEnded || skipped ||
             (effD && elapsed !== null && elapsed > effD + 8) ||
             (!effD && elapsed !== null && elapsed > 900);   // untuned + unknown length: 15-min cap
         if (!st.queue.length || !stale) { state.jukebox.starvedAt = 0; return; }
@@ -2596,6 +2733,7 @@
         var host = q('[data-chat-jbx-player]');
         if (!host) return;
         var offset = Math.max(0, _jbxElapsed(now) || 0);
+        host.classList.toggle('chat-jbx-player--audio', state.jukebox.videoHidden);
         if (!state.jukebox.player) {
             host.hidden = false;
             host.innerHTML = '<div data-chat-jbx-yt></div>';
@@ -2606,6 +2744,7 @@
                 events: {
                     onReady: function () {
                         state.jukebox.playerAlive = true;
+                        try { state.jukebox.player.setVolume(state.jukebox.vol); } catch (e) { /* gone */ }
                         _jbxSyncPlayer(_jbxState().now);   // catch a now-change during boot
                     },
                     onStateChange: _jbxOnPlayerState,

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -966,7 +966,10 @@
             if (!res.ok) {
                 if (body) {
                     body.innerHTML = '<div class="chat-gif-hint">' +
-                        esc(res.body && res.body.error || 'Could not browse') + '</div>';
+                        esc(res.body && res.body.error || 'Could not browse') + '</div>' +
+                        '<div class="chat-browse-retry-row">' +
+                        '<button type="button" class="modal-button modal-button--primary" ' +
+                            'data-chat-browse-retry>Try again</button></div>';
                 }
                 return;
             }
@@ -1827,6 +1830,8 @@
                 renderHead(); refresh();
                 return;
             }
+            t = e.target.closest('[data-chat-browse-retry]');
+            if (t) { if (_browse.user) openBrowse(_browse.user); return; }
             t = e.target.closest('[data-chat-pins-toggle]');
             if (t) { state.pinsOpen = !state.pinsOpen; renderPinbar(); return; }
             t = e.target.closest('[data-chat-pin-del-u]');
@@ -2390,6 +2395,11 @@
         var show = state.jukebox.open && state.view === 'room';
         panel.hidden = !show;
         if (!show) return;
+        var lc = q('[data-chat-jbx-listeners]');
+        if (lc && window.ChatProtocol) {
+            var nTuned = Object.keys(window.ChatProtocol.reduceTuned(_roomEvents())).length;
+            lc.textContent = nTuned ? '♪ ' + nTuned + ' listening' : '';
+        }
         // fingerprint: skip DOM writes when nothing visible changed (the
         // elapsed clock ticks via its own cheap textContent update below)
         var fp = JSON.stringify([now && now.id, ended, st.queue, state.jukebox.tunedIn, state.canSend]);

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -1134,6 +1134,127 @@
         pop.hidden = false;
     }
 
+    // ── slash commands (room only — power-user glue over existing features)
+    var SLASH_COMMANDS = [
+        { c: '/play',  a: '<song or link>', d: 'queue it on the jukebox' },
+        { c: '/skip',  a: '', d: 'vote to skip the current track' },
+        { c: '/tune',  a: '', d: 'tune in or out of the jukebox' },
+        { c: '/topic', a: '<text>', d: 'set the room topic' },
+        { c: '/poll',  a: '<question>', d: 'start a room poll' },
+        { c: '/pin',   a: '', d: 'pin the latest message' },
+        { c: '/gif',   a: '<search>', d: 'find a GIF' },
+        { c: '/shrug', a: '[message]', d: 'appends \u00af\\_(\u30c4)_/\u00af' },
+    ];
+
+    function updateSlashPop(input) {
+        var pop = q('[data-chat-mention-pop]');
+        if (!pop) return;
+        var v = String(input.value || '');
+        var active = state.view === 'room' && state.canSend &&
+            v[0] === '/' && v.length <= 12 && !/\s/.test(v);
+        if (!active) {
+            // only clear the pop when WE own it (mentions share the host)
+            if (pop.querySelector('[data-chat-slash-pick]')) { pop.hidden = true; pop.innerHTML = ''; }
+            return;
+        }
+        var hits = SLASH_COMMANDS.filter(function (sc) { return sc.c.indexOf(v) === 0; });
+        if (!hits.length) { pop.hidden = true; return; }
+        pop.innerHTML = hits.map(function (sc) {
+            return '<button type="button" class="chat-mention-opt chat-slash-opt" ' +
+                'data-chat-slash-pick="' + attr(sc.c) + '">' +
+                '<span class="chat-slash-cmd">' + esc(sc.c) +
+                    (sc.a ? ' <i>' + esc(sc.a) + '</i>' : '') + '</span>' +
+                '<span class="chat-slash-desc">' + esc(sc.d) + '</span></button>';
+        }).join('');
+        pop.hidden = false;
+    }
+
+    function pickSlash(cmd) {
+        var input = q('[data-chat-input]');
+        var pop = q('[data-chat-mention-pop]');
+        if (pop) { pop.hidden = true; pop.innerHTML = ''; }
+        if (!input || !cmd) return;
+        var meta = null;
+        SLASH_COMMANDS.forEach(function (sc) { if (sc.c === cmd) meta = sc; });
+        if (meta && !meta.a) {                     // no-arg commands run on click
+            input.value = '';
+            _runSlash(cmd);
+            return;
+        }
+        input.value = cmd + ' ';
+        input.focus();
+    }
+
+    function _runSlash(text) {
+        // true = handled; a string = transformed message text; false = not a command
+        var m = text.match(/^\/([a-z]+)\s*([\s\S]*)$/);
+        if (!m) return false;
+        var cmd = m[1], arg = (m[2] || '').trim();
+        var toast = function (msg, kind) {
+            if (typeof showToast === 'function') showToast(msg, kind || 'info');
+        };
+        if (cmd === 'shrug') {
+            return (arg ? arg + ' ' : '') + '\u00af\\_(\u30c4)_/\u00af';
+        }
+        if (cmd === 'skip') {
+            var stS = _jbxState();
+            if (stS.now) sendProtocol('jbx.skip', { o: stS.now.id });
+            else toast('Nothing is playing');
+            return true;
+        }
+        if (cmd === 'tune') {
+            if (state.jukebox.tunedIn) { _jbxTuneOut(); renderJukebox(); }
+            else if (_jbxState().now) { if (!state.jukebox.open) toggleJukebox(); _jbxTuneIn(); }
+            else toast('Nothing is playing');
+            return true;
+        }
+        if (cmd === 'topic') {
+            sendProtocol('topic.set', { t: arg });
+            return true;
+        }
+        if (cmd === 'play') {
+            if (!arg) {
+                var hb = q('[data-chat-jbx-input]');
+                if (hb) hb.focus();
+                return true;
+            }
+            postJSON('/api/chat/jukebox/resolve', { q: arg }).then(function (res) {
+                var r0 = res.ok && res.body.results && res.body.results[0];
+                if (r0) _jbxPick(r0);
+                else toast((res.body && res.body.error) || 'Nothing found for that', 'error');
+            });
+            return true;
+        }
+        if (cmd === 'poll') {
+            togglePollPop();
+            var qEl = q('[data-chat-poll-q]');
+            if (qEl && arg) { qEl.value = arg.slice(0, 160); }
+            var o1 = q('[data-chat-poll-o1]');
+            if (o1 && arg) o1.focus();
+            return true;
+        }
+        if (cmd === 'pin') {
+            var last = (state.msgs || [])[state.msgs.length - 1];
+            if (last && last.username) {
+                sendProtocol('pin.add', { u: last.username, ts: String(last.timestamp || ''),
+                                          x: String(last.message || '').slice(0, 140) });
+                toast('\ud83d\udccc Pinned for the room', 'success');
+            } else toast('Nothing to pin yet');
+            return true;
+        }
+        if (cmd === 'gif') {
+            toggleGifPicker();
+            var gs = q('[data-chat-gif-search]');
+            if (gs) {
+                gs.value = arg;
+                gs.focus();
+                if (arg) gs.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+            return true;
+        }
+        return false;                              // unknown /word → plain message
+    }
+
     function pickMention(name) {
         var input = q('[data-chat-input]');
         var pop = q('[data-chat-mention-pop]');
@@ -1712,6 +1833,17 @@
         var text = (input.value || '').trim();
         if (!text || !state.canSend) return;
         state.lastTypSentAt = 0;
+        if (state.view === 'room' && text[0] === '/') {
+            var slash = _runSlash(text);
+            if (slash === true) {
+                input.value = '';
+                input.style.height = 'auto';
+                var spop = q('[data-chat-mention-pop]');
+                if (spop) { spop.hidden = true; spop.innerHTML = ''; }
+                return;
+            }
+            if (typeof slash === 'string') text = slash;
+        }
         input.value = '';
         input.style.height = 'auto';
         var url = state.view === 'room'
@@ -1841,6 +1973,8 @@
             }
             t = e.target.closest('[data-chat-reply-cancel]');
             if (t) { cancelReply(); return; }
+            t = e.target.closest('[data-chat-slash-pick]');
+            if (t) { pickSlash(t.getAttribute('data-chat-slash-pick')); return; }
             t = e.target.closest('[data-chat-mention-pick]');
             if (t) { pickMention(t.getAttribute('data-chat-mention-pick')); return; }
             t = e.target.closest('[data-chat-settings-btn]');
@@ -2069,11 +2203,20 @@
                     var mp = q('[data-chat-mention-pop]');
                     if (mp) mp.hidden = true;
                 }
+                if (e.key === 'Tab') {
+                    var sp = q('[data-chat-mention-pop]');
+                    var first = sp && !sp.hidden && sp.querySelector('[data-chat-slash-pick]');
+                    if (first) {
+                        e.preventDefault();
+                        pickSlash(first.getAttribute('data-chat-slash-pick'));
+                    }
+                }
             });
             inputEl.addEventListener('input', function () {
                 inputEl.style.height = 'auto';
                 inputEl.style.height = Math.min(inputEl.scrollHeight, 132) + 'px';
                 updateMentionPop(inputEl);
+                updateSlashPop(inputEl);
                 _maybeSendTyping(inputEl);
             });
         }

--- a/webui/static/core.js
+++ b/webui/static/core.js
@@ -455,6 +455,9 @@ function initializeWebSocket() {
     socket.on('chat:unread', function (d) {
         if (window.ChatPage && ChatPage.onUnread) ChatPage.onUnread(d);
     });
+    socket.on('chat:room_protocol', function (d) {
+        if (window.ChatPage && ChatPage.onRoomProtocol) ChatPage.onRoomProtocol(d);
+    });
 
     // Phase 2 event listeners (dashboard pollers)
     socket.on('rate-monitor:update', _handleRateMonitorUpdate);

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3482,17 +3482,16 @@ function closeHelperSearch() {
 const WHATS_NEW = {
     // Convention: keep only the CURRENT release here, plus a single brief
     // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.1.6': [
-        { date: 'July 2026 · 3.1.6' },
-        { title: 'Video files land safely (the skipping-playback fix)', desc: 'downloads copied straight to their final library filename, so Plex/Jellyfin could index a half-written file — playback then skipped like corruption, and an interrupted copy left a truncated file that looked complete. Files now land under a hidden temp name, get their byte count verified, and appear at the real name in one atomic rename. A move never deletes its source until the destination is proven whole.' },
-        { title: 'Automations, next level', desc: 'custom webhook payload templates (write the exact JSON gotify/ntfy/Slack/Home Assistant want, with {variable} tags), per-step conditions ("only ping Discord when status is error"), numeric condition operators, a Send-test button on every notification step, timezone-aware schedules, and a builder bug sweep (monthly schedules configurable + real countdowns, proper labels everywhere). New triggers too: music Maintenance Finding/Scan events, video Release Grabbed (Sonarr\'s On Grab) and Request Filed/Approved.' },
-        { title: 'Automations page redesigned', desc: 'one clean uniform card language across music and video: status rail with a live pulsing orb, color-coded WHEN → DO → THEN pipeline chips, quiet ghost controls, live progress with a terminal-style log, a command strip with the master switch, and a rebuilt builder canvas with glowing drop slots.' },
-        { title: 'Cross-source ownership on discographies (#1071)', desc: 'an album you own no longer shows as missing just because the viewing source dates it differently — when a card\'s id matches the enrichment id stored on your local album, that\'s identity proof and OWNED lights up. "Other Sources" cards get real ownership checks too.' },
-        { title: 'Artist letter "#" folder (#1072)', desc: 'opt-in file-organization toggle: artists starting with digits, symbols or non-Latin scripts all sort into one "#" folder instead of one folder per character; accented letters fold to their base letter (Édith Piaf → E). Off by default — nothing changes unless you flip it.' },
-        { title: 'M3U path prefix rewrite', desc: 'generate playlists inside a container, play them anywhere: a new setting hot-swaps a path prefix on every m3u entry (/data/media → M:/media) so the file plays directly on the machine that mounts the same storage elsewhere. Plus a guard so entries can never start with "#" (players would read them as comments).' },
-        { title: 'Video detail fixes', desc: 'episode action buttons (auto search / manual search / wishlist) never disappear behind a "Downloaded" badge anymore, and Grab Season sends the show poster along so the Downloads page stops showing art-less placeholder orbs.' },
-        { title: 'Music video filing', desc: 'a music video downloaded from a fan channel files under the real artist parsed from the title, not the uploader\'s channel name — "bad boy edd" folders are over.' },
-        { title: 'Earlier versions', desc: '3.1.5 made chat best-in-class and added the discography source picker + gap-fill. 3.1.4 added the Comma Artist Splitter + ReplayGain targets. 3.1.3 added record-label following. 3.1.2 brought the chat page.' },
+    '3.1.7': [
+        { date: 'July 2026 · 3.1.7' },
+        { title: 'The room jukebox', desc: 'listen together in any chat room. paste a YouTube link or search, the room votes on what plays next, and everyone who tunes in hears the same track at the same spot. no server runs it — every SoulSync client reduces the same hidden message stream to the same queue, so it stays in sync on its own.' },
+        { title: 'Jukebox, fully loaded', desc: 'vote to skip the current track, thumbnails everywhere with a now-playing progress bar and an "up next" highlight, recently-played with one-click requeue, pull your own submission back out, an audio-only toggle + a local volume slider, and auto-DJ — flip it on and the queue keeps itself fed with related tracks when it runs dry.' },
+        { title: 'Chat file sharing', desc: 'upload a file or pick a track straight from your library, and it lands in chat as a rich card you can preview inline. powered by filepost.dev (drop in your API key on the chat settings).' },
+        { title: 'Polls, pins, topics, presence', desc: 'ask the room a question with live vote bars, 📌 any message to a shared board, set a room topic, see typing indicators, and a ♫ next to whoever\'s tuned into the jukebox.' },
+        { title: 'Slash commands', desc: 'type / in the composer for autocomplete: /play, /skip, /tune, /topic, /poll, /pin, /gif, /shrug. plus the chat modals got rebuilt to match SoulSync\'s actual design instead of the old flat gray.' },
+        { title: 'HiFi failover (#1073)', desc: 'HiFi requests that hit a rate limit or a blocked instance now rotate to another instance instead of just failing — the way the monochrome instances do. thanks Lain2077.' },
+        { title: 'Track Repair, version + disc aware (#1075)', desc: 'repair stripped "(Why Us? Version)"-style qualifiers before matching, so different versions of a song looked identical and it grabbed the wrong disc\'s copy — the full title breaks ties now. multi-disc repairs also write the disc tag (so per-disc numbering can\'t create duplicate track numbers), and the change tells you when a number is disc-relative: "Track number: 1 → 10 (disc 2 of 3)". thanks Lain2077. heads up: multi-disc albums missing disc tags will show new findings — that\'s the fix tagging the whole album.' },
+        { title: 'Earlier versions', desc: '3.1.6 made video downloads land atomically (the skipping-playback fix) + redesigned automations. 3.1.5 made chat best-in-class + added the discography source picker. 3.1.4 added the Comma Artist Splitter. 3.1.3 added record-label following.' },
     ],
 };
 
@@ -3523,19 +3522,29 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.1.6: the safe-landings + automations release",
-        description: "video downloads land atomically (the skipping-playback corruption fix), the automations system gets custom webhook payloads, per-step conditions and new triggers under a full visual redesign, discography ownership stops being source-locked, and file organization learns the '#' folder.",
+        title: "3.1.7: the chat jukebox release",
+        description: "chat turns into a place you actually hang out — a shared room jukebox you listen to together and vote on, file sharing, polls, pins, typing indicators, slash commands. plus a hifi failover fix and a version + disc aware track repair.",
         features: [
-            "video files land safely: downloads used to copy straight to their final library filename, so your media server could index a half-written file (playback skipped like corruption) and an interrupted copy left a truncated file that looked complete. files now land under a hidden temp name, get byte-verified, and appear atomically — and a move never deletes its source until the destination is proven whole",
-            "automations, next level: custom webhook payload templates with {variable} tags (write the exact JSON gotify/ntfy/slack/home assistant want), per-step conditions ('only ping discord when status is error'), numeric operators, a send-test button on every notification step, timezone-aware schedules, and new triggers — music maintenance findings/scans, video release-grabbed (sonarr's on-grab) and request filed/approved",
-            "automations page redesigned: one uniform card language on both sides — status rail with a live pulsing orb, color-coded when → do → then pipeline chips, quiet ghost controls, live progress with a terminal-style log, and a rebuilt builder canvas with glowing drop slots",
-            "cross-source ownership (#1071, thanks QT3496): an album you own shows OWNED no matter which metadata source you view the artist through — enrichment ids are identity proof that beats edition-date differences, and 'other sources' cards get real ownership checks",
-            "the '#' folder (#1072, thanks QT3496): opt-in toggle groups digit/symbol/non-latin artists into one '#' folder for $artistletter templates; accents fold to their base letter (édith piaf → E). off by default",
-            "m3u portability (thanks wolf39us): a path-prefix rewrite setting turns container paths into playback-machine paths on every generated playlist (/data/media → M:/media), plus a guard so no entry can ever start with '#' and get skipped as a comment",
-            "video detail fixes: episode action buttons never vanish behind a downloaded badge, and grab season carries the show poster so the downloads page stops showing placeholder orbs",
-            "music videos file under the real artist parsed from the title, not the uploader's fan-channel name",
+            "the room jukebox: listen to music together in any chat room. paste a youtube link or search, the room votes on what plays next, and everyone who tunes in hears the same track at the same spot. no server runs it — every soulsync client folds the same hidden message stream into the same queue, so it stays in sync on its own",
+            "jukebox, fully loaded: vote to skip (majority of listeners), thumbnails everywhere with a now-playing progress bar and an 'up next' highlight, recently-played with one-click requeue, pull your own submission back out, an audio-only toggle + a local volume slider, and auto-dj that keeps the queue fed with related tracks when it runs dry",
+            "chat file sharing (filepost.dev): upload a file or pick a track straight from your library, and it drops in chat as a rich card you can preview inline",
+            "polls, pins, topics, presence: ask the room a question with live vote bars, 📌 any message to a shared board, set a room topic, see who's typing, and a ♫ next to whoever's tuned into the jukebox",
+            "slash commands: /play /skip /tune /topic /poll /pin /gif /shrug with autocomplete — plus the chat modals rebuilt to match soulsync's real design instead of the old flat gray",
+            "hifi failover (#1073, thanks Lain2077): hifi requests that hit a rate limit or a blocked instance rotate to another instance instead of failing, like the monochrome instances do",
+            "track repair, version + disc aware (#1075, thanks Lain2077): repair used to strip '(Why Us? Version)'-style qualifiers before matching, so different versions of a song looked identical and it grabbed the wrong disc's copy — the full title breaks ties now. multi-disc repairs also write the disc tag so per-disc numbering can't create duplicate track numbers, and the change tells you when a number is disc-relative ('track number: 1 → 10 (disc 2 of 3)')",
         ],
-        usage_note: "webhook payload templates + per-step conditions live on each notification step in the automation builder. the '#' folder toggle and m3u rewrite are under settings → file organization / m3u export.",
+        usage_note: "the jukebox controls live in the chat page header (open a room to see them). drop your filepost.dev API key on the chat settings cog to enable file sharing. heads up: multi-disc albums missing disc tags will show new Track Repair findings after this update — that's the fix tagging the whole album.",
+    },
+    {
+        title: "Earlier in 3.1.6 — the safe-landings + automations release",
+        description: "video downloads land atomically (the skipping-playback corruption fix), automations get custom webhook payloads + per-step conditions + new triggers under a full page redesign, discography ownership stops being source-locked, and file organization learns the '#' folder.",
+        features: [
+            "video files land safely: downloads land under a hidden temp name, get byte-verified, and appear atomically — no more half-written files indexed as skipping/corrupt, and a move never deletes its source until the destination is proven whole",
+            "automations, next level: custom webhook payload templates with {variable} tags, per-step conditions, numeric operators, a send-test button, timezone-aware schedules, and new triggers (maintenance findings/scans, video release-grabbed + request filed/approved) — all under a rebuilt uniform card + builder design",
+            "cross-source ownership (#1071, thanks QT3496): an album you own shows OWNED no matter which metadata source you view the artist through",
+            "the '#' folder (#1072, thanks QT3496) + m3u path-prefix portability (thanks wolf39us), both opt-in",
+            "video detail fixes (episode buttons never vanish, grab-season carries the poster) + music videos file under the real artist, not the fan-channel name",
+        ],
     },
     {
         title: "Earlier in 3.1.5 — the chat + discography release",

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -71999,22 +71999,60 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 .chat-settings-overlay {
     position: absolute; inset: 0; z-index: 40; display: flex;
     align-items: center; justify-content: center;
-    background: rgba(0,0,0,0.55); border-radius: 14px;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+    border-radius: 14px;
 }
 .chat-settings-modal {
-    width: min(420px, 92%); padding: 20px; border-radius: 14px;
-    background: rgba(20,20,25,0.99); border: 1px solid rgba(255,255,255,0.12);
-    box-shadow: 0 16px 40px rgba(0,0,0,0.55);
-    display: flex; flex-direction: column; gap: 14px;
+    width: min(460px, 92%);
+    max-height: 88%;
+    overflow-y: auto;
+    padding: 0;
+    border-radius: 20px;
+    background: linear-gradient(135deg, #1a1a1a 0%, #121212 100%);
+    border: 1px solid rgba(var(--accent-rgb), 0.2);
+    box-shadow: 0 25px 80px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(var(--accent-rgb), 0.1);
+    display: flex; flex-direction: column;
 }
-.chat-settings-title { margin: 0 0 2px; font-size: 16px; font-weight: 800; color: #fff; }
+.chat-settings-title {
+    margin: 0;
+    padding: 18px 24px 14px;
+    font-size: 17px; font-weight: 700; color: #fff;
+    border-bottom: 1px solid rgba(var(--accent-rgb), 0.15);
+    background: linear-gradient(90deg, rgba(var(--accent-rgb), 0.04) 0%, transparent 55%);
+}
+/* everything between the header and the actions row shares the gutter */
+.chat-settings-modal > :not(.chat-settings-title):not(.chat-settings-actions) {
+    margin: 14px 24px 0;
+}
 .chat-settings-label { display: flex; flex-direction: column; gap: 6px;
-    font-size: 12.5px; font-weight: 700; color: rgba(255,255,255,0.75); }
+    font-size: 12.5px; font-weight: 600; color: rgba(255,255,255,0.75); }
 .chat-settings-hint { font-size: 11px; font-weight: 500; color: rgba(255,255,255,0.4); }
 .chat-settings-check { display: flex; align-items: center; gap: 9px;
     font-size: 13px; color: rgba(255,255,255,0.8); cursor: pointer; }
-.chat-settings-check input { accent-color: #1db954; width: 15px; height: 15px; }
-.chat-settings-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 4px; }
+.chat-settings-check input { accent-color: rgb(var(--accent-rgb)); width: 15px; height: 15px; }
+.chat-settings-actions {
+    margin-top: 18px;
+    padding: 14px 24px 18px;
+    border-top: 1px solid rgba(var(--accent-rgb), 0.1);
+    display: flex; justify-content: flex-end; gap: 10px;
+    flex-wrap: wrap;
+}
+/* modal-scoped inputs pick up the accent focus ring (the chat composer's
+   green stays chat-branded; modals follow the app accent) */
+.chat-settings-modal .chat-input {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+}
+.chat-settings-modal .chat-input:focus {
+    border-color: rgba(var(--accent-rgb), 0.55);
+    background: rgba(255, 255, 255, 0.07);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.12);
+}
+/* the standard buttons run large — trim them to chat-modal scale */
+.chat-settings-actions .modal-button { padding: 9px 18px; font-size: 13px; min-width: 0; }
 
 /* chat: composer textarea + unread affordances (chatbic P1) */
 .chat-input--area {
@@ -72271,6 +72309,10 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     max-height: 46vh;
     overflow-y: auto;
 }
+.chat-jbx-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.chat-jbx-brand { font-size: 13px; font-weight: 700; color: rgba(255,255,255,0.9); white-space: nowrap; }
+.chat-jbx-listeners { font-size: 11.5px; color: rgba(var(--accent-light-rgb), 0.85); white-space: nowrap; }
+.chat-jbx-head .chat-jbx-form { margin-left: auto; flex: 0 1 340px; min-width: 200px; }
 .chat-jbx-now { display: flex; align-items: center; gap: 8px; min-height: 26px; flex-wrap: wrap; }
 .chat-jbx-live { color: rgb(var(--accent-light-rgb)); font-size: 12px; }
 .chat-jbx-title {
@@ -72378,3 +72420,14 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 .chat-head-sub--topic { color: rgba(var(--accent-light-rgb), 0.9); }
 .chat-topic-in { max-width: 420px; margin-left: 12px; }
 .chat-user-tuned { color: rgb(var(--accent-light-rgb)); margin-left: 5px; font-size: 11px; }
+
+/* chat modal polish: browse retry + the note save button follow the accent */
+.chat-browse-retry-row { display: flex; justify-content: center; padding: 6px 0 10px; }
+.chat-card-note-save {
+    background: rgba(var(--accent-rgb), 0.15);
+    color: rgb(var(--accent-light-rgb));
+}
+.chat-card-note-save:hover {
+    background: rgba(var(--accent-rgb), 0.28);
+    color: #fff;
+}

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -71626,9 +71626,11 @@ body.app-locked > *:not(#launch-pin-overlay):not(#login-overlay):not(script):not
    ═══════════════════════════════════════════════════════════════════════════ */
 .chat-page-container { display: flex; flex-direction: column; height: 100%; }
 .chat-shell {
-    display: grid; grid-template-columns: 220px 1fr 180px; gap: 16px;
+    display: grid; grid-template-columns: 220px 1fr 250px; gap: 16px;
     flex: 1; min-height: 0; height: calc(100vh - 210px);
 }
+.chat-rail { display: flex; flex-direction: column; gap: 12px; min-height: 0; min-width: 0; }
+.chat-rail .chat-users { flex: 1 1 auto; }
 .chat-side, .chat-users {
     background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.08);
     border-radius: 14px; padding: 12px; overflow-y: auto; min-height: 0;
@@ -71828,7 +71830,7 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     .chat-side-label { display: none; }
     .chat-side-list { display: flex; gap: 6px; }
     .chat-side-item { width: auto; white-space: nowrap; }
-    .chat-users { display: none; }
+    .chat-rail { display: none; }
 }
 
 /* message-this-user links (chat P4) — any surface can render one */
@@ -72298,15 +72300,14 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 /* ── chat jukebox (shared room listening) ─────────────────────────────── */
 .chat-jukebox {
     flex: 0 0 auto;
-    margin: 0 16px 8px;
     padding: 10px 12px;
     background: rgba(255,255,255,0.03);
     border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 12px;
+    border-radius: 14px;
     display: flex;
     flex-direction: column;
     gap: 8px;
-    max-height: 46vh;
+    max-height: 52%;
     overflow-y: auto;
 }
 /* the jukebox control bar rides the page header's right side */
@@ -72339,7 +72340,7 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     max-width: 100%; min-width: 0; flex: 1 1 auto;
 }
-.chat-jbx-meta { font-size: 11.5px; color: rgba(255,255,255,0.45); white-space: nowrap; }
+.chat-jbx-meta { font-size: 11.5px; color: rgba(255,255,255,0.45); }
 .chat-jbx-tune { flex: 0 0 auto; }
 .chat-jbx-player { border-radius: 10px; overflow: hidden; line-height: 0; }
 .chat-jbx-player iframe { border: 0; }
@@ -72373,19 +72374,24 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 .chat-jbx-result:hover { background: rgba(255,255,255,0.05); }
 
 /* ── chat pin board + room poll + topic (protocol-bus surfaces) ───────── */
+.chat-pinbar[hidden] { display: none !important; }
 .chat-pinbar {
-    flex: 0 0 auto;
-    margin: 0 16px 6px;
-    padding: 4px 8px;
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(255,255,255,0.07);
-    border-radius: 10px;
+    position: absolute; top: 54px; right: 14px; z-index: 35;   /* under the modal overlay (40) */
+    width: min(400px, calc(100% - 28px));
+    max-height: 50%;
+    overflow-y: auto;
+    padding: 8px;
+    background: linear-gradient(135deg, #1a1a1a 0%, #121212 100%);
+    border: 1px solid rgba(var(--accent-rgb), 0.2);
+    border-radius: 14px;
+    box-shadow: 0 18px 50px rgba(0,0,0,0.6);
 }
-.chat-pinbar-head {
-    background: none; border: 0; cursor: pointer;
-    color: rgba(255,255,255,0.65); font-size: 12px; padding: 3px 4px;
+.chat-pins-title {
+    font-size: 12px; font-weight: 700; color: rgba(255,255,255,0.85);
+    padding: 4px 6px 8px;
+    border-bottom: 1px solid rgba(var(--accent-rgb), 0.12);
+    margin-bottom: 4px;
 }
-.chat-pinbar-head:hover { color: rgba(255,255,255,0.9); }
 .chat-pin-row {
     display: flex; align-items: center; gap: 10px;
     padding: 4px 6px; border-radius: 8px; font-size: 12.5px;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72333,8 +72333,37 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     box-shadow: 0 18px 50px rgba(0,0,0,0.6);
     padding: 6px;
 }
-.chat-jbx-now { display: flex; align-items: center; gap: 8px; min-height: 26px; flex-wrap: wrap; }
-.chat-jbx-live { color: rgb(var(--accent-light-rgb)); font-size: 12px; }
+.chat-jbx-now { display: flex; flex-direction: column; gap: 8px; }
+.chat-jbx-nowcard { display: flex; gap: 10px; align-items: flex-start; }
+.chat-jbx-art {
+    width: 72px; height: 54px; object-fit: cover; border-radius: 8px;
+    flex: 0 0 auto; background: rgba(255,255,255,0.05);
+    box-shadow: 0 4px 14px rgba(0,0,0,0.4);
+}
+.chat-jbx-nowmain { flex: 1 1 auto; min-width: 0; }
+.chat-jbx-titlerow { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.chat-jbx-eq { display: inline-flex; gap: 2px; align-items: flex-end; height: 12px; flex: 0 0 auto; }
+.chat-jbx-eq i {
+    width: 3px; background: rgb(var(--accent-light-rgb)); border-radius: 1px;
+    animation: chatJbxEq 1.1s ease-in-out infinite;
+}
+.chat-jbx-eq i:nth-child(2) { animation-delay: 0.3s; }
+.chat-jbx-eq i:nth-child(3) { animation-delay: 0.6s; }
+@keyframes chatJbxEq { 0%, 100% { height: 4px; } 50% { height: 12px; } }
+a.chat-jbx-title { text-decoration: none; }
+a.chat-jbx-title:hover { color: rgb(var(--accent-light-rgb)); }
+.chat-jbx-progress {
+    height: 3px; margin-top: 7px; border-radius: 2px; overflow: hidden;
+    background: rgba(255,255,255,0.08);
+}
+.chat-jbx-progbar {
+    display: block; height: 100%; border-radius: 2px;
+    background: rgb(var(--accent-rgb));
+    transition: width 5s linear;   /* glides between watchdog ticks */
+}
+.chat-jbx-controls { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+.chat-jbx-vol { flex: 1 1 60px; min-width: 50px; max-width: 110px; accent-color: rgb(var(--accent-rgb)); height: 4px; }
+.chat-jbx-idle { padding: 2px 0; }
 .chat-jbx-title {
     font-size: 13px; font-weight: 600; color: rgba(255,255,255,0.92);
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -72344,12 +72373,39 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 .chat-jbx-tune { flex: 0 0 auto; }
 .chat-jbx-player { border-radius: 10px; overflow: hidden; line-height: 0; }
 .chat-jbx-player iframe { border: 0; }
+/* audio-only: collapse the video but keep the iframe alive (audio plays on) */
+.chat-jbx-player--audio { height: 0 !important; border-radius: 0; }
 .chat-jbx-queue { display: flex; flex-direction: column; gap: 2px; }
 .chat-jbx-row {
-    display: flex; align-items: center; gap: 10px;
+    display: flex; align-items: center; gap: 8px;
     padding: 4px 6px; border-radius: 8px;
 }
 .chat-jbx-row:hover { background: rgba(255,255,255,0.04); }
+.chat-jbx-row--next {
+    background: rgba(var(--accent-rgb), 0.07);
+    outline: 1px solid rgba(var(--accent-rgb), 0.18);
+}
+.chat-jbx-qthumb {
+    width: 42px; height: 32px; object-fit: cover; border-radius: 6px;
+    flex: 0 0 auto; background: rgba(255,255,255,0.05);
+}
+.chat-jbx-qmain { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.chat-jbx-qmain .chat-jbx-title { font-weight: 600; font-size: 12.5px; flex: none; max-width: 100%; }
+.chat-jbx-next { color: rgb(var(--accent-light-rgb)); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.5px; }
+.chat-jbx-unsub {
+    background: none; border: 0; cursor: pointer; flex: 0 0 auto;
+    color: rgba(255,255,255,0.4); font-size: 14px; padding: 0 3px;
+}
+.chat-jbx-unsub:hover { color: rgb(252, 165, 165); }
+.chat-jbx-histbtn {
+    background: none; border: 0; cursor: pointer; text-align: left;
+    color: rgba(255,255,255,0.45); font-size: 11.5px; font-weight: 600;
+    padding: 6px 6px 2px; margin-top: 2px;
+    border-top: 1px solid rgba(255,255,255,0.06);
+}
+.chat-jbx-histbtn:hover { color: rgba(255,255,255,0.8); }
+.chat-jbx-row--hist { opacity: 0.75; }
+.chat-jbx-row--hist:hover { opacity: 1; }
 .chat-jbx-vote {
     flex: 0 0 auto;
     background: rgba(255,255,255,0.06);

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72309,10 +72309,29 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     max-height: 46vh;
     overflow-y: auto;
 }
-.chat-jbx-head { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+/* the jukebox control bar rides the page header's right side */
+.chat-page-head { display: flex; align-items: center; justify-content: space-between;
+    gap: 18px; flex-wrap: wrap; }
+.chat-jbx-headbar[hidden] { display: none !important; }
+.chat-jbx-headbar {
+    position: relative;
+    display: flex; align-items: center; gap: 12px;
+    flex: 0 1 460px; min-width: 260px;
+}
 .chat-jbx-brand { font-size: 13px; font-weight: 700; color: rgba(255,255,255,0.9); white-space: nowrap; }
 .chat-jbx-listeners { font-size: 11.5px; color: rgba(var(--accent-light-rgb), 0.85); white-space: nowrap; }
-.chat-jbx-head .chat-jbx-form { margin-left: auto; flex: 0 1 340px; min-width: 200px; }
+.chat-jbx-headbar .chat-jbx-form { margin-left: auto; flex: 1 1 auto; min-width: 180px; }
+.chat-jbx-headbar .chat-jbx-input { padding: 8px 12px; font-size: 13px; }
+/* search results float under the header input */
+.chat-jbx-headbar .chat-jbx-results {
+    position: absolute; top: calc(100% + 6px); right: 0; z-index: 60;
+    width: min(420px, 92vw);
+    background: linear-gradient(135deg, #1a1a1a 0%, #121212 100%);
+    border: 1px solid rgba(var(--accent-rgb), 0.2);
+    border-radius: 14px;
+    box-shadow: 0 18px 50px rgba(0,0,0,0.6);
+    padding: 6px;
+}
 .chat-jbx-now { display: flex; align-items: center; gap: 8px; min-height: 26px; flex-wrap: wrap; }
 .chat-jbx-live { color: rgb(var(--accent-light-rgb)); font-size: 12px; }
 .chat-jbx-title {

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72512,3 +72512,22 @@ a.chat-jbx-title:hover { color: rgb(var(--accent-light-rgb)); }
     background: rgba(var(--accent-rgb), 0.28);
     color: #fff;
 }
+
+/* ── typing indicators ────────────────────────────────────────────────── */
+.chat-typing[hidden] { display: none !important; }
+.chat-typing {
+    padding: 2px 18px 4px;
+    font-size: 11.5px;
+    color: rgba(255,255,255,0.5);
+}
+.chat-typing b { color: rgba(255,255,255,0.75); font-weight: 600; }
+.chat-typing-dots { display: inline-flex; gap: 3px; margin-right: 3px; vertical-align: middle; }
+.chat-typing-dots i {
+    width: 4px; height: 4px; border-radius: 50%;
+    background: rgba(var(--accent-light-rgb), 0.8);
+    animation: chatTypDot 1.2s ease-in-out infinite;
+}
+.chat-typing-dots i:nth-child(2) { animation-delay: 0.2s; }
+.chat-typing-dots i:nth-child(3) { animation-delay: 0.4s; }
+@keyframes chatTypDot { 0%, 60%, 100% { opacity: 0.35; transform: translateY(0); }
+                        30% { opacity: 1; transform: translateY(-2px); } }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72256,3 +72256,57 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 .chat-attach-results { max-height: 220px; overflow-y: auto; }
 .chat-attach-status { font-size: 11.5px; color: rgba(var(--accent-light-rgb), 0.9); padding: 6px 2px; }
 .chat-attach-status--err { color: rgb(252, 165, 165); }
+
+/* ── chat jukebox (shared room listening) ─────────────────────────────── */
+.chat-jukebox {
+    flex: 0 0 auto;
+    margin: 0 16px 8px;
+    padding: 10px 12px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 46vh;
+    overflow-y: auto;
+}
+.chat-jbx-now { display: flex; align-items: center; gap: 8px; min-height: 26px; flex-wrap: wrap; }
+.chat-jbx-live { color: rgb(var(--accent-light-rgb)); font-size: 12px; }
+.chat-jbx-title {
+    font-size: 13px; font-weight: 600; color: rgba(255,255,255,0.92);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    max-width: 100%; min-width: 0; flex: 1 1 auto;
+}
+.chat-jbx-meta { font-size: 11.5px; color: rgba(255,255,255,0.45); white-space: nowrap; }
+.chat-jbx-tune { flex: 0 0 auto; }
+.chat-jbx-player { border-radius: 10px; overflow: hidden; line-height: 0; }
+.chat-jbx-player iframe { border: 0; }
+.chat-jbx-queue { display: flex; flex-direction: column; gap: 2px; }
+.chat-jbx-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 4px 6px; border-radius: 8px;
+}
+.chat-jbx-row:hover { background: rgba(255,255,255,0.04); }
+.chat-jbx-vote {
+    flex: 0 0 auto;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.1);
+    color: rgba(255,255,255,0.8);
+    border-radius: 8px; padding: 2px 9px; font-size: 12px; cursor: pointer;
+}
+.chat-jbx-vote:hover:not(:disabled) {
+    background: rgba(var(--accent-light-rgb), 0.18);
+    border-color: rgba(var(--accent-light-rgb), 0.4);
+}
+.chat-jbx-vote:disabled { opacity: 0.4; cursor: default; }
+.chat-jbx-form { display: flex; gap: 8px; }
+.chat-jbx-input { flex: 1 1 auto; min-width: 0; }
+.chat-jbx-add { flex: 0 0 auto; }
+.chat-jbx-results { display: flex; flex-direction: column; gap: 2px; max-height: 200px; overflow-y: auto; }
+.chat-jbx-result {
+    display: flex; align-items: center; gap: 10px; text-align: left;
+    background: none; border: 0; cursor: pointer;
+    padding: 5px 6px; border-radius: 8px; width: 100%;
+}
+.chat-jbx-result:hover { background: rgba(255,255,255,0.05); }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72235,3 +72235,24 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
 }
 .chat-card-note-input:focus { outline: none; border-color: rgba(var(--accent-rgb), 0.45); }
 .chat-card-note-save { align-self: flex-end; }
+
+/* ── chat file sharing (filepost.dev, chat P2) ── */
+.chat-file-card {
+    display: flex; align-items: center; gap: 9px; flex-wrap: wrap;
+    padding: 9px 12px; margin: 2px 0; max-width: 460px;
+    background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 11px;
+}
+.chat-file-icon { font-size: 18px; }
+.chat-file-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.chat-file-name { font-size: 12.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chat-file-size { font-size: 10.5px; color: rgba(255,255,255,0.4); }
+.chat-file-dl { text-decoration: none; }
+.chat-file-slot { flex-basis: 100%; }
+.chat-file-player { width: 100%; margin-top: 6px; }
+.chat-file-player--video { max-height: 260px; border-radius: 8px; }
+.chat-attach-tabs { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.chat-attach-or { font-size: 11px; color: rgba(255,255,255,0.4); }
+.chat-attach-results { max-height: 220px; overflow-y: auto; }
+.chat-attach-status { font-size: 11.5px; color: rgba(var(--accent-light-rgb), 0.9); padding: 6px 2px; }
+.chat-attach-status--err { color: rgb(252, 165, 165); }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72537,3 +72537,10 @@ a.chat-jbx-title:hover { color: rgb(var(--accent-light-rgb)); }
 .chat-slash-cmd { font-size: 12.5px; font-weight: 700; color: rgba(255,255,255,0.9); white-space: nowrap; }
 .chat-slash-cmd i { font-style: normal; font-weight: 500; color: rgba(255,255,255,0.4); }
 .chat-slash-desc { font-size: 11.5px; color: rgba(255,255,255,0.45); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+/* auto-DJ toggle in the jukebox header bar */
+.chat-jbx-radiobtn { white-space: nowrap; }
+.chat-jbx-radiobtn--on {
+    background: rgba(var(--accent-rgb), 0.2);
+    color: rgb(var(--accent-light-rgb));
+}

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72531,3 +72531,9 @@ a.chat-jbx-title:hover { color: rgb(var(--accent-light-rgb)); }
 .chat-typing-dots i:nth-child(3) { animation-delay: 0.4s; }
 @keyframes chatTypDot { 0%, 60%, 100% { opacity: 0.35; transform: translateY(0); }
                         30% { opacity: 1; transform: translateY(-2px); } }
+
+/* slash-command options in the mention pop */
+.chat-slash-opt { display: flex; align-items: baseline; gap: 10px; }
+.chat-slash-cmd { font-size: 12.5px; font-weight: 700; color: rgba(255,255,255,0.9); white-space: nowrap; }
+.chat-slash-cmd i { font-style: normal; font-weight: 500; color: rgba(255,255,255,0.4); }
+.chat-slash-desc { font-size: 11.5px; color: rgba(255,255,255,0.45); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72220,3 +72220,18 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     font-weight: 800; text-transform: uppercase; font-size: 0.85em;
     color: rgba(255, 255, 255, 0.55);
 }
+
+/* ── chat user card: history + private note (chat P1) ── */
+.chat-card-hist {
+    margin-top: 8px; padding-top: 8px;
+    border-top: 1px solid rgba(255,255,255,0.07);
+}
+.chat-card-note { margin-top: 10px; display: flex; flex-direction: column; gap: 6px; }
+.chat-card-note-input {
+    width: 100%; resize: vertical; min-height: 40px;
+    background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 8px; color: #fff; font-size: 12px; font-family: inherit;
+    padding: 7px 9px;
+}
+.chat-card-note-input:focus { outline: none; border-color: rgba(var(--accent-rgb), 0.45); }
+.chat-card-note-save { align-self: flex-end; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -72310,3 +72310,71 @@ button.chat-hidden-note:hover { color: rgba(255,255,255,0.65); }
     padding: 5px 6px; border-radius: 8px; width: 100%;
 }
 .chat-jbx-result:hover { background: rgba(255,255,255,0.05); }
+
+/* ── chat pin board + room poll + topic (protocol-bus surfaces) ───────── */
+.chat-pinbar {
+    flex: 0 0 auto;
+    margin: 0 16px 6px;
+    padding: 4px 8px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.07);
+    border-radius: 10px;
+}
+.chat-pinbar-head {
+    background: none; border: 0; cursor: pointer;
+    color: rgba(255,255,255,0.65); font-size: 12px; padding: 3px 4px;
+}
+.chat-pinbar-head:hover { color: rgba(255,255,255,0.9); }
+.chat-pin-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 4px 6px; border-radius: 8px; font-size: 12.5px;
+}
+.chat-pin-row:hover { background: rgba(255,255,255,0.04); }
+.chat-pin-text {
+    color: rgba(255,255,255,0.85); min-width: 0; flex: 1 1 auto;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.chat-pin-by { font-size: 11px; color: rgba(255,255,255,0.35); white-space: nowrap; }
+.chat-pin-del {
+    background: none; border: 0; cursor: pointer;
+    color: rgba(255,255,255,0.4); font-size: 14px; padding: 0 4px;
+}
+.chat-pin-del:hover { color: rgb(252, 165, 165); }
+.chat-pollcard {
+    flex: 0 0 auto;
+    margin: 0 16px 8px;
+    padding: 10px 12px;
+    background: rgba(var(--accent-light-rgb), 0.05);
+    border: 1px solid rgba(var(--accent-light-rgb), 0.18);
+    border-radius: 12px;
+    display: flex; flex-direction: column; gap: 6px;
+}
+.chat-poll-head { display: flex; align-items: center; gap: 10px; font-size: 13px; flex-wrap: wrap; }
+.chat-poll-head b { color: rgba(255,255,255,0.92); }
+.chat-poll-opt {
+    position: relative; display: flex; align-items: center; gap: 10px;
+    padding: 5px 8px; border-radius: 8px; overflow: hidden;
+}
+.chat-poll-opt--win { outline: 1px solid rgba(var(--accent-light-rgb), 0.5); }
+.chat-poll-vote {
+    background: none; border: 0; cursor: pointer; text-align: left;
+    color: rgba(255,255,255,0.85); font-size: 12.5px; padding: 0;
+    flex: 1 1 auto; min-width: 0; position: relative; z-index: 1;
+}
+.chat-poll-vote:hover { color: rgb(var(--accent-light-rgb)); }
+.chat-poll-label { flex: 1 1 auto; min-width: 0; font-size: 12.5px; color: rgba(255,255,255,0.85); position: relative; z-index: 1; }
+.chat-poll-n { font-size: 11.5px; color: rgba(255,255,255,0.5); white-space: nowrap; position: relative; z-index: 1; }
+.chat-poll-bar {
+    position: absolute; left: 0; top: 0; bottom: 0; z-index: 0;
+    background: rgba(var(--accent-light-rgb), 0.14);
+    border-radius: 8px; transition: width 0.3s ease;
+}
+.chat-poll-pop .chat-input { margin-bottom: 6px; }
+.chat-topic-edit {
+    background: none; border: 0; cursor: pointer;
+    color: rgba(255,255,255,0.35); font-size: 11px; padding: 0 2px;
+}
+.chat-topic-edit:hover { color: rgba(255,255,255,0.8); }
+.chat-head-sub--topic { color: rgba(var(--accent-light-rgb), 0.9); }
+.chat-topic-in { max-width: 420px; margin-left: 12px; }
+.chat-user-tuned { color: rgb(var(--accent-light-rgb)); margin-left: 5px; font-size: 11px; }


### PR DESCRIPTION
# soulsync 3.1.7 — `dev` → `main`

chat turns into a place you actually hang out — a shared room jukebox, file sharing, polls, pins, slash commands. plus the hifi failover fix and a version + disc aware track repair.

---

## the room jukebox

listen to music together in any chat room. paste a youtube link or search, the room votes on what plays next, and everyone who tunes in hears the same track at the same spot. no server runs it — every soulsync client reduces the same hidden message stream to the same queue, so it stays in sync on its own.

- **votes pick the next song**, ties and no-vote rounds fall back to first-in-line
- **vote to skip** the current track (majority of listeners)
- **thumbnails everywhere**, a now-playing card with a progress bar, and an "up next" highlight
- **recently played** with one-click requeue, **pull your own** submission back out
- **audio only** toggle (kills the video, keeps the sound) + a local **volume** slider
- **auto-dj**: flip it on and when the queue runs dry it keeps the music going with related tracks

## more chat

- **file sharing** via filepost.dev — upload a file or pick a track from your library, drop the link in chat as a rich card you can preview inline
- **polls** — ask the room a question, live vote bars, starter closes it
- **pinned messages** — 📌 any message to a shared board (a popover in the room head)
- **room topic**, **typing indicators**, and **listening presence** (♫ next to whoever's tuned into the jukebox)
- **slash commands** — `/play` `/skip` `/tune` `/topic` `/poll` `/pin` `/gif` `/shrug` with autocomplete
- the chat modals got rebuilt to match soulsync's actual design instead of the old flat gray

## fixes

- **hifi failover (#1073, thanks Lain2077)**: hifi requests that hit a rate limit or a blocked instance now rotate to another instance instead of just failing, the way the monochrome instances do
- **track repair, version + disc aware (#1075, thanks Lain2077)**: repair used to strip "(Why Us? Version)"-style qualifiers before matching, so different versions of the same song looked identical and it grabbed the wrong disc's copy — the full title breaks ties now. multi-disc repairs also write the disc tag (so per-disc numbering can't create duplicate track numbers), and the proposed change tells you when a number is disc-relative, like "track number: 1 → 10 (disc 2 of 3)"

heads up: after this, multi-disc albums missing disc tags will show new Track Repair findings — that's the fix making sure the whole album gets tagged.
