### PR TITLE
React migration library

### DIFF
--- a/tests/test_artist_bubble_hydrate_hardening.py
+++ b/tests/test_artist_bubble_hydrate_hardening.py
@@ -15,6 +15,8 @@ error so the next report carries the cause.
 
 from __future__ import annotations
 
+import re
+
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -140,7 +142,34 @@ def test_library_downloads_section_anchors_on_the_grid_not_a_class_query():
     fn = _HELPERS_JS.split("function showLibraryDownloadsSection")[1].split("function createArtistBubbleCard")[0]
     assert "getElementById('library-artists-grid')" in fn
     assert "artistGrid.parentElement" in fn
-    assert "document.querySelector" not in fn    # the ambiguous global query is gone
     # the ambiguity is real: both sides carry the class (video first)
     index = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8")
     assert index.count('class="library-content"') >= 2
+
+    # The React library page renders a dedicated host and is preferred when
+    # present, so a querySelector is no longer disqualifying on its own — but it
+    # must target a selector that CANNOT match the video side. Anything matching
+    # by class (.library-content and friends) reopens #1038.
+    queried = re.findall(r"document\.querySelector\((['\"])(.+?)\1\)", fn)
+    assert [sel for _, sel in queried] == ["[data-library-downloads-host]"], (
+        f"only the unique React host may be queried here, got {queried}"
+    )
+
+
+def test_react_library_downloads_host_is_unique_to_the_music_page():
+    """The anchor above is only safe while exactly one page renders the host —
+    a second one (notably a video-side copy) would recreate #1038 with a
+    different selector."""
+    hosts = [
+        path
+        for path in _ROOT.joinpath("webui").rglob("*")
+        if path.suffix in {".tsx", ".jsx", ".js", ".html"}
+        and "node_modules" not in path.parts
+        and "dist" not in path.parts
+        and not path.name.endswith(".test.tsx")
+        and "data-library-downloads-host" in path.read_text(encoding="utf-8", errors="ignore")
+    ]
+    rendered = [p for p in hosts if p.name != "shared-helpers.js"]
+    assert [p.name for p in rendered] == ["library-page.tsx"], (
+        f"the host must be rendered by the music library page alone, got {rendered}"
+    )

