### PR TITLE
React migration automations

### DIFF
--- a/tests/test_video_automations_renderer_contract.py
+++ b/tests/test_video_automations_renderer_contract.py
@@ -1,0 +1,97 @@
+"""The video Automations page borrows its renderer from the music page.
+
+webui/static/video/video-automations.js is a ~200-line adapter with no
+renderer of its own: it fetches /api/automations, filters to owned_by='video',
+and then hands the rows to builders that live in the MUSIC page's
+stats-automations.js. The dependency is one-directional (music exports, video
+consumes) and entirely implicit — nothing but a prose comment records it.
+
+That makes it exactly the kind of thing a cleanup deletes by accident. The
+music Automations page is being migrated to React; when the vanilla file is
+finally pruned, these functions must survive or the video page renders
+nothing at all, with no error that points at the cause.
+
+This pins the contract itself, not a particular file: each name must be
+defined by SOME script the page loads, and its definer must load BEFORE the
+video adapter. So the functions may be moved or extracted freely — they just
+may not vanish.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_STATIC = _ROOT / "webui" / "static"
+_ADAPTER = _STATIC / "video" / "video-automations.js"
+_INDEX = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
+
+# The renderer surface the video page consumes. Hardcoded on purpose: deriving
+# it from the current source would shrink whenever a function is deleted and
+# let the test pass vacuously on the very regression it exists to catch.
+_CONTRACT = (
+    "renderAutomationCard",
+    "renderAutomationsMasterToggle",
+    "_buildAutomationSection",
+    "_buildAutomationHub",
+    "_hubGroups",
+    "_hubGuides",
+    "_hubRecipes",
+    "_hubReference",
+    "_hubTips",
+)
+
+_DEF = re.compile(r"^(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(", re.M)
+
+
+def _definitions() -> dict[str, str]:
+    """name -> filename, for every top-level function in the static tree."""
+    out: dict[str, str] = {}
+    for js in sorted(_STATIC.glob("*.js")) + sorted((_STATIC / "video").glob("*.js")):
+        for name in _DEF.findall(js.read_text(encoding="utf-8", errors="replace")):
+            out.setdefault(name, js.name)
+    return out
+
+
+@pytest.mark.parametrize("name", _CONTRACT)
+def test_borrowed_renderer_still_exists(name):
+    defs = _definitions()
+    assert name in defs, (
+        "video-automations.js calls %s(), but nothing in webui/static defines it "
+        "any more. The video Automations page renders via the music page's "
+        "builders — deleting one blanks that page silently. Keep it (moving it "
+        "to another loaded script is fine), or port the video page off it first."
+        % name
+    )
+
+
+@pytest.mark.parametrize("name", _CONTRACT)
+def test_adapter_actually_uses_it(name):
+    """Guards the other direction: if the video page stops needing one of these,
+    this list is stale and should shrink deliberately rather than by drift."""
+    src = _ADAPTER.read_text(encoding="utf-8")
+    assert re.search(r"\b%s\b" % re.escape(name), src), (
+        "%s is listed in this test's contract but video-automations.js no longer "
+        "references it — drop it from _CONTRACT so the pin stays honest." % name
+    )
+
+
+def test_definers_load_before_the_video_adapter():
+    """Order matters: these are plain globals, so the defining script must have
+    executed by the time the adapter runs."""
+    defs = _definitions()
+    def pos(filename: str) -> int:
+        m = re.search(r"filename='(?:video/)?%s'" % re.escape(filename), _INDEX)
+        assert m, "%s is not loaded by index.html" % filename
+        return m.start()
+
+    adapter_at = pos("video-automations.js")
+    for name in _CONTRACT:
+        owner = defs[name]
+        assert pos(owner) < adapter_at, (
+            "%s defines %s but loads AFTER video-automations.js — the adapter "
+            "would see it undefined." % (owner, name)
+        )

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -58,11 +58,18 @@ declare global {
     openWishlistIgnoreModal?: () => void;
     cleanupWishlistOverview?: () => void;
     /**
-     * The automation builder (create/edit) still lives in stats-automations.js
-     * — it is bound to module-scoped builder state, so the React page invokes
-     * it rather than reimplementing it. Ported in a later phase.
+     * The automation builder (create/edit) stays in stats-automations.js and is
+     * deliberately NOT ported: showVideoAutomationBuilder opens the very same
+     * builder with a video context, so a React copy would be a second
+     * implementation of something the video page still needs. The React page
+     * hands the shell over for the edit instead — see -automations.builder.ts.
      */
     showAutomationBuilder?: (automationId?: number) => void;
+    /**
+     * Closes the shared builder. Wrapped by the React automations page so it
+     * can reclaim the shell — every exit path (Back, Cancel, Save) calls it.
+     */
+    hideAutomationBuilder?: () => void;
     clearEntireWishlist?: () => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -57,6 +57,12 @@ declare global {
     startWishlistCountdownTimer?: (currentCycle: string, initialSeconds: number) => void;
     openWishlistIgnoreModal?: () => void;
     cleanupWishlistOverview?: () => void;
+    /**
+     * The automation builder (create/edit) still lives in stats-automations.js
+     * — it is bound to module-scoped builder state, so the React page invokes
+     * it rather than reimplementing it. Ported in a later phase.
+     */
+    showAutomationBuilder?: (automationId?: number) => void;
     clearEntireWishlist?: () => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -70,6 +70,21 @@ declare global {
      * can reclaim the shell — every exit path (Back, Cancel, Save) calls it.
      */
     hideAutomationBuilder?: () => void;
+    /**
+     * Builds the Automation Hub section (pipelines, recipes, guides, reference,
+     * tips) and returns the node. Shared verbatim with the VIDEO automations
+     * page, so React mounts what it returns rather than restating its content.
+     */
+    _buildAutomationHub?: () => HTMLElement;
+    /**
+     * The "Runs: N" run-history modal. Appends itself to document.body rather
+     * than into the page container, so it works unchanged from the React page.
+     */
+    showAutomationHistory?: (
+      automationId: number,
+      automationName: string,
+      actionType: string,
+    ) => void;
     clearEntireWishlist?: () => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;

--- a/webui/src/platform/shell/route-manifest.test.ts
+++ b/webui/src/platform/shell/route-manifest.test.ts
@@ -57,9 +57,11 @@ describe('shellRouteManifest', () => {
     expect(getShellRouteByPageId('watchlist')?.kind).toBe('react');
     // Order follows the manifest array, not the migration order.
     expect(getShellRouteByPageId('wishlist')?.kind).toBe('react');
+    expect(getShellRouteByPageId('automations')?.kind).toBe('react');
     expect(reactShellRoutes.map((route) => route.pageId)).toEqual([
       'watchlist',
       'wishlist',
+      'automations',
       'import',
       'stats',
       'issues',

--- a/webui/src/platform/shell/route-manifest.ts
+++ b/webui/src/platform/shell/route-manifest.ts
@@ -38,7 +38,7 @@ export const shellRouteManifest: readonly ShellRouteDefinition[] = [
   { pageId: 'playlist-explorer', path: '/playlist-explorer', kind: 'legacy' },
   { pageId: 'watchlist', path: '/watchlist', kind: 'react' },
   { pageId: 'wishlist', path: '/wishlist', kind: 'react' },
-  { pageId: 'automations', path: '/automations', kind: 'legacy' },
+  { pageId: 'automations', path: '/automations', kind: 'react' },
   { pageId: 'active-downloads', path: '/active-downloads', kind: 'legacy' },
   { pageId: 'import', path: '/import', kind: 'react' },
   { pageId: 'library', path: '/library', kind: 'legacy' },

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as WatchlistRouteRouteImport } from './routes/watchlist/route'
 import { Route as StatsRouteRouteImport } from './routes/stats/route'
 import { Route as IssuesRouteRouteImport } from './routes/issues/route'
 import { Route as ImportRouteRouteImport } from './routes/import/route'
+import { Route as AutomationsRouteRouteImport } from './routes/automations/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as ImportIndexRouteImport } from './routes/import/index'
 import { Route as LabelDetailIdRouteImport } from './routes/label-detail/$id'
@@ -51,6 +52,11 @@ const IssuesRouteRoute = IssuesRouteRouteImport.update({
 const ImportRouteRoute = ImportRouteRouteImport.update({
   id: '/import',
   path: '/import',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AutomationsRouteRoute = AutomationsRouteRouteImport.update({
+  id: '/automations',
+  path: '/automations',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -91,6 +97,7 @@ const ArtistDetailSourceIdRoute = ArtistDetailSourceIdRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRouteRoute
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
   '/stats': typeof StatsRouteRoute
@@ -106,6 +113,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRouteRoute
   '/issues': typeof IssuesRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
@@ -121,6 +129,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/automations': typeof AutomationsRouteRoute
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
   '/stats': typeof StatsRouteRoute
@@ -138,6 +147,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/automations'
     | '/import'
     | '/issues'
     | '/stats'
@@ -153,6 +163,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/automations'
     | '/issues'
     | '/stats'
     | '/watchlist'
@@ -167,6 +178,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/automations'
     | '/import'
     | '/issues'
     | '/stats'
@@ -183,6 +195,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AutomationsRouteRoute: typeof AutomationsRouteRoute
   ImportRouteRoute: typeof ImportRouteRouteWithChildren
   IssuesRouteRoute: typeof IssuesRouteRoute
   StatsRouteRoute: typeof StatsRouteRoute
@@ -235,6 +248,13 @@ declare module '@tanstack/react-router' {
       path: '/import'
       fullPath: '/import'
       preLoaderRoute: typeof ImportRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/automations': {
+      id: '/automations'
+      path: '/automations'
+      fullPath: '/automations'
+      preLoaderRoute: typeof AutomationsRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -309,6 +329,7 @@ const ImportRouteRouteWithChildren = ImportRouteRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AutomationsRouteRoute: AutomationsRouteRoute,
   ImportRouteRoute: ImportRouteRouteWithChildren,
   IssuesRouteRoute: IssuesRouteRoute,
   StatsRouteRoute: StatsRouteRoute,

--- a/webui/src/routes/automations/-automations.api.ts
+++ b/webui/src/routes/automations/-automations.api.ts
@@ -118,3 +118,35 @@ export async function setAutomationsMaster(
     'Could not update the master switch',
   );
 }
+
+/**
+ * Move one automation into a group (or out of it with null).
+ *
+ * Note the endpoint: PUT /api/automations/<id> with just {group_name}. The
+ * PLURAL /api/automations/group below is a different route used for bulk
+ * regrouping — mixing them up silently regroups the wrong set.
+ */
+export async function assignAutomationGroup(id: number, groupName: string | null): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(
+      apiClient.put(`automations/${id}`, { json: { group_name: groupName || null } }),
+    ),
+    'Could not move the automation',
+  );
+}
+
+/**
+ * Bulk-set the group on many automations. Used for rename (same ids, new name)
+ * and for dissolving a group (same ids, null). Returns how many changed.
+ */
+export async function regroupAutomations(ids: number[], groupName: string | null): Promise<number> {
+  const payload = assertOk(
+    await readJson<MutationResponse>(
+      apiClient.put('automations/group', {
+        json: { automation_ids: ids, group_name: groupName },
+      }),
+    ),
+    'Could not update the group',
+  );
+  return payload.updated ?? 0;
+}

--- a/webui/src/routes/automations/-automations.api.ts
+++ b/webui/src/routes/automations/-automations.api.ts
@@ -3,6 +3,7 @@ import { queryOptions } from '@tanstack/react-query';
 import { apiClient, readJson } from '@/app/api-client';
 
 import type {
+  AutomationBlocks,
   AutomationsListResponse,
   AutomationsMasterState,
   AutomationsProgressResponse,
@@ -149,4 +150,19 @@ export async function regroupAutomations(ids: number[], groupName: string | null
     'Could not update the group',
   );
   return payload.updated ?? 0;
+}
+
+/**
+ * Block definitions — the builder's palette, and the label source for any
+ * trigger/action type not in the static maps.
+ *
+ * Scoped to 'music' server-side, so the video-only types never appear here.
+ * Long-lived: these change only when the app ships new block types.
+ */
+export function automationBlocksQueryOptions() {
+  return queryOptions({
+    queryKey: [...AUTOMATIONS_QUERY_KEY, 'blocks'] as const,
+    queryFn: () => readJson<AutomationBlocks>(apiClient.get('automations/blocks')),
+    staleTime: Infinity,
+  });
 }

--- a/webui/src/routes/automations/-automations.api.ts
+++ b/webui/src/routes/automations/-automations.api.ts
@@ -44,3 +44,77 @@ export function automationsProgressQueryOptions() {
     queryFn: () => readJson<AutomationsProgressResponse>(apiClient.get('automations/progress')),
   });
 }
+
+// ── mutations ───────────────────────────────────────────────────────────────
+//
+// All of these mirror the vanilla handlers verb-for-verb. The endpoints answer
+// `{error}` on failure with a 200, so an HTTP-level check alone is not enough —
+// every one asserts on the payload as the vanilla code did.
+
+interface MutationResponse {
+  success?: boolean;
+  error?: string;
+  /** bulk-toggle / group report how many rows changed. */
+  updated?: number;
+}
+
+function assertOk(payload: MutationResponse, fallback: string): MutationResponse {
+  if (payload.error) throw new Error(payload.error);
+  if (payload.success === false) throw new Error(fallback);
+  return payload;
+}
+
+export async function toggleAutomation(id: number): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(apiClient.post(`automations/${id}/toggle`)),
+    'Could not toggle the automation',
+  );
+}
+
+export async function runAutomation(id: number): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(apiClient.post(`automations/${id}/run`)),
+    'Could not start the automation',
+  );
+}
+
+export async function duplicateAutomation(id: number): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(apiClient.post(`automations/${id}/duplicate`)),
+    'Could not duplicate the automation',
+  );
+}
+
+export async function deleteAutomation(id: number): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(apiClient.delete(`automations/${id}`)),
+    'Could not delete the automation',
+  );
+}
+
+/** Enable/disable every automation in a group in one call. Returns how many changed. */
+export async function bulkToggleAutomations(ids: number[], enabled: boolean): Promise<number> {
+  const payload = assertOk(
+    await readJson<MutationResponse>(
+      apiClient.post('automations/bulk-toggle', { json: { automation_ids: ids, enabled } }),
+    ),
+    'Could not update those automations',
+  );
+  return payload.updated ?? 0;
+}
+
+/**
+ * The per-side master pause. Admin-only server-side (403 otherwise), and NOT
+ * profile-scoped — it silences the whole side for everyone.
+ */
+export async function setAutomationsMaster(
+  side: 'music' | 'video',
+  enabled: boolean,
+): Promise<void> {
+  assertOk(
+    await readJson<MutationResponse>(
+      apiClient.post('automations/master', { json: { side, enabled } }),
+    ),
+    'Could not update the master switch',
+  );
+}

--- a/webui/src/routes/automations/-automations.api.ts
+++ b/webui/src/routes/automations/-automations.api.ts
@@ -1,0 +1,46 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { apiClient, readJson } from '@/app/api-client';
+
+import type {
+  AutomationsListResponse,
+  AutomationsMasterState,
+  AutomationsProgressResponse,
+} from './-automations.types';
+
+export const AUTOMATIONS_QUERY_KEY = ['automations'] as const;
+
+// /api/automations resolves the profile from the Flask SESSION, so no profile
+// header is sent — but the profile still keys the query: automations are
+// per-profile rows, and switching profiles must not serve the previous
+// profile's list out of the cache.
+
+export function automationsListQueryOptions(profileId: number) {
+  return queryOptions({
+    queryKey: [...AUTOMATIONS_QUERY_KEY, 'list', profileId] as const,
+    queryFn: () => readJson<AutomationsListResponse>(apiClient.get('automations')),
+  });
+}
+
+/**
+ * The per-side global pause. Not profile-scoped: it lives in the engine, gates
+ * every automation on that side for everyone, and is admin-only to change.
+ */
+export function automationsMasterQueryOptions() {
+  return queryOptions({
+    queryKey: [...AUTOMATIONS_QUERY_KEY, 'master'] as const,
+    queryFn: () => readJson<AutomationsMasterState>(apiClient.get('automations/master')),
+  });
+}
+
+/**
+ * In-flight run progress. The vanilla page fetched this once after rendering
+ * to catch up on runs already going when the page opened; live updates arrive
+ * over the socket.
+ */
+export function automationsProgressQueryOptions() {
+  return queryOptions({
+    queryKey: [...AUTOMATIONS_QUERY_KEY, 'progress'] as const,
+    queryFn: () => readJson<AutomationsProgressResponse>(apiClient.get('automations/progress')),
+  });
+}

--- a/webui/src/routes/automations/-automations.builder.test.ts
+++ b/webui/src/routes/automations/-automations.builder.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ROUTER_ROOT_ID } from '@/platform/shell/route-controllers';
+
+import { useVanillaBuilder } from './-automations.builder';
+
+/**
+ * The hybrid handoff.
+ *
+ * The builder markup lives inside #automations-page, and `.page` is
+ * display:none unless it carries .active — which the shell strips while React
+ * owns the route. So the page has to be handed back for the edit and reclaimed
+ * on close, and the reclaim has to survive every exit path.
+ */
+
+const legacy = () => document.getElementById('automations-page')!;
+const reactRoot = () => document.getElementById(ROUTER_ROOT_ID)!;
+
+let originalHide: () => void;
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div class="page" id="automations-page"></div>
+    <div id="${ROUTER_ROOT_ID}" class="active"></div>
+  `;
+  originalHide = vi.fn<() => void>();
+  window.showAutomationBuilder = vi.fn<(id?: number) => void>();
+  window.hideAutomationBuilder = originalHide;
+});
+
+afterEach(() => {
+  delete window.showAutomationBuilder;
+  delete window.hideAutomationBuilder;
+  document.body.innerHTML = '';
+});
+
+describe('useVanillaBuilder', () => {
+  it('reveals the legacy page before opening, so the builder is not measured hidden', () => {
+    const { result } = renderHook(() => useVanillaBuilder(vi.fn()));
+    act(() => result.current(42));
+
+    expect(legacy().classList.contains('active')).toBe(true);
+    expect(reactRoot().classList.contains('active')).toBe(false);
+    expect(window.showAutomationBuilder).toHaveBeenCalledWith(42);
+  });
+
+  it('opens with no id for a new automation', () => {
+    const { result } = renderHook(() => useVanillaBuilder(vi.fn()));
+    act(() => result.current());
+    expect(window.showAutomationBuilder).toHaveBeenCalledWith(undefined);
+  });
+
+  it('reclaims the shell when the builder closes, and still runs the original', () => {
+    const onClosed = vi.fn();
+    const { result } = renderHook(() => useVanillaBuilder(onClosed));
+    act(() => result.current(1));
+
+    act(() => window.hideAutomationBuilder!());
+
+    expect(originalHide).toHaveBeenCalled(); // the real close still happened
+    expect(reactRoot().classList.contains('active')).toBe(true);
+    expect(legacy().classList.contains('active')).toBe(false);
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a close it did not cause', () => {
+    // The VIDEO page shares hideAutomationBuilder. If its builder closes while
+    // this page happens to be mounted, we must not yank the shell around.
+    const onClosed = vi.fn();
+    renderHook(() => useVanillaBuilder(onClosed));
+
+    act(() => window.hideAutomationBuilder!());
+
+    expect(originalHide).toHaveBeenCalled();
+    expect(onClosed).not.toHaveBeenCalled();
+    expect(legacy().classList.contains('active')).toBe(false);
+  });
+
+  it('only reclaims once per open', () => {
+    const onClosed = vi.fn();
+    const { result } = renderHook(() => useVanillaBuilder(onClosed));
+    act(() => result.current(1));
+    act(() => window.hideAutomationBuilder!());
+    act(() => window.hideAutomationBuilder!());
+    expect(onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the original function on unmount', () => {
+    const { unmount } = renderHook(() => useVanillaBuilder(vi.fn()));
+    expect(window.hideAutomationBuilder).not.toBe(originalHide);
+    unmount();
+    expect(window.hideAutomationBuilder).toBe(originalHide);
+  });
+
+  it('restores the shell if the page unmounts mid-edit', () => {
+    // Navigating away with the builder open would otherwise leave the legacy
+    // container visible and the React host hidden.
+    const { result, unmount } = renderHook(() => useVanillaBuilder(vi.fn()));
+    act(() => result.current(1));
+    expect(legacy().classList.contains('active')).toBe(true);
+
+    unmount();
+
+    expect(reactRoot().classList.contains('active')).toBe(true);
+    expect(legacy().classList.contains('active')).toBe(false);
+  });
+
+  it('does nothing when the vanilla builder is unavailable', () => {
+    delete window.showAutomationBuilder;
+    const { result } = renderHook(() => useVanillaBuilder(vi.fn()));
+    act(() => result.current(1));
+    // No half-handover: the shell must not be left showing an empty legacy page.
+    expect(legacy().classList.contains('active')).toBe(false);
+    expect(reactRoot().classList.contains('active')).toBe(true);
+  });
+});

--- a/webui/src/routes/automations/-automations.builder.ts
+++ b/webui/src/routes/automations/-automations.builder.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { ROUTER_ROOT_ID } from '@/platform/shell/route-controllers';
+
+/** The legacy page container that physically holds the builder markup. */
+const LEGACY_PAGE_ID = 'automations-page';
+
+/**
+ * Hand off to the vanilla automation builder, then take the page back.
+ *
+ * The builder is NOT ported to React on purpose. It is ~645 lines and it is
+ * SHARED: showAutomationBuilder (music) and showVideoAutomationBuilder (video)
+ * both set a context and call the same _openAutomationBuilder. A React copy
+ * would be a second implementation of a builder the video page still needs,
+ * and the two would drift.
+ *
+ * The problem it creates: the builder's markup lives inside #automations-page,
+ * and `.page { display: none }` — only `.page.active` shows. When React owns
+ * the route the shell strips `.active` from every legacy page, so opening the
+ * builder would render it inside a hidden ancestor. A dead button.
+ *
+ * So this briefly gives the page back to the vanilla side for the duration of
+ * the edit, and reclaims it on close. Every exit — Back, Cancel and Save —
+ * routes through hideAutomationBuilder, so wrapping that one function is a
+ * complete interception; saveAutomation calls it before its onSaved hook.
+ */
+export function useVanillaBuilder(onClosed: () => void): (automationId?: number) => void {
+  // Only reclaim the page if WE handed it over. The video page shares this
+  // function, so an unrelated close must not yank the shell around.
+  const openedByUs = useRef(false);
+  const closed = useRef(onClosed);
+  closed.current = onClosed;
+
+  const showReact = useCallback(() => {
+    document.getElementById(LEGACY_PAGE_ID)?.classList.remove('active');
+    document.getElementById(ROUTER_ROOT_ID)?.classList.add('active');
+  }, []);
+
+  useEffect(() => {
+    const original = window.hideAutomationBuilder;
+    if (!original) return;
+
+    const wrapped = function patchedHideAutomationBuilder(this: unknown, ...args: unknown[]) {
+      const result = (original as (...a: unknown[]) => unknown).apply(this, args);
+      if (openedByUs.current) {
+        openedByUs.current = false;
+        showReact();
+        // The builder may have just created or edited a row; the vanilla
+        // onSaved hook repaints the hidden legacy list, not ours.
+        closed.current();
+      }
+      return result;
+    } as typeof window.hideAutomationBuilder;
+
+    window.hideAutomationBuilder = wrapped;
+    return () => {
+      // Restore on unmount, and if the user navigated away mid-edit make sure
+      // the shell is not left showing the legacy container.
+      window.hideAutomationBuilder = original;
+      if (openedByUs.current) {
+        openedByUs.current = false;
+        showReact();
+      }
+    };
+  }, [showReact]);
+
+  return useCallback((automationId?: number) => {
+    if (typeof window.showAutomationBuilder !== 'function') return;
+    openedByUs.current = true;
+    // Reveal the legacy container FIRST, so the builder is measured and
+    // painted in a visible tree rather than a display:none one.
+    document.getElementById(ROUTER_ROOT_ID)?.classList.remove('active');
+    document.getElementById(LEGACY_PAGE_ID)?.classList.add('active');
+    window.showAutomationBuilder(automationId);
+  }, []);
+}

--- a/webui/src/routes/automations/-automations.dnd.test.ts
+++ b/webui/src/routes/automations/-automations.dnd.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAutomationDnd } from './-automations.dnd';
+
+/** Minimal DragEvent stand-in — jsdom does not implement dataTransfer. */
+function dragEvent() {
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer: { setData: vi.fn(), effectAllowed: '', dropEffect: '' },
+  } as unknown as React.DragEvent;
+}
+
+type Props = Record<string, (e: React.DragEvent) => void>;
+
+describe('useAutomationDnd', () => {
+  it('makes user cards draggable and system cards not', () => {
+    const { result } = renderHook(() => useAutomationDnd(vi.fn()));
+    expect(result.current.cardProps(1, null, false)).toHaveProperty('draggable', true);
+    // System automations live in the protected section and cannot be moved.
+    expect(result.current.cardProps(2, null, true)).toEqual({});
+  });
+
+  it('moves a card to the dropped group', () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useAutomationDnd(onDrop));
+
+    act(() => (result.current.cardProps(7, null, false) as Props).onDragStart(dragEvent()));
+    act(() => (result.current.zoneProps('group:Chores', 'Chores') as Props).onDrop(dragEvent()));
+
+    expect(onDrop).toHaveBeenCalledWith({ id: 7, groupName: null }, 'Chores');
+  });
+
+  it('treats a drop back into the same group as a no-op', () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useAutomationDnd(onDrop));
+
+    act(() => (result.current.cardProps(7, 'Chores', false) as Props).onDragStart(dragEvent()));
+    act(() => (result.current.zoneProps('group:Chores', 'Chores') as Props).onDrop(dragEvent()));
+
+    // No PUT for a move that changes nothing.
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('drops into My Automations as a null group', () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useAutomationDnd(onDrop));
+
+    act(() => (result.current.cardProps(7, 'Chores', false) as Props).onDragStart(dragEvent()));
+    act(() => (result.current.zoneProps('ungrouped', null) as Props).onDrop(dragEvent()));
+
+    expect(onDrop).toHaveBeenCalledWith({ id: 7, groupName: 'Chores' }, null);
+  });
+
+  it('refuses protected sections as drop targets', () => {
+    const { result } = renderHook(() => useAutomationDnd(vi.fn()));
+    expect(result.current.zoneProps('system', null, { isProtected: true })).toEqual({});
+  });
+
+  it('keeps the zone lit while the pointer crosses child cards', () => {
+    // dragenter/dragleave fire for CHILDREN too, so a naive handler clears the
+    // highlight the moment the pointer moves over a card inside the zone.
+    // The counter is what keeps it lit until the pointer really leaves.
+    const { result } = renderHook(() => useAutomationDnd(vi.fn()));
+    act(() => (result.current.cardProps(1, null, false) as Props).onDragStart(dragEvent()));
+
+    const zone = () => result.current.zoneProps('group:A', 'A') as Props;
+    act(() => zone().onDragEnter(dragEvent())); // enter the body
+    act(() => zone().onDragEnter(dragEvent())); // enter a card inside it
+    expect(result.current.overKey).toBe('group:A');
+
+    act(() => zone().onDragLeave(dragEvent())); // leave the card, still inside
+    expect(result.current.overKey).toBe('group:A');
+
+    act(() => zone().onDragLeave(dragEvent())); // now leave the body
+    expect(result.current.overKey).toBeNull();
+  });
+
+  it('calls preventDefault on dragover, or the browser refuses the drop', () => {
+    const { result } = renderHook(() => useAutomationDnd(vi.fn()));
+    act(() => (result.current.cardProps(1, null, false) as Props).onDragStart(dragEvent()));
+
+    const e = dragEvent();
+    act(() => (result.current.zoneProps('group:A', 'A') as Props).onDragOver(e));
+    expect(e.preventDefault).toHaveBeenCalled();
+  });
+
+  it('ignores drag events when nothing is being dragged', () => {
+    const onDrop = vi.fn();
+    const { result } = renderHook(() => useAutomationDnd(onDrop));
+    const e = dragEvent();
+
+    act(() => (result.current.zoneProps('group:A', 'A') as Props).onDragOver(e));
+    act(() => (result.current.zoneProps('group:A', 'A') as Props).onDrop(dragEvent()));
+
+    expect(e.preventDefault).not.toHaveBeenCalled();
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it('reports the dragging card and clears state on dragend', () => {
+    const { result } = renderHook(() => useAutomationDnd(vi.fn()));
+    act(() => (result.current.cardProps(9, null, false) as Props).onDragStart(dragEvent()));
+    expect(result.current.dragging).toBe(true);
+    expect(result.current.isDraggingCard(9)).toBe(true);
+
+    act(() => (result.current.cardProps(9, null, false) as Props).onDragEnd(dragEvent()));
+    expect(result.current.dragging).toBe(false);
+    expect(result.current.isDraggingCard(9)).toBe(false);
+    expect(result.current.overKey).toBeNull();
+  });
+});

--- a/webui/src/routes/automations/-automations.dnd.ts
+++ b/webui/src/routes/automations/-automations.dnd.ts
@@ -1,0 +1,119 @@
+import { useCallback, useRef, useState } from 'react';
+
+/** The card currently being dragged, and the group it came from. */
+export interface AutomationDrag {
+  id: number;
+  groupName: string | null;
+}
+
+/**
+ * Drag a card between group sections.
+ *
+ * Mirrors the vanilla behaviour: only non-system cards are draggable, only
+ * non-protected section bodies accept a drop, protected sections are dimmed
+ * while a drag is in flight, and a collapsed section expands after hovering
+ * over it for a moment.
+ *
+ * The enter/leave counter is the important detail. dragenter and dragleave
+ * both fire for CHILD elements, so a naive handler clears the highlight the
+ * moment the pointer crosses a card inside the drop zone. Counting keeps the
+ * zone lit until the pointer genuinely leaves it.
+ */
+export const DRAG_EXPAND_MS = 500;
+
+export function useAutomationDnd(onDrop: (drag: AutomationDrag, toGroup: string | null) => void) {
+  const [drag, setDrag] = useState<AutomationDrag | null>(null);
+  // Which section body is lit. One at a time, so this is a single value rather
+  // than per-section state.
+  const [over, setOver] = useState<string | null>(null);
+  const enterCount = useRef(0);
+  const expandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearExpandTimer = () => {
+    if (expandTimer.current) {
+      clearTimeout(expandTimer.current);
+      expandTimer.current = null;
+    }
+  };
+
+  const cardProps = useCallback((id: number, groupName: string | null, isSystem: boolean) => {
+    // System automations are not movable — they live in the protected section.
+    if (isSystem) return {};
+    return {
+      draggable: true,
+      onDragStart: (e: React.DragEvent) => {
+        setDrag({ id, groupName });
+        e.dataTransfer.setData('text/plain', String(id));
+        e.dataTransfer.effectAllowed = 'move';
+      },
+      onDragEnd: () => {
+        setDrag(null);
+        setOver(null);
+        enterCount.current = 0;
+        clearExpandTimer();
+      },
+    };
+  }, []);
+
+  const zoneProps = useCallback(
+    (
+      sectionKey: string,
+      groupName: string | null,
+      opts: { isProtected?: boolean; onExpand?: () => void } = {},
+    ) => {
+      // Protected sections (System, Hub) are never drop targets.
+      if (opts.isProtected) return {};
+      return {
+        onDragOver: (e: React.DragEvent) => {
+          if (!drag) return;
+          // Without preventDefault the browser refuses the drop outright.
+          e.preventDefault();
+          e.dataTransfer.dropEffect = 'move';
+        },
+        onDragEnter: () => {
+          if (!drag) return;
+          enterCount.current += 1;
+          setOver(sectionKey);
+          if (opts.onExpand && !expandTimer.current) {
+            expandTimer.current = setTimeout(() => {
+              expandTimer.current = null;
+              opts.onExpand?.();
+            }, DRAG_EXPAND_MS);
+          }
+        },
+        onDragLeave: () => {
+          if (!drag) return;
+          enterCount.current -= 1;
+          if (enterCount.current <= 0) {
+            enterCount.current = 0;
+            setOver(null);
+            clearExpandTimer();
+          }
+        },
+        onDrop: (e: React.DragEvent) => {
+          e.preventDefault();
+          setOver(null);
+          enterCount.current = 0;
+          clearExpandTimer();
+          const dragged = drag;
+          setDrag(null);
+          if (!dragged) return;
+          // Dropping a card back in its own group is a no-op, not a PUT.
+          if (dragged.groupName === groupName) return;
+          onDrop(dragged, groupName);
+        },
+      };
+    },
+    [drag, onDrop],
+  );
+
+  return {
+    /** Truthy while a drag is in flight — protected sections dim on this. */
+    dragging: drag !== null,
+    /** Section key currently lit as a drop target. */
+    overKey: over,
+    isDraggingCard: (id: number) => drag?.id === id,
+    cardProps,
+    zoneProps,
+  };
+}

--- a/webui/src/routes/automations/-automations.format.test.ts
+++ b/webui/src/routes/automations/-automations.format.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  automationMeta,
+  formatAction,
+  formatTrigger,
+  humanizeType,
+  lastResultFacts,
+  parseServerTime,
+  timeAgo,
+  timeUntil,
+} from './-automations.format';
+
+// Every clock-dependent assertion passes `now` explicitly. A test that reads
+// the real clock is a time bomb — tests/library/test_expired_cleanup.py went
+// red on 2026-07-27 for exactly that reason, months after it was written.
+const NOW = Date.parse('2026-07-27T12:00:00Z');
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+const ahead = (ms: number) => new Date(NOW + ms).toISOString();
+
+describe('parseServerTime', () => {
+  it('reads a naive SQLite datetime as UTC, not local', () => {
+    // The whole point: `new Date('2026-07-27 12:00:00')` is LOCAL time, so on
+    // any machine east or west of UTC every relative label would be skewed.
+    expect(parseServerTime('2026-07-27 12:00:00')).toBe(Date.parse('2026-07-27T12:00:00Z'));
+  });
+
+  it('respects an explicit zone', () => {
+    expect(parseServerTime('2026-07-27T12:00:00Z')).toBe(Date.parse('2026-07-27T12:00:00Z'));
+    expect(parseServerTime('2026-07-27T13:00:00+01:00')).toBe(Date.parse('2026-07-27T12:00:00Z'));
+  });
+});
+
+describe('timeAgo', () => {
+  it('says Never when unset', () => {
+    expect(timeAgo(null, NOW)).toBe('Never');
+    expect(timeAgo(undefined, NOW)).toBe('Never');
+    expect(timeAgo('', NOW)).toBe('Never');
+  });
+
+  it('walks the buckets', () => {
+    expect(timeAgo(ago(30_000), NOW)).toBe('just now');
+    expect(timeAgo(ago(5 * 60_000), NOW)).toBe('5m ago');
+    expect(timeAgo(ago(3 * 3_600_000), NOW)).toBe('3h ago');
+    expect(timeAgo(ago(2 * 86_400_000), NOW)).toBe('2d ago');
+  });
+
+  it('floors, so a boundary never reads as the larger unit', () => {
+    expect(timeAgo(ago(59_999), NOW)).toBe('just now');
+    expect(timeAgo(ago(60_000), NOW)).toBe('1m ago');
+    expect(timeAgo(ago(3_599_999), NOW)).toBe('59m ago');
+  });
+});
+
+describe('timeUntil', () => {
+  it('is empty when unset and "soon" once due', () => {
+    expect(timeUntil(null, NOW)).toBe('');
+    expect(timeUntil(ago(1000), NOW)).toBe('soon');
+    expect(timeUntil(new Date(NOW).toISOString(), NOW)).toBe('soon');
+  });
+
+  it('rounds seconds and minutes UP so a pending run never shows "in 0m"', () => {
+    expect(timeUntil(ahead(500), NOW)).toBe('in 1s');
+    expect(timeUntil(ahead(61_000), NOW)).toBe('in 2m');
+  });
+
+  it('rounds hours and days to nearest', () => {
+    expect(timeUntil(ahead(110 * 60_000), NOW)).toBe('in 2h');
+    expect(timeUntil(ahead(36 * 3_600_000), NOW)).toBe('in 2d');
+  });
+});
+
+describe('humanizeType', () => {
+  it('strips the side prefix and title-cases', () => {
+    expect(humanizeType('video_deep_scan_tv')).toBe('Deep Scan Tv');
+    expect(humanizeType('run_duplicate_cleaner')).toBe('Run Duplicate Cleaner');
+  });
+
+  it('never returns raw snake_case or an empty label', () => {
+    expect(humanizeType('')).toBe('Unknown');
+    expect(humanizeType(null)).toBe('Unknown');
+    expect(humanizeType('video_')).toBe('Unknown');
+  });
+});
+
+describe('formatTrigger', () => {
+  it('renders schedule, daily and weekly from config', () => {
+    expect(formatTrigger('schedule', { interval: 6, unit: 'hours' })).toBe('Every 6 hours');
+    expect(formatTrigger('daily_time', { time: '03:30' })).toBe('Daily at 03:30');
+    expect(formatTrigger('weekly_time', { days: ['mon', 'fri'], time: '09:00' })).toBe(
+      'Mon, Fri at 09:00',
+    );
+  });
+
+  it('falls back within schedule/weekly when config keys are missing', () => {
+    expect(formatTrigger('schedule', {})).toBe('Every 1 hours');
+    expect(formatTrigger('weekly_time', {})).toBe('Every day at 00:00');
+  });
+
+  it('uses the label map for event triggers', () => {
+    expect(formatTrigger('watchlist_new_release', null)).toBe('New Release Found');
+  });
+
+  it('prefers the map over block definitions, then falls back to them', () => {
+    const block = (t: string) => (t === 'watchlist_new_release' ? 'WRONG' : `Block ${t}`);
+    expect(formatTrigger('watchlist_new_release', null, block)).toBe('New Release Found');
+    expect(formatTrigger('webhook_received', null, block)).toBe('Block webhook_received');
+  });
+
+  it('humanizes an unknown type rather than showing the identifier', () => {
+    expect(formatTrigger('video_something_new', null)).toBe('Something New');
+  });
+});
+
+describe('formatAction', () => {
+  it('maps known music and video actions', () => {
+    expect(formatAction('process_wishlist')).toBe('Process Wishlist');
+    expect(formatAction('video_scan_library')).toBe('Scan Video Library');
+  });
+
+  it('falls back to block label then humanize', () => {
+    expect(formatAction('mystery_action', (t) => `Block ${t}`)).toBe('Block mystery_action');
+    expect(formatAction('mystery_action')).toBe('Mystery Action');
+  });
+});
+
+describe('lastResultFacts', () => {
+  it('returns null for non-objects', () => {
+    expect(lastResultFacts(null)).toBeNull();
+    expect(lastResultFacts('done')).toBeNull();
+    expect(lastResultFacts([1, 2])).toBeNull();
+  });
+
+  it('skips status, underscore keys, zeros and empty strings', () => {
+    expect(
+      lastResultFacts({ status: 'ok', _internal: 5, downloaded: 0, note: '', zero: '0' }),
+    ).toBeNull();
+  });
+
+  it('keeps at most three facts and underscores read as spaces', () => {
+    const out = lastResultFacts({ tracks_added: 4, albums_found: 2, artists: 1, extra: 9 });
+    expect(out?.full).toBe('tracks added: 4 · albums found: 2 · artists: 1');
+  });
+
+  it('drops long strings but keeps short ones', () => {
+    expect(lastResultFacts({ mode: 'x'.repeat(25) })).toBeNull();
+    expect(lastResultFacts({ mode: 'quick' })?.full).toBe('mode: quick');
+  });
+
+  it('truncates the shown text at 64 chars but keeps the full text', () => {
+    const out = lastResultFacts({ alpha_key: 'a'.repeat(24), beta_key: 'b'.repeat(24) });
+    expect(out!.full.length).toBeGreaterThan(64);
+    expect(out!.shown.length).toBeLessThanOrEqual(64);
+    expect(out!.shown.endsWith('…')).toBe(true);
+    expect(out!.full.endsWith('…')).toBe(false);
+  });
+});
+
+describe('automationMeta', () => {
+  const base = { id: 1, name: 'a' };
+
+  it('shows a countdown only for enabled timer triggers', () => {
+    const next = ahead(3_600_000);
+    expect(
+      automationMeta({ ...base, trigger_type: 'schedule', enabled: 1, next_run: next }, NOW)
+        .nextRun,
+    ).toBe('in 1h');
+    // disabled -> no countdown, because it is not going to run
+    expect(
+      automationMeta({ ...base, trigger_type: 'schedule', enabled: 0, next_run: next }, NOW)
+        .nextRun,
+    ).toBeUndefined();
+    // event-driven -> no countdown even with a next_run value
+    expect(
+      automationMeta({ ...base, trigger_type: 'app_started', enabled: 1, next_run: next }, NOW)
+        .nextRun,
+    ).toBeUndefined();
+  });
+
+  it('marks event-driven automations as Listening, and timers not', () => {
+    expect(
+      automationMeta({ ...base, trigger_type: 'app_started', enabled: 1 }, NOW).listening,
+    ).toBe(true);
+    expect(automationMeta({ ...base, trigger_type: 'schedule', enabled: 1 }, NOW).listening).toBe(
+      false,
+    );
+    expect(
+      automationMeta({ ...base, trigger_type: 'app_started', enabled: 0 }, NOW).listening,
+    ).toBe(false);
+  });
+
+  it('lets an error replace the result summary', () => {
+    const meta = automationMeta({ ...base, last_error: 'boom', last_result: { tracks: 3 } }, NOW);
+    expect(meta.error).toBe('boom');
+    expect(meta.result).toBeUndefined();
+  });
+
+  it('drops a zero run_count rather than showing "Runs: 0"', () => {
+    expect(automationMeta({ ...base, run_count: 0 }, NOW).runs).toBeUndefined();
+    expect(automationMeta({ ...base, run_count: 3 }, NOW).runs).toBe(3);
+  });
+});

--- a/webui/src/routes/automations/-automations.format.ts
+++ b/webui/src/routes/automations/-automations.format.ts
@@ -1,4 +1,4 @@
-import type { Automation } from './-automations.types';
+import { type Automation, type AutomationBlocks, BLOCK_CATEGORIES } from './-automations.types';
 
 /**
  * Parse a server timestamp as UTC.
@@ -223,5 +223,27 @@ export function automationMeta(
     // `?? undefined` because lastResultFacts returns null for "nothing worth
     // showing", while every other field here uses undefined for absent.
     result: a.last_error ? undefined : (lastResultFacts(a.last_result) ?? undefined),
+  };
+}
+
+/**
+ * Label for a type that the static maps do not cover — video triggers,
+ * monthly_time, webhook_received and anything shipped later.
+ *
+ * Mirrors _findBlockDef: searches triggers, then actions, then notifications,
+ * and returns the first match. Returns undefined so callers fall through to
+ * humanizeType, which is the vanilla precedence (map, then block def, then
+ * humanized).
+ */
+export function blockLabelLookup(
+  blocks: AutomationBlocks | undefined,
+): (type: string) => string | undefined {
+  return (type: string) => {
+    if (!blocks || !type) return undefined;
+    for (const category of BLOCK_CATEGORIES) {
+      const found = blocks[category]?.find((b) => b.type === type);
+      if (found?.label) return found.label;
+    }
+    return undefined;
   };
 }

--- a/webui/src/routes/automations/-automations.format.ts
+++ b/webui/src/routes/automations/-automations.format.ts
@@ -1,0 +1,227 @@
+import type { Automation } from './-automations.types';
+
+/**
+ * Parse a server timestamp as UTC.
+ *
+ * The API hands back SQLite datetimes with no zone ("2026-07-27 02:10:37").
+ * `new Date(naive)` reads those as LOCAL time, so every relative label is wrong
+ * by the viewer's offset — "2h ago" for something that just ran. Timestamps
+ * that already carry a zone are parsed as-is.
+ */
+export function parseServerTime(ts: string): number {
+  if (/[Zz]$/.test(ts) || /[+-]\d{2}:\d{2}$/.test(ts)) return new Date(ts).getTime();
+  return new Date(`${ts}Z`).getTime();
+}
+
+/** "just now" / "5m ago" / "3h ago" / "2d ago"; "Never" when unset. */
+export function timeAgo(ts: string | null | undefined, now: number = Date.now()): string {
+  if (!ts) return 'Never';
+  const d = (now - parseServerTime(ts)) / 1000;
+  if (d < 60) return 'just now';
+  if (d < 3600) return `${Math.floor(d / 60)}m ago`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h ago`;
+  return `${Math.floor(d / 86400)}d ago`;
+}
+
+/**
+ * "in 30s" / "in 5m" / "in 2h" / "in 3d"; "soon" once due, "" when unset.
+ *
+ * Seconds and minutes round UP and hours/days round to NEAREST — that asymmetry
+ * is deliberate in the original: a countdown that reads "in 0m" while still
+ * waiting looks broken, but "in 2h" for 1h50m does not.
+ */
+export function timeUntil(ts: string | null | undefined, now: number = Date.now()): string {
+  if (!ts) return '';
+  const d = (parseServerTime(ts) - now) / 1000;
+  if (d <= 0) return 'soon';
+  if (d < 60) return `in ${Math.ceil(d)}s`;
+  if (d < 3600) return `in ${Math.ceil(d / 60)}m`;
+  if (d < 86400) return `in ${Math.round(d / 3600)}h`;
+  return `in ${Math.round(d / 86400)}d`;
+}
+
+/** Last-resort label: 'video_deep_scan_tv' -> 'Deep Scan Tv'. Never show raw snake_case. */
+export function humanizeType(type: string | null | undefined): string {
+  return (
+    String(type || '')
+      .replace(/^(video|music)_/, '')
+      .split('_')
+      .filter(Boolean)
+      .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+      .join(' ') || 'Unknown'
+  );
+}
+
+/**
+ * The compact "last run" summary on a card.
+ *
+ * Up to three scalar facts from last_result; full detail lives in the history
+ * modal. `status` is skipped because the status dot already says it, and `_`
+ * keys are internal. Zero numbers and the strings '' / '0' are dropped as
+ * noise, and strings over 24 chars are too long to sit on one line.
+ *
+ * Truncation is done HERE at a fixed length rather than in CSS: the original
+ * tried two CSS approaches and both failed differently, so the cut is
+ * deterministic and layout-independent. Callers put `full` in the tooltip.
+ */
+export function lastResultFacts(lastResult: unknown): { shown: string; full: string } | null {
+  // The vanilla check was `typeof === 'object'`, which lets an ARRAY through
+  // and renders index-keyed nonsense ("0: foo · 1: bar"). Results are always
+  // dicts, so this cannot trigger in practice; rejecting arrays is a
+  // deliberate, strictly-safer deviation rather than an oversight.
+  if (!lastResult || typeof lastResult !== 'object' || Array.isArray(lastResult)) return null;
+
+  const facts = Object.entries(lastResult as Record<string, unknown>)
+    .filter(
+      ([k, v]) =>
+        k !== 'status' &&
+        !k.startsWith('_') &&
+        ((typeof v === 'number' && v !== 0) ||
+          (typeof v === 'string' && v.length <= 24 && v !== '' && v !== '0')),
+    )
+    .slice(0, 3)
+    .map(([k, v]) => `${k.replace(/_/g, ' ')}: ${String(v).replace(/_/g, ' ')}`);
+
+  if (!facts.length) return null;
+  const full = facts.join(' · ');
+  const shown = full.length > 64 ? `${full.slice(0, 61).trimEnd()}…` : full;
+  return { shown, full };
+}
+
+/** Triggers driven by a timer — these are the only ones that show "Next:". */
+export const TIMER_TRIGGERS = ['schedule', 'daily_time', 'weekly_time', 'monthly_time'] as const;
+
+export function isTimerTrigger(type: string | null | undefined): boolean {
+  return (TIMER_TRIGGERS as readonly string[]).includes(type ?? '');
+}
+
+const TRIGGER_LABELS: Record<string, string> = {
+  app_started: 'App Started',
+  track_downloaded: 'Track Downloaded',
+  batch_complete: 'Batch Complete',
+  watchlist_new_release: 'New Release Found',
+  playlist_synced: 'Playlist Synced',
+  playlist_changed: 'Playlist Changed',
+  discovery_completed: 'Discovery Complete',
+  wishlist_processing_completed: 'Wishlist Processed',
+  watchlist_scan_completed: 'Watchlist Scan Done',
+  database_update_completed: 'Database Updated',
+  download_failed: 'Download Failed',
+  download_quarantined: 'File Quarantined',
+  wishlist_item_added: 'Wishlist Item Added',
+  watchlist_artist_added: 'Artist Watched',
+  watchlist_artist_removed: 'Artist Unwatched',
+  import_completed: 'Import Complete',
+  mirrored_playlist_created: 'Playlist Mirrored',
+  quality_scan_completed: 'Quality Scan Done',
+  duplicate_scan_completed: 'Duplicate Scan Done',
+  library_scan_completed: 'Library Scan Done',
+  signal_received: 'Signal Received',
+};
+
+/**
+ * Human label for a trigger.
+ *
+ * `blockLabel` supplies the label for anything not in the map — video triggers,
+ * monthly_time, webhook_received — from the fetched block definitions. Mapped
+ * labels always win, matching the vanilla precedence.
+ */
+export function formatTrigger(
+  type: string | null | undefined,
+  config: Record<string, unknown> | null | undefined,
+  blockLabel?: (type: string) => string | undefined,
+): string {
+  const cfg = (config ?? {}) as Record<string, unknown>;
+
+  if (type === 'schedule' && config) {
+    return `Every ${cfg.interval ?? 1} ${cfg.unit ?? 'hours'}`;
+  }
+  if (type === 'daily_time' && config) {
+    return `Daily at ${cfg.time ?? '00:00'}`;
+  }
+  if (type === 'weekly_time' && config) {
+    const days = (Array.isArray(cfg.days) ? (cfg.days as string[]) : [])
+      .map((d) => d.charAt(0).toUpperCase() + d.slice(1))
+      .join(', ');
+    return `${days || 'Every day'} at ${cfg.time ?? '00:00'}`;
+  }
+  if (type === 'signal_received' && config) {
+    return `Signal: ${cfg.signal_name ?? 'unknown'}`;
+  }
+  return TRIGGER_LABELS[type ?? ''] ?? blockLabel?.(type ?? '') ?? humanizeType(type);
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  process_wishlist: 'Process Wishlist',
+  scan_watchlist: 'Scan Watchlist',
+  scan_library: 'Scan Library',
+  refresh_mirrored: 'Refresh Mirrored',
+  sync_playlist: 'Sync Playlist',
+  discover_playlist: 'Discover Playlist',
+  notify_only: 'Notify Only',
+  start_database_update: 'Update Database',
+  run_duplicate_cleaner: 'Run Duplicate Cleaner',
+  clear_quarantine: 'Clear Quarantine',
+  cleanup_wishlist: 'Clean Up Wishlist',
+  update_discovery_pool: 'Update Discovery',
+  start_quality_scan: 'Run Quality Scan',
+  backup_database: 'Backup Database',
+  refresh_beatport_cache: 'Refresh Beatport Cache',
+  clean_search_history: 'Clean Search History',
+  clean_completed_downloads: 'Clean Completed Downloads',
+  full_cleanup: 'Full Cleanup',
+  playlist_pipeline: 'Playlist Pipeline',
+  video_scan_library: 'Scan Video Library',
+  video_scan_server: 'Scan Video Server',
+  video_update_database: 'Update Video Database',
+  video_update_database_hourly: 'Update Video Database (Hourly)',
+  video_add_airing_episodes: 'Wishlist Airing Episodes',
+  video_deep_scan_movies: 'Deep Scan Movie Library',
+  video_deep_scan_tv: 'Deep Scan TV Library',
+  video_scan_watchlist_people: 'Scan Watchlist People',
+  video_scan_watchlist_studios: 'Scan Watchlist Studios',
+  video_scan_watchlist_channels: 'Scan Watchlist Channels',
+  video_scan_watchlist_playlists: 'Scan Watchlist Playlists',
+  video_process_movie_wishlist: 'Process Movie Wishlist',
+  video_process_episode_wishlist: 'Process Episode Wishlist',
+  video_process_youtube_wishlist: 'Process YouTube Wishlist',
+  video_refresh_airing_schedules: 'Refresh Airing Schedules',
+  video_reenrich_stale: 'Refresh Stale Metadata',
+  video_clean_youtube_episodes: 'Clean Old YouTube Episodes',
+};
+
+export function formatAction(
+  type: string | null | undefined,
+  blockLabel?: (type: string) => string | undefined,
+): string {
+  return ACTION_LABELS[type ?? ''] ?? blockLabel?.(type ?? '') ?? humanizeType(type);
+}
+
+/** The meta line under a card name, already ordered the way the card renders it. */
+export function automationMeta(
+  a: Automation,
+  now: number = Date.now(),
+): {
+  lastRun?: string;
+  nextRun?: string;
+  listening: boolean;
+  runs?: number;
+  error?: string;
+  result?: { shown: string; full: string };
+} {
+  const enabled = a.enabled === true || a.enabled === 1;
+  const timer = isTimerTrigger(a.trigger_type);
+  return {
+    lastRun: a.last_run ? timeAgo(a.last_run, now) : undefined,
+    nextRun: a.next_run && enabled && timer ? timeUntil(a.next_run, now) : undefined,
+    // Event-driven automations advertise that they are armed; timer ones show
+    // a countdown instead, so the two are mutually exclusive.
+    listening: !timer && enabled,
+    runs: a.run_count || undefined,
+    error: a.last_error || undefined,
+    // An error replaces the result summary rather than joining it.
+    // `?? undefined` because lastResultFacts returns null for "nothing worth
+    // showing", while every other field here uses undefined for absent.
+    result: a.last_error ? undefined : (lastResultFacts(a.last_result) ?? undefined),
+  };
+}

--- a/webui/src/routes/automations/-automations.helpers.test.ts
+++ b/webui/src/routes/automations/-automations.helpers.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildAutomationsView,
+  filterAutomations,
+  forMusicSide,
+  readAutomationsList,
+} from './-automations.helpers';
+import { AUTO_FILTER_BAR_MIN, type Automation } from './-automations.types';
+
+function auto(over: Partial<Automation> & { id: number }): Automation {
+  return { name: `auto-${over.id}`, ...over };
+}
+
+describe('readAutomationsList', () => {
+  it('returns the array on success', () => {
+    expect(readAutomationsList([auto({ id: 1 })])).toHaveLength(1);
+  });
+
+  it('reads an {error} payload as empty rather than throwing', () => {
+    // The vanilla page rendered the empty state on error; it never blanked
+    // the shell or threw past the handler.
+    expect(readAutomationsList({ error: 'boom' })).toEqual([]);
+    expect(readAutomationsList(undefined)).toEqual([]);
+  });
+});
+
+describe('forMusicSide', () => {
+  it("drops the video side's rows", () => {
+    const rows = [
+      auto({ id: 1 }),
+      auto({ id: 2, owned_by: 'video' }),
+      auto({ id: 3, owned_by: 'music' }),
+    ];
+    expect(forMusicSide(rows).map((a) => a.id)).toEqual([1, 3]);
+  });
+
+  it('keeps rows with no owner — pre-migration rows predate the column', () => {
+    expect(forMusicSide([auto({ id: 1, owned_by: null })]).map((a) => a.id)).toEqual([1]);
+  });
+});
+
+describe('buildAutomationsView', () => {
+  it('splits system from user automations', () => {
+    const view = buildAutomationsView([auto({ id: 1, is_system: true }), auto({ id: 2 })]);
+    expect(view.system.map((a) => a.id)).toEqual([1]);
+    expect(view.ungrouped.map((a) => a.id)).toEqual([2]);
+  });
+
+  it('treats SQLite 1/0 as booleans', () => {
+    // enabled and is_system are INTEGER columns; a plain truthiness check on
+    // `=== true` would classify every real row as user-owned and disabled.
+    const view = buildAutomationsView([
+      auto({ id: 1, is_system: 1, enabled: 1 }),
+      auto({ id: 2, is_system: 0, enabled: 0 }),
+    ]);
+    expect(view.system.map((a) => a.id)).toEqual([1]);
+    expect(view.stats.active).toBe(1);
+  });
+
+  it('groups user automations by name, groups sorted', () => {
+    const view = buildAutomationsView([
+      auto({ id: 1, group_name: 'Zed' }),
+      auto({ id: 2, group_name: 'Alpha' }),
+      auto({ id: 3, group_name: 'Zed' }),
+      auto({ id: 4 }),
+    ]);
+    expect(view.groups.map((g) => g.name)).toEqual(['Alpha', 'Zed']);
+    // Order WITHIN a group is API order, because the vanilla page sorted the
+    // distinct names and then filtered — it never re-sorted the rows.
+    expect(view.groups[1].automations.map((a) => a.id)).toEqual([1, 3]);
+    expect(view.ungrouped.map((a) => a.id)).toEqual([4]);
+  });
+
+  it('never files a system automation under a group', () => {
+    // is_system wins: a seeded row carrying a group_name still belongs in the
+    // protected System section, which is what stops it being editable.
+    const view = buildAutomationsView([auto({ id: 1, is_system: 1, group_name: 'Alpha' })]);
+    expect(view.system.map((a) => a.id)).toEqual([1]);
+    expect(view.groups).toEqual([]);
+  });
+
+  it('counts stats over the whole list', () => {
+    const view = buildAutomationsView([
+      auto({ id: 1, is_system: 1, enabled: 1 }),
+      auto({ id: 2, enabled: 1 }),
+      auto({ id: 3, enabled: 0 }),
+    ]);
+    expect(view.stats).toEqual({ active: 2, system: 1, custom: 2, total: 3 });
+  });
+
+  it('shows the filter bar only at the vanilla threshold', () => {
+    const many = (n: number) => Array.from({ length: n }, (_, i) => auto({ id: i }));
+    expect(buildAutomationsView(many(AUTO_FILTER_BAR_MIN - 1)).showFilterBar).toBe(false);
+    expect(buildAutomationsView(many(AUTO_FILTER_BAR_MIN)).showFilterBar).toBe(true);
+  });
+});
+
+describe('filterAutomations', () => {
+  const rows = [
+    auto({ id: 1, name: 'Nightly wishlist' }),
+    auto({ id: 2, name: 'Scan', action_type: 'process_wishlist' }),
+    auto({ id: 3, name: 'Other', trigger_type: 'schedule', group_name: 'Chores' }),
+  ];
+
+  it('returns everything for an empty or blank query', () => {
+    expect(filterAutomations(rows, '')).toHaveLength(3);
+    expect(filterAutomations(rows, '   ')).toHaveLength(3);
+  });
+
+  it('matches name, action, trigger and group, case-insensitively', () => {
+    expect(filterAutomations(rows, 'WISHLIST').map((a) => a.id)).toEqual([1, 2]);
+    expect(filterAutomations(rows, 'schedule').map((a) => a.id)).toEqual([3]);
+    expect(filterAutomations(rows, 'chores').map((a) => a.id)).toEqual([3]);
+  });
+
+  it('does not crash on rows missing the optional columns', () => {
+    expect(filterAutomations([auto({ id: 9, name: 'x' })], 'zzz')).toEqual([]);
+  });
+});

--- a/webui/src/routes/automations/-automations.helpers.test.ts
+++ b/webui/src/routes/automations/-automations.helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAutomationsView,
   filterAutomations,
+  filterOptions,
   forMusicSide,
   readAutomationsList,
 } from './-automations.helpers';
@@ -97,24 +98,70 @@ describe('buildAutomationsView', () => {
 });
 
 describe('filterAutomations', () => {
+  // The vanilla filter read the RENDERED label text off the card, so the tests
+  // feed labels rather than raw types.
+  const labelFor = (a: Automation) => ({
+    trigger: a.trigger_type === 'schedule' ? 'Every 6 hours' : 'New Release Found',
+    action: a.action_type === 'process_wishlist' ? 'Process Wishlist' : 'Scan Library',
+  });
   const rows = [
-    auto({ id: 1, name: 'Nightly wishlist' }),
-    auto({ id: 2, name: 'Scan', action_type: 'process_wishlist' }),
-    auto({ id: 3, name: 'Other', trigger_type: 'schedule', group_name: 'Chores' }),
+    auto({ id: 1, name: 'Nightly', trigger_type: 'schedule', action_type: 'process_wishlist' }),
+    auto({
+      id: 2,
+      name: 'Scan',
+      trigger_type: 'watchlist_new_release',
+      action_type: 'scan_library',
+    }),
+    auto({
+      id: 3,
+      name: 'Other',
+      trigger_type: 'schedule',
+      action_type: 'scan_library',
+      group_name: 'Chores',
+    }),
   ];
+  const ids = (f: Parameters<typeof filterAutomations>[1]) =>
+    filterAutomations(rows, f, labelFor).map((a) => a.id);
 
-  it('returns everything for an empty or blank query', () => {
-    expect(filterAutomations(rows, '')).toHaveLength(3);
-    expect(filterAutomations(rows, '   ')).toHaveLength(3);
+  it('returns everything when nothing is set', () => {
+    expect(ids({})).toEqual([1, 2, 3]);
+    expect(ids({ q: '   ' })).toEqual([1, 2, 3]);
   });
 
-  it('matches name, action, trigger and group, case-insensitively', () => {
-    expect(filterAutomations(rows, 'WISHLIST').map((a) => a.id)).toEqual([1, 2]);
-    expect(filterAutomations(rows, 'schedule').map((a) => a.id)).toEqual([3]);
-    expect(filterAutomations(rows, 'chores').map((a) => a.id)).toEqual([3]);
+  it('matches the rendered label, not the raw type', () => {
+    // 'process wishlist' with a SPACE only exists in the label; the raw type is
+    // process_wishlist, so a raw-type match would miss this.
+    expect(ids({ q: 'process wishlist' })).toEqual([1]);
+    expect(ids({ q: 'new release' })).toEqual([2]);
   });
 
-  it('does not crash on rows missing the optional columns', () => {
-    expect(filterAutomations([auto({ id: 9, name: 'x' })], 'zzz')).toEqual([]);
+  it('matches the name case-insensitively', () => {
+    expect(ids({ q: 'NIGHTLY' })).toEqual([1]);
+  });
+
+  it('does NOT search group names, matching the vanilla filter', () => {
+    expect(ids({ q: 'chores' })).toEqual([]);
+  });
+
+  it('matches the dropdowns on the exact raw type', () => {
+    expect(ids({ trigger: 'schedule' })).toEqual([1, 3]);
+    expect(ids({ action: 'scan_library' })).toEqual([2, 3]);
+  });
+
+  it('ANDs the three controls together', () => {
+    expect(ids({ q: 'other', trigger: 'schedule', action: 'scan_library' })).toEqual([3]);
+    expect(ids({ q: 'other', trigger: 'watchlist_new_release' })).toEqual([]);
+  });
+});
+
+describe('filterOptions', () => {
+  it('lists distinct types, sorted, ignoring blanks', () => {
+    const out = filterOptions([
+      auto({ id: 1, trigger_type: 'schedule', action_type: 'scan_library' }),
+      auto({ id: 2, trigger_type: 'app_started', action_type: 'scan_library' }),
+      auto({ id: 3 }),
+    ]);
+    expect(out.triggers).toEqual(['app_started', 'schedule']);
+    expect(out.actions).toEqual(['scan_library']);
   });
 });

--- a/webui/src/routes/automations/-automations.helpers.ts
+++ b/webui/src/routes/automations/-automations.helpers.ts
@@ -69,13 +69,52 @@ export function buildAutomationsView(automations: Automation[]): AutomationsView
   };
 }
 
-/** Filter-bar match: name, plus the action/trigger so "wishlist" finds handlers. */
-export function filterAutomations(automations: Automation[], query: string): Automation[] {
-  const needle = query.toLowerCase().trim();
-  if (!needle) return automations;
-  return automations.filter((a) =>
-    [a.name, a.action_type, a.trigger_type, a.group_name].some((field) =>
-      (field ?? '').toLowerCase().includes(needle),
-    ),
-  );
+/**
+ * The three filter-bar controls, applied together.
+ *
+ * The text box matches the RENDERED labels, not the raw types: _filterAutomations
+ * read `.flow-trigger` / `.flow-action` textContent, so a user typing "process
+ * wishlist" matches the label while the underlying `process_wishlist` is never
+ * what they are aiming at. `labelFor` supplies those strings, keeping this pure
+ * and DOM-free. Group names are deliberately NOT searched — the vanilla filter
+ * did not, and silently widening the match would change what people find.
+ *
+ * The dropdowns compare the raw type exactly, as they did through the card's
+ * data-trigger-type / data-action-type attributes.
+ */
+export function filterAutomations(
+  automations: Automation[],
+  filters: { q?: string; trigger?: string; action?: string },
+  labelFor: (a: Automation) => { trigger: string; action: string },
+): Automation[] {
+  const q = (filters.q ?? '').toLowerCase().trim();
+  const trigger = filters.trigger ?? '';
+  const action = filters.action ?? '';
+  if (!q && !trigger && !action) return automations;
+
+  return automations.filter((a) => {
+    const labels = labelFor(a);
+    const matchesQuery =
+      !q ||
+      (a.name ?? '').toLowerCase().includes(q) ||
+      labels.trigger.toLowerCase().includes(q) ||
+      labels.action.toLowerCase().includes(q);
+    return (
+      matchesQuery &&
+      (!trigger || (a.trigger_type ?? '') === trigger) &&
+      (!action || (a.action_type ?? '') === action)
+    );
+  });
+}
+
+/** Distinct trigger/action types, sorted — the two dropdowns' option lists. */
+export function filterOptions(automations: Automation[]): {
+  triggers: string[];
+  actions: string[];
+} {
+  const triggers = [...new Set(automations.map((a) => a.trigger_type ?? ''))].filter(Boolean);
+  const actions = [...new Set(automations.map((a) => a.action_type ?? ''))].filter(Boolean);
+  triggers.sort();
+  actions.sort();
+  return { triggers, actions };
 }

--- a/webui/src/routes/automations/-automations.helpers.ts
+++ b/webui/src/routes/automations/-automations.helpers.ts
@@ -1,0 +1,81 @@
+import {
+  AUTO_FILTER_BAR_MIN,
+  type Automation,
+  type AutomationsListResponse,
+  type AutomationsView,
+} from './-automations.types';
+
+/** `enabled` / `is_system` arrive as SQLite ints (0/1), not booleans. */
+function truthy(value: boolean | number | null | undefined): boolean {
+  return value === true || value === 1;
+}
+
+/**
+ * Unwrap GET /api/automations.
+ *
+ * The endpoint returns a bare array on success and `{error}` on failure, and
+ * the vanilla page treated any non-array as empty rather than throwing — a
+ * broken automations list must not blank the page.
+ */
+export function readAutomationsList(payload: AutomationsListResponse | undefined): Automation[] {
+  return Array.isArray(payload) ? payload : [];
+}
+
+/**
+ * Drop the other side's rows.
+ *
+ * The automation engine is app-wide: music and video automations share one
+ * table and ONE endpoint, distinguished only by `owned_by`. The music page
+ * hides 'video' rows and the video page keeps only them. Anyone without the
+ * video side simply has no such rows, so this is a no-op for them.
+ */
+export function forMusicSide(automations: Automation[]): Automation[] {
+  return automations.filter((a) => a.owned_by !== 'video');
+}
+
+/**
+ * Split the list the way the page renders it: System, then named groups in
+ * name order, then the ungrouped remainder.
+ *
+ * Group order is `sort()` on the distinct names — the vanilla page sorted the
+ * names, not the automations, so two groups keep API order internally.
+ */
+export function buildAutomationsView(automations: Automation[]): AutomationsView {
+  const system = automations.filter((a) => truthy(a.is_system));
+  const user = automations.filter((a) => !truthy(a.is_system));
+
+  const names = [...new Set(user.filter((a) => a.group_name).map((a) => a.group_name as string))];
+  names.sort();
+
+  const groups = names
+    .map((name) => ({ name, automations: user.filter((a) => a.group_name === name) }))
+    // A name only reaches here by being present on a row, so this cannot drop
+    // anything today; it mirrors the vanilla `if (groupAutos.length)` guard so
+    // the behaviour survives if grouping ever changes.
+    .filter((group) => group.automations.length > 0);
+
+  return {
+    system,
+    groups,
+    ungrouped: user.filter((a) => !a.group_name),
+    stats: {
+      active: automations.filter((a) => truthy(a.enabled)).length,
+      system: system.length,
+      custom: user.length,
+      total: automations.length,
+    },
+    // Counted over the whole (music-side) list, not per section.
+    showFilterBar: automations.length >= AUTO_FILTER_BAR_MIN,
+  };
+}
+
+/** Filter-bar match: name, plus the action/trigger so "wishlist" finds handlers. */
+export function filterAutomations(automations: Automation[], query: string): Automation[] {
+  const needle = query.toLowerCase().trim();
+  if (!needle) return automations;
+  return automations.filter((a) =>
+    [a.name, a.action_type, a.trigger_type, a.group_name].some((field) =>
+      (field ?? '').toLowerCase().includes(needle),
+    ),
+  );
+}

--- a/webui/src/routes/automations/-automations.icons.test.ts
+++ b/webui/src/routes/automations/-automations.icons.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { AUTOMATION_ICONS, automationIcon, formatNotify } from './-automations.icons';
+
+/**
+ * Parity against the vanilla source, not against my transcription.
+ *
+ * AUTOMATION_ICONS was lifted from _autoIcons in stats-automations.js. The
+ * values are surrogate-pair emoji carrying U+FE0F variation selectors, which
+ * survive a copy/paste looking identical while differing byte-for-byte — so a
+ * hand check proves nothing. This re-evaluates the original object literal and
+ * demands exact equality.
+ *
+ * The vanilla map stays alive after the music page is ported: the VIDEO
+ * automations page renders through renderAutomationCard, which uses it. If
+ * that ever stops being true this test fails loudly, which is the point —
+ * update it deliberately rather than letting the two silently diverge.
+ */
+function vanillaIcons(): Record<string, string> {
+  const src = readFileSync(resolve(process.cwd(), 'static/stats-automations.js'), 'utf8');
+  const PREFIX = 'const _autoIcons = ';
+  const start = src.indexOf(PREFIX);
+  if (start < 0) throw new Error('_autoIcons is gone from stats-automations.js');
+  const end = src.indexOf('\n};', start);
+  const literal = src.slice(start + PREFIX.length, end + 2);
+  // eslint-disable-next-line no-eval -- evaluating a data literal from our own
+  // repo is the only way to resolve JS escapes exactly as the browser does.
+  return eval(`(${literal})`) as Record<string, string>;
+}
+
+describe('automation icons match the vanilla map', () => {
+  it('has exactly the same keys', () => {
+    expect(Object.keys(AUTOMATION_ICONS).sort()).toEqual(Object.keys(vanillaIcons()).sort());
+  });
+
+  it('has byte-identical values, variation selectors included', () => {
+    expect(AUTOMATION_ICONS).toEqual(vanillaIcons());
+  });
+
+  it('carries a real number of icons, so an empty parse cannot pass', () => {
+    // Both sides being {} would satisfy the equality assertions above.
+    expect(Object.keys(AUTOMATION_ICONS).length).toBeGreaterThan(80);
+  });
+});
+
+describe('automationIcon', () => {
+  it('resolves known types', () => {
+    expect(automationIcon('schedule')).toBe(AUTOMATION_ICONS.schedule);
+  });
+
+  it('falls back to the gear for unknown or missing types', () => {
+    expect(automationIcon('not_a_real_type')).toBe('⚙️');
+    expect(automationIcon(null)).toBe('⚙️');
+  });
+});
+
+describe('formatNotify', () => {
+  it('names the notification channels', () => {
+    expect(formatNotify('discord_webhook')).toBe('Discord');
+    expect(formatNotify('telegram')).toBe('Telegram');
+  });
+
+  it('keeps the inline icon on signal and script', () => {
+    expect(formatNotify('fire_signal')).toBe('⚡ Signal');
+    expect(formatNotify('run_script')).toBe('💻 Script');
+  });
+
+  it('passes through anything unmapped, and empty for missing', () => {
+    expect(formatNotify('future_channel')).toBe('future_channel');
+    expect(formatNotify(null)).toBe('');
+  });
+});

--- a/webui/src/routes/automations/-automations.icons.ts
+++ b/webui/src/routes/automations/-automations.icons.ts
@@ -1,0 +1,119 @@
+/**
+ * Trigger/action emoji, lifted verbatim from _autoIcons in stats-automations.js.
+ *
+ * Extracted by evaluating the original object literal rather than retyping it —
+ * the values are surrogate-pair emoji and hand-copying them silently mangles
+ * variation selectors (the U+FE0F suffixes below).
+ */
+export const AUTOMATION_ICONS: Record<string, string> = {
+  schedule: '⏱️',
+  daily_time: '🕰️',
+  weekly_time: '📅',
+  app_started: '🚀',
+  track_downloaded: '⬇️',
+  batch_complete: '✅',
+  watchlist_new_release: '🔔',
+  playlist_synced: '🔄',
+  playlist_changed: '✏️',
+  process_wishlist: '📋',
+  scan_watchlist: '👁️',
+  scan_library: '🔄',
+  refresh_mirrored: '📂',
+  sync_playlist: '🔁',
+  discover_playlist: '🔍',
+  discovery_completed: '🔍',
+  notify_only: '🔔',
+  discord_webhook: '💬',
+  pushbullet: '🔔',
+  telegram: '✉️',
+  webhook: '🌐',
+  signal_received: '⚡',
+  fire_signal: '⚡',
+  run_script: '💻',
+  wishlist_processing_completed: '✅',
+  watchlist_scan_completed: '✅',
+  database_update_completed: '🗄️',
+  download_failed: '❌',
+  download_quarantined: '⚠️',
+  wishlist_item_added: '➕',
+  watchlist_artist_added: '👤',
+  watchlist_artist_removed: '👤',
+  import_completed: '📥',
+  mirrored_playlist_created: '📂',
+  quality_scan_completed: '📊',
+  duplicate_scan_completed: '🗂️',
+  library_scan_completed: '📡',
+  start_database_update: '🗄️',
+  run_duplicate_cleaner: '🗂️',
+  clear_quarantine: '🗑️',
+  cleanup_wishlist: '🧹',
+  update_discovery_pool: '🧭',
+  start_quality_scan: '📊',
+  backup_database: '💾',
+  refresh_beatport_cache: '🎵',
+  clean_search_history: '🗑️',
+  clean_completed_downloads: '✅',
+  full_cleanup: '🧹',
+  playlist_pipeline: '🚀',
+  video_scan_library: '🎬',
+  video_scan_server: '🔄',
+  video_update_database: '🗄️',
+  video_update_database_hourly: '🗄️',
+  video_add_airing_episodes: '📺',
+  video_deep_scan_movies: '🎬',
+  video_deep_scan_tv: '📺',
+  video_scan_watchlist_people: '🎭',
+  video_scan_watchlist_channels: '📡',
+  video_scan_watchlist_playlists: '🎵',
+  video_scan_watchlist_studios: '🎬',
+  video_process_movie_wishlist: '🎬',
+  video_process_episode_wishlist: '📺',
+  video_process_youtube_wishlist: '⬇️',
+  video_refresh_airing_schedules: '🗓️',
+  video_clean_youtube_episodes: '🧹',
+  video_reenrich_stale: '🔄',
+  video_clean_search_history: '🗑️',
+  video_clean_completed_downloads: '✅',
+  video_full_cleanup: '🧹',
+  video_backup_database: '💾',
+  video_apply_overlays: '🎨',
+  video_clean_plex_images: '🖼️',
+  video_sync_collections: '🗂️',
+  video_rss_sync: '📡',
+  video_seeding_sweep: '🌱',
+  video_import_lists: '📥',
+  monthly_time: '📅',
+  video_batch_complete: '✅',
+  video_library_scan_completed: '📡',
+  video_download_completed: '⬇️',
+  video_download_failed: '❌',
+  video_import_failed: '⚠️',
+  video_upgrade_completed: '📈',
+  video_repair_finding_created: '🔧',
+  video_repair_scan_completed: '🔧',
+  video_wishlist_item_added: '➕',
+  video_watchlist_added: '👁️',
+  video_watchlist_removed: '🚫',
+  video_collections_synced: '🗂️',
+  video_overlays_applied: '🎨',
+  video_database_update_completed: '🗄️',
+  video_run_repair_job: '🔧',
+};
+
+/** Anything unmapped falls back to the gear, as the vanilla card did. */
+export const AUTOMATION_ICON_FALLBACK = '⚙️';
+
+export function automationIcon(type: string | null | undefined): string {
+  return AUTOMATION_ICONS[type ?? ''] ?? AUTOMATION_ICON_FALLBACK;
+}
+
+/** Notification/then-action label. Two carry their own icon inline. */
+export function formatNotify(type: string | null | undefined): string {
+  if (type === 'discord_webhook') return 'Discord';
+  if (type === 'pushbullet') return 'Pushbullet';
+  if (type === 'telegram') return 'Telegram';
+  if (type === 'webhook') return 'Webhook';
+  if (type === 'fire_signal') return '⚡ Signal';
+  if (type === 'run_script') return '💻 Script';
+  return type || '';
+}

--- a/webui/src/routes/automations/-automations.progress.test.ts
+++ b/webui/src/routes/automations/-automations.progress.test.ts
@@ -4,10 +4,12 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
+  _tickDiagnostics,
   AUTOMATION_PROGRESS_EVENT,
   isFinished,
   isRunning,
   useAutomationProgress,
+  useSecondTick,
 } from './-automations.progress';
 
 function emit(detail: unknown) {
@@ -50,6 +52,29 @@ describe('useAutomationProgress', () => {
     expect(Object.keys(result.current)).toEqual(['1']);
   });
 
+  it('seeds from the catch-up response so a page opened mid-run shows it', () => {
+    // Without this, a card stays blank until the next socket frame — which in a
+    // long quiet phase can be a while. loadAutomations did the same catch-up.
+    const { result } = renderHook(() =>
+      useAutomationProgress({ '5': { status: 'running', progress: 25 } }),
+    );
+    expect(result.current[5]?.progress).toBe(25);
+  });
+
+  it('ignores the {error} shape of that response', () => {
+    const { result } = renderHook(() => useAutomationProgress({ error: 'nope' }));
+    expect(result.current).toEqual({});
+  });
+
+  it('lets a live frame win over the catch-up seed', () => {
+    // A socket frame that landed while the catch-up was in flight is newer.
+    const { result } = renderHook(() =>
+      useAutomationProgress({ '5': { status: 'running', progress: 10 } }),
+    );
+    emit({ '5': { status: 'finished', progress: 100 } });
+    expect(result.current[5]?.status).toBe('finished');
+  });
+
   it('stops listening once unmounted', () => {
     const { result, unmount } = renderHook(() => useAutomationProgress());
     unmount();
@@ -87,9 +112,60 @@ describe('the vanilla side of the progress seam', () => {
     expect(read('core.js')).toContain('updateAutomationProgressFromData(data)');
   });
 
+  it('loadAutomations refuses to repaint the legacy list behind React', () => {
+    // Reachable via the shared builder: saveAutomation calls onSaved ->
+    // loadAutomations after the React page has reclaimed the shell. Without
+    // this guard the hidden container gets a full duplicate render, and every
+    // #auto-section-* id and .automation-card[data-id] exists twice.
+    const src = read('stats-automations.js');
+    const fn = src.slice(src.indexOf('async function loadAutomations()'));
+    expect(fn.slice(0, 1200)).toContain("getElementById('webui-react-root')");
+  });
+
   it('the vanilla renderer refuses to write into React-owned cards', () => {
     // Without this guard the document-wide querySelector finds React's cards
     // and injects panels React clobbers on its next render.
     expect(read('stats-automations.js')).toContain("card.closest('#webui-react-root')");
+  });
+});
+
+describe('useSecondTick', () => {
+  it('runs ONE interval no matter how many countdowns subscribe', () => {
+    // The vanilla page ticked every countdown from a single module-level
+    // interval. A timer per card means N timers and N re-renders a second for
+    // the same output.
+    const a = renderHook(() => useSecondTick());
+    const b = renderHook(() => useSecondTick());
+    const c = renderHook(() => useSecondTick());
+    expect(_tickDiagnostics()).toEqual({ running: true, listeners: 3 });
+    a.unmount();
+    b.unmount();
+    c.unmount();
+  });
+
+  it('stops the interval once the last subscriber leaves', () => {
+    // A page with no scheduled automations must not leave a timer running.
+    const a = renderHook(() => useSecondTick());
+    const b = renderHook(() => useSecondTick());
+    a.unmount();
+    expect(_tickDiagnostics().running).toBe(true);
+    b.unmount();
+    expect(_tickDiagnostics()).toEqual({ running: false, listeners: 0 });
+  });
+
+  it('re-renders subscribers on each tick', () => {
+    vi.useFakeTimers();
+    let renders = 0;
+    const h = renderHook(() => {
+      renders += 1;
+      useSecondTick();
+    });
+    const before = renders;
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(renders).toBeGreaterThan(before);
+    h.unmount();
+    vi.useRealTimers();
   });
 });

--- a/webui/src/routes/automations/-automations.progress.test.ts
+++ b/webui/src/routes/automations/-automations.progress.test.ts
@@ -1,0 +1,95 @@
+import { act, renderHook } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AUTOMATION_PROGRESS_EVENT,
+  isFinished,
+  isRunning,
+  useAutomationProgress,
+} from './-automations.progress';
+
+function emit(detail: unknown) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(AUTOMATION_PROGRESS_EVENT, { detail }));
+  });
+}
+
+describe('useAutomationProgress', () => {
+  it('records a frame keyed by automation id', () => {
+    const { result } = renderHook(() => useAutomationProgress());
+    emit({ '7': { status: 'running', progress: 40, phase: 'Scanning' } });
+    expect(result.current[7]).toEqual({ status: 'running', progress: 40, phase: 'Scanning' });
+  });
+
+  it('MERGES frames instead of replacing the map', () => {
+    // The server reports only the automations it has news about. Replacing
+    // would make a still-running automation's panel vanish the moment an
+    // unrelated one reported.
+    const { result } = renderHook(() => useAutomationProgress());
+    emit({ '1': { status: 'running', progress: 10 } });
+    emit({ '2': { status: 'running', progress: 90 } });
+    expect(result.current[1]?.progress).toBe(10);
+    expect(result.current[2]?.progress).toBe(90);
+  });
+
+  it('lets a later frame supersede the same id', () => {
+    const { result } = renderHook(() => useAutomationProgress());
+    emit({ '1': { status: 'running', progress: 10 } });
+    emit({ '1': { status: 'finished', progress: 100 } });
+    expect(result.current[1]).toEqual({ status: 'finished', progress: 100 });
+  });
+
+  it('ignores junk without corrupting the map', () => {
+    const { result } = renderHook(() => useAutomationProgress());
+    emit({ '1': { status: 'running' } });
+    emit(null);
+    emit('nonsense');
+    emit({ notanumber: { status: 'running' } }); // would become NaN as a key
+    expect(Object.keys(result.current)).toEqual(['1']);
+  });
+
+  it('stops listening once unmounted', () => {
+    const { result, unmount } = renderHook(() => useAutomationProgress());
+    unmount();
+    emit({ '9': { status: 'running' } });
+    expect(result.current[9]).toBeUndefined();
+  });
+});
+
+describe('run state predicates', () => {
+  it('separates running from finished and errored', () => {
+    expect(isRunning({ status: 'running' })).toBe(true);
+    expect(isRunning({ status: 'finished' })).toBe(false);
+    expect(isRunning(undefined)).toBe(false);
+    expect(isFinished({ status: 'finished' })).toBe(true);
+    expect(isFinished({ status: 'error' })).toBe(true);
+    expect(isFinished({ status: 'running' })).toBe(false);
+  });
+});
+
+/**
+ * The seam itself. React only ever sees progress if core.js mirrors the socket
+ * frame onto the window, and it only owns its cards if the vanilla renderer
+ * skips them — both live in plain scripts no bundler or typechecker guards.
+ */
+describe('the vanilla side of the progress seam', () => {
+  const read = (file: string) => readFileSync(resolve(process.cwd(), 'static', file), 'utf8');
+
+  it('core.js mirrors automation:progress onto the window', () => {
+    const src = read('core.js');
+    expect(src).toContain("socket.on('automation:progress'");
+    expect(src).toContain(AUTOMATION_PROGRESS_EVENT);
+  });
+
+  it('still calls the vanilla renderer, for the legacy and video pages', () => {
+    expect(read('core.js')).toContain('updateAutomationProgressFromData(data)');
+  });
+
+  it('the vanilla renderer refuses to write into React-owned cards', () => {
+    // Without this guard the document-wide querySelector finds React's cards
+    // and injects panels React clobbers on its next render.
+    expect(read('stats-automations.js')).toContain("card.closest('#webui-react-root')");
+  });
+});

--- a/webui/src/routes/automations/-automations.progress.ts
+++ b/webui/src/routes/automations/-automations.progress.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export const AUTOMATION_PROGRESS_EVENT = 'ss:automation-progress';
 
@@ -28,8 +28,9 @@ function normalise(raw: unknown): AutomationProgressMap {
   const out: AutomationProgressMap = {};
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
     const id = Number.parseInt(key, 10);
-    // The socket keys these by id-as-string; a non-numeric key is not an
-    // automation and must not become NaN in the map.
+    // The socket keys these by id-as-string. A non-numeric key — including
+    // the `error` of a failed catch-up response — is not an automation and
+    // must not become a NaN entry.
     if (Number.isNaN(id) || !value || typeof value !== 'object') continue;
     out[id] = value as AutomationRunState;
   }
@@ -48,13 +49,28 @@ function normalise(raw: unknown): AutomationProgressMap {
  * `seed` hydrates from /api/automations/progress so a page opened mid-run
  * shows the run already in flight instead of waiting for the next frame.
  */
-export function useAutomationProgress(seed?: AutomationProgressMap): AutomationProgressMap {
-  const [progress, setProgress] = useState<AutomationProgressMap>(() => seed ?? {});
+export function useAutomationProgress(seed?: unknown): AutomationProgressMap {
+  // The seed arrives as the raw /api/automations/progress body, so it goes
+  // through the same normaliser as a socket frame — it carries an `error` key
+  // on failure and string ids on success.
+  const [progress, setProgress] = useState<AutomationProgressMap>(() => normalise(seed));
 
+  // Applied ONCE, guarded by a ref rather than by the effect's dependency.
+  //
+  // `seed` is an object, so depending on its identity re-runs this on every
+  // render for any caller that does not memoise it — each run calling
+  // setProgress, which renders again, forever. React Query's `data` happens to
+  // be referentially stable, so the page never looped; a plain object literal
+  // hung the test worker outright. A catch-up is a one-shot anyway.
+  const hasSeeded = useRef(false);
   useEffect(() => {
-    if (seed && Object.keys(seed).length > 0) {
-      setProgress((prev) => ({ ...seed, ...prev }));
-    }
+    if (hasSeeded.current) return;
+    const seeded = normalise(seed);
+    if (Object.keys(seeded).length === 0) return;
+    hasSeeded.current = true;
+    // Existing live state wins: a socket frame that landed while the catch-up
+    // request was in flight is newer than the catch-up.
+    setProgress((prev) => ({ ...seeded, ...prev }));
   }, [seed]);
 
   useEffect(() => {
@@ -78,4 +94,44 @@ export function isRunning(state: AutomationRunState | undefined): boolean {
 
 export function isFinished(state: AutomationRunState | undefined): boolean {
   return state?.status === 'finished' || state?.status === 'error';
+}
+
+// ── shared 1s tick ──────────────────────────────────────────────────────────
+//
+// The "Next: in 4m" countdowns need re-rendering once a second. The vanilla
+// page did that with ONE module-level interval rewriting every
+// `.auto-next-run` node; giving each card its own interval would run N timers
+// and re-render N components per second for the same result.
+//
+// One interval, shared by every subscriber, started on the first and stopped
+// with the last — so a page with no scheduled automations runs no timer at all.
+
+let tickHandle: ReturnType<typeof setInterval> | null = null;
+const tickListeners = new Set<() => void>();
+
+function subscribeToTick(listener: () => void): () => void {
+  tickListeners.add(listener);
+  if (tickHandle === null) {
+    tickHandle = setInterval(() => {
+      for (const fn of tickListeners) fn();
+    }, 1000);
+  }
+  return () => {
+    tickListeners.delete(listener);
+    if (tickListeners.size === 0 && tickHandle !== null) {
+      clearInterval(tickHandle);
+      tickHandle = null;
+    }
+  };
+}
+
+/** Re-render once a second, off a single interval shared by all callers. */
+export function useSecondTick(): void {
+  const [, force] = useState(0);
+  useEffect(() => subscribeToTick(() => force((n) => n + 1)), []);
+}
+
+/** Test-only: how many timers are live. Exposed to pin the "one interval" claim. */
+export function _tickDiagnostics(): { running: boolean; listeners: number } {
+  return { running: tickHandle !== null, listeners: tickListeners.size };
 }

--- a/webui/src/routes/automations/-automations.progress.ts
+++ b/webui/src/routes/automations/-automations.progress.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+export const AUTOMATION_PROGRESS_EVENT = 'ss:automation-progress';
+
+export interface AutomationLogLine {
+  text: string;
+  type?: string;
+}
+
+export interface AutomationRunState {
+  status?: 'running' | 'finished' | 'error' | string;
+  progress?: number;
+  phase?: string;
+  log?: AutomationLogLine[];
+}
+
+/** automation id -> its in-flight run state. */
+export type AutomationProgressMap = Record<number, AutomationRunState>;
+
+/**
+ * How long a finished panel stays on screen before collapsing.
+ * 30s, matching _autoProgressHideTimers in stats-automations.js.
+ */
+export const PROGRESS_HIDE_MS = 30_000;
+
+function normalise(raw: unknown): AutomationProgressMap {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: AutomationProgressMap = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    const id = Number.parseInt(key, 10);
+    // The socket keys these by id-as-string; a non-numeric key is not an
+    // automation and must not become NaN in the map.
+    if (Number.isNaN(id) || !value || typeof value !== 'object') continue;
+    out[id] = value as AutomationRunState;
+  }
+  return out;
+}
+
+/**
+ * Live automation run progress.
+ *
+ * The socket frame is emitted app-wide by core.js and mirrored onto the
+ * window as ss:automation-progress. Frames are MERGED rather than replacing
+ * the map: the server sends only the automations it has news about, so
+ * replacing would make a still-running automation's panel vanish whenever an
+ * unrelated one reported.
+ *
+ * `seed` hydrates from /api/automations/progress so a page opened mid-run
+ * shows the run already in flight instead of waiting for the next frame.
+ */
+export function useAutomationProgress(seed?: AutomationProgressMap): AutomationProgressMap {
+  const [progress, setProgress] = useState<AutomationProgressMap>(() => seed ?? {});
+
+  useEffect(() => {
+    if (seed && Object.keys(seed).length > 0) {
+      setProgress((prev) => ({ ...seed, ...prev }));
+    }
+  }, [seed]);
+
+  useEffect(() => {
+    const onFrame = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      const incoming = normalise(detail);
+      if (Object.keys(incoming).length === 0) return;
+      setProgress((prev) => ({ ...prev, ...incoming }));
+    };
+    window.addEventListener(AUTOMATION_PROGRESS_EVENT, onFrame);
+    return () => window.removeEventListener(AUTOMATION_PROGRESS_EVENT, onFrame);
+  }, []);
+
+  return progress;
+}
+
+/** Whether a run state should still be showing its panel. */
+export function isRunning(state: AutomationRunState | undefined): boolean {
+  return state?.status === 'running';
+}
+
+export function isFinished(state: AutomationRunState | undefined): boolean {
+  return state?.status === 'finished' || state?.status === 'error';
+}

--- a/webui/src/routes/automations/-automations.types.ts
+++ b/webui/src/routes/automations/-automations.types.ts
@@ -1,0 +1,98 @@
+import { z } from 'zod';
+
+/**
+ * Coerce a raw search value to a string.
+ *
+ * TanStack JSON-parses search values, so an all-digits filter arrives as a
+ * NUMBER and a bare `z.string()` would throw SearchParamError and take the
+ * route down. Only primitives are stringified — a hand-edited `?q[]=x` parses
+ * to an object, which must read as absent rather than "[object Object]".
+ */
+function searchString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+export const automationsSearchSchema = z.object({
+  /** Filter-bar text. Transient DOM state in the vanilla page, lost on reload. */
+  q: z
+    .preprocess((v) => searchString(v) ?? '', z.string())
+    .default('')
+    .catch(''),
+});
+
+export type AutomationsSearch = z.infer<typeof automationsSearchSchema>;
+
+/**
+ * The vanilla filter bar hides itself below this many automations — the exact
+ * test is `automations.length < 7` in _initAutoFilterBar. Named so the React
+ * port cannot quietly drift to "6+", which is what the surrounding comment
+ * claims it does.
+ */
+export const AUTO_FILTER_BAR_MIN = 7;
+
+/**
+ * One row from GET /api/automations.
+ *
+ * These are `automations` table rows passed through _hydrate_automation, which
+ * JSON-parses the config columns and backfills `then_actions` from the legacy
+ * notify_* pair. Fields are optional because the table grew by migration —
+ * is_system, group_name, owned_by and then_actions were all added later, so an
+ * older row can genuinely lack them.
+ */
+export interface Automation {
+  id: number;
+  name: string;
+  enabled?: boolean | number;
+  trigger_type?: string;
+  trigger_config?: Record<string, unknown> | null;
+  action_type?: string;
+  action_config?: Record<string, unknown> | null;
+  then_actions?: { type?: string; config?: Record<string, unknown> }[];
+  last_run?: string | null;
+  next_run?: string | null;
+  run_count?: number;
+  last_error?: string | null;
+  last_result?: string | null;
+  /** Seeded, undeletable automations. Rendered in the protected System section. */
+  is_system?: boolean | number;
+  /** User-defined grouping; drives the 📁 sections. */
+  group_name?: string | null;
+  /**
+   * Which side owns the row. The engine is app-wide and both sides read the
+   * SAME endpoint, so 'video' rows must be filtered out of the music page —
+   * and vice versa on the video page.
+   */
+  owned_by?: string | null;
+  profile_id?: number;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** GET /api/automations returns the bare array, or {error} on failure. */
+export type AutomationsListResponse = Automation[] | { error?: string };
+
+/** GET /api/automations/master — the per-side global pause. */
+export interface AutomationsMasterState {
+  music?: boolean;
+  video?: boolean;
+  error?: string;
+}
+
+/** GET /api/automations/progress — in-flight runs, keyed by automation id. */
+export interface AutomationsProgressResponse {
+  [key: string]: unknown;
+  error?: string;
+}
+
+/** The list view, already split the way the page renders it. */
+export interface AutomationsView {
+  system: Automation[];
+  /** User automations that carry a group_name, sorted by group name. */
+  groups: { name: string; automations: Automation[] }[];
+  /** User automations with no group — the "My Automations" section. */
+  ungrouped: Automation[];
+  stats: { active: number; system: number; custom: number; total: number };
+  showFilterBar: boolean;
+}

--- a/webui/src/routes/automations/-automations.types.ts
+++ b/webui/src/routes/automations/-automations.types.ts
@@ -113,3 +113,21 @@ export interface AutomationsView {
   stats: { active: number; system: number; custom: number; total: number };
   showFilterBar: boolean;
 }
+
+/** One entry in the builder palette. */
+export interface AutomationBlockDef {
+  type: string;
+  label?: string;
+}
+
+/**
+ * GET /api/automations/blocks. `_findBlockDef` searches these three categories
+ * in order, so the label lookup below must too.
+ */
+export interface AutomationBlocks {
+  triggers?: AutomationBlockDef[];
+  actions?: AutomationBlockDef[];
+  notifications?: AutomationBlockDef[];
+}
+
+export const BLOCK_CATEGORIES = ['triggers', 'actions', 'notifications'] as const;

--- a/webui/src/routes/automations/-automations.types.ts
+++ b/webui/src/routes/automations/-automations.types.ts
@@ -54,7 +54,12 @@ export interface Automation {
   next_run?: string | null;
   run_count?: number;
   last_error?: string | null;
-  last_result?: string | null;
+  /**
+   * JSON-parsed by _hydrate_automation, so normally a dict of run facts. It is
+   * NOT in _JSON_DEFAULT_DICT, so a malformed value hydrates to null rather
+   * than {} — hence unknown rather than a record type.
+   */
+  last_result?: unknown;
   /** Seeded, undeletable automations. Rendered in the protected System section. */
   is_system?: boolean | number;
   /** User-defined grouping; drives the 📁 sections. */

--- a/webui/src/routes/automations/-automations.types.ts
+++ b/webui/src/routes/automations/-automations.types.ts
@@ -14,9 +14,21 @@ function searchString(value: unknown): string | undefined {
   return undefined;
 }
 
+// All three filter-bar controls, not just the text box. They were transient DOM
+// state in the vanilla page — a reload dropped them — so putting them in the URL
+// only adds state that used to be thrown away.
 export const automationsSearchSchema = z.object({
-  /** Filter-bar text. Transient DOM state in the vanilla page, lost on reload. */
   q: z
+    .preprocess((v) => searchString(v) ?? '', z.string())
+    .default('')
+    .catch(''),
+  /** Raw trigger_type from the dropdown; '' means All Triggers. */
+  trigger: z
+    .preprocess((v) => searchString(v) ?? '', z.string())
+    .default('')
+    .catch(''),
+  /** Raw action_type from the dropdown; '' means All Actions. */
+  action: z
     .preprocess((v) => searchString(v) ?? '', z.string())
     .default('')
     .catch(''),

--- a/webui/src/routes/automations/-route.test.tsx
+++ b/webui/src/routes/automations/-route.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
@@ -8,25 +8,13 @@ import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 /**
- * The /automations route exists but is DORMANT.
+ * /automations is now React-owned.
  *
- * TanStack matches a route from the generated tree, not from the manifest — so
- * the moment this route file landed, /automations started matching even though
- * the shell still owns the page. The guard inside route.tsx is what keeps the
- * vanilla page in charge; without it the legacy page and a React host would
- * both activate on the same URL.
- *
- * These tests pin that handover. When the manifest flips to 'react' in P5 they
- * are expected to be rewritten — deliberately, not by drift.
- *
- * Strength, measured rather than assumed: forcing isReactOwned() true fails
- * three of the five — the handover, the markup check and the API check. The
- * permission gate holds either way by design, and the manifest assertion reads
- * the manifest directly, so neither should move.
- *
- * (While the route rendered LegacyRouteController down BOTH branches — before
- * the page component was wired in — only the API case could detect a defeated
- * guard. Wiring the page is what gave the render assertions teeth.)
+ * This file previously pinned the DORMANT state — that the route existed but
+ * deferred to the vanilla page. Those assertions were written to fail the
+ * moment the manifest flipped, which is exactly what happened; they are
+ * replaced here rather than deleted, so the route keeps a guard on both the
+ * handover and the permission gate.
  */
 
 function renderRoute(entries = ['/automations']) {
@@ -34,7 +22,6 @@ function renderRoute(entries = ['/automations']) {
   const history = createMemoryHistory({ initialEntries: entries });
   const router = createAppRouter({ history, queryClient });
   return {
-    history,
     router,
     ...render(<AppRouterProvider router={router} queryClient={queryClient} />),
   };
@@ -42,18 +29,24 @@ function renderRoute(entries = ['/automations']) {
 
 let requested: string[] = [];
 
-describe('automations route (dormant)', () => {
+describe('automations route', () => {
   beforeEach(() => {
     window.SoulSyncWebShellBridge = createShellBridge();
-    // The app shell fetches on its own (profile context, status) no matter
-    // which route is active, so this records URLs rather than forbidding calls
-    // outright — the invariant is that no AUTOMATIONS endpoint is touched.
     requested = [];
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
-        requested.push(input instanceof Request ? input.url : String(input));
-        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+        const url = input instanceof Request ? input.url : String(input);
+        requested.push(url);
+        const body = url.includes('/api/automations/master')
+          ? { music: true }
+          : url.includes('/api/automations/progress')
+            ? {}
+            : [{ id: 1, name: 'Nightly', enabled: 1, is_system: 1 }];
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }),
     );
   });
@@ -62,46 +55,29 @@ describe('automations route (dormant)', () => {
     delete window.SoulSyncWebShellBridge;
   });
 
-  it('is still owned by the shell', () => {
-    // If this fails the page was handed to React without its UI being built.
-    expect(getShellRouteByPageId('automations')?.kind).toBe('legacy');
+  it('is owned by React in the manifest', () => {
+    expect(getShellRouteByPageId('automations')?.kind).toBe('react');
   });
 
-  it('hands /automations to the vanilla page instead of rendering React', async () => {
+  it('renders the React page instead of handing off to the vanilla shell', async () => {
     renderRoute();
 
-    const bridge = window.SoulSyncWebShellBridge!;
-    await waitFor(() => {
-      expect(bridge.activateLegacyPath).toHaveBeenCalledWith('/automations');
-    });
+    await screen.findByText('Nightly');
+    expect(document.querySelector('.automations-container')).not.toBeNull();
+    // The legacy controller must NOT have been asked to activate the old page.
+    expect(window.SoulSyncWebShellBridge!.activateLegacyPath).not.toHaveBeenCalled();
   });
 
-  it('renders no React page markup of its own', async () => {
-    const { container } = renderRoute();
-
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled();
-    });
-    // LegacyRouteController renders null — the vanilla DOM in index.html is
-    // what the user sees. Anything here would be a second, competing page.
-    expect(container.querySelector('.automations-container')).toBeNull();
-  });
-
-  it('does not touch the automations API while dormant', async () => {
+  it('loads the list and the master state before painting', async () => {
     renderRoute();
-
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled();
-    });
-    // The loader returns early before ensureQueryData, so nothing should ask
-    // for the list, the master toggle or progress.
-    expect(requested.filter((u) => u.includes('/api/automations'))).toEqual([]);
+    await screen.findByText('Nightly');
+    expect(requested.some((u) => u.endsWith('/api/automations'))).toBe(true);
+    expect(requested.some((u) => u.includes('/api/automations/master'))).toBe(true);
   });
 
   it('still respects the page permission gate', async () => {
-    // A profile denied the page must be redirected even while dormant —
-    // otherwise the dormant period is a hole in the IDOR gate.
-    // createShellBridge already homes to 'discover'; only the gate changes.
+    // A profile denied the page must be redirected — the gate has to survive
+    // the handover to React, not just exist while the route was dormant.
     window.SoulSyncWebShellBridge = createShellBridge({
       isPageAllowed: vi.fn(() => false),
     });
@@ -110,5 +86,12 @@ describe('automations route (dormant)', () => {
     await waitFor(() => {
       expect(router.state.location.pathname).not.toBe('/automations');
     });
+  });
+
+  it('carries the filter controls in the URL', async () => {
+    renderRoute(['/automations?q=night&trigger=schedule&action=scan_library']);
+    await waitFor(() => expect(document.querySelector('.automations-container')).not.toBeNull());
+    // validateSearch must accept all three without throwing the route down.
+    expect(document.querySelector('.automations-container')).not.toBeNull();
   });
 });

--- a/webui/src/routes/automations/-route.test.tsx
+++ b/webui/src/routes/automations/-route.test.tsx
@@ -19,12 +19,14 @@ import { createShellBridge } from '@/test/shell-bridge';
  * These tests pin that handover. When the manifest flips to 'react' in P5 they
  * are expected to be rewritten — deliberately, not by drift.
  *
- * Honest caveat on their strength right now: defeating the guard (forcing
- * isReactOwned() true) is caught ONLY by the "does not touch the automations
- * API" case. The others still pass, because until P2 builds the real page the
- * component returns LegacyRouteController down BOTH branches, so there is
- * nothing to tell them apart. The loader is the only observable difference at
- * this phase. Once the page exists, the render assertions gain their teeth.
+ * Strength, measured rather than assumed: forcing isReactOwned() true fails
+ * three of the five — the handover, the markup check and the API check. The
+ * permission gate holds either way by design, and the manifest assertion reads
+ * the manifest directly, so neither should move.
+ *
+ * (While the route rendered LegacyRouteController down BOTH branches — before
+ * the page component was wired in — only the API case could detect a defeated
+ * guard. Wiring the page is what gave the render assertions teeth.)
  */
 
 function renderRoute(entries = ['/automations']) {

--- a/webui/src/routes/automations/-route.test.tsx
+++ b/webui/src/routes/automations/-route.test.tsx
@@ -1,0 +1,112 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+/**
+ * The /automations route exists but is DORMANT.
+ *
+ * TanStack matches a route from the generated tree, not from the manifest — so
+ * the moment this route file landed, /automations started matching even though
+ * the shell still owns the page. The guard inside route.tsx is what keeps the
+ * vanilla page in charge; without it the legacy page and a React host would
+ * both activate on the same URL.
+ *
+ * These tests pin that handover. When the manifest flips to 'react' in P5 they
+ * are expected to be rewritten — deliberately, not by drift.
+ *
+ * Honest caveat on their strength right now: defeating the guard (forcing
+ * isReactOwned() true) is caught ONLY by the "does not touch the automations
+ * API" case. The others still pass, because until P2 builds the real page the
+ * component returns LegacyRouteController down BOTH branches, so there is
+ * nothing to tell them apart. The loader is the only observable difference at
+ * this phase. Once the page exists, the render assertions gain their teeth.
+ */
+
+function renderRoute(entries = ['/automations']) {
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: entries });
+  const router = createAppRouter({ history, queryClient });
+  return {
+    history,
+    router,
+    ...render(<AppRouterProvider router={router} queryClient={queryClient} />),
+  };
+}
+
+let requested: string[] = [];
+
+describe('automations route (dormant)', () => {
+  beforeEach(() => {
+    window.SoulSyncWebShellBridge = createShellBridge();
+    // The app shell fetches on its own (profile context, status) no matter
+    // which route is active, so this records URLs rather than forbidding calls
+    // outright — the invariant is that no AUTOMATIONS endpoint is touched.
+    requested = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        requested.push(input instanceof Request ? input.url : String(input));
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete window.SoulSyncWebShellBridge;
+  });
+
+  it('is still owned by the shell', () => {
+    // If this fails the page was handed to React without its UI being built.
+    expect(getShellRouteByPageId('automations')?.kind).toBe('legacy');
+  });
+
+  it('hands /automations to the vanilla page instead of rendering React', async () => {
+    renderRoute();
+
+    const bridge = window.SoulSyncWebShellBridge!;
+    await waitFor(() => {
+      expect(bridge.activateLegacyPath).toHaveBeenCalledWith('/automations');
+    });
+  });
+
+  it('renders no React page markup of its own', async () => {
+    const { container } = renderRoute();
+
+    await waitFor(() => {
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled();
+    });
+    // LegacyRouteController renders null — the vanilla DOM in index.html is
+    // what the user sees. Anything here would be a second, competing page.
+    expect(container.querySelector('.automations-container')).toBeNull();
+  });
+
+  it('does not touch the automations API while dormant', async () => {
+    renderRoute();
+
+    await waitFor(() => {
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled();
+    });
+    // The loader returns early before ensureQueryData, so nothing should ask
+    // for the list, the master toggle or progress.
+    expect(requested.filter((u) => u.includes('/api/automations'))).toEqual([]);
+  });
+
+  it('still respects the page permission gate', async () => {
+    // A profile denied the page must be redirected even while dormant —
+    // otherwise the dormant period is a hole in the IDOR gate.
+    // createShellBridge already homes to 'discover'; only the gate changes.
+    window.SoulSyncWebShellBridge = createShellBridge({
+      isPageAllowed: vi.fn(() => false),
+    });
+    const { router } = renderRoute();
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).not.toBe('/automations');
+    });
+  });
+});

--- a/webui/src/routes/automations/-ui/automation-card.test.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Automation } from '../-automations.types';
+
+import { AutomationCard } from './automation-card';
+
+function auto(over: Partial<Automation> & { id: number }): Automation {
+  return { name: `auto-${over.id}`, ...over };
+}
+
+const card = () => document.querySelector('.automation-card')!;
+
+describe('AutomationCard markup', () => {
+  it('carries the classes and data attributes the CSS and vanilla filter rely on', () => {
+    render(
+      <AutomationCard
+        automation={auto({
+          id: 7,
+          name: 'Nightly',
+          enabled: 1,
+          trigger_type: 'schedule',
+          action_type: 'process_wishlist',
+        })}
+      />,
+    );
+    const el = card();
+    expect(el.className).toBe('automation-card');
+    expect(el.getAttribute('data-id')).toBe('7');
+    // _filterAutomations reads these two to apply the dropdowns.
+    expect(el.getAttribute('data-trigger-type')).toBe('schedule');
+    expect(el.getAttribute('data-action-type')).toBe('process_wishlist');
+    expect(document.querySelector('.automation-status')?.className).toContain('enabled');
+  });
+
+  it('marks disabled and system rows with their modifier classes', () => {
+    render(<AutomationCard automation={auto({ id: 1, enabled: 0, is_system: 1 })} />);
+    expect(card().className).toBe('automation-card disabled system');
+    expect(document.querySelector('.automation-status')?.className).toContain('disabled');
+  });
+
+  it('renders the trigger → action flow with icons', () => {
+    render(
+      <AutomationCard
+        automation={auto({
+          id: 1,
+          trigger_type: 'schedule',
+          trigger_config: { interval: 6, unit: 'hours' },
+          action_type: 'process_wishlist',
+        })}
+      />,
+    );
+    expect(document.querySelector('.flow-trigger')?.textContent).toContain('Every 6 hours');
+    expect(document.querySelector('.flow-action')?.textContent).toContain('Process Wishlist');
+  });
+
+  it('shows the delay chip only when a delay is configured', () => {
+    const { unmount } = render(
+      <AutomationCard automation={auto({ id: 1, action_config: { delay: 5 } })} />,
+    );
+    expect(document.querySelector('.flow-delay')?.textContent).toContain('5m');
+    unmount();
+    render(<AutomationCard automation={auto({ id: 2, action_config: { delay: 0 } })} />);
+    expect(document.querySelector('.flow-delay')).toBeNull();
+  });
+
+  it('renders one notify chip per then_action', () => {
+    render(
+      <AutomationCard
+        automation={auto({
+          id: 1,
+          then_actions: [{ type: 'discord_webhook' }, { type: 'telegram' }],
+        })}
+      />,
+    );
+    const chips = [...document.querySelectorAll('.flow-notify')].map((n) => n.textContent);
+    expect(chips).toEqual(['Discord', 'Telegram']);
+  });
+
+  it('hides duplicate/group/delete on system automations', () => {
+    const { unmount } = render(<AutomationCard automation={auto({ id: 1, is_system: 1 })} />);
+    expect(document.querySelector('.automation-dupe-btn')).toBeNull();
+    expect(document.querySelector('.automation-group-btn')).toBeNull();
+    expect(document.querySelector('.automation-delete-btn')).toBeNull();
+    // Run / toggle / edit stay: system automations are still runnable.
+    expect(document.querySelector('.automation-run-btn')).not.toBeNull();
+    expect(document.querySelector('.automation-edit-btn')).not.toBeNull();
+    unmount();
+
+    render(<AutomationCard automation={auto({ id: 2 })} />);
+    expect(document.querySelector('.automation-dupe-btn')).not.toBeNull();
+    expect(document.querySelector('.automation-delete-btn')).not.toBeNull();
+  });
+
+  it('omits data-next so the vanilla 1s interval cannot fight React over the node', () => {
+    // stats-automations.js rewrites `.auto-next-run[data-next]` document-wide
+    // every second. Keeping the class but not the attribute leaves this node
+    // outside that selector.
+    render(
+      <AutomationCard
+        automation={auto({
+          id: 1,
+          enabled: 1,
+          trigger_type: 'schedule',
+          next_run: new Date(Date.now() + 3_600_000).toISOString(),
+        })}
+      />,
+    );
+    const next = document.querySelector('.auto-next-run');
+    expect(next).not.toBeNull();
+    expect(next!.hasAttribute('data-next')).toBe(false);
+  });
+});
+
+describe('AutomationCard actions', () => {
+  it('fires each handler with the automation', () => {
+    const onRun = vi.fn();
+    const onToggle = vi.fn();
+    const onDelete = vi.fn();
+    const a = auto({ id: 3, name: 'Nightly', enabled: 1 });
+    render(<AutomationCard automation={a} onRun={onRun} onToggle={onToggle} onDelete={onDelete} />);
+
+    fireEvent.click(document.querySelector('.automation-run-btn')!);
+    expect(onRun).toHaveBeenCalledWith(a);
+
+    fireEvent.click(screen.getByLabelText('Disable Nightly'));
+    expect(onToggle).toHaveBeenCalledWith(a);
+
+    fireEvent.click(document.querySelector('.automation-delete-btn')!);
+    expect(onDelete).toHaveBeenCalledWith(a);
+  });
+
+  it('offers the run-history link only once the automation has run', () => {
+    const { unmount } = render(<AutomationCard automation={auto({ id: 1, run_count: 0 })} />);
+    expect(document.querySelector('.auto-runs-link')).toBeNull();
+    unmount();
+    render(<AutomationCard automation={auto({ id: 2, run_count: 4 })} />);
+    expect(document.querySelector('.auto-runs-link')?.textContent).toBe('Runs: 4');
+  });
+});

--- a/webui/src/routes/automations/-ui/automation-card.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.tsx
@@ -28,6 +28,10 @@ interface Props extends AutomationCardHandlers {
   automation: Automation;
   /** Live run state for this automation, if one is in flight or just ended. */
   progress?: AutomationRunState;
+  /** draggable + drag handlers, empty for system automations. */
+  dragProps?: Record<string, unknown>;
+  /** This card is the one being dragged. */
+  isDragging?: boolean;
 }
 
 /**
@@ -107,7 +111,14 @@ function NextRun({ nextRun }: { nextRun: string }) {
 }
 
 /** One automation row. Markup mirrors renderAutomationCard so the CSS applies unchanged. */
-export function AutomationCard({ automation: a, blockLabel, progress, ...on }: Props) {
+export function AutomationCard({
+  automation: a,
+  blockLabel,
+  progress,
+  dragProps,
+  isDragging,
+  ...on
+}: Props) {
   const enabled = a.enabled === true || a.enabled === 1;
   const isSystem = a.is_system === true || a.is_system === 1;
   const running = isRunning(progress);
@@ -149,7 +160,8 @@ export function AutomationCard({ automation: a, blockLabel, progress, ...on }: P
     <div
       className={`automation-card${enabled ? '' : ' disabled'}${isSystem ? ' system' : ''}${
         running ? ' running' : ''
-      }`}
+      }${isDragging ? ' dragging' : ''}`}
+      {...dragProps}
       data-id={a.id}
       data-trigger-type={a.trigger_type ?? ''}
       data-action-type={a.action_type ?? ''}

--- a/webui/src/routes/automations/-ui/automation-card.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.tsx
@@ -9,6 +9,7 @@ import {
   isFinished,
   isRunning,
   PROGRESS_HIDE_MS,
+  useSecondTick,
 } from '../-automations.progress';
 
 export interface AutomationCardHandlers {
@@ -99,11 +100,9 @@ function ProgressPanel({ state }: { state: AutomationRunState }) {
  * outside that selector, so React owns it alone.
  */
 function NextRun({ nextRun }: { nextRun: string }) {
-  const [, force] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => force((n) => n + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // One shared interval for every countdown on the page, mirroring the single
+  // module-level timer the vanilla page used — not one timer per card.
+  useSecondTick();
   return <span className="auto-next-run">Next: {timeUntil(nextRun)}</span>;
 }
 

--- a/webui/src/routes/automations/-ui/automation-card.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react';
+
+import type { Automation } from '../-automations.types';
+
+import { automationMeta, formatAction, formatTrigger, timeUntil } from '../-automations.format';
+import { automationIcon, formatNotify } from '../-automations.icons';
+
+export interface AutomationCardHandlers {
+  onRun?: (a: Automation) => void;
+  onToggle?: (a: Automation) => void;
+  onEdit?: (a: Automation) => void;
+  onDuplicate?: (a: Automation) => void;
+  onAssignGroup?: (a: Automation, event: React.MouseEvent) => void;
+  onDelete?: (a: Automation) => void;
+  onShowHistory?: (a: Automation) => void;
+  /** Label for a trigger/action type not in the static maps, from /blocks. */
+  blockLabel?: (type: string) => string | undefined;
+}
+
+interface Props extends AutomationCardHandlers {
+  automation: Automation;
+}
+
+/**
+ * Live "Next: in 4m" countdown.
+ *
+ * The vanilla page ticks these from ONE module-level setInterval that rewrites
+ * `.auto-next-run[data-next]` across the whole document every second. That
+ * script is still loaded while this page runs, so a React node carrying both
+ * the class AND the attribute would be written to by vanilla between renders
+ * and overwritten by React on the next one — two owners for one text node.
+ *
+ * Keeping the class (it is styled) but omitting data-next puts this node
+ * outside that selector, so React owns it alone.
+ */
+function NextRun({ nextRun }: { nextRun: string }) {
+  const [, force] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => force((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return <span className="auto-next-run">Next: {timeUntil(nextRun)}</span>;
+}
+
+/** One automation row. Markup mirrors renderAutomationCard so the CSS applies unchanged. */
+export function AutomationCard({ automation: a, blockLabel, ...on }: Props) {
+  const enabled = a.enabled === true || a.enabled === 1;
+  const isSystem = a.is_system === true || a.is_system === 1;
+  const meta = automationMeta(a);
+  const thenItems = a.then_actions ?? [];
+  const delay = (a.action_config as { delay?: number } | null)?.delay ?? 0;
+
+  const triggerLabel = `${automationIcon(a.trigger_type)} ${formatTrigger(a.trigger_type, a.trigger_config, blockLabel)}`;
+  const actionLabel = `${automationIcon(a.action_type)} ${formatAction(a.action_type, blockLabel)}`;
+
+  // Assembled as nodes rather than a joined string so the separator lands
+  // between exactly the parts that are present, as the vanilla join did.
+  const metaParts: React.ReactNode[] = [];
+  if (meta.lastRun) metaParts.push(<>Last: {meta.lastRun}</>);
+  if (meta.nextRun && a.next_run) metaParts.push(<NextRun nextRun={a.next_run} />);
+  if (meta.listening) metaParts.push(<>Listening</>);
+  if (meta.runs)
+    metaParts.push(
+      <span
+        className="auto-runs-link"
+        title="View run history"
+        onClick={(e) => {
+          e.stopPropagation();
+          on.onShowHistory?.(a);
+        }}
+      >
+        Runs: {meta.runs}
+      </span>,
+    );
+  if (meta.error) metaParts.push(<>Error: {meta.error}</>);
+  else if (meta.result)
+    metaParts.push(
+      <span className="auto-last-result" title={`Last run: ${meta.result.full}`}>
+        {meta.result.shown}
+      </span>,
+    );
+
+  return (
+    <div
+      className={`automation-card${enabled ? '' : ' disabled'}${isSystem ? ' system' : ''}`}
+      data-id={a.id}
+      data-trigger-type={a.trigger_type ?? ''}
+      data-action-type={a.action_type ?? ''}
+    >
+      <div className={`automation-status ${enabled ? 'enabled' : 'disabled'}`} />
+      <div className="automation-info">
+        <div className="automation-name" title={a.name}>
+          {a.name}
+        </div>
+        <div className="automation-flow">
+          <span className="flow-trigger">{triggerLabel}</span>
+          <span className="flow-arrow">→</span>
+          {delay ? (
+            <>
+              <span className="flow-delay">⏳ {delay}m</span>
+              <span className="flow-arrow">→</span>
+            </>
+          ) : null}
+          <span className="flow-action">{actionLabel}</span>
+          {thenItems.map((t, i) => (
+            <span key={`${t.type}-${i}`}>
+              <span className="flow-arrow">→</span>
+              <span className="flow-notify">{formatNotify(t.type)}</span>
+            </span>
+          ))}
+        </div>
+        <div className="automation-meta">
+          {metaParts.map((part, i) => (
+            <span key={i}>
+              {i > 0 ? ' · ' : null}
+              {part}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div className="automation-actions">
+        <button
+          type="button"
+          className="automation-run-btn"
+          title="Run now"
+          onClick={(e) => {
+            e.stopPropagation();
+            on.onRun?.(a);
+          }}
+        >
+          ▶
+        </button>
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- the
+            input IS the control; the label is the styled switch, as in vanilla. */}
+        <label className="automation-toggle" onClick={(e) => e.stopPropagation()}>
+          <input
+            type="checkbox"
+            checked={enabled}
+            aria-label={`${enabled ? 'Disable' : 'Enable'} ${a.name}`}
+            onChange={() => on.onToggle?.(a)}
+          />
+          <span className="toggle-slider" />
+        </label>
+        <button
+          type="button"
+          className="automation-edit-btn"
+          title="Edit"
+          onClick={(e) => {
+            e.stopPropagation();
+            on.onEdit?.(a);
+          }}
+        >
+          ⚙
+        </button>
+        {/* System automations are seeded and undeletable, so they expose no
+            duplicate / group / delete affordances at all. */}
+        {isSystem ? null : (
+          <>
+            <button
+              type="button"
+              className="automation-dupe-btn"
+              title="Duplicate"
+              onClick={(e) => {
+                e.stopPropagation();
+                on.onDuplicate?.(a);
+              }}
+            >
+              📋
+            </button>
+            <button
+              type="button"
+              className={`automation-group-btn${a.group_name ? ' grouped' : ''}`}
+              data-group={a.group_name ?? ''}
+              title={a.group_name ? `Group: ${a.group_name}` : 'Assign group'}
+              onClick={(e) => {
+                e.stopPropagation();
+                on.onAssignGroup?.(a, e);
+              }}
+            >
+              📁
+            </button>
+            <button
+              type="button"
+              className="automation-delete-btn"
+              title="Delete"
+              onClick={(e) => {
+                e.stopPropagation();
+                on.onDelete?.(a);
+              }}
+            >
+              🗑
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/automations/-ui/automation-card.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import type { Automation } from '../-automations.types';
 
 import { automationMeta, formatAction, formatTrigger, timeUntil } from '../-automations.format';
 import { automationIcon, formatNotify } from '../-automations.icons';
+import {
+  type AutomationRunState,
+  isFinished,
+  isRunning,
+  PROGRESS_HIDE_MS,
+} from '../-automations.progress';
 
 export interface AutomationCardHandlers {
   onRun?: (a: Automation) => void;
@@ -19,6 +25,65 @@ export interface AutomationCardHandlers {
 
 interface Props extends AutomationCardHandlers {
   automation: Automation;
+  /** Live run state for this automation, if one is in flight or just ended. */
+  progress?: AutomationRunState;
+}
+
+/**
+ * The run panel: bar, phase, and the streaming log.
+ *
+ * A finished panel lingers for 30s then collapses, matching the vanilla hide
+ * timer — long enough to read the result, short enough not to accumulate.
+ */
+function ProgressPanel({ state }: { state: AutomationRunState }) {
+  const [hidden, setHidden] = useState(false);
+  const logRef = useRef<HTMLDivElement>(null);
+  const done = isFinished(state);
+
+  useEffect(() => {
+    if (!done) {
+      // A re-run inside the hide window must bring the panel back.
+      setHidden(false);
+      return;
+    }
+    const id = setTimeout(() => setHidden(true), PROGRESS_HIDE_MS);
+    return () => clearTimeout(id);
+  }, [done, state.status]);
+
+  const lines = state.log ?? [];
+  useEffect(() => {
+    // Follow the tail as lines arrive, as the vanilla renderer did.
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [lines.length]);
+
+  const classes = [
+    'automation-output',
+    hidden ? '' : 'visible',
+    done ? 'finished' : '',
+    state.status === 'error' ? 'error' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes}>
+      <div className="auto-progress-bar-wrap">
+        {/* A finished run reads 100% regardless of the last reported number. */}
+        <div
+          className="auto-progress-bar"
+          style={{ width: `${done ? 100 : (state.progress ?? 0)}%` }}
+        />
+      </div>
+      <div className="auto-progress-phase">{state.phase ?? ''}</div>
+      <div className="auto-progress-log" ref={logRef}>
+        {lines.map((line, i) => (
+          <div key={i} className={`auto-log-line ${line.type || 'info'}`}>
+            {line.text}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -43,9 +108,10 @@ function NextRun({ nextRun }: { nextRun: string }) {
 }
 
 /** One automation row. Markup mirrors renderAutomationCard so the CSS applies unchanged. */
-export function AutomationCard({ automation: a, blockLabel, ...on }: Props) {
+export function AutomationCard({ automation: a, blockLabel, progress, ...on }: Props) {
   const enabled = a.enabled === true || a.enabled === 1;
   const isSystem = a.is_system === true || a.is_system === 1;
+  const running = isRunning(progress);
   const meta = automationMeta(a);
   const thenItems = a.then_actions ?? [];
   const delay = (a.action_config as { delay?: number } | null)?.delay ?? 0;
@@ -82,12 +148,17 @@ export function AutomationCard({ automation: a, blockLabel, ...on }: Props) {
 
   return (
     <div
-      className={`automation-card${enabled ? '' : ' disabled'}${isSystem ? ' system' : ''}`}
+      className={`automation-card${enabled ? '' : ' disabled'}${isSystem ? ' system' : ''}${
+        running ? ' running' : ''
+      }`}
       data-id={a.id}
       data-trigger-type={a.trigger_type ?? ''}
       data-action-type={a.action_type ?? ''}
     >
-      <div className={`automation-status ${enabled ? 'enabled' : 'disabled'}`} />
+      {/* While running the dot shows the run, not the enabled state. */}
+      <div
+        className={`automation-status ${running ? 'running' : enabled ? 'enabled' : 'disabled'}`}
+      />
       <div className="automation-info">
         <div className="automation-name" title={a.name}>
           {a.name}
@@ -193,6 +264,8 @@ export function AutomationCard({ automation: a, blockLabel, ...on }: Props) {
           </>
         )}
       </div>
+
+      {progress ? <ProgressPanel state={progress} /> : null}
     </div>
   );
 }

--- a/webui/src/routes/automations/-ui/automation-hub.tsx
+++ b/webui/src/routes/automations/-ui/automation-hub.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * The Automation Hub section.
+ *
+ * loadAutomations renders this between System and the user groups, and it is
+ * pure informational content — pipelines, recipes, guides, reference and tips —
+ * built by _buildAutomationHub in stats-automations.js.
+ *
+ * That builder is SHARED with the video automations page, so its content is
+ * mounted here rather than restated in JSX. Re-authoring it would fork a body
+ * of copy that has to stay identical on both sides, which is precisely the
+ * drift the icon parity test exists to prevent.
+ *
+ * React owns an empty host node and hands the subtree to the builder. Nothing
+ * inside is React-managed, so the builder's own collapse handler and
+ * localStorage state keep working untouched.
+ */
+export function AutomationHub() {
+  const host = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = host.current;
+    if (!mount || typeof window._buildAutomationHub !== 'function') return;
+
+    const section = window._buildAutomationHub();
+    mount.appendChild(section);
+    // Strict mode mounts effects twice; without this the hub appears twice.
+    return () => {
+      section.remove();
+    };
+  }, []);
+
+  return <div ref={host} data-automation-hub="" />;
+}

--- a/webui/src/routes/automations/-ui/automations-page.test.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.test.tsx
@@ -1,0 +1,185 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+import type { Automation } from '../-automations.types';
+
+/**
+ * Driven through the REAL router, with the manifest reporting /automations as
+ * React-owned.
+ *
+ * The page cannot be rendered standalone — useProfile() reads the root route
+ * context — and going through the router also exercises the loader, the
+ * dormancy guard and URL-driven filter state rather than a stub of them.
+ * Only getShellRouteByPageId is faked; the rest of the manifest is real,
+ * because the router builds its route table from it.
+ */
+vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/platform/shell/route-manifest')>();
+  return {
+    ...actual,
+    getShellRouteByPageId: (pageId: string) =>
+      pageId === 'automations'
+        ? { ...actual.getShellRouteByPageId('automations'), kind: 'react' }
+        : actual.getShellRouteByPageId(pageId as never),
+  };
+});
+
+function auto(over: Partial<Automation> & { id: number }): Automation {
+  return { name: `auto-${over.id}`, enabled: 1, ...over };
+}
+
+let requests: { url: string; method: string; body?: unknown }[] = [];
+
+function stubFetch(rows: Automation[], master: { music: boolean } = { music: true }) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      const method = (
+        init?.method ?? (input instanceof Request ? input.method : 'GET')
+      ).toUpperCase();
+      // ky sends a Request object, so a JSON payload is NOT on init.body —
+      // reading only init.body silently recorded `undefined` for every call
+      // that carries one.
+      let raw: string | undefined;
+      if (init?.body) raw = String(init.body);
+      else if (input instanceof Request) raw = (await input.clone().text()) || undefined;
+      let body: unknown;
+      if (raw) {
+        try {
+          body = JSON.parse(raw);
+        } catch {
+          body = raw;
+        }
+      }
+      requests.push({ url, method, body });
+
+      const json = (data: unknown) =>
+        new Response(JSON.stringify(data), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+      if (url.includes('/api/automations/master')) return json(master);
+      if (url.match(/\/api\/automations\/\d+/) || url.includes('bulk-toggle'))
+        return json({ success: true, updated: 2 });
+      if (url.includes('/api/automations')) return json(rows);
+      return json({});
+    }),
+  );
+}
+
+function renderPage(rows: Automation[], master?: { music: boolean }, entry = '/automations') {
+  requests = [];
+  stubFetch(rows, master);
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: [entry] });
+  const router = createAppRouter({ history, queryClient });
+  return render(<AppRouterProvider router={router} queryClient={queryClient} />);
+}
+
+const sent = (fragment: string, method = 'POST') =>
+  requests.filter((r) => r.url.includes(fragment) && r.method === method);
+
+describe('AutomationsPage interactions', () => {
+  beforeEach(() => {
+    window.SoulSyncWebShellBridge = createShellBridge();
+    window.showToast = vi.fn();
+    window.showConfirmDialog = vi.fn(async () => true);
+    window.showAutomationBuilder = vi.fn();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete window.SoulSyncWebShellBridge;
+  });
+
+  it('toggles an automation without a toast', async () => {
+    renderPage([auto({ id: 5, name: 'Nightly' })]);
+    await screen.findByText('Nightly');
+
+    fireEvent.click(screen.getByLabelText('Disable Nightly'));
+    await waitFor(() => expect(sent('/automations/5/toggle')).toHaveLength(1));
+    // The switch is its own feedback; vanilla showed nothing on success.
+    expect(window.showToast).not.toHaveBeenCalled();
+  });
+
+  it('runs an automation and reports it', async () => {
+    renderPage([auto({ id: 6, name: 'Nightly' })]);
+    await screen.findByText('Nightly');
+
+    fireEvent.click(document.querySelector('.automation-run-btn')!);
+    await waitFor(() => expect(sent('/automations/6/run')).toHaveLength(1));
+    expect(window.showToast).toHaveBeenCalledWith('Automation triggered', 'success');
+  });
+
+  it('confirms before deleting, and does nothing if declined', async () => {
+    window.showConfirmDialog = vi.fn(async () => false);
+    renderPage([auto({ id: 7, name: 'Nightly' })]);
+    await screen.findByText('Nightly');
+
+    fireEvent.click(document.querySelector('.automation-delete-btn')!);
+    await waitFor(() => expect(window.showConfirmDialog).toHaveBeenCalled());
+    // The important half: a declined confirm must not issue the DELETE.
+    expect(sent('/automations/7', 'DELETE')).toHaveLength(0);
+  });
+
+  it('deletes once confirmed', async () => {
+    renderPage([auto({ id: 8, name: 'Nightly' })]);
+    await screen.findByText('Nightly');
+
+    fireEvent.click(document.querySelector('.automation-delete-btn')!);
+    await waitFor(() => expect(sent('/automations/8', 'DELETE')).toHaveLength(1));
+    expect(window.showToast).toHaveBeenCalledWith('Automation deleted', 'success');
+  });
+
+  it('flips the master switch to the opposite of its current state', async () => {
+    renderPage([auto({ id: 1 })], { music: true });
+    await waitFor(() => expect(document.querySelector('.auto-master-toggle.on')).not.toBeNull());
+
+    fireEvent.click(document.querySelector('.auto-master-toggle')!);
+    await waitFor(() => expect(sent('/automations/master')).toHaveLength(1));
+    expect(sent('/automations/master')[0].body).toEqual({ side: 'music', enabled: false });
+  });
+
+  it('bulk-toggles every automation in the group, including ones the filter hides', async () => {
+    // React removes filtered-out cards from the DOM entirely, so sourcing ids
+    // from the rendered cards would toggle only the visible subset.
+    renderPage(
+      [
+        auto({ id: 11, name: 'Alpha', group_name: 'Chores' }),
+        auto({ id: 12, name: 'Beta', group_name: 'Chores' }),
+      ],
+      undefined,
+      '/automations?q=Alpha',
+    );
+    await screen.findByText('Alpha');
+    expect(screen.queryByText('Beta')).toBeNull(); // genuinely not rendered
+
+    fireEvent.click(document.querySelector('.section-action-btn')!);
+    await waitFor(() => expect(sent('bulk-toggle')).toHaveLength(1));
+    expect(sent('bulk-toggle')[0].body).toEqual({ automation_ids: [11, 12], enabled: false });
+  });
+
+  it('surfaces a server error as a toast', async () => {
+    renderPage([auto({ id: 9, name: 'Nightly' })]);
+    await screen.findByText('Nightly');
+    // The endpoints answer {error} with HTTP 200, so the payload check is what
+    // catches this — an ok-status check alone would report success.
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'engine unavailable' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    fireEvent.click(document.querySelector('.automation-run-btn')!);
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Error: engine unavailable', 'error'),
+    );
+  });
+});

--- a/webui/src/routes/automations/-ui/automations-page.test.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.test.tsx
@@ -86,18 +86,20 @@ function renderPage(rows: Automation[], master?: { music: boolean }, entry = '/a
 const sent = (fragment: string, method = 'POST') =>
   requests.filter((r) => r.url.includes(fragment) && r.method === method);
 
-describe('AutomationsPage interactions', () => {
-  beforeEach(() => {
-    window.SoulSyncWebShellBridge = createShellBridge();
-    window.showToast = vi.fn();
-    window.showConfirmDialog = vi.fn(async () => true);
-    window.showAutomationBuilder = vi.fn();
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-    delete window.SoulSyncWebShellBridge;
-  });
+// Shared by every block below — a missing shell bridge makes the route
+// redirect instead of rendering, which surfaces as "cannot find text".
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  window.showToast = vi.fn();
+  window.showConfirmDialog = vi.fn(async () => true);
+  window.showAutomationBuilder = vi.fn();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.SoulSyncWebShellBridge;
+});
 
+describe('AutomationsPage interactions', () => {
   it('toggles an automation without a toast', async () => {
     renderPage([auto({ id: 5, name: 'Nightly' })]);
     await screen.findByText('Nightly');
@@ -181,5 +183,136 @@ describe('AutomationsPage interactions', () => {
     await waitFor(() =>
       expect(window.showToast).toHaveBeenCalledWith('Error: engine unavailable', 'error'),
     );
+  });
+});
+
+describe('AutomationsPage group management', () => {
+  const chores = () => [
+    auto({ id: 21, name: 'Alpha', group_name: 'Chores' }),
+    auto({ id: 22, name: 'Beta', group_name: 'Chores' }),
+  ];
+
+  it('assigns an automation to an existing group', async () => {
+    renderPage([...chores(), auto({ id: 23, name: 'Loose' })]);
+    await screen.findByText('Loose');
+
+    // The group button on the ungrouped card opens the dropdown.
+    const looseCard = [...document.querySelectorAll('.automation-card')].find(
+      (c) => c.getAttribute('data-id') === '23',
+    )!;
+    fireEvent.click(looseCard.querySelector('.automation-group-btn')!);
+
+    const option = await screen.findByText('Chores', { selector: '.auto-group-option' });
+    fireEvent.click(option);
+
+    await waitFor(() => expect(sent('/automations/23', 'PUT')).toHaveLength(1));
+    expect(sent('/automations/23', 'PUT')[0].body).toEqual({ group_name: 'Chores' });
+  });
+
+  it('creates a new group from the input, ignoring an empty submit', async () => {
+    renderPage([auto({ id: 24, name: 'Loose' })]);
+    await screen.findByText('Loose');
+    fireEvent.click(document.querySelector('.automation-group-btn')!);
+
+    const input = await screen.findByLabelText('New group name');
+    // Enter on blank must NOT fire. The vanilla handler passed '' straight to
+    // _assignGroup, where `|| null` silently UNGROUPED instead.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // Same reasoning: give an errant request a chance to be issued.
+    await waitFor(() => expect(screen.getByLabelText('New group name')).toBeInTheDocument());
+    expect(sent('/automations/24', 'PUT')).toHaveLength(0);
+
+    fireEvent.change(input, { target: { value: '  Errands  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => expect(sent('/automations/24', 'PUT')).toHaveLength(1));
+    expect(sent('/automations/24', 'PUT')[0].body).toEqual({ group_name: 'Errands' });
+  });
+
+  it('renames a group over every automation in it', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Rename group'));
+    const input = await screen.findByLabelText('Rename group Chores');
+    fireEvent.change(input, { target: { value: 'Errands' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(sent('automations/group', 'PUT')).toHaveLength(1));
+    expect(sent('automations/group', 'PUT')[0].body).toEqual({
+      automation_ids: [21, 22],
+      group_name: 'Errands',
+    });
+  });
+
+  it('does not PUT when a rename is unchanged or blank', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Rename group'));
+    const input = await screen.findByLabelText('Rename group Chores');
+    fireEvent.keyDown(input, { key: 'Enter' }); // unchanged
+    fireEvent.click(screen.getByTitle('Rename group'));
+    const again = await screen.findByLabelText('Rename group Chores');
+    fireEvent.change(again, { target: { value: '   ' } });
+    fireEvent.keyDown(again, { key: 'Enter' }); // blank
+
+    await waitFor(() => expect(screen.queryByLabelText('Rename group Chores')).toBeNull());
+    expect(sent('automations/group', 'PUT')).toHaveLength(0);
+  });
+
+  it('escape abandons a rename without saving', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Rename group'));
+    const input = await screen.findByLabelText('Rename group Chores');
+    fireEvent.change(input, { target: { value: 'Errands' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    // Wait for the editor to actually close before asserting. Checking
+    // synchronously here passes whatever Escape does, because the mutation
+    // would not have issued its request yet — the assertion has to outlive it.
+    await waitFor(() => expect(screen.queryByLabelText('Rename group Chores')).toBeNull());
+    expect(sent('automations/group', 'PUT')).toHaveLength(0);
+  });
+
+  it('offers keep-or-delete when removing a group, and cancel does nothing', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Delete group'));
+    await screen.findByText(/Delete Group/);
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(sent('automations/group', 'PUT')).toHaveLength(0);
+    expect(sent('/automations/21', 'DELETE')).toHaveLength(0);
+  });
+
+  it('dissolving a group ungroups its automations rather than deleting them', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Delete group'));
+    fireEvent.click(await screen.findByText(/Keep Automations/));
+
+    await waitFor(() => expect(sent('automations/group', 'PUT')).toHaveLength(1));
+    expect(sent('automations/group', 'PUT')[0].body).toEqual({
+      automation_ids: [21, 22],
+      group_name: null,
+    });
+    // The destructive path must NOT have run.
+    expect(sent('/automations/21', 'DELETE')).toHaveLength(0);
+  });
+
+  it('deleting everything removes each automation in the group', async () => {
+    renderPage(chores());
+    await screen.findByText('Alpha');
+
+    fireEvent.click(screen.getByTitle('Delete group'));
+    fireEvent.click(await screen.findByText(/Delete Everything/));
+
+    await waitFor(() => expect(sent('/automations/21', 'DELETE')).toHaveLength(1));
+    await waitFor(() => expect(sent('/automations/22', 'DELETE')).toHaveLength(1));
+    expect(sent('automations/group', 'PUT')).toHaveLength(0);
   });
 });

--- a/webui/src/routes/automations/-ui/automations-page.test.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.test.tsx
@@ -316,3 +316,138 @@ describe('AutomationsPage group management', () => {
     expect(sent('automations/group', 'PUT')).toHaveLength(0);
   });
 });
+
+describe('AutomationsPage layout parity', () => {
+  it('puts cards inside .automations-grid, not loose in the section body', () => {
+    // .automations-grid is `repeat(2, 1fr)`. Rendering cards as direct children
+    // of .automations-section-body silently collapses the page to one card per
+    // row — which is exactly what shipped before this test existed.
+    renderPage([auto({ id: 1, name: 'Alpha' }), auto({ id: 2, name: 'Beta' })]);
+    return screen.findByText('Alpha').then(() => {
+      const grid = document.querySelector('.automations-section-body > .automations-grid');
+      expect(grid).not.toBeNull();
+      expect(grid!.querySelectorAll('.automation-card')).toHaveLength(2);
+      // and no card escaped the grid
+      expect(
+        document.querySelectorAll('.automations-section-body > .automation-card'),
+      ).toHaveLength(0);
+    });
+  });
+
+  it('renders the Automation Hub, mounted from the shared vanilla builder', async () => {
+    const built = document.createElement('div');
+    built.className = 'automations-section';
+    built.id = 'auto-section-hub';
+    built.textContent = 'Automation Hub';
+    window._buildAutomationHub = vi.fn(() => built);
+
+    renderPage([auto({ id: 1, name: 'Alpha' })]);
+    await screen.findByText('Alpha');
+
+    expect(window._buildAutomationHub).toHaveBeenCalled();
+    expect(document.querySelector('#auto-section-hub')).not.toBeNull();
+    delete window._buildAutomationHub;
+  });
+
+  it('hides the Hub when there are no automations', async () => {
+    // loadAutomations returns before appending the hub on an empty list, so a
+    // fresh install must not see the empty state AND a wall of reference docs.
+    window._buildAutomationHub = vi.fn(() => document.createElement('div'));
+    renderPage([]);
+    await screen.findByText('No automations yet');
+    expect(window._buildAutomationHub).not.toHaveBeenCalled();
+    delete window._buildAutomationHub;
+  });
+
+  it('survives the hub builder being unavailable', async () => {
+    delete window._buildAutomationHub;
+    renderPage([auto({ id: 1, name: 'Alpha' })]);
+    // The page must still render; a missing hub is not a crash.
+    await screen.findByText('Alpha');
+    expect(document.querySelector('.automation-card')).not.toBeNull();
+  });
+});
+
+describe('AutomationsPage handler coverage', () => {
+  it('opens the run-history modal from the Runs link', async () => {
+    window.showAutomationHistory = vi.fn();
+    renderPage([auto({ id: 31, name: 'Nightly', run_count: 4, action_type: 'scan_library' })]);
+    await screen.findByText('Nightly');
+
+    fireEvent.click(document.querySelector('.auto-runs-link')!);
+    expect(window.showAutomationHistory).toHaveBeenCalledWith(31, 'Nightly', 'scan_library');
+    delete window.showAutomationHistory;
+  });
+
+  it('supplies a handler for every affordance the card renders', async () => {
+    // onShowHistory was declared as a prop and simply never passed, so the
+    // Runs link rendered and did nothing. This asserts the card is never handed
+    // an incomplete handler set again — the failure mode is a dead control,
+    // which no type error and no rendering test would catch.
+    const { AutomationCard } = await import('./automation-card');
+    const declared = [
+      'onRun',
+      'onToggle',
+      'onEdit',
+      'onDuplicate',
+      'onAssignGroup',
+      'onDelete',
+      'onShowHistory',
+    ];
+    const source = AutomationCard.toString();
+    // Every handler the component invokes must be one the page provides.
+    const invoked = declared.filter((name) => source.includes(name));
+    const pageSource = (await import('node:fs')).readFileSync(
+      'src/routes/automations/-ui/automations-page.tsx',
+      'utf8',
+    );
+    const missing = invoked.filter((name) => !pageSource.includes(`${name}:`));
+    expect(missing).toEqual([]);
+  });
+});
+
+describe('AutomationsPage filtering parity', () => {
+  const two = () => [
+    auto({ id: 41, name: 'Alpha', group_name: 'Chores' }),
+    auto({ id: 42, name: 'Beta', group_name: 'Chores' }),
+  ];
+
+  it('keeps the section and its count fixed while filtering', async () => {
+    // The vanilla filter only set display:none on cards, so a section never
+    // vanished mid-search and its header count never moved. Deriving either
+    // from the filtered list makes the count tick down as you type.
+    renderPage(two(), undefined, '/automations?q=Alpha');
+    await screen.findByText('Alpha');
+
+    expect(screen.queryByText('Beta')).toBeNull(); // card filtered out
+    expect(document.querySelector('.automations-section')).not.toBeNull(); // section stays
+    expect(document.querySelector('.section-count')?.textContent).toBe('2'); // count unmoved
+  });
+
+  it('keeps a section whose every card is filtered away', async () => {
+    renderPage(two(), undefined, '/automations?q=zzzznomatch');
+    await waitFor(() => expect(document.querySelector('.automations-section')).not.toBeNull());
+    expect(document.querySelectorAll('.automation-card')).toHaveLength(0);
+    expect(document.querySelector('.section-count')?.textContent).toBe('2');
+  });
+
+  it('judges Enable/Disable all over the whole group, not the visible subset', async () => {
+    // The discriminating case: the group is PARTLY enabled, and the filter
+    // leaves only the enabled one visible. Judged over the visible subset the
+    // button reads "Disable all" (1 of 1 enabled); judged over the group it
+    // reads "Enable all" (1 of 2). A group where every member is enabled
+    // cannot tell the two apart — which is what an earlier version of this
+    // test did, and it passed against the wrong implementation.
+    renderPage(
+      [
+        auto({ id: 43, name: 'Alpha', group_name: 'Chores', enabled: 1 }),
+        auto({ id: 44, name: 'Beta', group_name: 'Chores', enabled: 0 }),
+      ],
+      undefined,
+      '/automations?q=Alpha',
+    );
+    await screen.findByText('Alpha');
+    expect(screen.getByTitle('Enable all')).toBeInTheDocument();
+    expect(screen.queryByTitle('Disable all')).toBeNull();
+  });
+});

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -1,0 +1,231 @@
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useCallback, useMemo } from 'react';
+
+import { useProfile, useReactPageShell } from '@/platform/shell/route-controllers';
+
+import type { Automation } from '../-automations.types';
+
+import { automationsListQueryOptions, automationsMasterQueryOptions } from '../-automations.api';
+import { formatAction, formatTrigger } from '../-automations.format';
+import {
+  buildAutomationsView,
+  filterAutomations,
+  filterOptions,
+  forMusicSide,
+  readAutomationsList,
+} from '../-automations.helpers';
+import { Route } from '../route';
+import { AutomationsSection, groupSectionId } from './automations-section';
+
+export function AutomationsPage() {
+  useReactPageShell('automations');
+
+  const { profileId } = useProfile();
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const listQuery = useQuery(automationsListQueryOptions(profileId));
+  const masterQuery = useQuery(automationsMasterQueryOptions());
+
+  // Both sides share ONE endpoint; only owned_by separates them.
+  const automations = useMemo(
+    () => forMusicSide(readAutomationsList(listQuery.data)),
+    [listQuery.data],
+  );
+
+  // The vanilla filter matched the rendered label text, so the same formatters
+  // that build the card must produce the strings the filter searches.
+  const labelFor = useCallback(
+    (a: Automation) => ({
+      trigger: formatTrigger(a.trigger_type, a.trigger_config),
+      action: formatAction(a.action_type),
+    }),
+    [],
+  );
+
+  // Stats and the filter-bar threshold describe the WHOLE set: filtering down
+  // to one card must not make the bar read "1 Active" or hide the very filter
+  // being used. Only the section contents narrow.
+  const view = useMemo(() => buildAutomationsView(automations), [automations]);
+  const options = useMemo(() => filterOptions(automations), [automations]);
+  const visible = useMemo(
+    () => filterAutomations(automations, search, labelFor),
+    [automations, search, labelFor],
+  );
+  const shown = useMemo(() => new Set(visible.map((a) => a.id)), [visible]);
+  const keep = useMemo(
+    () => ({
+      system: view.system.filter((a) => shown.has(a.id)),
+      groups: view.groups
+        .map((g) => ({ ...g, automations: g.automations.filter((a) => shown.has(a.id)) }))
+        .filter((g) => g.automations.length > 0),
+      ungrouped: view.ungrouped.filter((a) => shown.has(a.id)),
+    }),
+    [view, shown],
+  );
+
+  const filtering = Boolean(search.q || search.trigger || search.action);
+  const masterOn = masterQuery.data?.music !== false;
+  const isEmpty = automations.length === 0;
+
+  const setSearch = (patch: Partial<typeof search>) =>
+    void navigate({ search: (prev) => ({ ...prev, ...patch }), replace: true });
+
+  // NOTE: deliberately no id attributes below.
+  //
+  // The vanilla markup in index.html keeps #automations-list, #auto-filter-bar,
+  // #auto-filter-search and friends until the cleanup PR, and three vanilla
+  // functions still reach for them with getElementById — which returns the
+  // FIRST match in document order. Rendering the same ids here would create
+  // duplicates and hand those functions the wrong node. Every rule that styles
+  // this page is class-scoped (only #automations-list-view, the outer wrapper
+  // we do not render, is an id rule), so nothing is lost by omitting them.
+  return (
+    <div className="page-shell automations-container">
+      <div className="dashboard-header">
+        <div className="dashboard-header-sweep" aria-hidden="true">
+          <span />
+        </div>
+        <div className="header-text">
+          <h2 className="header-title">
+            <img src="/static/automation.png" className="page-header-icon" alt="" />
+            <span>Automations</span>
+          </h2>
+          <p className="header-subtitle">Configure scheduled tasks and automated workflows</p>
+        </div>
+        <div className="header-spacer" />
+        <div className="header-actions">
+          <button
+            type="button"
+            className="auto-new-btn"
+            onClick={() => window.showAutomationBuilder?.()}
+          >
+            + New Automation
+          </button>
+        </div>
+      </div>
+
+      <div className="automations-stats">
+        {/* The master switch is prepended to this bar and stays reachable even
+            with nothing configured — pausing is a side-wide control. */}
+        <button
+          type="button"
+          className={`auto-master-toggle${masterOn ? ' on' : ''}`}
+          title={
+            masterOn
+              ? 'Automations are live. Click to pause every scheduled and event run on this side — individual switches keep their state, and manual Run still works.'
+              : 'Automations are paused: nothing runs on a schedule or event. Individual switches keep their state, and manual Run still works.'
+          }
+        >
+          <span className="auto-master-sw" />
+          <span className="auto-master-label">
+            {masterOn ? 'Automations on' : 'Automations paused'}
+          </span>
+        </button>
+        {isEmpty ? null : (
+          <>
+            <span className="auto-stat">
+              <strong>{view.stats.active}</strong> Active
+            </span>
+            <span className="auto-stat">
+              <strong>{view.stats.system}</strong> System
+            </span>
+            <span className="auto-stat">
+              <strong>{view.stats.custom}</strong> Custom
+            </span>
+          </>
+        )}
+      </div>
+
+      {view.showFilterBar ? (
+        <div className="auto-filter-bar">
+          <input
+            type="text"
+            className="auto-filter-search"
+            placeholder="Filter automations…"
+            aria-label="Filter automations"
+            value={search.q}
+            onChange={(e) => setSearch({ q: e.target.value })}
+          />
+          <select
+            className="auto-filter-select"
+            aria-label="Filter by trigger"
+            value={search.trigger}
+            onChange={(e) => setSearch({ trigger: e.target.value })}
+          >
+            <option value="">All Triggers</option>
+            {options.triggers.map((t) => (
+              <option key={t} value={t}>
+                {formatTrigger(t, {})}
+              </option>
+            ))}
+          </select>
+          <select
+            className="auto-filter-select"
+            aria-label="Filter by action"
+            value={search.action}
+            onChange={(e) => setSearch({ action: e.target.value })}
+          >
+            <option value="">All Actions</option>
+            {options.actions.map((t) => (
+              <option key={t} value={t}>
+                {formatAction(t)}
+              </option>
+            ))}
+          </select>
+          {/* Blank unless a filter is active, exactly as the vanilla count did. */}
+          <span className="auto-filter-count">
+            {filtering ? `${visible.length} of ${automations.length}` : ''}
+          </span>
+        </div>
+      ) : null}
+
+      <div className="automations-list">
+        {keep.system.length > 0 ? (
+          <AutomationsSection
+            id="auto-section-system"
+            label="System"
+            automations={keep.system}
+            isProtected
+          />
+        ) : null}
+
+        {keep.groups.map((group) => (
+          <AutomationsSection
+            key={group.name}
+            id={groupSectionId(group.name)}
+            label={`📁 ${group.name}`}
+            automations={group.automations}
+            groupName={group.name}
+          />
+        ))}
+
+        {keep.ungrouped.length > 0 ? (
+          <AutomationsSection
+            id="auto-section-custom"
+            label="My Automations"
+            automations={keep.ungrouped}
+          />
+        ) : null}
+      </div>
+
+      {isEmpty ? (
+        <div className="automations-empty">
+          <div className="automations-empty-icon">⚡</div>
+          <div className="automations-empty-title">No automations yet</div>
+          <div className="automations-empty-text">
+            Create your first automation to schedule tasks and trigger actions automatically.
+          </div>
+          <button
+            type="button"
+            className="auto-new-btn"
+            onClick={() => window.showAutomationBuilder?.()}
+          >
+            + New Automation
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -19,6 +19,7 @@ import {
   setAutomationsMaster,
   toggleAutomation,
 } from '../-automations.api';
+import { useVanillaBuilder } from '../-automations.builder';
 import { formatAction, formatTrigger } from '../-automations.format';
 import {
   buildAutomationsView,
@@ -46,6 +47,9 @@ export function AutomationsPage() {
   // Live run state, merged from the socket mirror. Not query-cached: it is a
   // stream of transient frames, not a resource with a canonical server copy.
   const progress = useAutomationProgress();
+  // The builder stays in vanilla and is shared with the video page; this hands
+  // the shell over for the edit and takes it back on close.
+  const openBuilder = useVanillaBuilder(() => void refresh());
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
   const fail = (error: Error) => window.showToast?.(`Error: ${error.message}`, 'error');
@@ -181,7 +185,7 @@ export function AutomationsPage() {
     onRun: (a: Automation) => run.mutate(a),
     onDuplicate: (a: Automation) => duplicate.mutate(a),
     onDelete: (a: Automation) => void confirmDelete(a),
-    onEdit: (a: Automation) => window.showAutomationBuilder?.(a.id),
+    onEdit: (a: Automation) => openBuilder(a.id),
     progressFor: (id: number) => progress[id],
     onAssignGroup: (a: Automation, event: React.MouseEvent) => {
       const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
@@ -279,11 +283,7 @@ export function AutomationsPage() {
         </div>
         <div className="header-spacer" />
         <div className="header-actions">
-          <button
-            type="button"
-            className="auto-new-btn"
-            onClick={() => window.showAutomationBuilder?.()}
-          >
+          <button type="button" className="auto-new-btn" onClick={() => openBuilder()}>
             + New Automation
           </button>
         </div>
@@ -417,11 +417,7 @@ export function AutomationsPage() {
           <div className="automations-empty-text">
             Create your first automation to schedule tasks and trigger actions automatically.
           </div>
-          <button
-            type="button"
-            className="auto-new-btn"
-            onClick={() => window.showAutomationBuilder?.()}
-          >
+          <button type="button" className="auto-new-btn" onClick={() => openBuilder()}>
             + New Automation
           </button>
         </div>

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { useProfile, useReactPageShell } from '@/platform/shell/route-controllers';
 
@@ -10,9 +10,11 @@ import {
   AUTOMATIONS_QUERY_KEY,
   automationsListQueryOptions,
   automationsMasterQueryOptions,
+  assignAutomationGroup,
   bulkToggleAutomations,
   deleteAutomation,
   duplicateAutomation,
+  regroupAutomations,
   runAutomation,
   setAutomationsMaster,
   toggleAutomation,
@@ -27,6 +29,8 @@ import {
 } from '../-automations.helpers';
 import { Route } from '../route';
 import { AutomationsSection, groupSectionId } from './automations-section';
+import { type DeleteGroupChoice, DeleteGroupDialog } from './delete-group-dialog';
+import { GroupDropdown } from './group-dropdown';
 
 export function AutomationsPage() {
   useReactPageShell('automations');
@@ -114,12 +118,85 @@ export function AutomationsPage() {
     remove.mutate(a);
   };
 
+  const assign = useMutation({
+    mutationFn: ({ id, group }: { id: number; group: string | null }) =>
+      assignAutomationGroup(id, group),
+    onSuccess: async (_v, { group }) => {
+      window.showToast?.(group ? `Moved to "${group}"` : 'Removed from group', 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  const regroup = useMutation({
+    mutationFn: ({ ids, group }: { ids: number[]; group: string | null; toast: string }) =>
+      regroupAutomations(ids, group),
+    onSuccess: async (updated, { toast }) => {
+      window.showToast?.(toast.replace('{n}', String(updated)), 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  // Deleting every automation in a group is N deletes; the API has no bulk
+  // delete. Sequential rather than parallel so a mid-way failure leaves a
+  // comprehensible state instead of a scatter of partial results.
+  const deleteGroupAll = useMutation({
+    mutationFn: async (ids: number[]) => {
+      for (const id of ids) await deleteAutomation(id);
+      return ids.length;
+    },
+    onSuccess: async (n) => {
+      window.showToast?.(`Deleted ${n} automation${n !== 1 ? 's' : ''}`, 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  const idsInGroup = (name: string) =>
+    view.groups.find((g) => g.name === name)?.automations.map((a) => a.id) ?? [];
+
+  const onDeleteGroupChoice = (choice: DeleteGroupChoice) => {
+    if (!deletingGroup) return;
+    const { name } = deletingGroup;
+    const ids = idsInGroup(name);
+    setDeletingGroup(null);
+    if (choice === 'ungroup') {
+      regroup.mutate({
+        ids,
+        group: null,
+        toast: `Dissolved group "${name}" — {n} automations moved to My Automations`,
+      });
+    } else {
+      deleteGroupAll.mutate(ids);
+    }
+  };
+
   const cardHandlers = {
     onToggle: (a: Automation) => toggle.mutate(a),
     onRun: (a: Automation) => run.mutate(a),
     onDuplicate: (a: Automation) => duplicate.mutate(a),
     onDelete: (a: Automation) => void confirmDelete(a),
     onEdit: (a: Automation) => window.showAutomationBuilder?.(a.id),
+    onAssignGroup: (a: Automation, event: React.MouseEvent) => {
+      const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+      setGroupMenu({
+        id: a.id,
+        current: a.group_name ?? null,
+        anchor: { top: rect.top, bottom: rect.bottom, right: rect.right },
+      });
+    },
+  };
+
+  const groupActions = {
+    onRename: (name: string, next: string) =>
+      regroup.mutate({ ids: idsInGroup(name), group: next, toast: `Renamed to "${next}"` }),
+    onDeleteGroup: (name: string) => {
+      const count = idsInGroup(name).length;
+      // Nothing to decide about an empty group; just refresh it away.
+      if (count === 0) return void refresh();
+      setDeletingGroup({ name, count });
+    },
   };
 
   // Both sides share ONE endpoint; only owned_by separates them.
@@ -158,6 +235,13 @@ export function AutomationsPage() {
     }),
     [view, shown],
   );
+
+  const [groupMenu, setGroupMenu] = useState<{
+    id: number;
+    current: string | null;
+    anchor: { top: number; bottom: number; right: number };
+  } | null>(null);
+  const [deletingGroup, setDeletingGroup] = useState<{ name: string; count: number } | null>(null);
 
   const filtering = Boolean(search.q || search.trigger || search.action);
   const masterOn = masterQuery.data?.music !== false;
@@ -295,6 +379,7 @@ export function AutomationsPage() {
             label={`📁 ${group.name}`}
             automations={group.automations}
             groupName={group.name}
+            {...groupActions}
             onBulkToggle={(name, allEnabled) =>
               bulkToggle.mutate({
                 // Ids come from the unfiltered data. _bulkToggleGroup scraped
@@ -335,6 +420,28 @@ export function AutomationsPage() {
             + New Automation
           </button>
         </div>
+      ) : null}
+
+      {groupMenu ? (
+        <GroupDropdown
+          groups={view.groups.map((g) => g.name)}
+          currentGroup={groupMenu.current}
+          anchor={groupMenu.anchor}
+          onClose={() => setGroupMenu(null)}
+          onAssign={(name) => {
+            assign.mutate({ id: groupMenu.id, group: name });
+            setGroupMenu(null);
+          }}
+        />
+      ) : null}
+
+      {deletingGroup ? (
+        <DeleteGroupDialog
+          groupName={deletingGroup.name}
+          count={deletingGroup.count}
+          onChoose={onDeleteGroupChoice}
+          onCancel={() => setDeletingGroup(null)}
+        />
       ) : null}
     </div>
   );

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -10,6 +10,7 @@ import {
   AUTOMATIONS_QUERY_KEY,
   automationsListQueryOptions,
   automationsMasterQueryOptions,
+  automationsProgressQueryOptions,
   assignAutomationGroup,
   bulkToggleAutomations,
   deleteAutomation,
@@ -30,6 +31,7 @@ import {
 } from '../-automations.helpers';
 import { useAutomationProgress } from '../-automations.progress';
 import { Route } from '../route';
+import { AutomationHub } from './automation-hub';
 import { AutomationsSection, groupSectionId } from './automations-section';
 import { type DeleteGroupChoice, DeleteGroupDialog } from './delete-group-dialog';
 import { GroupDropdown } from './group-dropdown';
@@ -46,7 +48,13 @@ export function AutomationsPage() {
   const masterQuery = useQuery(automationsMasterQueryOptions());
   // Live run state, merged from the socket mirror. Not query-cached: it is a
   // stream of transient frames, not a resource with a canonical server copy.
-  const progress = useAutomationProgress();
+  //
+  // Seeded from /api/automations/progress so a page opened DURING a run shows
+  // that run immediately. Without the seed the card stays blank until the next
+  // socket frame — which for a long quiet phase can be a while. loadAutomations
+  // did the same catch-up fetch right after painting.
+  const progressSeed = useQuery(automationsProgressQueryOptions());
+  const progress = useAutomationProgress(progressSeed.data);
   // The builder stays in vanilla and is shared with the video page; this hands
   // the shell over for the edit and takes it back on close.
   const openBuilder = useVanillaBuilder(() => void refresh());
@@ -186,6 +194,9 @@ export function AutomationsPage() {
     onDuplicate: (a: Automation) => duplicate.mutate(a),
     onDelete: (a: Automation) => void confirmDelete(a),
     onEdit: (a: Automation) => openBuilder(a.id),
+    // Body-attached modal, so unlike the builder it needs no shell handoff.
+    onShowHistory: (a: Automation) =>
+      window.showAutomationHistory?.(a.id, a.name, a.action_type ?? ''),
     progressFor: (id: number) => progress[id],
     onAssignGroup: (a: Automation, event: React.MouseEvent) => {
       const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
@@ -367,22 +378,36 @@ export function AutomationsPage() {
       ) : null}
 
       <div className="automations-list">
-        {keep.system.length > 0 ? (
+        {/* Presence and count come from the UNFILTERED set: the vanilla filter
+            only hid cards, so a section never disappeared mid-search and its
+            count never moved. Only the cards inside narrow. */}
+        {view.system.length > 0 ? (
           <AutomationsSection
             id="auto-section-system"
             label="System"
             automations={keep.system}
+            totalCount={view.system.length}
+            allAutomations={view.system}
             isProtected
             {...cardHandlers}
           />
         ) : null}
 
-        {keep.groups.map((group) => (
+        {/* The Hub sits between System and the user groups, as loadAutomations
+            ordered it, and is static content so the filter does not touch it.
+            Hidden on an EMPTY list: loadAutomations returns before appending it,
+            so a fresh install sees the empty state alone rather than the empty
+            state plus a wall of reference material. */}
+        {isEmpty ? null : <AutomationHub />}
+
+        {view.groups.map((group) => (
           <AutomationsSection
             key={group.name}
             id={groupSectionId(group.name)}
             label={`📁 ${group.name}`}
-            automations={group.automations}
+            automations={keep.groups.find((g) => g.name === group.name)?.automations ?? []}
+            totalCount={group.automations.length}
+            allAutomations={group.automations}
             groupName={group.name}
             {...groupActions}
             onBulkToggle={(name, allEnabled) =>
@@ -400,11 +425,13 @@ export function AutomationsPage() {
           />
         ))}
 
-        {keep.ungrouped.length > 0 ? (
+        {view.ungrouped.length > 0 ? (
           <AutomationsSection
             id="auto-section-custom"
             label="My Automations"
             automations={keep.ungrouped}
+            totalCount={view.ungrouped.length}
+            allAutomations={view.ungrouped}
             {...cardHandlers}
           />
         ) : null}

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useCallback, useMemo } from 'react';
 
@@ -6,7 +6,17 @@ import { useProfile, useReactPageShell } from '@/platform/shell/route-controller
 
 import type { Automation } from '../-automations.types';
 
-import { automationsListQueryOptions, automationsMasterQueryOptions } from '../-automations.api';
+import {
+  AUTOMATIONS_QUERY_KEY,
+  automationsListQueryOptions,
+  automationsMasterQueryOptions,
+  bulkToggleAutomations,
+  deleteAutomation,
+  duplicateAutomation,
+  runAutomation,
+  setAutomationsMaster,
+  toggleAutomation,
+} from '../-automations.api';
 import { formatAction, formatTrigger } from '../-automations.format';
 import {
   buildAutomationsView,
@@ -25,8 +35,92 @@ export function AutomationsPage() {
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 
+  const queryClient = useQueryClient();
   const listQuery = useQuery(automationsListQueryOptions(profileId));
   const masterQuery = useQuery(automationsMasterQueryOptions());
+
+  const refresh = () => queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
+  const fail = (error: Error) => window.showToast?.(`Error: ${error.message}`, 'error');
+
+  const toggle = useMutation({
+    mutationFn: (a: Automation) => toggleAutomation(a.id),
+    // Silent on success, as the vanilla toggle was — the switch itself is the
+    // feedback, and a toast per flick would be noise.
+    onSuccess: () => refresh(),
+    onError: fail,
+  });
+
+  const run = useMutation({
+    mutationFn: (a: Automation) => runAutomation(a.id),
+    onSuccess: () => {
+      window.showToast?.('Automation triggered', 'success');
+      // The run is async server-side; the vanilla page waited 1.5s before
+      // refetching so last_run/run_count have a chance to move. Refetching
+      // immediately would just redraw the same card.
+      setTimeout(() => void refresh(), 1500);
+    },
+    onError: fail,
+  });
+
+  const duplicate = useMutation({
+    mutationFn: (a: Automation) => duplicateAutomation(a.id),
+    onSuccess: async () => {
+      window.showToast?.('Automation duplicated', 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  const remove = useMutation({
+    mutationFn: (a: Automation) => deleteAutomation(a.id),
+    onSuccess: async () => {
+      window.showToast?.('Automation deleted', 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  const bulkToggle = useMutation({
+    mutationFn: ({ ids, enabled }: { ids: number[]; enabled: boolean }) =>
+      bulkToggleAutomations(ids, enabled),
+    onSuccess: async (updated, { enabled }) => {
+      window.showToast?.(`${enabled ? 'Enabled' : 'Disabled'} ${updated} automations`, 'success');
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  const master = useMutation({
+    mutationFn: (enabled: boolean) => setAutomationsMaster('music', enabled),
+    onSuccess: async (_v, enabled) => {
+      window.showToast?.(
+        `Music automations ${enabled ? 'resumed' : 'paused'}`,
+        enabled ? 'success' : 'info',
+      );
+      await refresh();
+    },
+    onError: fail,
+  });
+
+  // Destructive, so it is confirm-gated exactly as the vanilla handler was.
+  const confirmDelete = async (a: Automation) => {
+    const ok = await window.showConfirmDialog?.({
+      title: 'Delete Automation',
+      message: `Delete automation "${a.name}"?`,
+      confirmText: 'Delete',
+      destructive: true,
+    });
+    if (ok === false) return;
+    remove.mutate(a);
+  };
+
+  const cardHandlers = {
+    onToggle: (a: Automation) => toggle.mutate(a),
+    onRun: (a: Automation) => run.mutate(a),
+    onDuplicate: (a: Automation) => duplicate.mutate(a),
+    onDelete: (a: Automation) => void confirmDelete(a),
+    onEdit: (a: Automation) => window.showAutomationBuilder?.(a.id),
+  };
 
   // Both sides share ONE endpoint; only owned_by separates them.
   const automations = useMemo(
@@ -112,6 +206,8 @@ export function AutomationsPage() {
         <button
           type="button"
           className={`auto-master-toggle${masterOn ? ' on' : ''}`}
+          disabled={master.isPending}
+          onClick={() => master.mutate(!masterOn)}
           title={
             masterOn
               ? 'Automations are live. Click to pause every scheduled and event run on this side — individual switches keep their state, and manual Run still works.'
@@ -188,6 +284,7 @@ export function AutomationsPage() {
             label="System"
             automations={keep.system}
             isProtected
+            {...cardHandlers}
           />
         ) : null}
 
@@ -198,6 +295,18 @@ export function AutomationsPage() {
             label={`📁 ${group.name}`}
             automations={group.automations}
             groupName={group.name}
+            onBulkToggle={(name, allEnabled) =>
+              bulkToggle.mutate({
+                // Ids come from the unfiltered data. _bulkToggleGroup scraped
+                // the DOM, which was equivalent there because its filter only
+                // set display:none and left the cards in place. React does not
+                // render filtered-out cards at all, so a DOM query here would
+                // genuinely miss them and quietly toggle a subset of the group.
+                ids: view.groups.find((g) => g.name === name)?.automations.map((a) => a.id) ?? [],
+                enabled: !allEnabled,
+              })
+            }
+            {...cardHandlers}
           />
         ))}
 
@@ -206,6 +315,7 @@ export function AutomationsPage() {
             id="auto-section-custom"
             label="My Automations"
             automations={keep.ungrouped}
+            {...cardHandlers}
           />
         ) : null}
       </div>

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -9,6 +9,7 @@ import type { Automation } from '../-automations.types';
 import {
   AUTOMATIONS_QUERY_KEY,
   automationsListQueryOptions,
+  automationBlocksQueryOptions,
   automationsMasterQueryOptions,
   automationsProgressQueryOptions,
   assignAutomationGroup,
@@ -21,7 +22,8 @@ import {
   toggleAutomation,
 } from '../-automations.api';
 import { useVanillaBuilder } from '../-automations.builder';
-import { formatAction, formatTrigger } from '../-automations.format';
+import { useAutomationDnd } from '../-automations.dnd';
+import { blockLabelLookup, formatAction, formatTrigger } from '../-automations.format';
 import {
   buildAutomationsView,
   filterAutomations,
@@ -53,6 +55,11 @@ export function AutomationsPage() {
   // that run immediately. Without the seed the card stays blank until the next
   // socket frame — which for a long quiet phase can be a while. loadAutomations
   // did the same catch-up fetch right after painting.
+  // Labels for trigger/action types the static maps do not cover. Cached
+  // indefinitely — block definitions only change when the app ships new ones.
+  const blocksQuery = useQuery(automationBlocksQueryOptions());
+  const blockLabel = useMemo(() => blockLabelLookup(blocksQuery.data), [blocksQuery.data]);
+
   const progressSeed = useQuery(automationsProgressQueryOptions());
   const progress = useAutomationProgress(progressSeed.data);
   // The builder stays in vanilla and is shared with the video page; this hands
@@ -169,6 +176,12 @@ export function AutomationsPage() {
     onError: fail,
   });
 
+  // Dragging a card into another group's body reuses the same single-row PUT
+  // the 📁 dropdown issues, so both paths land on one endpoint.
+  const dnd = useAutomationDnd((dragged, toGroup) =>
+    assign.mutate({ id: dragged.id, group: toGroup }),
+  );
+
   const idsInGroup = (name: string) =>
     view.groups.find((g) => g.name === name)?.automations.map((a) => a.id) ?? [];
 
@@ -198,6 +211,7 @@ export function AutomationsPage() {
     onShowHistory: (a: Automation) =>
       window.showAutomationHistory?.(a.id, a.name, a.action_type ?? ''),
     progressFor: (id: number) => progress[id],
+    blockLabel,
     onAssignGroup: (a: Automation, event: React.MouseEvent) => {
       const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
       setGroupMenu({
@@ -229,10 +243,10 @@ export function AutomationsPage() {
   // that build the card must produce the strings the filter searches.
   const labelFor = useCallback(
     (a: Automation) => ({
-      trigger: formatTrigger(a.trigger_type, a.trigger_config),
-      action: formatAction(a.action_type),
+      trigger: formatTrigger(a.trigger_type, a.trigger_config, blockLabel),
+      action: formatAction(a.action_type, blockLabel),
     }),
-    [],
+    [blockLabel],
   );
 
   // Stats and the filter-bar threshold describe the WHOLE set: filtering down
@@ -353,7 +367,7 @@ export function AutomationsPage() {
             <option value="">All Triggers</option>
             {options.triggers.map((t) => (
               <option key={t} value={t}>
-                {formatTrigger(t, {})}
+                {formatTrigger(t, {}, blockLabel)}
               </option>
             ))}
           </select>
@@ -366,7 +380,7 @@ export function AutomationsPage() {
             <option value="">All Actions</option>
             {options.actions.map((t) => (
               <option key={t} value={t}>
-                {formatAction(t)}
+                {formatAction(t, blockLabel)}
               </option>
             ))}
           </select>
@@ -389,6 +403,12 @@ export function AutomationsPage() {
             totalCount={view.system.length}
             allAutomations={view.system}
             isProtected
+            zoneProps={dnd.zoneProps('system', null, { isProtected: true })}
+            isDragActive={dnd.dragging}
+            cardDragProps={(a) =>
+              dnd.cardProps(a.id, a.group_name ?? null, a.is_system === true || a.is_system === 1)
+            }
+            isCardDragging={dnd.isDraggingCard}
             {...cardHandlers}
           />
         ) : null}
@@ -409,6 +429,13 @@ export function AutomationsPage() {
             totalCount={group.automations.length}
             allAutomations={group.automations}
             groupName={group.name}
+            zoneProps={dnd.zoneProps(`group:${group.name}`, group.name)}
+            isDropTarget={dnd.overKey === `group:${group.name}`}
+            isDragActive={dnd.dragging}
+            cardDragProps={(a) =>
+              dnd.cardProps(a.id, a.group_name ?? null, a.is_system === true || a.is_system === 1)
+            }
+            isCardDragging={dnd.isDraggingCard}
             {...groupActions}
             onBulkToggle={(name, allEnabled) =>
               bulkToggle.mutate({
@@ -432,6 +459,13 @@ export function AutomationsPage() {
             automations={keep.ungrouped}
             totalCount={view.ungrouped.length}
             allAutomations={view.ungrouped}
+            zoneProps={dnd.zoneProps('ungrouped', null)}
+            isDropTarget={dnd.overKey === 'ungrouped'}
+            isDragActive={dnd.dragging}
+            cardDragProps={(a) =>
+              dnd.cardProps(a.id, a.group_name ?? null, a.is_system === true || a.is_system === 1)
+            }
+            isCardDragging={dnd.isDraggingCard}
             {...cardHandlers}
           />
         ) : null}

--- a/webui/src/routes/automations/-ui/automations-page.tsx
+++ b/webui/src/routes/automations/-ui/automations-page.tsx
@@ -27,6 +27,7 @@ import {
   forMusicSide,
   readAutomationsList,
 } from '../-automations.helpers';
+import { useAutomationProgress } from '../-automations.progress';
 import { Route } from '../route';
 import { AutomationsSection, groupSectionId } from './automations-section';
 import { type DeleteGroupChoice, DeleteGroupDialog } from './delete-group-dialog';
@@ -42,6 +43,9 @@ export function AutomationsPage() {
   const queryClient = useQueryClient();
   const listQuery = useQuery(automationsListQueryOptions(profileId));
   const masterQuery = useQuery(automationsMasterQueryOptions());
+  // Live run state, merged from the socket mirror. Not query-cached: it is a
+  // stream of transient frames, not a resource with a canonical server copy.
+  const progress = useAutomationProgress();
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: AUTOMATIONS_QUERY_KEY });
   const fail = (error: Error) => window.showToast?.(`Error: ${error.message}`, 'error');
@@ -178,6 +182,7 @@ export function AutomationsPage() {
     onDuplicate: (a: Automation) => duplicate.mutate(a),
     onDelete: (a: Automation) => void confirmDelete(a),
     onEdit: (a: Automation) => window.showAutomationBuilder?.(a.id),
+    progressFor: (id: number) => progress[id],
     onAssignGroup: (a: Automation, event: React.MouseEvent) => {
       const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
       setGroupMenu({

--- a/webui/src/routes/automations/-ui/automations-section.tsx
+++ b/webui/src/routes/automations/-ui/automations-section.tsx
@@ -51,6 +51,16 @@ interface Props extends AutomationCardHandlers, GroupActions {
   id: string;
   label: string;
   automations: Automation[];
+  /**
+   * Size of the section BEFORE filtering, for the header count.
+   *
+   * The vanilla filter only set display:none on cards — sections and their
+   * counts were already rendered from the unfiltered data, so the count stayed
+   * put while you typed. Defaults to what is rendered.
+   */
+  totalCount?: number;
+  /** The unfiltered members, for decisions that must not depend on the filter. */
+  allAutomations?: Automation[];
   /** System/Hub sections: no group actions, and no drop target. */
   isProtected?: boolean;
   groupName?: string;
@@ -62,6 +72,8 @@ export function AutomationsSection({
   automations,
   isProtected = false,
   groupName,
+  totalCount,
+  allAutomations,
   onBulkToggle,
   onRename,
   onDeleteGroup,
@@ -91,8 +103,11 @@ export function AutomationsSection({
     });
   };
 
-  const enabledCount = automations.filter((a) => a.enabled === true || a.enabled === 1).length;
-  const allEnabled = enabledCount === automations.length;
+  // Judged over the whole group: with a filter active, "Disable all" must not
+  // flip to "Enable all" just because the only visible card happens to be off.
+  const forToggle = allAutomations ?? automations;
+  const enabledCount = forToggle.filter((a) => a.enabled === true || a.enabled === 1).length;
+  const allEnabled = forToggle.length > 0 && enabledCount === forToggle.length;
   const showGroupActions = Boolean(groupName) && !isProtected;
 
   return (
@@ -138,7 +153,7 @@ export function AutomationsSection({
             />
           </span>
         )}
-        <span className="section-count">{automations.length}</span>
+        <span className="section-count">{totalCount ?? automations.length}</span>
         {showGroupActions ? (
           <div className="section-actions" onClick={(e) => e.stopPropagation()}>
             <button
@@ -171,14 +186,20 @@ export function AutomationsSection({
       </div>
 
       <div className="automations-section-body">
-        {automations.map((a) => (
-          <AutomationCard
-            key={a.id}
-            automation={a}
-            progress={progressFor?.(a.id)}
-            {...cardHandlers}
-          />
-        ))}
+        {/* The cards live in their own container, NOT directly in the body:
+            .automations-grid is `repeat(2, 1fr)`, so omitting it silently
+            collapses the page to one card per row. Every call site — music and
+            video alike — passes useGrid, hence the grid class here. */}
+        <div className="automations-grid">
+          {automations.map((a) => (
+            <AutomationCard
+              key={a.id}
+              automation={a}
+              progress={progressFor?.(a.id)}
+              {...cardHandlers}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/webui/src/routes/automations/-ui/automations-section.tsx
+++ b/webui/src/routes/automations/-ui/automations-section.tsx
@@ -40,7 +40,8 @@ export function groupSectionId(groupName: string): string {
 
 export interface GroupActions {
   onBulkToggle?: (groupName: string, allEnabled: boolean) => void;
-  onRename?: (groupName: string) => void;
+  /** Commit a rename. Called only with a changed, non-empty name. */
+  onRename?: (groupName: string, newName: string) => void;
   onDeleteGroup?: (groupName: string) => void;
 }
 
@@ -65,6 +66,20 @@ export function AutomationsSection({
   ...cardHandlers
 }: Props) {
   const [collapsed, setCollapsed] = useState(() => readCollapsed(id));
+  // null = not renaming. The vanilla version swapped the label for an input
+  // in place, so the section header keeps its layout while editing.
+  const [rename, setRename] = useState<string | null>(null);
+
+  // A no-op rename (empty or unchanged) just closes the editor: the vanilla
+  // handler bailed on both rather than issuing a pointless PUT.
+  const commitRename = () => {
+    setRename((draft) => {
+      if (draft === null) return null;
+      const next = draft.trim();
+      if (next && groupName && next !== groupName) onRename?.(groupName, next);
+      return null;
+    });
+  };
 
   const toggle = () => {
     setCollapsed((was) => {
@@ -95,7 +110,31 @@ export function AutomationsSection({
         }}
       >
         <span className="section-chevron">▼</span>
-        <span className="section-label">{label}</span>
+        {rename === null ? (
+          <span className="section-label">{label}</span>
+        ) : (
+          <span className="section-label">
+            <input
+              className="section-rename-input"
+              aria-label={`Rename group ${groupName ?? ''}`}
+              value={rename}
+              autoFocus
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => setRename(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitRename();
+                }
+                if (e.key === 'Escape') setRename(null);
+              }}
+              // Blur SAVES, matching the vanilla input — clicking away is
+              // treated as accepting the edit, not discarding it.
+              onBlur={commitRename}
+            />
+          </span>
+        )}
         <span className="section-count">{automations.length}</span>
         {showGroupActions ? (
           <div className="section-actions" onClick={(e) => e.stopPropagation()}>
@@ -111,7 +150,7 @@ export function AutomationsSection({
               type="button"
               className="section-action-btn"
               title="Rename group"
-              onClick={() => onRename?.(groupName!)}
+              onClick={() => setRename(groupName!)}
             >
               ✏️
             </button>

--- a/webui/src/routes/automations/-ui/automations-section.tsx
+++ b/webui/src/routes/automations/-ui/automations-section.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react';
+
+import type { Automation } from '../-automations.types';
+
+import { type AutomationCardHandlers, AutomationCard } from './automation-card';
+
+/**
+ * Collapse state key.
+ *
+ * Deliberately the SAME key the vanilla page used, so anyone who had sections
+ * collapsed keeps them collapsed across the migration instead of having every
+ * section spring open once.
+ */
+export function sectionStorageKey(id: string): string {
+  return `auto_section_${id}`;
+}
+
+function readCollapsed(id: string): boolean {
+  try {
+    return localStorage.getItem(sectionStorageKey(id)) === '1';
+  } catch {
+    // Safari private mode and friends throw on localStorage access; a section
+    // that cannot remember its state must still render.
+    return false;
+  }
+}
+
+function writeCollapsed(id: string, collapsed: boolean): void {
+  try {
+    localStorage.setItem(sectionStorageKey(id), collapsed ? '1' : '0');
+  } catch {
+    /* not remembering is acceptable; failing to collapse is not */
+  }
+}
+
+/** Section id for a user group, matching the vanilla sanitiser. */
+export function groupSectionId(groupName: string): string {
+  return `auto-section-group-${groupName.replace(/\W+/g, '_')}`;
+}
+
+export interface GroupActions {
+  onBulkToggle?: (groupName: string, allEnabled: boolean) => void;
+  onRename?: (groupName: string) => void;
+  onDeleteGroup?: (groupName: string) => void;
+}
+
+interface Props extends AutomationCardHandlers, GroupActions {
+  id: string;
+  label: string;
+  automations: Automation[];
+  /** System/Hub sections: no group actions, and no drop target. */
+  isProtected?: boolean;
+  groupName?: string;
+}
+
+export function AutomationsSection({
+  id,
+  label,
+  automations,
+  isProtected = false,
+  groupName,
+  onBulkToggle,
+  onRename,
+  onDeleteGroup,
+  ...cardHandlers
+}: Props) {
+  const [collapsed, setCollapsed] = useState(() => readCollapsed(id));
+
+  const toggle = () => {
+    setCollapsed((was) => {
+      writeCollapsed(id, !was);
+      return !was;
+    });
+  };
+
+  const enabledCount = automations.filter((a) => a.enabled === true || a.enabled === 1).length;
+  const allEnabled = enabledCount === automations.length;
+  const showGroupActions = Boolean(groupName) && !isProtected;
+
+  return (
+    <div
+      className={`automations-section${isProtected ? ' section-protected' : ''}${
+        collapsed ? ' collapsed' : ''
+      }`}
+      id={id}
+      data-group-name={groupName}
+    >
+      {/* Matches the vanilla header: the whole bar toggles, except clicks that
+          land inside .section-actions. */}
+      <div
+        className="automations-section-header"
+        onClick={(e) => {
+          if ((e.target as HTMLElement).closest('.section-actions')) return;
+          toggle();
+        }}
+      >
+        <span className="section-chevron">▼</span>
+        <span className="section-label">{label}</span>
+        <span className="section-count">{automations.length}</span>
+        {showGroupActions ? (
+          <div className="section-actions" onClick={(e) => e.stopPropagation()}>
+            <button
+              type="button"
+              className="section-action-btn"
+              title={allEnabled ? 'Disable all' : 'Enable all'}
+              onClick={() => onBulkToggle?.(groupName!, allEnabled)}
+            >
+              {allEnabled ? '⏸' : '▶'}
+            </button>
+            <button
+              type="button"
+              className="section-action-btn"
+              title="Rename group"
+              onClick={() => onRename?.(groupName!)}
+            >
+              ✏️
+            </button>
+            <button
+              type="button"
+              className="section-action-btn section-action-danger"
+              title="Delete group"
+              onClick={() => onDeleteGroup?.(groupName!)}
+            >
+              🗑️
+            </button>
+          </div>
+        ) : null}
+        <span className="section-line" />
+      </div>
+
+      <div className="automations-section-body">
+        {automations.map((a) => (
+          <AutomationCard key={a.id} automation={a} {...cardHandlers} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/automations/-ui/automations-section.tsx
+++ b/webui/src/routes/automations/-ui/automations-section.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { Automation } from '../-automations.types';
 
+import { DRAG_EXPAND_MS } from '../-automations.dnd';
 import { type AutomationCardHandlers, AutomationCard } from './automation-card';
 
 /**
@@ -48,6 +49,17 @@ export interface GroupActions {
 interface Props extends AutomationCardHandlers, GroupActions {
   /** Live run state lookup, threaded down to each card. */
   progressFor?: (id: number) => import('../-automations.progress').AutomationRunState | undefined;
+  blockLabel?: (type: string) => string | undefined;
+  /** Drop-zone handlers for this section body, empty when protected. */
+  zoneProps?: Record<string, unknown>;
+  /** This body is the current drop target. */
+  isDropTarget?: boolean;
+  /** A drag is in flight — protected sections dim to show they refuse drops. */
+  isDragActive?: boolean;
+  /** Per-card drag handlers, keyed by automation. */
+  cardDragProps?: (a: Automation) => Record<string, unknown>;
+  isCardDragging?: (id: number) => boolean;
+
   id: string;
   label: string;
   automations: Automation[];
@@ -74,6 +86,11 @@ export function AutomationsSection({
   groupName,
   totalCount,
   allAutomations,
+  zoneProps,
+  isDropTarget,
+  isDragActive,
+  cardDragProps,
+  isCardDragging,
   onBulkToggle,
   onRename,
   onDeleteGroup,
@@ -96,6 +113,18 @@ export function AutomationsSection({
     });
   };
 
+  // Hovering a COLLAPSED section during a drag opens it, so you can drop into
+  // a group you cannot see. Owned here rather than plumbed from the page: the
+  // collapsed state lives in this component, and the timer must die with it.
+  useEffect(() => {
+    if (!isDropTarget || !collapsed) return;
+    const timer = setTimeout(() => {
+      writeCollapsed(id, false);
+      setCollapsed(false);
+    }, DRAG_EXPAND_MS);
+    return () => clearTimeout(timer);
+  }, [isDropTarget, collapsed, id]);
+
   const toggle = () => {
     setCollapsed((was) => {
       writeCollapsed(id, !was);
@@ -114,7 +143,7 @@ export function AutomationsSection({
     <div
       className={`automations-section${isProtected ? ' section-protected' : ''}${
         collapsed ? ' collapsed' : ''
-      }`}
+      }${isProtected && isDragActive ? ' no-drop' : ''}`}
       id={id}
       data-group-name={groupName}
     >
@@ -185,7 +214,10 @@ export function AutomationsSection({
         <span className="section-line" />
       </div>
 
-      <div className="automations-section-body">
+      <div
+        className={`automations-section-body${isDropTarget ? ' drop-target' : ''}`}
+        {...zoneProps}
+      >
         {/* The cards live in their own container, NOT directly in the body:
             .automations-grid is `repeat(2, 1fr)`, so omitting it silently
             collapses the page to one card per row. Every call site — music and
@@ -196,6 +228,8 @@ export function AutomationsSection({
               key={a.id}
               automation={a}
               progress={progressFor?.(a.id)}
+              dragProps={cardDragProps?.(a)}
+              isDragging={isCardDragging?.(a.id)}
               {...cardHandlers}
             />
           ))}

--- a/webui/src/routes/automations/-ui/automations-section.tsx
+++ b/webui/src/routes/automations/-ui/automations-section.tsx
@@ -46,6 +46,8 @@ export interface GroupActions {
 }
 
 interface Props extends AutomationCardHandlers, GroupActions {
+  /** Live run state lookup, threaded down to each card. */
+  progressFor?: (id: number) => import('../-automations.progress').AutomationRunState | undefined;
   id: string;
   label: string;
   automations: Automation[];
@@ -63,6 +65,7 @@ export function AutomationsSection({
   onBulkToggle,
   onRename,
   onDeleteGroup,
+  progressFor,
   ...cardHandlers
 }: Props) {
   const [collapsed, setCollapsed] = useState(() => readCollapsed(id));
@@ -169,7 +172,12 @@ export function AutomationsSection({
 
       <div className="automations-section-body">
         {automations.map((a) => (
-          <AutomationCard key={a.id} automation={a} {...cardHandlers} />
+          <AutomationCard
+            key={a.id}
+            automation={a}
+            progress={progressFor?.(a.id)}
+            {...cardHandlers}
+          />
         ))}
       </div>
     </div>

--- a/webui/src/routes/automations/-ui/delete-group-dialog.tsx
+++ b/webui/src/routes/automations/-ui/delete-group-dialog.tsx
@@ -1,0 +1,68 @@
+import { useEffect } from 'react';
+
+export type DeleteGroupChoice = 'ungroup' | 'delete_all';
+
+interface Props {
+  groupName: string;
+  count: number;
+  onChoose: (choice: DeleteGroupChoice) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Deleting a group asks what to do with its contents.
+ *
+ * Three outcomes, not two, so showConfirmDialog cannot express it: keep the
+ * automations and move them to My Automations, delete the group AND every
+ * automation in it, or cancel. Collapsing that into a yes/no would either hide
+ * the safe option or make the destructive one the default.
+ */
+export function DeleteGroupDialog({ groupName, count, onChoose, onCancel }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  const plural = count !== 1 ? 's' : '';
+
+  return (
+    <div
+      className="modal-overlay"
+      style={{ display: 'flex' }}
+      // Clicking the backdrop cancels; clicks inside the dialog must not.
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="delete-group-dialog" role="dialog" aria-modal="true">
+        <div className="delete-group-icon">🗑️</div>
+        <h3 className="delete-group-title">Delete Group &quot;{groupName}&quot;</h3>
+        <p className="delete-group-message">
+          This group contains {count} automation{plural}. What would you like to do?
+        </p>
+        <div className="delete-group-actions">
+          <button
+            type="button"
+            className="delete-group-btn delete-group-keep"
+            onClick={() => onChoose('ungroup')}
+          >
+            Keep Automations — move to My Automations
+          </button>
+          <button
+            type="button"
+            className="delete-group-btn delete-group-remove"
+            onClick={() => onChoose('delete_all')}
+          >
+            Delete Everything — remove group and all {count} automation{plural}
+          </button>
+          <button type="button" className="delete-group-btn delete-group-cancel" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/automations/-ui/group-dropdown.tsx
+++ b/webui/src/routes/automations/-ui/group-dropdown.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface Props {
+  /** Every group name that currently exists, for the "move to" list. */
+  groups: string[];
+  currentGroup: string | null;
+  /** Screen position of the button that opened this, as a fixed-position anchor. */
+  anchor: { top: number; bottom: number; right: number };
+  onAssign: (groupName: string | null) => void;
+  onClose: () => void;
+}
+
+/**
+ * "Assign group" popup.
+ *
+ * The vanilla version appended this to document.body to escape an
+ * overflow:hidden ancestor, positioned it with getBoundingClientRect, and
+ * flipped it upward when there was no room below. Same behaviour here, but
+ * React owns the node and its lifetime — no _activeGroupDropdown global to
+ * leave dangling if a re-render removes the card underneath it.
+ */
+export function GroupDropdown({ groups, currentGroup, anchor, onAssign, onClose }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [flipUp, setFlipUp] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  // Measure after paint, matching the vanilla flip test: open upward only if it
+  // does not fit below AND does fit above.
+  useEffect(() => {
+    const height = ref.current?.offsetHeight ?? 0;
+    setFlipUp(anchor.bottom + 4 + height > window.innerHeight && anchor.top - 4 - height > 0);
+  }, [anchor]);
+
+  // Any click outside closes it, as the vanilla document listener did.
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    };
+    // Deferred so the click that OPENED the dropdown does not immediately
+    // close it on the same tick.
+    const id = setTimeout(() => document.addEventListener('click', onDocClick), 0);
+    return () => {
+      clearTimeout(id);
+      document.removeEventListener('click', onDocClick);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="auto-group-dropdown"
+      style={{
+        position: 'fixed',
+        right: window.innerWidth - anchor.right,
+        left: 'auto',
+        ...(flipUp ? { bottom: window.innerHeight - anchor.top + 4 } : { top: anchor.bottom + 4 }),
+      }}
+    >
+      {currentGroup ? (
+        <>
+          <div className="auto-group-option ungroup" onClick={() => onAssign(null)}>
+            Remove from group
+          </div>
+          <div className="auto-group-divider" />
+        </>
+      ) : null}
+
+      {groups.map((g) => (
+        <div
+          key={g}
+          className={`auto-group-option${g === currentGroup ? ' active' : ''}`}
+          onClick={() => onAssign(g)}
+        >
+          {g}
+        </div>
+      ))}
+      {groups.length > 0 ? <div className="auto-group-divider" /> : null}
+
+      <input
+        className="auto-group-input"
+        placeholder="New group name..."
+        aria-label="New group name"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key !== 'Enter') return;
+          e.preventDefault();
+          // Trim, and ignore an empty submit rather than creating a nameless
+          // group — the vanilla handler passed the trimmed value straight on,
+          // where '' became null and silently UNgrouped instead.
+          const name = draft.trim();
+          if (name) onAssign(name);
+        }}
+      />
+    </div>
+  );
+}

--- a/webui/src/routes/automations/route.tsx
+++ b/webui/src/routes/automations/route.tsx
@@ -6,6 +6,7 @@ import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
 
 import { automationsListQueryOptions, automationsMasterQueryOptions } from './-automations.api';
 import { automationsSearchSchema } from './-automations.types';
+import { AutomationsPage } from './-ui/automations-page';
 
 /**
  * Whether the shell has handed /automations over to React yet.
@@ -50,7 +51,5 @@ function AutomationsRouteComponent() {
   if (!isReactOwned()) {
     return <LegacyRouteController pathname="/automations" />;
   }
-  // Replaced by the real page in P2; until the manifest flips, this branch is
-  // unreachable, so rendering the legacy controller keeps it honest.
-  return <LegacyRouteController pathname="/automations" />;
+  return <AutomationsPage />;
 }

--- a/webui/src/routes/automations/route.tsx
+++ b/webui/src/routes/automations/route.tsx
@@ -1,0 +1,56 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { getProfileHomePath } from '@/platform/shell/bridge';
+import { LegacyRouteController } from '@/platform/shell/route-controllers';
+import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
+
+import { automationsListQueryOptions, automationsMasterQueryOptions } from './-automations.api';
+import { automationsSearchSchema } from './-automations.types';
+
+/**
+ * Whether the shell has handed /automations over to React yet.
+ *
+ * The route file exists (and is tested) before the React page reaches parity.
+ * Without this check TanStack would match /automations regardless of the
+ * manifest and the vanilla page and the React host would both activate.
+ * Delete this indirection once the vanilla automations page is gone.
+ */
+function isReactOwned(): boolean {
+  return getShellRouteByPageId('automations')?.kind === 'react';
+}
+
+export const Route = createFileRoute('/automations')({
+  validateSearch: automationsSearchSchema,
+  beforeLoad: ({ context }) => {
+    const { bridge } = context.shell;
+
+    if (!bridge.isPageAllowed('automations')) {
+      throw redirect({ href: getProfileHomePath(bridge), replace: true });
+    }
+  },
+  loader: async ({ context }) => {
+    if (!isReactOwned()) return;
+
+    const { profile } = context.shell;
+    const { queryClient } = context;
+
+    // Both feed the first paint: the sections need the list, and the stats bar
+    // renders the master toggle beside the counts. Progress is deliberately
+    // NOT prefetched — it is a catch-up read for runs already in flight, and
+    // blocking paint on it would delay the page for the common idle case.
+    await Promise.all([
+      queryClient.ensureQueryData(automationsListQueryOptions(profile.profileId)),
+      queryClient.ensureQueryData(automationsMasterQueryOptions()),
+    ]);
+  },
+  component: AutomationsRouteComponent,
+});
+
+function AutomationsRouteComponent() {
+  if (!isReactOwned()) {
+    return <LegacyRouteController pathname="/automations" />;
+  }
+  // Replaced by the real page in P2; until the manifest flips, this branch is
+  // unreachable, so rendering the legacy controller keeps it honest.
+  return <LegacyRouteController pathname="/automations" />;
+}

--- a/webui/static/core.js
+++ b/webui/static/core.js
@@ -539,7 +539,14 @@ function initializeWebSocket() {
     socket.on('scan:media', (data) => { if (_qaToolBusy(data)) qaSignal('tools'); updateMediaScanFromData(data); });
     socket.on('wishlist:stats', (data) => updateWishlistStatsFromData(data));
     // Phase 6: Automation progress
-    socket.on('automation:progress', (data) => { qaSignal('auto'); updateAutomationProgressFromData(data); });
+    socket.on('automation:progress', (data) => {
+        qaSignal('auto');
+        updateAutomationProgressFromData(data);
+        // Mirror to the React automations page. Same seam as ss:watchlist-scan:
+        // the progress state is module-scoped in stats-automations.js and cannot
+        // be read from a module, so the vanilla side announces and React reacts.
+        window.dispatchEvent(new CustomEvent('ss:automation-progress', { detail: data }));
+    });
     socket.on('overlay:progress', (data) => { if (typeof updateOverlayTask === 'function') updateOverlayTask(data); });
     socket.on('collections:sync', (data) => { if (typeof updateCollectionSyncTask === 'function') updateCollectionSyncTask(data); });
     socket.on('collections:artwork', (data) => { if (typeof updateCollectionArtTask === 'function') updateCollectionArtTask(data); });

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -3314,6 +3314,15 @@ async function loadAutomations() {
     const empty = document.getElementById('automations-empty');
     const statsBar = document.getElementById('automations-stats');
     if (!list || !empty) return;
+    // If React owns /automations, IT is the live page and this container is
+    // hidden. Repainting it would put a second copy of every section and card
+    // in the document — duplicate #auto-section-* ids and duplicate
+    // .automation-card[data-id] nodes, which document-wide getElementById /
+    // querySelector calls then resolve to instead of the visible ones.
+    //
+    // This is reachable: the shared builder's onSaved hook calls back into
+    // here after a save made from the React page.
+    if (document.getElementById('webui-react-root')?.classList.contains('active')) return;
     try {
         const res = await fetch('/api/automations');
         const payload = await res.json();

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -4372,7 +4372,13 @@ function updateAutomationProgressFromData(data) {
     for (const [aidStr, state] of Object.entries(data)) {
         const aid = parseInt(aidStr);
         const card = document.querySelector(`.automation-card[data-id="${aid}"]`);
-        if (!card) continue;
+        // Skip cards React owns. This query is document-wide, so once /automations
+        // is a React route it would otherwise inject .automation-output panels
+        // into React's DOM — which React then clobbers on its next render, and
+        // the two fight over the same node. React renders its own progress from
+        // the ss:automation-progress event instead. Vanilla music + video cards
+        // live outside the React root and are unaffected.
+        if (!card || card.closest('#webui-react-root')) continue;
 
         let panel = card.querySelector('.automation-output');
         if (!panel) {

--- a/webui/vitest.setup.ts
+++ b/webui/vitest.setup.ts
@@ -1,3 +1,12 @@
+// Pin the suite to a NON-UTC zone.
+//
+// The app reads naive SQLite timestamps ("2026-07-27 02:10:37") and must treat
+// them as UTC; `new Date(naive)` reads them as local, which skews every
+// relative label by the viewer's offset. Under TZ=UTC — what CI runs — local
+// and UTC coincide, so that bug is invisible and no test can catch it. Running
+// tests at an offset reproduces the condition real users are in.
+process.env.TZ = 'America/Los_Angeles';
+
 import '@testing-library/jest-dom/vitest';
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 


### PR DESCRIPTION
# automations page → react

third page on the react migration, after watchlist (#1085) and wishlist (#1088). music side only — the video automations page stays vanilla and is untouched.

11 commits. everything up to the last three was dormant: the route existed and was tested, but the manifest still said `legacy`, so the vanilla page stayed in charge. `feat(webui): hand /automations to React` is the one word that changes what you see, and reverting it puts the old page back.

## the video side is the interesting part

this page is not self-contained. `video/video-automations.js` is a 209-line adapter with **no renderer of its own** — it borrows nine functions out of `stats-automations.js` (`renderAutomationCard`, `_buildAutomationSection`, `_buildAutomationHub`, the five `_hub*` builders, the master toggle). music exports, video consumes, nothing flows back.

so two things are deliberately NOT ported:

- **the builder** (~645 lines) — `showVideoAutomationBuilder` opens the same `_openAutomationBuilder` with a video context. a react copy would be a second implementation the video page still needs. instead the react page hands the shell back for the edit and reclaims it on close. wrapping `hideAutomationBuilder` is a complete interception: Back and Cancel call it from index.html, and `saveAutomation` calls it before its onSaved hook.
- **the Automation Hub** — static content built by a shared builder. react mounts what it returns rather than restating it in JSX.

a test pins that contract (`tests/test_video_automations_renderer_contract.py`), mutation-verified by actually deleting `renderAutomationCard` and confirming the failure names the function.

## vanilla files touched — 17 lines, both guarded

`core.js` mirrors the `automation:progress` socket frame onto the window as `ss:automation-progress` (same seam as `ss:watchlist-scan`) and still calls the vanilla renderer, so legacy and video are unaffected.

`stats-automations.js` gets two early-returns:
- the progress renderer skips cards inside `#webui-react-root`
- `loadAutomations` refuses to repaint while react owns the page

that second one matters more than it looks. `saveAutomation` → `hideAutomationBuilder` → `onSaved` → `loadAutomations` repainted the *hidden* legacy list after every save, leaving a duplicate `#auto-section-*` and a duplicate `.automation-card[data-id]` for every automation in the document — and document-wide `getElementById`/`querySelector` resolve to the first match. same class of bug as the wishlist modal's Back button.

it also closes the class: `loadAutomations` is the only thing that populates `#automations-list`, so with it guarded no vanilla card can exist while react owns the page, which makes `_filterAutomations`, `_initAutoFilterBar` and the group/card handlers unreachable rather than merely untested.

## nine bugs found after the page was "done"

worth stating plainly: the page passed 344 tests and was still wrong in nine ways. all nine were the same shape — something the vanilla renderer does that the port silently omitted. none were logic errors in new code.

three boulder found by clicking (cards 1-per-row from a missing `.automations-grid`, the whole Automation Hub missing, a dead "Runs" link). the rest came from reading vanilla control flow, auditing unused exports, comparing runtime cost, and checking whether my own commit messages were still true.

the two worth calling out:
- **an infinite render loop** — the progress seed effect depended on an object identity; it hung the test worker. react-query's `data` is referentially stable so the page never looped, which was luck, not design.
- **the duplicate-page bug above** — reachable by any user who saves an automation.

two of my own tests were vacuous and only surfaced under mutation: one asserted synchronously before an async mutation could fire, the other used an all-enabled group where the right and wrong implementations give the same answer.

## also in here

the vitest suite is now pinned to a non-UTC timezone. the app reads naive sqlite timestamps and must treat them as UTC; under `TZ=UTC` — what CI runs — local and UTC coincide, so that bug class was **structurally undetectable**. verified by mutation with `TZ=UTC` forced: parsing naive input as local now fails on a UTC runner, which it could not before.

## verified

- 360 webui tests, 0 type errors, build clean, formatter clean against the 20 pre-existing warnings
- 491 python tests over the automation + shared-file contracts
- every guard mutation-tested — i broke each one and confirmed a test died

## not done

- **drag-and-drop regrouping** — deliberately deferred, lowest-value piece, still vanilla-only
- **`blockLabel`** unwired: a trigger/action type absent from the static maps shows a humanized name instead of its `/blocks` label. cosmetic, exotic types only
- cleanup of the now-dead vanilla list code is a **separate PR** — the shared renderer and builder must survive for video
