### PR TITLE
refactor(webui): retire the vanilla automations list

### DIFF
--- a/tests/test_automations_redesign_css.py
+++ b/tests/test_automations_redesign_css.py
@@ -24,7 +24,18 @@ _CSS = (_ROOT / "webui" / "static" / "automations-redesign.css").read_text(encod
 _HTML = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
 _JS = (_ROOT / "webui" / "static" / "stats-automations.js").read_text(encoding="utf-8")
 _VJS = (_ROOT / "webui" / "static" / "video" / "video-automations.js").read_text(encoding="utf-8")
-_SOURCES = _HTML + _JS + _VJS
+
+# The MUSIC automations list is a React page now (webui/src/routes/automations),
+# so its markup lives in JSX rather than in index.html or stats-automations.js.
+# The video page still renders from the shared vanilla builders, which is why
+# those two sources stay. Without the React source this check reports every
+# music-side class as an unused selector.
+_REACT = "".join(
+    p.read_text(encoding="utf-8")
+    for p in sorted((_ROOT / "webui" / "src" / "routes" / "automations").rglob("*.ts*"))
+    if ".test." not in p.name
+)
+_SOURCES = _HTML + _JS + _VJS + _REACT
 
 # Ancestors that guarantee a rule only applies on the automations surfaces.
 _SCOPES = (

--- a/webui/index.html
+++ b/webui/index.html
@@ -4290,35 +4290,15 @@
             </div>
             <!-- Automations Page -->
             <div class="page" id="automations-page">
-                <!-- List View -->
-                <div class="automations-list-view" id="automations-list-view">
-                    <div class="page-shell automations-container">
-                        <div class="dashboard-header"><div class="dashboard-header-sweep" aria-hidden="true"><span></span></div>
-                            <div class="header-text">
-                                <h2 class="header-title"><img src="/static/automation.png" class="page-header-icon" alt=""><span>Automations</span></h2>
-                                <p class="header-subtitle">Configure scheduled tasks and automated workflows</p>
-                            </div>
-                            <div class="header-spacer"></div>
-                            <div class="header-actions">
-                                <button class="auto-new-btn" onclick="showAutomationBuilder()">+ New Automation</button>
-                            </div>
-                        </div>
-                        <div class="automations-stats" id="automations-stats"></div>
-                        <div class="auto-filter-bar" id="auto-filter-bar" style="display:none;">
-                            <input type="text" class="auto-filter-search" id="auto-filter-search" placeholder="Filter automations…">
-                            <select class="auto-filter-select" id="auto-filter-trigger"><option value="">All Triggers</option></select>
-                            <select class="auto-filter-select" id="auto-filter-action"><option value="">All Actions</option></select>
-                            <span class="auto-filter-count" id="auto-filter-count"></span>
-                        </div>
-                        <div class="automations-list" id="automations-list"></div>
-                        <div class="automations-empty" id="automations-empty" style="display:none;">
-                            <div class="automations-empty-icon">&#9889;</div>
-                            <div class="automations-empty-title">No automations yet</div>
-                            <div class="automations-empty-text">Create your first automation to schedule tasks and trigger actions automatically.</div>
-                            <button class="auto-new-btn" onclick="showAutomationBuilder()">+ New Automation</button>
-                        </div>
-                    </div>
-                </div>
+                <!-- List View — INTENTIONALLY EMPTY.
+                     React renders the automations list (see
+                     webui/src/routes/automations/). This container has to stay:
+                     the shared builder toggles it directly, and
+                     hideAutomationBuilder does `_bEl('listView').style.display`
+                     with no null guard, so removing it would throw on every
+                     Back / Cancel / Save — on the VIDEO side too, which drives
+                     the same builder through its own context. -->
+                <div class="automations-list-view" id="automations-list-view"></div>
 
                 <!-- Builder View -->
                 <div class="automations-builder-view" id="automations-builder-view" style="display:none;">

--- a/webui/src/routes/automations/-automations.types.ts
+++ b/webui/src/routes/automations/-automations.types.ts
@@ -38,9 +38,9 @@ export type AutomationsSearch = z.infer<typeof automationsSearchSchema>;
 
 /**
  * The vanilla filter bar hides itself below this many automations — the exact
- * test is `automations.length < 7` in _initAutoFilterBar. Named so the React
- * port cannot quietly drift to "6+", which is what the surrounding comment
- * claims it does.
+ * test was `automations.length < 7` in the vanilla _initAutoFilterBar (since
+ * deleted with the rest of the legacy list). Named so this cannot quietly
+ * drift to "6+", which is what that code's own comment claimed it did.
  */
 export const AUTO_FILTER_BAR_MIN = 7;
 

--- a/webui/src/routes/automations/-ui/automation-card.test.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.test.tsx
@@ -27,7 +27,8 @@ describe('AutomationCard markup', () => {
     const el = card();
     expect(el.className).toBe('automation-card');
     expect(el.getAttribute('data-id')).toBe('7');
-    // _filterAutomations reads these two to apply the dropdowns.
+    // The vanilla filter read these two to apply its dropdowns; the React
+    // filter matches on them, and the CSS still selects on the card classes.
     expect(el.getAttribute('data-trigger-type')).toBe('schedule');
     expect(el.getAttribute('data-action-type')).toBe('process_wishlist');
     expect(document.querySelector('.automation-status')?.className).toContain('enabled');

--- a/webui/static/stats-automations.js
+++ b/webui/static/stats-automations.js
@@ -3376,8 +3376,6 @@ async function loadAutomations() {
             renderAutomationsMasterToggle(statsBar, 'music');
         }
 
-        // Filter bar — show when 6+ automations
-        _initAutoFilterBar(automations);
         // Catch up on current automation progress
         try {
             const progRes = await fetch('/api/automations/progress');
@@ -3963,63 +3961,7 @@ function _promptNotifyConfig(groupName) {
 }
 
 // --- Filter Bar ---
-function _initAutoFilterBar(automations) {
-    const bar = document.getElementById('auto-filter-bar');
-    if (!bar) return;
-    if (automations.length < 7) { bar.style.display = 'none'; return; }
-    bar.style.display = '';
 
-    // Populate trigger dropdown
-    const trigSel = document.getElementById('auto-filter-trigger');
-    const actSel = document.getElementById('auto-filter-action');
-    const trigTypes = [...new Set(automations.map(a => a.trigger_type))].sort();
-    const actTypes = [...new Set(automations.map(a => a.action_type))].sort();
-    const prevTrig = trigSel.value;
-    const prevAct = actSel.value;
-    trigSel.innerHTML = '<option value="">All Triggers</option>' + trigTypes.map(t =>
-        `<option value="${_escAttr(t)}">${_esc(_autoFormatTrigger(t, {}))}</option>`).join('');
-    actSel.innerHTML = '<option value="">All Actions</option>' + actTypes.map(t =>
-        `<option value="${_escAttr(t)}">${_esc(_autoFormatAction(t))}</option>`).join('');
-    trigSel.value = prevTrig;
-    actSel.value = prevAct;
-
-    // Bind events (use a flag to avoid double-binding)
-    if (!bar.dataset.bound) {
-        bar.dataset.bound = '1';
-        document.getElementById('auto-filter-search').addEventListener('input', _filterAutomations);
-        trigSel.addEventListener('change', _filterAutomations);
-        actSel.addEventListener('change', _filterAutomations);
-    }
-    _filterAutomations();
-}
-
-function _filterAutomations() {
-    const q = (document.getElementById('auto-filter-search').value || '').toLowerCase().trim();
-    const trigFilter = document.getElementById('auto-filter-trigger').value;
-    const actFilter = document.getElementById('auto-filter-action').value;
-    const cards = document.querySelectorAll('#automations-list .automation-card');
-    let visible = 0;
-    cards.forEach(card => {
-        const name = (card.querySelector('.automation-name')?.textContent || '').toLowerCase();
-        const trig = card.querySelector('.flow-trigger')?.textContent || '';
-        const act = card.querySelector('.flow-action')?.textContent || '';
-        // Match search text against name, trigger label, action label
-        const matchQ = !q || name.includes(q) || trig.toLowerCase().includes(q) || act.toLowerCase().includes(q);
-        // Match trigger/action type filters using data attributes
-        const matchTrig = !trigFilter || card.dataset.triggerType === trigFilter;
-        const matchAct = !actFilter || card.dataset.actionType === actFilter;
-        const show = matchQ && matchTrig && matchAct;
-        card.style.display = show ? '' : 'none';
-        if (show) visible++;
-    });
-    const countEl = document.getElementById('auto-filter-count');
-    if (countEl) {
-        countEl.textContent = (q || trigFilter || actFilter) ? `${visible} of ${cards.length}` : '';
-    }
-}
-
-// --- Group Dropdown ---
-let _activeGroupDropdown = null;
 
 function _showGroupDropdown(event, autoId, currentGroup) {
     // Close any existing dropdown


### PR DESCRIPTION
# automations cleanup — retire the vanilla list

follow-up to the automations react migration (#1090), now that the page has run live. deliberately **small**: most of `stats-automations.js` is shared with the video automations page, so this deletes only what the music side exclusively owned.

## what went

- the music list-view markup in `index.html` — header, stats bar, filter bar, list, empty state. react renders all of it now.
- `_initAutoFilterBar` and `_filterAutomations`, plus their call site.

~58 lines of js, ~38 lines of markup. that's it — and the small number is the point.

## what stays, and why

this is the actual risk of the PR, so it's worth being explicit. every one of these looks deletable and isn't:

- **`#automations-list-view`** (the now-empty container). the shared builder toggles it, and `hideAutomationBuilder` does `_bEl('listView').style.display` with **no null guard** — removing it throws on every Back / Cancel / Save, on the **video** side too, which drives the same builder through its own context.
- **the entire builder view.** react hands the shell over to it.
- **`loadAutomations`.** it is now inert — its own `if (!list || !empty) return` fires because the markup is gone — but it is still called transitively by `toggleAutomation`, `runAutomation`, `deleteAutomation`, `duplicateAutomation`, `_bulkToggleGroup`, `_deleteGroup`, `_startRenameGroup` and `_assignGroup`, **all of which the video page reaches** through the shared card and section builders. deleting it throws there. emptying its eight callers instead is a bigger, riskier edit to shared code for the sake of one inert function.
- **the ten shared handlers, the shared renderer, the Hub builder, and the three react guards** in `core.js` / `stats-automations.js`.

## video is provably unaffected

`video-automations.js` keeps its own `load()`, and its own comment already says *"the reused music card handlers fire on the music list, not ours"* — it re-loads itself 700ms after a click and exposes `window._reloadVideoAutomations` for the shared builder. it never depended on `loadAutomations` doing anything, so making it inert changes nothing there.

## the one test that had to move

`test_automations_redesign_css.py` checks that every class the redesign stylesheet targets actually exists in the markup — a typo'd selector silently no-ops. with the music markup now in JSX, it reads the react route as a source too. **verified it still bites**: adding a selector nothing renders failed two of its tests.

## verified

- 369 webui tests, 0 type errors, build clean
- 973 python tests across all 57 files that read `index.html` or `stats-automations.js`
- `index.html` div balance 0 on both sides (2931 → 2918)
- all five vanilla scripts still parse
- reachability recomputed after the deletion: 145 functions, 144 reachable

## noted, not done

`writeArtistImageToDisk` (~60 lines in `stats-automations.js`) is genuinely dead, but it is **pre-existing** and unrelated to automations — it predates this whole migration. left alone to keep this diff mechanical; worth its own sweep alongside the other repo-wide dead code.