--- a/tests/test_library_react_handoff.py
+++ b/tests/test_library_react_handoff.py
@@ -1,0 +1,87 @@
+"""/library is served by React; library.js must not repaint behind it.
+
+The vanilla Library page still exists in index.html (its markup and its ~197
+functions are removed in the cleanup PR), so both could paint into the same
+document. What keeps them apart is a single guard in the one function that
+fills the grid, plus one event for the vanilla modal that still changes the
+list. Neither is visible from the React side, so they are pinned here.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIBRARY_JS = (_ROOT / "webui" / "static" / "library.js").read_text(encoding="utf-8")
+_MANIFEST = (_ROOT / "webui" / "src" / "platform" / "shell" / "route-manifest.ts").read_text(
+    encoding="utf-8"
+)
+
+
+def _fn(source: str, name: str) -> str:
+    """The body of a top-level function, up to the next top-level declaration."""
+    start = source.index(f"function {name}(")
+    rest = source[start:]
+    end = re.search(r"\n(?:async )?function ", rest[1:])
+    return rest[: end.start() + 1] if end else rest
+
+
+def test_manifest_hands_library_to_react():
+    assert "{ pageId: 'library', path: '/library', kind: 'react' }" in _MANIFEST
+
+
+def test_load_library_artists_bails_out_when_react_owns_the_page():
+    """The single choke point.
+
+    loadLibraryArtists is the ONLY thing that writes #library-artists-grid, so
+    guarding it makes the vanilla filters, alphabet and pagination buttons
+    unreachable rather than merely unused — they all route through here.
+    """
+    fn = _fn(_LIBRARY_JS, "loadLibraryArtists")
+    guard = "if (document.getElementById('webui-react-root')?.classList.contains('active')) return;"
+    assert guard in fn, "the React guard is gone — vanilla would repaint under the React page"
+
+    # It must come before the fetch, not after.
+    assert fn.index(guard) < fn.index("fetch("), "the guard runs after the request"
+
+
+def test_watch_all_modal_announces_its_change_to_react():
+    """The vanilla "Watch All Unwatched" modal used to refresh by calling
+    loadLibraryArtists(), which the guard above now turns into a no-op. Without
+    the event the watch badges stay stale until the user navigates away."""
+    fn = _fn(_LIBRARY_JS, "closeWatchAllUnwatchedModal")
+    assert "ss:library-changed" in fn, "React is never told the list changed"
+    assert "needsRefresh" in fn, "the event must stay gated on an actual change"
+
+
+def test_react_listens_for_that_exact_event():
+    """Both halves of the seam, so a rename on either side fails here rather
+    than silently going quiet."""
+    live = (
+        _ROOT / "webui" / "src" / "routes" / "library" / "-library.live.ts"
+    ).read_text(encoding="utf-8")
+    assert "'ss:library-changed'" in live
+
+
+def test_the_page_react_renders_claims_no_vanilla_ids():
+    """Duplicate ids would make getElementById return whichever comes first in
+    the document — the vanilla page's node, since its markup is still in
+    index.html. The React page uses the classes only."""
+    page = (
+        _ROOT / "webui" / "src" / "routes" / "library" / "-ui" / "library-page.tsx"
+    ).read_text(encoding="utf-8")
+    card = (
+        _ROOT / "webui" / "src" / "routes" / "library" / "-ui" / "library-artist-card.tsx"
+    ).read_text(encoding="utf-8")
+    for name, source in (("library-page.tsx", page), ("library-artist-card.tsx", card)):
+        assert " id=" not in source, f"{name} renders an id that the vanilla page still owns"
+
+
+def test_react_owned_pages_are_declared_once_each():
+    """A stray second entry for a pageId would make getShellRouteByPageId's
+    answer depend on array order."""
+    ids = re.findall(r"\{ pageId: '([a-z-]+)', path:", _MANIFEST)
+    assert len(ids) == len(set(ids)), f"duplicate manifest entries: {sorted(ids)}"
+    assert json.dumps(ids).count("library") >= 1

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -86,6 +86,22 @@ declare global {
       actionType: string,
     ) => void;
     clearEntireWishlist?: () => void;
+    /**
+     * Library page handoffs, all owned by vanilla and INVOKED rather than
+     * reimplemented:
+     *   - the two export / watch-all modals live in library.js
+     *   - the empty-state CTA drives the vanilla /search page's DOM
+     *   - showLibraryDownloadsSection is bound to `artistDownloadBubbles`,
+     *     module state in core.js, so it cannot move into a module
+     *   - currentMusicSourceName decides which provider id makes an artist
+     *     watchable
+     */
+    openArtistExportModal?: () => void;
+    openWatchAllUnwatchedModal?: () => void;
+    _handoffLibrarySearchToEnhancedSearch?: (query: string) => void;
+    showLibraryDownloadsSection?: () => void;
+    currentMusicSourceName?: string;
+    updateWatchlistCount?: () => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/route-manifest.test.ts
+++ b/webui/src/platform/shell/route-manifest.test.ts
@@ -58,11 +58,13 @@ describe('shellRouteManifest', () => {
     // Order follows the manifest array, not the migration order.
     expect(getShellRouteByPageId('wishlist')?.kind).toBe('react');
     expect(getShellRouteByPageId('automations')?.kind).toBe('react');
+    expect(getShellRouteByPageId('library')?.kind).toBe('react');
     expect(reactShellRoutes.map((route) => route.pageId)).toEqual([
       'watchlist',
       'wishlist',
       'automations',
       'import',
+      'library',
       'stats',
       'issues',
     ]);

--- a/webui/src/platform/shell/route-manifest.ts
+++ b/webui/src/platform/shell/route-manifest.ts
@@ -41,7 +41,7 @@ export const shellRouteManifest: readonly ShellRouteDefinition[] = [
   { pageId: 'automations', path: '/automations', kind: 'react' },
   { pageId: 'active-downloads', path: '/active-downloads', kind: 'legacy' },
   { pageId: 'import', path: '/import', kind: 'react' },
-  { pageId: 'library', path: '/library', kind: 'legacy' },
+  { pageId: 'library', path: '/library', kind: 'react' },
   { pageId: 'tools', path: '/tools', kind: 'legacy' },
   { pageId: 'artist-detail', path: '/artist-detail', kind: 'legacy' },
   { pageId: 'label-detail', path: '/label-detail', kind: 'legacy' },

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SplatRouteImport } from './routes/$'
 import { Route as WishlistRouteRouteImport } from './routes/wishlist/route'
 import { Route as WatchlistRouteRouteImport } from './routes/watchlist/route'
 import { Route as StatsRouteRouteImport } from './routes/stats/route'
+import { Route as LibraryRouteRouteImport } from './routes/library/route'
 import { Route as IssuesRouteRouteImport } from './routes/issues/route'
 import { Route as ImportRouteRouteImport } from './routes/import/route'
 import { Route as AutomationsRouteRouteImport } from './routes/automations/route'
@@ -42,6 +43,11 @@ const WatchlistRouteRoute = WatchlistRouteRouteImport.update({
 const StatsRouteRoute = StatsRouteRouteImport.update({
   id: '/stats',
   path: '/stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LibraryRouteRoute = LibraryRouteRouteImport.update({
+  id: '/library',
+  path: '/library',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IssuesRouteRoute = IssuesRouteRouteImport.update({
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/automations': typeof AutomationsRouteRoute
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
+  '/library': typeof LibraryRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -115,6 +122,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/automations': typeof AutomationsRouteRoute
   '/issues': typeof IssuesRouteRoute
+  '/library': typeof LibraryRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -132,6 +140,7 @@ export interface FileRoutesById {
   '/automations': typeof AutomationsRouteRoute
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
+  '/library': typeof LibraryRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -150,6 +159,7 @@ export interface FileRouteTypes {
     | '/automations'
     | '/import'
     | '/issues'
+    | '/library'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -165,6 +175,7 @@ export interface FileRouteTypes {
     | '/'
     | '/automations'
     | '/issues'
+    | '/library'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -181,6 +192,7 @@ export interface FileRouteTypes {
     | '/automations'
     | '/import'
     | '/issues'
+    | '/library'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -198,6 +210,7 @@ export interface RootRouteChildren {
   AutomationsRouteRoute: typeof AutomationsRouteRoute
   ImportRouteRoute: typeof ImportRouteRouteWithChildren
   IssuesRouteRoute: typeof IssuesRouteRoute
+  LibraryRouteRoute: typeof LibraryRouteRoute
   StatsRouteRoute: typeof StatsRouteRoute
   WatchlistRouteRoute: typeof WatchlistRouteRoute
   WishlistRouteRoute: typeof WishlistRouteRoute
@@ -234,6 +247,13 @@ declare module '@tanstack/react-router' {
       path: '/stats'
       fullPath: '/stats'
       preLoaderRoute: typeof StatsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/library': {
+      id: '/library'
+      path: '/library'
+      fullPath: '/library'
+      preLoaderRoute: typeof LibraryRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/issues': {
@@ -332,6 +352,7 @@ const rootRouteChildren: RootRouteChildren = {
   AutomationsRouteRoute: AutomationsRouteRoute,
   ImportRouteRoute: ImportRouteRouteWithChildren,
   IssuesRouteRoute: IssuesRouteRoute,
+  LibraryRouteRoute: LibraryRouteRoute,
   StatsRouteRoute: StatsRouteRoute,
   WatchlistRouteRoute: WatchlistRouteRoute,
   WishlistRouteRoute: WishlistRouteRoute,

--- a/webui/src/routes/library/-library.api.ts
+++ b/webui/src/routes/library/-library.api.ts
@@ -10,6 +10,31 @@ import {
 
 export const LIBRARY_QUERY_KEY = ['library'] as const;
 
+interface SuccessResponse {
+  success?: boolean;
+  error?: string;
+}
+
+/**
+ * Add / remove straight from a card badge.
+ *
+ * Same two endpoints the vanilla card handler used; `artistId` is the
+ * source-matched id (see watchlistArtistId), which is what the watchlist is
+ * keyed on — not the library's own row id.
+ */
+export async function setArtistWatchlisted(
+  artistId: string,
+  artistName: string,
+  watch: boolean,
+): Promise<void> {
+  const payload = await readJson<SuccessResponse>(
+    watch
+      ? apiClient.post('watchlist/add', { json: { artist_id: artistId, artist_name: artistName } })
+      : apiClient.post('watchlist/remove', { json: { artist_id: artistId } }),
+  );
+  if (!payload.success) throw new Error(payload.error || 'Watchlist update failed');
+}
+
 /**
  * The artist grid. ONE endpoint backs the whole list page.
  *

--- a/webui/src/routes/library/-library.api.ts
+++ b/webui/src/routes/library/-library.api.ts
@@ -1,0 +1,37 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { apiClient, readJson } from '@/app/api-client';
+
+import {
+  LIBRARY_PAGE_SIZE,
+  type LibraryArtistsResponse,
+  type LibrarySearch,
+} from './-library.types';
+
+export const LIBRARY_QUERY_KEY = ['library'] as const;
+
+/**
+ * The artist grid. ONE endpoint backs the whole list page.
+ *
+ * `source_filter` is omitted when empty, matching the vanilla loader — it only
+ * `set()` the param when a source was chosen, and the backend defaults it to
+ * '' anyway, so sending an empty one would be noise in the query key too.
+ */
+export function libraryArtistsQueryOptions(profileId: number, search: LibrarySearch) {
+  const params: Record<string, string | number> = {
+    search: search.q,
+    letter: search.letter,
+    page: search.page,
+    limit: LIBRARY_PAGE_SIZE,
+    watchlist: search.watchlist,
+  };
+  if (search.source) params.source_filter = search.source;
+
+  return queryOptions({
+    // Every filter is part of the key: changing any of them is a different
+    // result set, and paging back should hit the cache rather than refetch.
+    queryKey: [...LIBRARY_QUERY_KEY, 'artists', profileId, params] as const,
+    queryFn: () =>
+      readJson<LibraryArtistsResponse>(apiClient.get('library/artists', { searchParams: params })),
+  });
+}

--- a/webui/src/routes/library/-library.helpers.test.ts
+++ b/webui/src/routes/library/-library.helpers.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  BRAND_LOGOS,
+  buildArtistBadges,
+  canWatchArtist,
+  cardAnimationDelay,
+  MAX_BADGES_PER_COLUMN,
+  readArtistsResponse,
+  splitBadgeColumns,
+  trackCountLabel,
+} from './-library.helpers';
+import { type LibraryArtist } from './-library.types';
+
+function artist(over: Partial<LibraryArtist> = {}): LibraryArtist {
+  return { id: 1, name: 'Aphex Twin', ...over };
+}
+
+describe('brand logos match the vanilla source', () => {
+  // Most are top-level `const`s in core.js, which a module cannot read, so the
+  // helper restates them. One (SoulID) is not a constant at all — it is an
+  // inline literal in library.js's badge builder. Checking BOTH files is what
+  // makes this a real parity pin rather than a guess about where each lives;
+  // a moved or renamed asset would otherwise ship a silently broken image.
+  const vanilla =
+    readFileSync(resolve(process.cwd(), 'static/core.js'), 'utf8') +
+    readFileSync(resolve(process.cwd(), 'static/library.js'), 'utf8');
+
+  it.each(Object.entries(BRAND_LOGOS))('%s -> %s', (_key, path) => {
+    expect(vanilla).toContain(`'${path}'`);
+  });
+});
+
+describe('buildArtistBadges', () => {
+  it('returns nothing for an unenriched artist', () => {
+    expect(buildArtistBadges(artist())).toEqual([]);
+  });
+
+  it('keeps the vanilla declaration order, which is visible on the card', () => {
+    const badges = buildArtistBadges(
+      artist({
+        // deliberately supplied out of order
+        tidal_id: 't',
+        spotify_artist_id: 's',
+        genius_url: 'https://genius.com/x',
+        musicbrainz_id: 'mb',
+      }),
+    );
+    expect(badges.map((b) => b.key)).toEqual(['spotify', 'musicbrainz', 'genius', 'tidal']);
+  });
+
+  it('deep-links each provider', () => {
+    const [spotify] = buildArtistBadges(artist({ spotify_artist_id: 'abc' }));
+    expect(spotify.url).toBe('https://open.spotify.com/artist/abc');
+    const [mb] = buildArtistBadges(artist({ musicbrainz_id: 'xyz' }));
+    expect(mb.url).toBe('https://musicbrainz.org/artist/xyz');
+  });
+
+  it('passes through the raw url for Last.fm and Genius', () => {
+    // These arrive as full URLs, not ids — building a URL from them would
+    // produce a double-prefixed link.
+    const [lfm] = buildArtistBadges(artist({ lastfm_url: 'https://last.fm/music/X' }));
+    expect(lfm.url).toBe('https://last.fm/music/X');
+  });
+
+  it('gives Amazon and SoulID no link', () => {
+    expect(buildArtistBadges(artist({ amazon_id: 'a' }))[0].url).toBeNull();
+    expect(buildArtistBadges(artist({ soul_id: 'real-id' }))[0].url).toBeNull();
+  });
+
+  it('ignores a placeholder soul_id', () => {
+    // soul_unnamed_* is a generated stand-in, not an identity — badging it
+    // would claim an enrichment that never happened.
+    expect(buildArtistBadges(artist({ soul_id: 'soul_unnamed_123' }))).toEqual([]);
+    expect(buildArtistBadges(artist({ soul_id: 'soul_real' })).map((b) => b.key)).toEqual([
+      'soulsync',
+    ]);
+  });
+
+  it('slugifies the artist name into the AudioDB url', () => {
+    // Spaces become hyphens FIRST, then non-alphanumerics are stripped — so
+    // the hyphen survives and the accent does not. Verified against the exact
+    // vanilla expression rather than reasoned about: "Sigur Rós!" -> Sigur-Rs.
+    const [adb] = buildArtistBadges(artist({ audiodb_id: 5, name: 'Sigur Rós!' }));
+    expect(adb.url).toBe('https://www.theaudiodb.com/artist/5-Sigur-Rs');
+  });
+
+  it('treats a zero id as absent', () => {
+    // Ids arrive as numbers for some providers; 0 is not a real id.
+    expect(buildArtistBadges(artist({ deezer_id: 0 }))).toEqual([]);
+  });
+});
+
+describe('splitBadgeColumns', () => {
+  const many = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      key: `k${i}`,
+      logo: '',
+      fallback: '',
+      title: '',
+      url: null,
+    }));
+
+  it('keeps everything in one column at or below the cap', () => {
+    const out = splitBadgeColumns(many(MAX_BADGES_PER_COLUMN));
+    expect(out.needsOverflow).toBe(false);
+    expect(out.primary).toHaveLength(MAX_BADGES_PER_COLUMN);
+    expect(out.overflow).toEqual([]);
+  });
+
+  it('spills the remainder over the cap', () => {
+    const out = splitBadgeColumns(many(MAX_BADGES_PER_COLUMN + 3));
+    expect(out.needsOverflow).toBe(true);
+    expect(out.primary).toHaveLength(MAX_BADGES_PER_COLUMN);
+    expect(out.overflow).toHaveLength(3);
+  });
+});
+
+describe('cardAnimationDelay', () => {
+  it('staggers by 20ms and caps at 600', () => {
+    expect(cardAnimationDelay(0)).toBe(0);
+    expect(cardAnimationDelay(5)).toBe(100);
+    // Without the cap a 75-card page would stagger the last card by 1.5s.
+    expect(cardAnimationDelay(30)).toBe(600);
+    expect(cardAnimationDelay(74)).toBe(600);
+  });
+});
+
+describe('canWatchArtist', () => {
+  it('accepts either id, whichever source is active', () => {
+    expect(canWatchArtist(artist({ spotify_artist_id: 's' }), 'Spotify')).toBe(true);
+    expect(canWatchArtist(artist({ itunes_artist_id: 1 }), 'iTunes')).toBe(true);
+    // The source only expresses preference — the other id still qualifies.
+    expect(canWatchArtist(artist({ spotify_artist_id: 's' }), 'iTunes')).toBe(true);
+    expect(canWatchArtist(artist({ itunes_artist_id: 1 }), 'Spotify')).toBe(true);
+  });
+
+  it('refuses an artist with neither', () => {
+    expect(canWatchArtist(artist({ musicbrainz_id: 'mb' }), 'Spotify')).toBe(false);
+  });
+});
+
+describe('trackCountLabel', () => {
+  it('pluralises and hides zero', () => {
+    expect(trackCountLabel(1)).toBe('1 track');
+    expect(trackCountLabel(12)).toBe('12 tracks');
+    expect(trackCountLabel(0)).toBe('');
+    expect(trackCountLabel(undefined)).toBe('');
+  });
+});
+
+describe('readArtistsResponse', () => {
+  it('unwraps a successful payload', () => {
+    const out = readArtistsResponse({
+      success: true,
+      artists: [artist()],
+      pagination: {
+        page: 2,
+        limit: 75,
+        total_count: 90,
+        total_pages: 2,
+        has_prev: true,
+        has_next: false,
+      },
+    });
+    expect(out.artists).toHaveLength(1);
+    expect(out.pagination).toEqual({
+      page: 2,
+      totalPages: 2,
+      totalCount: 90,
+      hasPrev: true,
+      hasNext: false,
+    });
+  });
+
+  it('throws the server reason on success:false', () => {
+    // The endpoint answers 500 WITH a body, but also has paths that report
+    // success:false — swallowing it would show an empty library as if the
+    // user simply had no artists.
+    expect(() => readArtistsResponse({ success: false, error: 'db locked' })).toThrow('db locked');
+  });
+
+  it('falls back to a generic message when the reason is missing', () => {
+    expect(() => readArtistsResponse({ success: false })).toThrow('Failed to load artists');
+  });
+
+  it('survives a payload with no pagination', () => {
+    const out = readArtistsResponse({ artists: [] });
+    expect(out.pagination.page).toBe(1);
+    expect(out.pagination.hasNext).toBe(false);
+  });
+});

--- a/webui/src/routes/library/-library.helpers.ts
+++ b/webui/src/routes/library/-library.helpers.ts
@@ -161,11 +161,22 @@ export function splitBadgeColumns(badges: ArtistBadge[]): {
  * Either id satisfies it — the order only expresses preference.
  */
 export function canWatchArtist(artist: LibraryArtist, musicSource: string | undefined): boolean {
-  return Boolean(
+  return watchlistArtistId(artist, musicSource) !== null;
+}
+
+/**
+ * The id the watchlist endpoints are keyed on — the same preference order, so
+ * a card that OFFERS the watch badge can always act on it.
+ */
+export function watchlistArtistId(
+  artist: LibraryArtist,
+  musicSource: string | undefined,
+): string | null {
+  const id =
     musicSource === 'iTunes'
       ? artist.itunes_artist_id || artist.spotify_artist_id
-      : artist.spotify_artist_id || artist.itunes_artist_id,
-  );
+      : artist.spotify_artist_id || artist.itunes_artist_id;
+  return id ? String(id) : null;
 }
 
 /** "12 tracks" / "1 track"; empty when the artist has none. */

--- a/webui/src/routes/library/-library.helpers.ts
+++ b/webui/src/routes/library/-library.helpers.ts
@@ -1,0 +1,206 @@
+import type { ArtistBadge, LibraryArtist, LibraryArtistsResponse } from './-library.types';
+
+/**
+ * Provider logo paths, mirroring the constants in core.js.
+ *
+ * They are top-level `const`s in a classic script, which creates a global
+ * LEXICAL binding rather than a window property — so a module cannot read
+ * them. They are static asset paths, so they are restated here and pinned
+ * against core.js by a parity test rather than bridged at runtime.
+ */
+export const BRAND_LOGOS = {
+  musicbrainz: '/static/img/brands/musicbrainz.png',
+  deezer: '/static/img/brands/deezer.png',
+  spotify: '/static/img/brands/spotify.png',
+  itunes: '/static/img/brands/itunes.png',
+  lastfm: '/static/img/brands/lastfm.png',
+  genius: '/static/img/brands/genius.png',
+  tidal: '/static/img/brands/tidal.svg',
+  qobuz: '/static/img/brands/qobuz.svg',
+  discogs: '/static/img/brands/discogs.svg',
+  amazon: '/static/amazon.svg',
+  soulsync: '/static/trans2.png',
+} as const;
+
+/** Badges beyond this many spill into the overflow column. */
+export const MAX_BADGES_PER_COLUMN = 6;
+
+/** Card entry animation, capped so the last card does not wait. */
+export function cardAnimationDelay(index: number): number {
+  return Math.min(index * 20, 600);
+}
+
+/**
+ * AudioDB has no fixed logo path — the vanilla card read it off an existing
+ * `img.audiodb-logo` in the document. Same lookup, same "no logo, show the
+ * fallback text" outcome when it is absent.
+ */
+function audioDbLogo(): string {
+  if (typeof document === 'undefined') return '';
+  return document.querySelector<HTMLImageElement>('img.audiodb-logo')?.src ?? '';
+}
+
+/** AudioDB artist URLs carry a slug built from the name. */
+function audioDbSlug(name: string | undefined): string {
+  return (name ?? '').replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+}
+
+/**
+ * The provider badges for one artist, in the vanilla declaration order —
+ * Spotify, MusicBrainz, Deezer, AudioDB, iTunes, Last.fm, Genius, Tidal,
+ * Qobuz, Discogs, Amazon, SoulID. Order is visible on the card, so it is
+ * part of the contract.
+ *
+ * Amazon and SoulID have no link (url null); the rest deep-link to the
+ * provider.
+ */
+export function buildArtistBadges(artist: LibraryArtist): ArtistBadge[] {
+  const badges: ArtistBadge[] = [];
+  const add = (key: string, logo: string, fallback: string, title: string, url: string | null) =>
+    badges.push({ key, logo, fallback, title, url });
+
+  if (artist.spotify_artist_id)
+    add(
+      'spotify',
+      BRAND_LOGOS.spotify,
+      'SP',
+      'Spotify',
+      `https://open.spotify.com/artist/${artist.spotify_artist_id}`,
+    );
+  if (artist.musicbrainz_id)
+    add(
+      'musicbrainz',
+      BRAND_LOGOS.musicbrainz,
+      'MB',
+      'MusicBrainz',
+      `https://musicbrainz.org/artist/${artist.musicbrainz_id}`,
+    );
+  if (artist.deezer_id)
+    add(
+      'deezer',
+      BRAND_LOGOS.deezer,
+      'Dz',
+      'Deezer',
+      `https://www.deezer.com/artist/${artist.deezer_id}`,
+    );
+  if (artist.audiodb_id)
+    add(
+      'audiodb',
+      audioDbLogo(),
+      'ADB',
+      'AudioDB',
+      `https://www.theaudiodb.com/artist/${artist.audiodb_id}-${audioDbSlug(artist.name)}`,
+    );
+  if (artist.itunes_artist_id)
+    add(
+      'itunes',
+      BRAND_LOGOS.itunes,
+      'IT',
+      'Apple Music',
+      `https://music.apple.com/artist/${artist.itunes_artist_id}`,
+    );
+  if (artist.lastfm_url) add('lastfm', BRAND_LOGOS.lastfm, 'LFM', 'Last.fm', artist.lastfm_url);
+  if (artist.genius_url) add('genius', BRAND_LOGOS.genius, 'GEN', 'Genius', artist.genius_url);
+  if (artist.tidal_id)
+    add(
+      'tidal',
+      BRAND_LOGOS.tidal,
+      'TD',
+      'Tidal',
+      `https://tidal.com/browse/artist/${artist.tidal_id}`,
+    );
+  if (artist.qobuz_id)
+    add(
+      'qobuz',
+      BRAND_LOGOS.qobuz,
+      'Qz',
+      'Qobuz',
+      `https://www.qobuz.com/artist/${artist.qobuz_id}`,
+    );
+  if (artist.discogs_id)
+    add(
+      'discogs',
+      BRAND_LOGOS.discogs,
+      'DC',
+      'Discogs',
+      `https://www.discogs.com/artist/${artist.discogs_id}`,
+    );
+  if (artist.amazon_id) add('amazon', BRAND_LOGOS.amazon, 'AMZ', 'Amazon Music', null);
+  // A placeholder soul_id is not a real identity and must not earn a badge.
+  if (artist.soul_id && !String(artist.soul_id).startsWith('soul_unnamed_'))
+    add('soulsync', BRAND_LOGOS.soulsync, 'SS', `SoulID: ${artist.soul_id}`, null);
+
+  return badges;
+}
+
+/**
+ * Split badges into the two rendered columns.
+ *
+ * Under the cap everything sits in one row. Over it, the FIRST six go to the
+ * primary column and the remainder to the overflow column — note the vanilla
+ * markup renders the overflow column FIRST in the DOM.
+ */
+export function splitBadgeColumns(badges: ArtistBadge[]): {
+  overflow: ArtistBadge[];
+  primary: ArtistBadge[];
+  needsOverflow: boolean;
+} {
+  const needsOverflow = badges.length > MAX_BADGES_PER_COLUMN;
+  return {
+    needsOverflow,
+    primary: needsOverflow ? badges.slice(0, MAX_BADGES_PER_COLUMN) : badges,
+    overflow: needsOverflow ? badges.slice(MAX_BADGES_PER_COLUMN) : [],
+  };
+}
+
+/**
+ * Whether the artist can be added to the watchlist.
+ *
+ * Watching needs an id on the ACTIVE music source, and which id counts flips
+ * with the source: on iTunes the iTunes id is preferred, otherwise Spotify.
+ * Either id satisfies it — the order only expresses preference.
+ */
+export function canWatchArtist(artist: LibraryArtist, musicSource: string | undefined): boolean {
+  return Boolean(
+    musicSource === 'iTunes'
+      ? artist.itunes_artist_id || artist.spotify_artist_id
+      : artist.spotify_artist_id || artist.itunes_artist_id,
+  );
+}
+
+/** "12 tracks" / "1 track"; empty when the artist has none. */
+export function trackCountLabel(count: number | undefined): string {
+  if (!count || count <= 0) return '';
+  return `${count} track${count !== 1 ? 's' : ''}`;
+}
+
+/**
+ * Unwrap /api/library/artists.
+ *
+ * `success: false` carries the reason in `error`, and the vanilla loader threw
+ * it so the catch could toast it. Throwing here lets React Query own the error
+ * state instead of it being swallowed into an empty grid.
+ */
+export function readArtistsResponse(payload: LibraryArtistsResponse | undefined): {
+  artists: LibraryArtist[];
+  pagination: {
+    page: number;
+    totalPages: number;
+    totalCount: number;
+    hasPrev: boolean;
+    hasNext: boolean;
+  };
+} {
+  if (payload?.success === false) throw new Error(payload.error || 'Failed to load artists');
+  const p = payload?.pagination;
+  return {
+    artists: payload?.artists ?? [],
+    pagination: {
+      page: p?.page ?? 1,
+      totalPages: p?.total_pages ?? 0,
+      totalCount: p?.total_count ?? 0,
+      hasPrev: p?.has_prev ?? false,
+      hasNext: p?.has_next ?? false,
+    },
+  };
+}

--- a/webui/src/routes/library/-library.live.ts
+++ b/webui/src/routes/library/-library.live.ts
@@ -1,0 +1,30 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { LIBRARY_QUERY_KEY } from './-library.api';
+
+/**
+ * Fired by library.js when vanilla code changes the artist list under the page.
+ *
+ * Today that is one caller: closeWatchAllUnwatchedModal, after "Watch All
+ * Unwatched" has added artists to the watchlist. The modal is still vanilla
+ * (it is invoked, not reimplemented), and it used to refresh by calling
+ * loadLibraryArtists() — which now no-ops while React owns the page, so
+ * without this the watch badges stay stale until you navigate away and back.
+ */
+export const LIBRARY_CHANGED_EVENT = 'ss:library-changed';
+
+export function useLibraryChanged(): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const onChanged = () => {
+      // Invalidate rather than patch: Watch All touches an unknown number of
+      // artists, so there is nothing local to apply.
+      void queryClient.invalidateQueries({ queryKey: LIBRARY_QUERY_KEY });
+    };
+
+    window.addEventListener(LIBRARY_CHANGED_EVENT, onChanged);
+    return () => window.removeEventListener(LIBRARY_CHANGED_EVENT, onChanged);
+  }, [queryClient]);
+}

--- a/webui/src/routes/library/-library.types.ts
+++ b/webui/src/routes/library/-library.types.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+/**
+ * Coerce a raw search value to a string.
+ *
+ * TanStack JSON-parses search values, so an all-digits query arrives as a
+ * NUMBER and a bare `z.string()` would throw SearchParamError and take the
+ * route down. Only primitives are stringified — a hand-edited `?q[]=x` parses
+ * to an object, which must read as absent rather than "[object Object]".
+ */
+function searchString(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return undefined;
+}
+
+function searchNumber(value: unknown, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number.parseInt(String(value ?? ''), 10);
+  return Number.isFinite(n) && n >= 1 ? n : fallback;
+}
+
+/** The four watchlist filter buttons. */
+export const WATCHLIST_FILTERS = ['all', 'watched', 'unwatched', 'ignored'] as const;
+
+/**
+ * Page size. Fixed at 75 in libraryPageState and never exposed in the UI, so
+ * it is a constant here rather than URL state.
+ */
+export const LIBRARY_PAGE_SIZE = 75;
+
+/**
+ * All five filters live in the URL.
+ *
+ * They were module-scoped `libraryPageState` fields in the vanilla page, lost
+ * on reload and unshareable. Putting them in the URL only adds state that used
+ * to be thrown away — the same call made for the wishlist's q/failing.
+ */
+export const librarySearchSchema = z.object({
+  /** Free-text search. `search` in the API, `q` in the URL for consistency. */
+  q: z
+    .preprocess((v) => searchString(v) ?? '', z.string())
+    .default('')
+    .catch(''),
+  /** Alphabet selector; 'all' means no letter filter. */
+  letter: z
+    .preprocess((v) => searchString(v) ?? 'all', z.string())
+    .default('all')
+    .catch('all'),
+  /** 1-based. Anything unparseable or < 1 falls back to page 1. */
+  page: z
+    .preprocess((v) => searchNumber(v, 1), z.number())
+    .default(1)
+    .catch(1),
+  watchlist: z
+    .preprocess((v) => searchString(v) ?? 'all', z.string())
+    .default('all')
+    .catch('all'),
+  /** Metadata source filter; '' means all sources and is NOT sent to the API. */
+  source: z
+    .preprocess((v) => searchString(v) ?? '', z.string())
+    .default('')
+    .catch(''),
+});
+
+export type LibrarySearch = z.infer<typeof librarySearchSchema>;
+
+/**
+ * One row from /api/library/artists.
+ *
+ * The provider id fields each drive one badge on the card; they are all
+ * optional because an artist is only enriched by the providers that matched.
+ */
+export interface LibraryArtist {
+  id: string | number;
+  name: string;
+  image_url?: string | null;
+  track_count?: number;
+  is_watched?: boolean;
+  /** Provider ids — each present one adds a badge, in this declaration order. */
+  spotify_artist_id?: string | null;
+  musicbrainz_id?: string | null;
+  deezer_id?: string | number | null;
+  audiodb_id?: string | number | null;
+  itunes_artist_id?: string | number | null;
+  lastfm_url?: string | null;
+  genius_url?: string | null;
+  tidal_id?: string | number | null;
+  qobuz_id?: string | number | null;
+  discogs_id?: string | number | null;
+  amazon_id?: string | null;
+  soul_id?: string | null;
+}
+
+export interface LibraryPagination {
+  page: number;
+  limit: number;
+  total_count: number;
+  total_pages: number;
+  has_prev: boolean;
+  has_next: boolean;
+}
+
+export interface LibraryArtistsResponse {
+  success?: boolean;
+  error?: string;
+  artists?: LibraryArtist[];
+  pagination?: LibraryPagination;
+}
+
+/** A resolved badge, ready to render. `url` null means it is not a link. */
+export interface ArtistBadge {
+  key: string;
+  logo: string;
+  /** Two/three-letter text shown if the logo image fails to load. */
+  fallback: string;
+  title: string;
+  url: string | null;
+}

--- a/webui/src/routes/library/-library.types.ts
+++ b/webui/src/routes/library/-library.types.ts
@@ -41,9 +41,16 @@ export const librarySearchSchema = z.object({
     .preprocess((v) => searchString(v) ?? '', z.string())
     .default('')
     .catch(''),
-  /** Alphabet selector; 'all' means no letter filter. */
+  /**
+   * Alphabet selector; 'all' means no letter filter.
+   *
+   * Lowercased because the buttons carry lowercase values and the active-letter
+   * highlight compares against them — a hand-typed `?letter=A` would otherwise
+   * filter correctly (the backend compares with UPPER on both sides) while
+   * highlighting nothing.
+   */
   letter: z
-    .preprocess((v) => searchString(v) ?? 'all', z.string())
+    .preprocess((v) => (searchString(v) ?? 'all').toLowerCase(), z.string())
     .default('all')
     .catch('all'),
   /** 1-based. Anything unparseable or < 1 falls back to page 1. */

--- a/webui/src/routes/library/-route.test.tsx
+++ b/webui/src/routes/library/-route.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
@@ -8,16 +8,15 @@ import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
 
 /**
- * /library exists as a route but is DORMANT.
+ * /library is LIVE — the manifest hands it to React.
  *
- * TanStack matches from the generated route tree, not the manifest, so this
- * route began matching the moment the file landed. The isReactOwned() guard is
- * what keeps the vanilla page in charge; without it both would activate.
+ * These were the dormant-route tests; they were written to fail the moment the
+ * manifest flipped, and this is that rewrite. The point of the suite is
+ * unchanged: the route must not hand the page back to vanilla, validateSearch
+ * must survive whatever is in the URL, and the permission gate still applies.
  *
- * Honest note on strength: until P2 adds the page component, the route returns
- * LegacyRouteController down BOTH branches, so only the "does not fetch" case
- * can detect a defeated guard. The render assertions gain teeth once the page
- * exists — the same progression the automations route went through.
+ * Unlike library-page.test.tsx this file does NOT mock the manifest — the flip
+ * itself is what it is checking.
  */
 
 function renderRoute(entries = ['/library']) {
@@ -29,60 +28,81 @@ function renderRoute(entries = ['/library']) {
 
 let requested: string[] = [];
 
-describe('library route (dormant)', () => {
+describe('library route (live)', () => {
   beforeEach(() => {
     window.SoulSyncWebShellBridge = createShellBridge();
+    window.showLibraryDownloadsSection = vi.fn();
     requested = [];
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
-        requested.push(input instanceof Request ? input.url : String(input));
-        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+        const url = input instanceof Request ? input.url : String(input);
+        requested.push(url);
+        const body = url.includes('/api/library/artists')
+          ? {
+              success: true,
+              artists: [{ id: 1, name: 'Aphex Twin' }],
+              pagination: {
+                page: 1,
+                limit: 75,
+                total_count: 1,
+                total_pages: 1,
+                has_prev: false,
+                has_next: false,
+              },
+            }
+          : {};
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
       }),
     );
   });
   afterEach(() => {
     vi.unstubAllGlobals();
     delete window.SoulSyncWebShellBridge;
+    delete window.showLibraryDownloadsSection;
   });
 
-  it('is still owned by the shell', () => {
-    // Fails the moment the manifest flips — which is the point. Rewrite it
-    // then, deliberately, rather than letting it rot.
-    expect(getShellRouteByPageId('library')?.kind).toBe('legacy');
+  it('is owned by React', () => {
+    expect(getShellRouteByPageId('library')?.kind).toBe('react');
   });
 
-  it('hands /library to the vanilla page', async () => {
+  it('renders the React page instead of handing /library to vanilla', async () => {
+    renderRoute();
+    await screen.findByText('Aphex Twin');
+    // The vanilla page must not activate underneath — two live library pages
+    // would fight over #library-artists-grid and the downloads section.
+    expect(window.SoulSyncWebShellBridge!.activateLegacyPath).not.toHaveBeenCalledWith('/library');
+  });
+
+  it('loads the artists through the route loader', async () => {
     renderRoute();
     await waitFor(() =>
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalledWith('/library'),
+      expect(requested.filter((u) => u.includes('/api/library/artists'))).not.toEqual([]),
     );
-  });
-
-  it('does not touch the library API while dormant', async () => {
-    renderRoute();
-    await waitFor(() =>
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
-    );
-    // The shell fetches on its own regardless of route, so this checks the
-    // library endpoint specifically rather than forbidding all traffic.
-    expect(requested.filter((u) => u.includes('/api/library'))).toEqual([]);
   });
 
   it('accepts every filter in the URL without throwing the route down', async () => {
-    // validateSearch runs even while dormant. An all-digits q arrives as a
-    // NUMBER from TanStack's JSON parse, which a bare z.string() would reject.
+    // An all-digits q arrives as a NUMBER from TanStack's JSON parse, which a
+    // bare z.string() would reject and take the route down with.
     renderRoute(['/library?q=123&letter=A&page=3&watchlist=unwatched&source=spotify']);
     await waitFor(() =>
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
+      expect(requested.filter((u) => u.includes('/api/library/artists'))).not.toEqual([]),
     );
+    const url = new URL(requested.find((u) => u.includes('/api/library/artists'))!, 'http://x');
+    expect(url.searchParams.get('search')).toBe('123');
+    expect(url.searchParams.get('letter')).toBe('a');
   });
 
   it('falls back rather than crashing on a nonsense page number', async () => {
     renderRoute(['/library?page=notanumber']);
     await waitFor(() =>
-      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
+      expect(requested.filter((u) => u.includes('/api/library/artists'))).not.toEqual([]),
     );
+    const url = new URL(requested.find((u) => u.includes('/api/library/artists'))!, 'http://x');
+    expect(url.searchParams.get('page')).toBe('1');
   });
 
   it('still respects the page permission gate', async () => {

--- a/webui/src/routes/library/-route.test.tsx
+++ b/webui/src/routes/library/-route.test.tsx
@@ -1,0 +1,93 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+/**
+ * /library exists as a route but is DORMANT.
+ *
+ * TanStack matches from the generated route tree, not the manifest, so this
+ * route began matching the moment the file landed. The isReactOwned() guard is
+ * what keeps the vanilla page in charge; without it both would activate.
+ *
+ * Honest note on strength: until P2 adds the page component, the route returns
+ * LegacyRouteController down BOTH branches, so only the "does not fetch" case
+ * can detect a defeated guard. The render assertions gain teeth once the page
+ * exists — the same progression the automations route went through.
+ */
+
+function renderRoute(entries = ['/library']) {
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: entries });
+  const router = createAppRouter({ history, queryClient });
+  return { router, ...render(<AppRouterProvider router={router} queryClient={queryClient} />) };
+}
+
+let requested: string[] = [];
+
+describe('library route (dormant)', () => {
+  beforeEach(() => {
+    window.SoulSyncWebShellBridge = createShellBridge();
+    requested = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        requested.push(input instanceof Request ? input.url : String(input));
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }),
+    );
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete window.SoulSyncWebShellBridge;
+  });
+
+  it('is still owned by the shell', () => {
+    // Fails the moment the manifest flips — which is the point. Rewrite it
+    // then, deliberately, rather than letting it rot.
+    expect(getShellRouteByPageId('library')?.kind).toBe('legacy');
+  });
+
+  it('hands /library to the vanilla page', async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalledWith('/library'),
+    );
+  });
+
+  it('does not touch the library API while dormant', async () => {
+    renderRoute();
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
+    );
+    // The shell fetches on its own regardless of route, so this checks the
+    // library endpoint specifically rather than forbidding all traffic.
+    expect(requested.filter((u) => u.includes('/api/library'))).toEqual([]);
+  });
+
+  it('accepts every filter in the URL without throwing the route down', async () => {
+    // validateSearch runs even while dormant. An all-digits q arrives as a
+    // NUMBER from TanStack's JSON parse, which a bare z.string() would reject.
+    renderRoute(['/library?q=123&letter=A&page=3&watchlist=unwatched&source=spotify']);
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
+    );
+  });
+
+  it('falls back rather than crashing on a nonsense page number', async () => {
+    renderRoute(['/library?page=notanumber']);
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge!.activateLegacyPath).toHaveBeenCalled(),
+    );
+  });
+
+  it('still respects the page permission gate', async () => {
+    window.SoulSyncWebShellBridge = createShellBridge({ isPageAllowed: vi.fn(() => false) });
+    const { router } = renderRoute();
+    await waitFor(() => expect(router.state.location.pathname).not.toBe('/library'));
+  });
+});

--- a/webui/src/routes/library/-ui/library-artist-card.test.tsx
+++ b/webui/src/routes/library/-ui/library-artist-card.test.tsx
@@ -1,0 +1,222 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { LibraryArtist } from '../-library.types';
+
+import { LibraryArtistCard } from './library-artist-card';
+
+/**
+ * The card is pure presentation, so it renders standalone — but the details it
+ * encodes (the two-stage image fallback, which column the watch badge lands in)
+ * are exactly the kind of vanilla behaviour a port drops silently.
+ */
+function renderCard(
+  artist: Partial<LibraryArtist> & { id: LibraryArtist['id'] },
+  musicSource?: string,
+) {
+  return render(
+    <LibraryArtistCard
+      artist={{ name: 'Aphex Twin', ...artist }}
+      index={0}
+      musicSource={musicSource}
+      href={`/artist-detail/library/${artist.id}`}
+    />,
+  );
+}
+
+const img = () => document.querySelector('.library-artist-image img') as HTMLImageElement | null;
+const placeholder = () => document.querySelector('.library-artist-image-fallback');
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('LibraryArtistCard image fallback', () => {
+  it('shows the placeholder outright when there is no image', () => {
+    renderCard({ id: 1 });
+    expect(img()).toBeNull();
+    expect(placeholder()?.textContent).toBe('🎵');
+  });
+
+  it('treats a blank image_url as no image', () => {
+    renderCard({ id: 1, image_url: '   ' });
+    expect(placeholder()).not.toBeNull();
+  });
+
+  it('falls back through Deezer before giving up', () => {
+    // The vanilla onerror hopped to Deezer's image API once; dropping that hop
+    // would lose artwork for every artist whose stored url has rotted.
+    renderCard({ id: 1, image_url: 'https://cdn/rotted.jpg', deezer_id: 27 });
+    expect(img()!.src).toBe('https://cdn/rotted.jpg');
+
+    fireEvent.error(img()!);
+    expect(img()!.src).toBe('https://api.deezer.com/artist/27/image?size=big');
+
+    // ...and only once. A failing Deezer url must not loop.
+    fireEvent.error(img()!);
+    expect(img()).toBeNull();
+    expect(placeholder()).not.toBeNull();
+  });
+
+  it('goes straight to the placeholder with no deezer id', () => {
+    renderCard({ id: 1, image_url: 'https://cdn/rotted.jpg' });
+    fireEvent.error(img()!);
+    expect(placeholder()).not.toBeNull();
+  });
+
+  it('lazy-loads, so a 75-card page does not fetch 75 images at once', () => {
+    renderCard({ id: 1, image_url: 'https://cdn/a.jpg' });
+    expect(img()!.getAttribute('loading')).toBe('lazy');
+  });
+});
+
+describe('LibraryArtistCard badges', () => {
+  // Seven — one past MAX_BADGES_PER_COLUMN. Typed so a renamed field breaks the
+  // build instead of silently building fewer badges (a spread into the props
+  // object skips TypeScript's excess-property check).
+  const sevenProviders: Partial<LibraryArtist> = {
+    spotify_artist_id: 'sp',
+    musicbrainz_id: 'mb',
+    deezer_id: 1,
+    discogs_id: 'dc',
+    audiodb_id: 'ad',
+    itunes_artist_id: 'it',
+    lastfm_url: 'https://last.fm/x',
+  };
+
+  it('renders no badge container for an unenriched, unwatchable artist', () => {
+    renderCard({ id: 1 });
+    expect(document.querySelector('.card-badge-container')).toBeNull();
+  });
+
+  it('keeps one column at or below the cap, with the watch badge LAST', () => {
+    renderCard({ id: 1, spotify_artist_id: 'sp', is_watched: true });
+    expect(document.querySelector('.badge-overflow-column')).toBeNull();
+    const kids = [...document.querySelector('.card-badge-container')!.children];
+    expect(kids.at(-1)!.classList.contains('watch-card-icon')).toBe(true);
+  });
+
+  it('puts the watch badge in the overflow column, which renders FIRST', () => {
+    // The CSS positions the two columns, so their document order is visible.
+    renderCard({ id: 1, ...sevenProviders, is_watched: true });
+    const container = document.querySelector('.card-badge-container')!;
+    expect(container.children[0].classList.contains('badge-overflow-column')).toBe(true);
+    expect(container.children[1].classList.contains('badge-primary-column')).toBe(true);
+    expect(container.querySelector('.badge-overflow-column .watch-card-icon')).not.toBeNull();
+    expect(document.querySelectorAll('.badge-primary-column .source-card-icon')).toHaveLength(6);
+  });
+
+  it('offers Watch only when the ACTIVE source has an id for the artist', () => {
+    renderCard({ id: 1, spotify_artist_id: 'sp' }, 'spotify');
+    expect(document.querySelector('.watch-card-icon[data-unwatched="1"]')).not.toBeNull();
+
+    document.body.innerHTML = '';
+    renderCard({ id: 1, lastfm_url: 'https://last.fm/x' }, 'spotify');
+    expect(document.querySelector('.watch-card-icon')).toBeNull();
+  });
+
+  it('marks an already-watched artist as watching, not watchable', () => {
+    renderCard({ id: 1, spotify_artist_id: 'sp', is_watched: true }, 'spotify');
+    const badge = document.querySelector('.watch-card-icon')!;
+    expect(badge.classList.contains('watched')).toBe(true);
+    expect(badge.getAttribute('data-unwatched')).toBeNull();
+  });
+
+  it('hides a broken provider logo instead of leaving a gap', () => {
+    renderCard({ id: 1, spotify_artist_id: 'sp' });
+    const logo = document.querySelector('.source-card-icon img') as HTMLImageElement;
+    fireEvent.error(logo);
+    expect(logo.style.display).toBe('none');
+  });
+});
+
+describe('LibraryArtistCard badge clicks', () => {
+  /**
+   * The whole card is an <a>, so any badge that does not swallow its click
+   * navigates to artist detail instead of doing its job. fireEvent.click
+   * returns false exactly when preventDefault was called.
+   */
+  it('opens a provider badge in a new tab instead of following the card link', () => {
+    const open = vi.fn();
+    vi.stubGlobal('open', open);
+    renderCard({ id: 1, spotify_artist_id: 'sp' });
+
+    const badge = document.querySelector('.source-card-icon')!;
+    const notPrevented = fireEvent.click(badge);
+
+    expect(open).toHaveBeenCalledWith('https://open.spotify.com/artist/sp', '_blank');
+    expect(notPrevented).toBe(false);
+  });
+
+  it('swallows the click on a badge that has no link, rather than navigating', () => {
+    // Amazon and SoulID render a badge but carry no url.
+    renderCard({ id: 1, amazon_id: 'az' });
+    expect(fireEvent.click(document.querySelector('.source-card-icon')!)).toBe(false);
+  });
+
+  it('toggles the watchlist from the unwatched badge', () => {
+    const onToggleWatch = vi.fn();
+    render(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp' }}
+        index={0}
+        musicSource="spotify"
+        href="/artist-detail/library/1"
+        onToggleWatch={onToggleWatch}
+      />,
+    );
+    const badge = document.querySelector('.watch-card-icon')!;
+    expect(fireEvent.click(badge)).toBe(false);
+    expect(onToggleWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a second click while the first is still in flight', () => {
+    const onToggleWatch = vi.fn();
+    render(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp' }}
+        index={0}
+        musicSource="spotify"
+        href="/artist-detail/library/1"
+        onToggleWatch={onToggleWatch}
+        watchPending
+      />,
+    );
+    const badge = document.querySelector('.watch-card-icon')!;
+    expect(badge.querySelector('.watch-icon-label')?.textContent).toBe('...');
+    fireEvent.click(badge);
+    expect(onToggleWatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing on an already-watched badge, but still swallows the click', () => {
+    // Vanilla gated the toggle on data-unwatched, so "Watching" was inert —
+    // removal happens on the Watchlist page.
+    const onToggleWatch = vi.fn();
+    render(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp', is_watched: true }}
+        index={0}
+        musicSource="spotify"
+        href="/artist-detail/library/1"
+        onToggleWatch={onToggleWatch}
+      />,
+    );
+    expect(fireEvent.click(document.querySelector('.watch-card-icon')!)).toBe(false);
+    expect(onToggleWatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('LibraryArtistCard link', () => {
+  it('links to the artist detail page and carries the vanilla data attributes', () => {
+    // The vanilla delegated click handler reads both attributes.
+    renderCard({ id: 42, name: 'Boards of Canada', track_count: 1 });
+    const card = document.querySelector('.library-artist-card') as HTMLAnchorElement;
+    expect(card.getAttribute('href')).toBe('/artist-detail/library/42');
+    expect(card.dataset.artistId).toBe('42');
+    expect(card.dataset.artistName).toBe('Boards of Canada');
+    expect(document.querySelector('.library-artist-stat')?.textContent).toBe('1 track');
+  });
+
+  it('omits the stat line entirely when the artist has no tracks', () => {
+    renderCard({ id: 1, track_count: 0 });
+    expect(document.querySelector('.library-artist-stat')).toBeNull();
+  });
+});

--- a/webui/src/routes/library/-ui/library-artist-card.tsx
+++ b/webui/src/routes/library/-ui/library-artist-card.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react';
+
+import type { ArtistBadge, LibraryArtist } from '../-library.types';
+
+import {
+  buildArtistBadges,
+  canWatchArtist,
+  cardAnimationDelay,
+  splitBadgeColumns,
+  trackCountLabel,
+} from '../-library.helpers';
+
+interface Props {
+  artist: LibraryArtist;
+  index: number;
+  /** Active music source name; decides which id makes an artist watchable. */
+  musicSource?: string;
+  href: string;
+  /** Toggle this artist's watchlist membership. Undefined = not watchable. */
+  onToggleWatch?: () => void;
+  /** True while that toggle is in flight — the badge label shows "…". */
+  watchPending?: boolean;
+}
+
+/**
+ * A badge click must never fall through to the card's link.
+ *
+ * A plain factory, NOT a hook — it is called conditionally below.
+ *
+ * The vanilla grid delegated this: any `.source-card-icon` click called
+ * preventDefault + stopPropagation, then either opened the provider url in a
+ * new tab or toggled the watchlist. Without it every badge would just navigate
+ * to artist detail.
+ */
+function badgeClickHandler(action?: () => void) {
+  return (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    action?.();
+  };
+}
+
+function BadgeIcon({ badge }: { badge: ArtistBadge }) {
+  const onClick = badgeClickHandler(
+    badge.url ? () => window.open(badge.url as string, '_blank') : undefined,
+  );
+
+  return (
+    <div
+      className="source-card-icon"
+      title={badge.title}
+      data-url={badge.url ?? undefined}
+      onClick={onClick}
+    >
+      {badge.logo ? (
+        <img
+          src={badge.logo}
+          style={{ width: 16, height: 'auto', display: 'block' }}
+          alt=""
+          // The vanilla markup swapped the whole icon for its text fallback on
+          // error. React cannot replace its own parent, so the text sits
+          // underneath and the image is hidden instead — same visual result,
+          // without reaching outside this component's tree.
+          onError={(e) => {
+            e.currentTarget.style.display = 'none';
+          }}
+        />
+      ) : null}
+      <span
+        style={{ fontSize: 9, fontWeight: 700 }}
+        className={badge.logo ? 'source-card-icon-fallback' : undefined}
+      >
+        {badge.logo ? '' : badge.fallback}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The artist image, with the vanilla TWO-stage fallback.
+ *
+ * The original `onerror` tried Deezer's image API once (guarded by a
+ * `triedDeezer` dataset flag so a failing Deezer url could not loop), and only
+ * then replaced the node with the music-note placeholder. Dropping the Deezer
+ * hop would silently lose artwork for every artist whose stored image_url has
+ * rotted but who has a deezer_id.
+ */
+function ArtistImage({ artist, hasImage }: { artist: LibraryArtist; hasImage: boolean }) {
+  type Stage = 'primary' | 'deezer' | 'placeholder';
+  const [stage, setStage] = useState<Stage>(hasImage ? 'primary' : 'placeholder');
+
+  const onError = () => {
+    // One retry only, and only when there is a Deezer id to retry with.
+    setStage((s) => (s === 'primary' && artist.deezer_id ? 'deezer' : 'placeholder'));
+  };
+
+  if (stage === 'placeholder') return <div className="library-artist-image-fallback">🎵</div>;
+
+  const src =
+    stage === 'deezer'
+      ? `https://api.deezer.com/artist/${artist.deezer_id}/image?size=big`
+      : (artist.image_url ?? '');
+
+  // `key` remounts rather than swapping src on the element that just errored,
+  // so each stage gets a clean load cycle. Not test-observable: jsdom never
+  // fetches images, so the error events above are synthetic either way.
+  return <img key={stage} src={src} alt={artist.name} loading="lazy" onError={onError} />;
+}
+
+/** One artist tile. Markup mirrors buildLibraryArtistCardHTML so the CSS applies unchanged. */
+export function LibraryArtistCard({
+  artist,
+  index,
+  musicSource,
+  href,
+  onToggleWatch,
+  watchPending,
+}: Props) {
+  const badges = buildArtistBadges(artist);
+  const { primary, overflow, needsOverflow } = splitBadgeColumns(badges);
+  const watched = Boolean(artist.is_watched);
+  const watchable = canWatchArtist(artist, musicSource);
+  const tracks = trackCountLabel(artist.track_count);
+  const hasImage = Boolean(artist.image_url && artist.image_url.trim() !== '');
+  const onWatchClick = badgeClickHandler(watchPending ? undefined : onToggleWatch);
+
+  // Only the UNWATCHED badge acts: the vanilla handler gated the toggle on
+  // `badge.dataset.unwatched`, so a "Watching" badge swallowed its click and
+  // did nothing. Removing is done from the Watchlist page, not from here.
+  const watchBadge = watched ? (
+    <div
+      className="watch-card-icon watched source-card-icon"
+      title="On your watchlist"
+      onClick={badgeClickHandler()}
+    >
+      <span className="watch-icon-emoji">👁️</span>
+      <span className="watch-icon-label">Watching</span>
+    </div>
+  ) : watchable ? (
+    <div
+      className="watch-card-icon source-card-icon"
+      data-unwatched="1"
+      title="Add to Watchlist"
+      style={{ opacity: 0.4 }}
+      onClick={onWatchClick}
+    >
+      <span className="watch-icon-emoji">👁️</span>
+      <span className="watch-icon-label">{watchPending ? '...' : 'Watch'}</span>
+    </div>
+  ) : null;
+
+  return (
+    <a
+      className="library-artist-card"
+      href={href}
+      data-artist-id={String(artist.id)}
+      data-artist-name={artist.name}
+      style={{
+        position: 'relative',
+        display: 'block',
+        animation: `cardFadeIn 0.35s cubic-bezier(0.4,0,0.2,1) ${cardAnimationDelay(index)}ms both`,
+        textDecoration: 'none',
+        color: 'inherit',
+      }}
+    >
+      {badges.length > 0 || watchBadge ? (
+        needsOverflow ? (
+          // Note the order: the overflow column renders FIRST, as in the
+          // vanilla markup — the CSS positions them, so swapping them moves
+          // the badges on screen.
+          <div className="card-badge-container">
+            <div className="badge-overflow-column">
+              {watchBadge}
+              {overflow.map((b) => (
+                <BadgeIcon key={b.key} badge={b} />
+              ))}
+            </div>
+            <div className="badge-primary-column">
+              {primary.map((b) => (
+                <BadgeIcon key={b.key} badge={b} />
+              ))}
+            </div>
+          </div>
+        ) : (
+          // Without overflow the watch badge comes LAST, not first.
+          <div className="card-badge-container">
+            {primary.map((b) => (
+              <BadgeIcon key={b.key} badge={b} />
+            ))}
+            {watchBadge}
+          </div>
+        )
+      ) : null}
+
+      <div className="library-artist-image">
+        <ArtistImage artist={artist} hasImage={hasImage} />
+      </div>
+
+      <div className="library-artist-info">
+        <h3 className="library-artist-name" title={artist.name}>
+          {artist.name}
+        </h3>
+        <div className="library-artist-stats">
+          {tracks ? <span className="library-artist-stat">{tracks}</span> : null}
+        </div>
+      </div>
+    </a>
+  );
+}

--- a/webui/src/routes/library/-ui/library-page.test.tsx
+++ b/webui/src/routes/library/-ui/library-page.test.tsx
@@ -9,22 +9,13 @@ import { createShellBridge } from '@/test/shell-bridge';
 import type { LibraryArtist } from '../-library.types';
 
 /**
- * Driven through the REAL router with /library reported as React-owned.
+ * Driven through the REAL router and the real manifest, which now hands
+ * /library to React.
  *
  * The page cannot render standalone (useProfile reads the root route context),
  * and going through the router also exercises validateSearch, the loader and
  * the URL-driven filter state rather than stubs of them.
  */
-vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/platform/shell/route-manifest')>();
-  return {
-    ...actual,
-    getShellRouteByPageId: (pageId: string) =>
-      pageId === 'library'
-        ? { ...actual.getShellRouteByPageId('library'), kind: 'react' }
-        : actual.getShellRouteByPageId(pageId as never),
-  };
-});
 
 function artist(over: Partial<LibraryArtist> & { id: number }): LibraryArtist {
   return { name: `Artist ${over.id}`, ...over };
@@ -361,6 +352,40 @@ describe('LibraryPage watchlist from a card', () => {
       expect(window.showToast).toHaveBeenCalledWith('Error: already watching', 'error'),
     );
     expect(document.querySelector('.watch-icon-label')?.textContent).toBe('Watch');
+  });
+});
+
+describe('LibraryPage vanilla refresh seam', () => {
+  it('refetches when vanilla announces the list changed', async () => {
+    // "Watch All Unwatched" is a vanilla modal; it used to refresh by calling
+    // loadLibraryArtists(), which no-ops now that React owns the page.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    const before = libraryCalls().length;
+
+    window.dispatchEvent(new CustomEvent('ss:library-changed'));
+
+    await waitFor(() => expect(libraryCalls().length).toBeGreaterThan(before));
+  });
+
+  it('stops listening once the page unmounts', async () => {
+    // Asserted on the registration itself: after unmount the query has no
+    // observers, so a leaked listener would invalidate silently and a
+    // fetch-count check would pass either way.
+    const add = vi.spyOn(window, 'addEventListener');
+    const remove = vi.spyOn(window, 'removeEventListener');
+    const { unmount } = renderPage();
+    await screen.findByText('Aphex Twin');
+
+    const handler = add.mock.calls.find(([type]) => type === 'ss:library-changed')?.[1];
+    expect(handler).toBeDefined();
+
+    unmount();
+    expect(
+      remove.mock.calls.some(([type, fn]) => type === 'ss:library-changed' && fn === handler),
+    ).toBe(true);
+    add.mockRestore();
+    remove.mockRestore();
   });
 });
 

--- a/webui/src/routes/library/-ui/library-page.test.tsx
+++ b/webui/src/routes/library/-ui/library-page.test.tsx
@@ -1,0 +1,434 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+import type { LibraryArtist } from '../-library.types';
+
+/**
+ * Driven through the REAL router with /library reported as React-owned.
+ *
+ * The page cannot render standalone (useProfile reads the root route context),
+ * and going through the router also exercises validateSearch, the loader and
+ * the URL-driven filter state rather than stubs of them.
+ */
+vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/platform/shell/route-manifest')>();
+  return {
+    ...actual,
+    getShellRouteByPageId: (pageId: string) =>
+      pageId === 'library'
+        ? { ...actual.getShellRouteByPageId('library'), kind: 'react' }
+        : actual.getShellRouteByPageId(pageId as never),
+  };
+});
+
+function artist(over: Partial<LibraryArtist> & { id: number }): LibraryArtist {
+  return { name: `Artist ${over.id}`, ...over };
+}
+
+let requested: string[] = [];
+/** Request bodies, captured BEFORE ky consumes them — a Request cannot be
+ *  cloned once its body has been read ("TypeError: unusable"). */
+let sent: { url: string; body: unknown }[] = [];
+
+async function record(input: RequestInfo | URL): Promise<string> {
+  const url = input instanceof Request ? input.url : String(input);
+  requested.push(url);
+  if (input instanceof Request && input.body) {
+    sent.push({ url, body: await input.clone().json() });
+  }
+  return url;
+}
+
+function stubFetch(artists: LibraryArtist[], total = artists.length, pages = 1) {
+  requested = [];
+  sent = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = await record(input);
+      if (url.includes('/api/watchlist/')) {
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const body = url.includes('/api/library/artists')
+        ? {
+            success: true,
+            artists,
+            pagination: {
+              page: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1),
+              limit: 75,
+              total_count: total,
+              total_pages: pages,
+              has_prev: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) > 1,
+              has_next: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) < pages,
+            },
+          }
+        : {};
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderPage(entry = '/library') {
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: [entry] });
+  const router = createAppRouter({ history, queryClient });
+  return { router, ...render(<AppRouterProvider router={router} queryClient={queryClient} />) };
+}
+
+const libraryCalls = () => requested.filter((u) => u.includes('/api/library/artists'));
+const lastQuery = () => new URL(libraryCalls().at(-1)!, 'http://x').searchParams;
+
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  window.showLibraryDownloadsSection = vi.fn();
+  window.openArtistExportModal = vi.fn();
+  window.openWatchAllUnwatchedModal = vi.fn();
+  window._handoffLibrarySearchToEnhancedSearch = vi.fn();
+  window.showToast = vi.fn();
+  window.updateWatchlistCount = vi.fn();
+  window.currentMusicSourceName = 'spotify';
+  stubFetch([artist({ id: 1, name: 'Aphex Twin', track_count: 12 })]);
+});
+afterEach(() => {
+  // Unconditional: a test that fails before its inline restore would otherwise
+  // leak fake timers into every later test, and they all hang in waitFor.
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  delete window.SoulSyncWebShellBridge;
+  delete window.showLibraryDownloadsSection;
+});
+
+describe('LibraryPage rendering', () => {
+  it('renders the artist grid with the vanilla classes', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.querySelector('.library-artists-grid')).not.toBeNull();
+    expect(document.querySelectorAll('.library-artist-card')).toHaveLength(1);
+    expect(document.querySelector('.library-artist-stat')?.textContent).toBe('12 tracks');
+  });
+
+  it('shows the artist count from pagination, not the page length', async () => {
+    // A 75-per-page library must report its TOTAL, not the 75 on screen.
+    stubFetch([artist({ id: 1 })], 4213, 57);
+    renderPage();
+    await waitFor(() => expect(document.querySelector('.stat-number')?.textContent).toBe('4213'));
+  });
+
+  it('calls the vanilla downloads-bubble renderer on mount', async () => {
+    // It is bound to module state in core.js and cannot move into React.
+    renderPage();
+    await waitFor(() => expect(window.showLibraryDownloadsSection).toHaveBeenCalled());
+    expect(document.querySelector('[data-library-downloads-host]')).not.toBeNull();
+  });
+});
+
+describe('LibraryPage filters', () => {
+  it('sends every filter to the API', async () => {
+    renderPage('/library?q=aphex&letter=a&page=2&watchlist=watched&source=spotify');
+    await waitFor(() => expect(libraryCalls().length).toBeGreaterThan(0));
+    const p = lastQuery();
+    expect(p.get('search')).toBe('aphex');
+    expect(p.get('letter')).toBe('a');
+    expect(p.get('page')).toBe('2');
+    expect(p.get('watchlist')).toBe('watched');
+    expect(p.get('source_filter')).toBe('spotify');
+    expect(p.get('limit')).toBe('75');
+  });
+
+  it('omits source_filter when no source is chosen', async () => {
+    // The vanilla loader only set() it when non-empty; sending an empty one
+    // would also fragment the query cache.
+    renderPage('/library');
+    await waitFor(() => expect(libraryCalls().length).toBeGreaterThan(0));
+    expect(lastQuery().has('source_filter')).toBe(false);
+  });
+
+  it('debounces typing for 300ms, then resets to page 1', async () => {
+    vi.useFakeTimers();
+    // Entering on page 7 also proves the TYPING path resets the page — it
+    // navigates itself rather than going through setSearch.
+    const { router } = renderPage('/library?page=7');
+    await vi.advanceTimersByTimeAsync(0);
+    const before = libraryCalls().length;
+    const input = document.querySelector('.library-search-input') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.change(input, { target: { value: 'ap' } });
+    fireEvent.change(input, { target: { value: 'aph' } });
+    expect(libraryCalls().length).toBe(before);
+
+    // Still inside the window: a shorter timer would have fired by now, so
+    // this is what pins the 300ms rather than merely "is deferred at all".
+    await vi.advanceTimersByTimeAsync(250);
+    expect(libraryCalls().length).toBe(before);
+
+    await vi.advanceTimersByTimeAsync(100);
+    vi.useRealTimers();
+    await waitFor(() => expect(lastQuery().get('search')).toBe('aph'));
+    expect(router.state.location.search).toMatchObject({ page: 1 });
+  });
+
+  it('resets to page 1 whenever a filter changes', async () => {
+    // Page 7 of the old result set is meaningless against a new one.
+    const { router } = renderPage('/library?page=7');
+    await waitFor(() => expect(libraryCalls().length).toBeGreaterThan(0));
+
+    fireEvent.click(screen.getByText('Watched'));
+    await waitFor(() => expect(router.state.location.search).toMatchObject({ page: 1 }));
+  });
+
+  it('clears the search on Escape', async () => {
+    const { router } = renderPage('/library?q=aphex');
+    // waitFor resolves on the first call that does not THROW, and returning
+    // null does not throw — so the assertion has to live inside it.
+    const input = (await screen.findByLabelText('Filter your library')) as HTMLInputElement;
+    expect(input.value).toBe('aphex');
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(router.state.location.search).toMatchObject({ q: '' }));
+  });
+
+  it('marks the active filter and letter', async () => {
+    renderPage('/library?watchlist=unwatched&letter=c');
+    await waitFor(() =>
+      expect(document.querySelector('.watchlist-filter-btn.active')?.textContent).toBe('Unwatched'),
+    );
+    expect(document.querySelector('.alphabet-btn.active')?.textContent).toBe('C');
+  });
+
+  it('offers Watch All Unwatched only while filtered to unwatched', async () => {
+    const { unmount } = renderPage('/library?watchlist=unwatched');
+    await waitFor(() =>
+      expect(document.querySelector('.library-watchlist-all-btn.hidden')).toBeNull(),
+    );
+    unmount();
+
+    renderPage('/library?watchlist=all');
+    await waitFor(() =>
+      expect(document.querySelector('.library-watchlist-all-btn.hidden')).not.toBeNull(),
+    );
+  });
+});
+
+describe('LibraryPage empty state', () => {
+  it('offers the search-online CTA when a query found nothing', async () => {
+    stubFetch([], 0, 0);
+    renderPage('/library?q=nonesuch');
+    await screen.findByText(/isn't in your library/);
+    fireEvent.click(document.querySelector('.library-empty-search-cta')!);
+    expect(window._handoffLibrarySearchToEnhancedSearch).toHaveBeenCalledWith('nonesuch');
+  });
+
+  it('shows the generic empty copy with no query', async () => {
+    stubFetch([], 0, 0);
+    renderPage('/library');
+    await screen.findByText('No artists found');
+    // No CTA to hand off — there is nothing to search for.
+    expect(document.querySelector('.library-empty-search-cta')).toBeNull();
+  });
+});
+
+describe('LibraryPage watchlist from a card', () => {
+  const posted = () => sent.find((c) => c.url.includes('/api/watchlist/'));
+
+  it('adds the artist with the SOURCE-matched id, then flips the badge', async () => {
+    window.currentMusicSourceName = 'spotify';
+    stubFetch([
+      artist({ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp', itunes_artist_id: 9 }),
+    ]);
+    renderPage();
+    await screen.findByText('Aphex Twin');
+
+    fireEvent.click(document.querySelector('.watch-card-icon')!);
+    await waitFor(() => expect(posted()).toBeDefined());
+
+    expect(posted()!.url).toContain('/api/watchlist/add');
+    expect(posted()!.body).toEqual({ artist_id: 'sp', artist_name: 'Aphex Twin' });
+    await waitFor(() =>
+      expect(document.querySelector('.watch-icon-label')?.textContent).toBe('Watching'),
+    );
+    expect(window.showToast).toHaveBeenCalledWith('Added Aphex Twin to watchlist', 'success');
+    expect(window.updateWatchlistCount).toHaveBeenCalled();
+  });
+
+  it('keeps the pending badge on the card that is actually waiting', async () => {
+    // Two adds in flight at once: the mutation's own `variables` hold only the
+    // latest, so the first card must not lose its "...".
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => (release = r));
+    requested = [];
+    sent = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = await record(input);
+        if (url.includes('/api/watchlist/')) await gate;
+        const body = url.includes('/api/watchlist/')
+          ? { success: true }
+          : {
+              success: true,
+              artists: [
+                artist({ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp1' }),
+                artist({ id: 2, name: 'Boards of Canada', spotify_artist_id: 'sp2' }),
+              ],
+              pagination: {
+                page: 1,
+                limit: 75,
+                total_count: 2,
+                total_pages: 1,
+                has_prev: false,
+                has_next: false,
+              },
+            };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+    renderPage();
+    await screen.findByText('Boards of Canada');
+
+    const badges = document.querySelectorAll('.watch-card-icon');
+    fireEvent.click(badges[0]);
+    fireEvent.click(badges[1]);
+
+    await waitFor(() =>
+      expect([...document.querySelectorAll('.watch-icon-label')].map((n) => n.textContent)).toEqual(
+        ['...', '...'],
+      ),
+    );
+    release?.();
+  });
+
+  it('prefers the iTunes id when iTunes is the active source', async () => {
+    window.currentMusicSourceName = 'iTunes';
+    stubFetch([
+      artist({ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp', itunes_artist_id: 9 }),
+    ]);
+    renderPage();
+    await screen.findByText('Aphex Twin');
+
+    fireEvent.click(document.querySelector('.watch-card-icon')!);
+    await waitFor(() => expect(posted()).toBeDefined());
+    expect(posted()!.body).toMatchObject({ artist_id: '9' });
+  });
+
+  it('toasts the reason and leaves the badge unwatched when the server refuses', async () => {
+    window.currentMusicSourceName = 'spotify';
+    requested = [];
+    sent = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = await record(input);
+        const body = url.includes('/api/watchlist/')
+          ? { success: false, error: 'already watching' }
+          : {
+              success: true,
+              artists: [artist({ id: 1, name: 'Aphex Twin', spotify_artist_id: 'sp' })],
+              pagination: {
+                page: 1,
+                limit: 75,
+                total_count: 1,
+                total_pages: 1,
+                has_prev: false,
+                has_next: false,
+              },
+            };
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+    renderPage();
+    await screen.findByText('Aphex Twin');
+
+    fireEvent.click(document.querySelector('.watch-card-icon')!);
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Error: already watching', 'error'),
+    );
+    expect(document.querySelector('.watch-icon-label')?.textContent).toBe('Watch');
+  });
+});
+
+describe('LibraryPage failure', () => {
+  function stubFailure(body: unknown, status = 200) {
+    requested = [];
+    sent = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        await record(input);
+        return new Response(JSON.stringify(body), {
+          status,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+  }
+
+  it('toasts the vanilla fixed string when the server reports failure', async () => {
+    // Not the server's reason — vanilla only used that as the thrown message.
+    stubFailure({ success: false, error: 'db locked' });
+    renderPage();
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Failed to load artists', 'error'),
+    );
+  });
+
+  it('toasts on a transport failure too', async () => {
+    stubFailure({ error: 'boom' }, 500);
+    renderPage();
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Failed to load artists', 'error'),
+    );
+  });
+
+  it('keeps the honest empty copy after a failure, even with a query', async () => {
+    // Vanilla claimed "X isn't in your library" here; the library was never read.
+    stubFailure({ success: false, error: 'db locked' });
+    renderPage('/library?q=aphex');
+    await screen.findByText('No artists found');
+    expect(document.querySelector('.library-empty-search-cta')).toBeNull();
+  });
+
+  it('stops showing the loading spinner after a failure', async () => {
+    stubFailure({ success: false, error: 'db locked' });
+    renderPage();
+    await screen.findByText('No artists found');
+    expect(document.querySelector('.library-loading')).toBeNull();
+  });
+});
+
+describe('LibraryPage pagination', () => {
+  it('hides pagination for a single page', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.querySelector('.library-pagination')).toBeNull();
+  });
+
+  it('pages forward and back, and disables the ends', async () => {
+    stubFetch([artist({ id: 1 })], 150, 2);
+    const { router } = renderPage('/library');
+    await screen.findByText(/Page 1 of 2/);
+    expect(
+      (document.querySelector('#prev-page-btn, .pagination-btn') as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    fireEvent.click(screen.getByText('Next →'));
+    await waitFor(() => expect(router.state.location.search).toMatchObject({ page: 2 }));
+  });
+});

--- a/webui/src/routes/library/-ui/library-page.tsx
+++ b/webui/src/routes/library/-ui/library-page.tsx
@@ -1,0 +1,377 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useProfile, useReactPageShell } from '@/platform/shell/route-controllers';
+
+import type { LibraryArtist, LibraryArtistsResponse } from '../-library.types';
+
+import { libraryArtistsQueryOptions, setArtistWatchlisted } from '../-library.api';
+import { readArtistsResponse, watchlistArtistId } from '../-library.helpers';
+import { Route } from '../route';
+import { LibraryArtistCard } from './library-artist-card';
+
+const ALPHABET = ['all', ...'abcdefghijklmnopqrstuvwxyz'.split(''), '#'];
+
+/** The metadata-source filter's two option groups, verbatim from index.html. */
+const SOURCES = [
+  'spotify',
+  'musicbrainz',
+  'deezer',
+  'discogs',
+  'audiodb',
+  'itunes',
+  'lastfm',
+  'genius',
+  'tidal',
+  'qobuz',
+] as const;
+const SOURCE_LABELS: Record<string, string> = {
+  spotify: 'Spotify',
+  musicbrainz: 'MusicBrainz',
+  deezer: 'Deezer',
+  discogs: 'Discogs',
+  audiodb: 'AudioDB',
+  itunes: 'iTunes',
+  lastfm: 'Last.fm',
+  genius: 'Genius',
+  tidal: 'Tidal',
+  qobuz: 'Qobuz',
+};
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export function LibraryPage() {
+  useReactPageShell('library');
+
+  const { profileId } = useProfile();
+  const search = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  // The input is local so typing stays responsive; the URL only catches up
+  // after the debounce, exactly as the vanilla 300ms timer did.
+  const [draft, setDraft] = useState(search.q);
+  const committed = useRef(search.q);
+  useEffect(() => {
+    // Reflect a URL change that did not come from typing (back button, a
+    // cleared filter) back into the box.
+    if (search.q !== committed.current) {
+      committed.current = search.q;
+      setDraft(search.q);
+    }
+  }, [search.q]);
+
+  useEffect(() => {
+    if (draft === committed.current) return;
+    const timer = setTimeout(() => {
+      committed.current = draft;
+      // Any filter change resets to page 1 — page 7 of the old result set is
+      // meaningless against a new one.
+      void navigate({ search: (prev) => ({ ...prev, q: draft, page: 1 }), replace: true });
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [draft, navigate]);
+
+  const query = useQuery(libraryArtistsQueryOptions(profileId, search));
+  const { artists, pagination } = useMemo(() => {
+    try {
+      return readArtistsResponse(query.data);
+    } catch {
+      // The thrown reason surfaces through query.error below; the grid just
+      // renders empty rather than taking the page down.
+      return {
+        artists: [],
+        pagination: { page: 1, totalPages: 0, totalCount: 0, hasPrev: false, hasNext: false },
+      };
+    }
+  }, [query.data]);
+
+  const failed = query.isError || query.data?.success === false;
+  const loading = query.isPending;
+  const isEmpty = !loading && artists.length === 0;
+
+  // The vanilla catch toasted a FIXED string on every failed load — not the
+  // server's reason, which it only used as the thrown message. Keyed on the
+  // update timestamp so each distinct failure toasts once, rather than on
+  // every re-render (or never again after the first).
+  const failedAt = failed ? query.errorUpdatedAt || query.dataUpdatedAt : 0;
+  useEffect(() => {
+    if (!failedAt) return;
+    window.showToast?.('Failed to load artists', 'error');
+  }, [failedAt]);
+
+  // Add-to-watchlist straight from a card badge.
+  //
+  // The result is patched into THIS page of the cache rather than invalidated:
+  // the vanilla handler only repainted the one badge, and a refetch here would
+  // pull all 75 artists back down for a one-field change.
+  const queryClient = useQueryClient();
+  // Tracked per artist, not off the mutation's `variables`: those hold only the
+  // LATEST call, so adding a second artist while the first is still in flight
+  // would move the "..." off the card that is actually waiting.
+  const [watching, setWatching] = useState<ReadonlySet<string>>(new Set());
+  const watchArtist = useMutation({
+    onMutate: (artist: LibraryArtist) => setWatching((s) => new Set(s).add(String(artist.id))),
+    onSettled: (_data, _error, artist) =>
+      setWatching((s) => {
+        const next = new Set(s);
+        next.delete(String(artist.id));
+        return next;
+      }),
+    mutationFn: async (artist: LibraryArtist) => {
+      const artistId = watchlistArtistId(artist, window.currentMusicSourceName);
+      // The badge is only offered when this resolves, so reaching here means
+      // the card and the id-picker disagreed.
+      if (!artistId) throw new Error('No iTunes or Spotify ID available for this artist');
+      await setArtistWatchlisted(artistId, artist.name, true);
+    },
+    onSuccess: (_data, artist) => {
+      queryClient.setQueryData(
+        libraryArtistsQueryOptions(profileId, search).queryKey,
+        (prev: LibraryArtistsResponse | undefined) =>
+          prev?.artists
+            ? {
+                ...prev,
+                artists: prev.artists.map((a) =>
+                  a.id === artist.id ? { ...a, is_watched: true } : a,
+                ),
+              }
+            : prev,
+      );
+      window.showToast?.(`Added ${artist.name} to watchlist`, 'success');
+      window.updateWatchlistCount?.();
+    },
+    onError: (error: Error) => window.showToast?.(`Error: ${error.message}`, 'error'),
+  });
+
+  const setSearch = (patch: Partial<typeof search>) =>
+    void navigate({ search: (prev) => ({ ...prev, ...patch, page: patch.page ?? 1 }) });
+
+  // TRAP 0 — showLibraryDownloadsSection (shared-helpers.js) inserts a
+  // #library-downloads-section node as a SIBLING before #library-artists-grid,
+  // and fires on download events, not just page load. It is bound to
+  // `artistDownloadBubbles`, module state in core.js, so it cannot move here.
+  // This host is rendered with NO React children, so the vanilla function owns
+  // its subtree outright and React never reconciles it away — the same
+  // arrangement used to mount the Automation Hub.
+  const downloadsHost = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    window.showLibraryDownloadsSection?.();
+  }, []);
+
+  return (
+    <div className="library-container">
+      <div className="library-header">
+        <div className="library-header-content">
+          <h2 className="library-title">
+            <img src="/static/library.png" className="page-header-icon" alt="" />
+            <span>Music Library</span>
+          </h2>
+          <p className="library-subtitle">Browse your complete music collection</p>
+        </div>
+        <div className="library-stats">
+          <span className="library-stat">
+            <span className="stat-number">{pagination.totalCount}</span>
+            <span className="stat-label">Artists</span>
+          </span>
+        </div>
+        <button
+          type="button"
+          className="library-watchlist-all-btn library-export-btn"
+          title="Export artists — pick watchlist or whole library, as JSON / CSV / text"
+          onClick={() => window.openArtistExportModal?.()}
+        >
+          <span className="watchlist-all-icon">⬇</span>
+          <span className="watchlist-all-text">Export</span>
+        </button>
+      </div>
+
+      <div className="library-controls">
+        <div className="library-search-container">
+          <input
+            type="text"
+            className="library-search-input"
+            placeholder="Filter your library…"
+            aria-label="Filter your library"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              // Escape clears the box AND reloads, as the vanilla handler did.
+              if (e.key !== 'Escape') return;
+              setDraft('');
+              committed.current = '';
+              void navigate({ search: (prev) => ({ ...prev, q: '', page: 1 }), replace: true });
+            }}
+          />
+          <div className="library-search-icon">🔍</div>
+        </div>
+
+        <div className="watchlist-filter">
+          {(['all', 'watched', 'unwatched'] as const).map((f) => (
+            <button
+              key={f}
+              type="button"
+              className={`watchlist-filter-btn${search.watchlist === f ? ' active' : ''}`}
+              data-filter={f}
+              onClick={() => setSearch({ watchlist: f })}
+            >
+              {f === 'all' ? 'All' : f === 'watched' ? 'Watched' : 'Unwatched'}
+            </button>
+          ))}
+          {/* Only offered while filtered to unwatched — it acts on that set. */}
+          <button
+            type="button"
+            className={`library-watchlist-all-btn${search.watchlist === 'unwatched' ? '' : ' hidden'}`}
+            onClick={() => window.openWatchAllUnwatchedModal?.()}
+          >
+            <span className="watchlist-all-icon">👁️</span>
+            <span className="watchlist-all-text">Watch All Unwatched</span>
+          </button>
+        </div>
+
+        <div className="library-source-filter">
+          <select
+            className="library-source-filter-select"
+            aria-label="Filter by metadata source"
+            value={search.source}
+            onChange={(e) => setSearch({ source: e.target.value })}
+          >
+            <option value="">All Sources</option>
+            {/* The `!` prefix means "unmatched to", and the backend parses it. */}
+            <optgroup label="Unmatched to">
+              {SOURCES.map((s) => (
+                <option key={`!${s}`} value={`!${s}`}>
+                  No {SOURCE_LABELS[s]}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Matched to">
+              {SOURCES.map((s) => (
+                <option key={s} value={s}>
+                  Has {SOURCE_LABELS[s]}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+        </div>
+
+        <div className="alphabet-selector">
+          <div className="alphabet-selector-inner">
+            {ALPHABET.map((letter) => (
+              <button
+                key={letter}
+                type="button"
+                className={`alphabet-btn${search.letter === letter ? ' active' : ''}`}
+                data-letter={letter}
+                onClick={() => setSearch({ letter })}
+              >
+                {letter === 'all' ? 'All' : letter === '#' ? '#' : letter.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="library-content">
+        {loading ? (
+          <div className="library-loading">
+            <div className="loading-spinner" />
+            <div className="loading-text">Loading artists...</div>
+          </div>
+        ) : null}
+
+        {/* Host for the vanilla downloads bubbles — see TRAP 0 above. Sits
+            directly before the grid, where insertBefore(section, artistGrid)
+            put it: after the loading row, above the cards. */}
+        <div ref={downloadsHost} data-library-downloads-host="" />
+
+        <div className="library-artists-grid">
+          {artists.map((artist, i) => (
+            <LibraryArtistCard
+              key={artist.id}
+              artist={artist}
+              index={i}
+              musicSource={window.currentMusicSourceName}
+              href={`/artist-detail/library/${artist.id}`}
+              onToggleWatch={() => watchArtist.mutate(artist)}
+              watchPending={watching.has(String(artist.id))}
+            />
+          ))}
+        </div>
+
+        {isEmpty ? <LibraryEmpty query={search.q} failed={failed} /> : null}
+
+        {pagination.totalPages > 1 ? (
+          <div className="library-pagination">
+            <button
+              type="button"
+              className="pagination-btn"
+              disabled={!pagination.hasPrev}
+              onClick={() => setSearch({ page: Math.max(1, search.page - 1) })}
+            >
+              <span>← Previous</span>
+            </button>
+            <div className="pagination-info">
+              <span>
+                Page {pagination.page} of {pagination.totalPages}
+              </span>
+            </div>
+            <button
+              type="button"
+              className="pagination-btn"
+              disabled={!pagination.hasNext}
+              onClick={() => setSearch({ page: search.page + 1 })}
+            >
+              <span>Next →</span>
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Empty state.
+ *
+ * With an active search that found nothing, the copy switches to a CTA that
+ * hands the query to /search so the user can look the artist up across
+ * metadata sources without retyping — the vanilla page rewrote the icon,
+ * title, subtitle and button for exactly this case.
+ *
+ * DELIBERATE deviation: vanilla showed that same CTA after a FAILED load,
+ * because its catch called showLibraryEmpty(true) and the empty state only
+ * looked at the search box. "X isn't in your library" is a lie when the
+ * library was never successfully read, so a failure keeps the generic copy.
+ */
+function LibraryEmpty({ query, failed }: { query: string; failed: boolean }) {
+  const q = query.trim();
+  const searching = q.length > 0 && !failed;
+
+  return (
+    <div className="library-empty">
+      <div className="empty-icon">{searching ? '🔎' : '🎵'}</div>
+      <div className="empty-title">
+        {searching ? `"${q}" isn't in your library` : 'No artists found'}
+      </div>
+      <div className="empty-subtitle">
+        {searching
+          ? 'They might be available on a connected metadata source.'
+          : 'Try adjusting your search or filters'}
+      </div>
+      {searching ? (
+        <button
+          type="button"
+          className="library-empty-search-cta"
+          onClick={() => window._handoffLibrarySearchToEnhancedSearch?.(q)}
+        >
+          <span className="library-empty-search-cta-icon">🔍</span>
+          <span className="library-empty-search-cta-text">
+            Search online for <span>&quot;{q}&quot;</span>
+          </span>
+          <span className="library-empty-search-cta-arrow">→</span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/routes/library/-ui/library-page.tsx
+++ b/webui/src/routes/library/-ui/library-page.tsx
@@ -8,6 +8,7 @@ import type { LibraryArtist, LibraryArtistsResponse } from '../-library.types';
 
 import { libraryArtistsQueryOptions, setArtistWatchlisted } from '../-library.api';
 import { readArtistsResponse, watchlistArtistId } from '../-library.helpers';
+import { useLibraryChanged } from '../-library.live';
 import { Route } from '../route';
 import { LibraryArtistCard } from './library-artist-card';
 
@@ -45,6 +46,7 @@ export function LibraryPage() {
   useReactPageShell('library');
 
   const { profileId } = useProfile();
+  useLibraryChanged();
   const search = Route.useSearch();
   const navigate = useNavigate({ from: Route.fullPath });
 

--- a/webui/src/routes/library/route.tsx
+++ b/webui/src/routes/library/route.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { getProfileHomePath } from '@/platform/shell/bridge';
+import { LegacyRouteController } from '@/platform/shell/route-controllers';
+import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
+
+import { libraryArtistsQueryOptions } from './-library.api';
+import { librarySearchSchema } from './-library.types';
+
+/**
+ * Whether the shell has handed /library over to React yet.
+ *
+ * The route file exists (and is tested) before the React page reaches parity.
+ * Without this check TanStack would match /library regardless of the manifest
+ * and the vanilla page and the React host would both activate. Delete this
+ * indirection once the vanilla library page is gone.
+ */
+function isReactOwned(): boolean {
+  return getShellRouteByPageId('library')?.kind === 'react';
+}
+
+export const Route = createFileRoute('/library')({
+  validateSearch: librarySearchSchema,
+  beforeLoad: ({ context }) => {
+    const { bridge } = context.shell;
+
+    if (!bridge.isPageAllowed('library')) {
+      throw redirect({ href: getProfileHomePath(bridge), replace: true });
+    }
+  },
+  loaderDeps: ({ search }) => search,
+  loader: async ({ context, deps }) => {
+    if (!isReactOwned()) return;
+
+    const { profile } = context.shell;
+    await context.queryClient.ensureQueryData(libraryArtistsQueryOptions(profile.profileId, deps));
+  },
+  component: LibraryRouteComponent,
+});
+
+function LibraryRouteComponent() {
+  if (!isReactOwned()) {
+    return <LegacyRouteController pathname="/library" />;
+  }
+  // The page component lands in P2. Until the manifest flips this branch is
+  // unreachable, so deferring to the legacy controller keeps it honest.
+  return <LegacyRouteController pathname="/library" />;
+}

--- a/webui/src/routes/library/route.tsx
+++ b/webui/src/routes/library/route.tsx
@@ -6,6 +6,7 @@ import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
 
 import { libraryArtistsQueryOptions } from './-library.api';
 import { librarySearchSchema } from './-library.types';
+import { LibraryPage } from './-ui/library-page';
 
 /**
  * Whether the shell has handed /library over to React yet.
@@ -33,7 +34,15 @@ export const Route = createFileRoute('/library')({
     if (!isReactOwned()) return;
 
     const { profile } = context.shell;
-    await context.queryClient.ensureQueryData(libraryArtistsQueryOptions(profile.profileId, deps));
+    // Warming the cache for the first paint — NOT a gate. Letting this reject
+    // would hand the route to defaultErrorComponent and replace the whole page
+    // with "Something went wrong" on any backend hiccup, where the vanilla page
+    // toasted and stayed usable (filters and the alphabet still work, and the
+    // next click retries). The component's useQuery reads the same failure and
+    // renders the error state itself.
+    await context.queryClient
+      .ensureQueryData(libraryArtistsQueryOptions(profile.profileId, deps))
+      .catch(() => undefined);
   },
   component: LibraryRouteComponent,
 });
@@ -42,7 +51,5 @@ function LibraryRouteComponent() {
   if (!isReactOwned()) {
     return <LegacyRouteController pathname="/library" />;
   }
-  // The page component lands in P2. Until the manifest flips this branch is
-  // unreachable, so deferring to the legacy controller keeps it honest.
-  return <LegacyRouteController pathname="/library" />;
+  return <LibraryPage />;
 }

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -160,6 +160,13 @@ function initializeLibraryPagination() {
 }
 
 async function loadLibraryArtists() {
+    // React owns /library. This is the ONLY thing that fills
+    // #library-artists-grid, so guarding it here makes the whole vanilla list
+    // — the filter handlers, the pagination buttons, displayLibraryArtists —
+    // unreachable rather than merely unused, and stops a stray call from
+    // repainting the hidden vanilla page behind the React one.
+    if (document.getElementById('webui-react-root')?.classList.contains('active')) return;
+
     try {
         // Show loading state
         showLibraryLoading(true);
@@ -615,7 +622,11 @@ function closeWatchAllUnwatchedModal() {
     if (!overlay) return;
     const needsRefresh = overlay.dataset.needsRefresh === 'true';
     overlay.remove();
-    if (needsRefresh) loadLibraryArtists();
+    if (!needsRefresh) return;
+    // The modal is vanilla but the list it just changed is React, and
+    // loadLibraryArtists() no-ops there — announce it instead.
+    loadLibraryArtists();
+    window.dispatchEvent(new CustomEvent('ss:library-changed'));
 }
 
 async function toggleLibraryCardWatchlist(btn, artist) {

--- a/webui/static/shared-helpers.js
+++ b/webui/static/shared-helpers.js
@@ -2980,9 +2980,14 @@ function showLibraryDownloadsSection() {
     // that class and its copy comes FIRST in the DOM, so the old global query
     // grabbed the wrong container and insertBefore threw ("not a child of
     // this node") — killing the whole Library page init (#1038).
-    const artistGrid = document.getElementById('library-artists-grid');
-    if (!artistGrid || !artistGrid.parentElement) return;
-    const libraryContent = artistGrid.parentElement;
+    // The React library page renders a dedicated host with NO React children,
+    // so this section can own that subtree outright and React never reconciles
+    // it away. Preferred when present; the vanilla music page and the video
+    // library keep the original anchor-on-the-grid path below.
+    const reactHost = document.querySelector('[data-library-downloads-host]');
+    const artistGrid = reactHost ? null : document.getElementById('library-artists-grid');
+    if (!reactHost && (!artistGrid || !artistGrid.parentElement)) return;
+    const libraryContent = reactHost || artistGrid.parentElement;
 
     let downloadsSection = document.getElementById('library-downloads-section');
 
@@ -2992,6 +2997,13 @@ function showLibraryDownloadsSection() {
         downloadsSection.id = 'library-downloads-section';
         downloadsSection.className = 'artist-downloads-section';
         downloadsSection.style.display = 'none';   // revealed below only when bubbles exist
+        // insertBefore(node, null) === appendChild, which is what the React
+        // host wants; the vanilla path still lands ahead of the grid.
+        libraryContent.insertBefore(downloadsSection, artistGrid);
+    } else if (downloadsSection.parentElement !== libraryContent) {
+        // The page was re-rendered under it (React remount, or a nav back to
+        // the vanilla page). Re-home it rather than leaving it orphaned in a
+        // detached tree where the user can never see it.
         libraryContent.insertBefore(downloadsSection, artistGrid);
     }
 


### PR DESCRIPTION
# library list page → react

next page in the migration. this is the **list** half only — artist detail (32 functions, ~39 endpoints, still living inside `library.js`) and label detail get their own PRs after this.

three commits: route + data layer, the page, then the manifest flip.

## what moved

the whole list page — header/stats/export, search, watchlist + source filters, alphabet, the 75-per-page grid, both empty states, pagination. filters live in the url now (`?q=&letter=&page=&watchlist=&source=`), so a filtered library is linkable and back/forward works.

one endpoint backs all of it, which is why the list was the tractable half to do first.

## two things i changed on purpose

**a failed load no longer lies.** vanilla's empty state only looked at the search box, so when the request failed with a query typed it said *"aphex twin isn't in your library"* — the library was never read. a failure keeps the generic copy + the toast now.

**a backend hiccup doesn't blank the page.** the route loader was allowed to reject, which hands the whole page to the router's "something went wrong" screen. it catches now and lets the page render its own error state, the way vanilla did.

heads up: `/wishlist` and `/automations` still have that second problem. didn't touch them here — worth a follow-up.

## the fiddly bits

- the download bubbles section (`showLibraryDownloadsSection`) is bound to module state in `core.js` and fires on download events, not page load. so react renders an empty host div and the vanilla function owns that subtree outright — same trick as the automation hub.
- "watch all unwatched" is still a vanilla modal and used to refresh by calling `loadLibraryArtists()`, which no-ops now. it fires `ss:library-changed` instead.
- **i missed the grid's delegated click handler on the first pass.** provider badges would've navigated to artist detail instead of opening their link, and the watch badge would've done nothing at all. caught it reviewing the vanilla function top-to-bottom, ported both.

## nothing deleted yet

the vanilla page is guarded, not removed. `loadLibraryArtists` bails when react owns the page — it's the only thing that fills the grid, so the vanilla filters, alphabet and pagination all become unreachable rather than just unused. cleanup PR takes out the markup and the ~197 functions once you've run this live.

## tests

77 library tests, 446 webui total, all green, no type errors. mutation-tested every behaviour — 30 mutants, all killed; the two that survived along the way were real gaps in my own tests. python contract tests pin the guard, the refresh event on both sides, and that the react page claims none of the ids the vanilla page still owns.
