### PR TITLE
React migration artist detail

### DIFF
--- a/known_issues_esc_shadowing.md
+++ b/known_issues_esc_shadowing.md
@@ -1,0 +1,72 @@
+# `_esc` / `_escAttr` are declared twice — the later script silently wins
+
+Found 2026-07-27 while mapping `stats-automations.js` for the artist-detail
+port. **Pre-existing, not caused by the React migration.** Not fixed: changing
+it shifts rendering app-wide, and the current work is under a 1:1 parity
+instruction.
+
+## What happens
+
+`index.html` loads, in order: `core.js` → `library.js` → `stats-automations.js`
+→ `init.js`. They share one global scope, so a later `function foo()` overwrites
+an earlier one with no error.
+
+| name | declared in | which one actually runs |
+|---|---|---|
+| `_esc` | `library.js:2464` **and** `stats-automations.js:5764` | stats-automations |
+| `_escAttr` | `downloads.js:5187` **and** `stats-automations.js:5771` | stats-automations |
+
+## Why it matters — they are NOT equivalent
+
+```js
+// library.js — dead code, never executes
+function _esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+// stats-automations.js — this is what every caller gets
+function _esc(str) { if (!str) return ''; /* ...same as above... */ }
+```
+
+The `if (!str) return ''` guard is the whole difference, and it is falsy-based:
+
+- `_esc(0)` → `''` instead of `'0'`
+- `_esc(false)` → `''`
+- `_esc('')` → `''` (fine, same either way)
+
+So any **zero** value passed through `_esc` renders as blank rather than "0" —
+track number 0, disc 0, a 0 play count, a 0 year. ~245 call sites across 7
+files go through this.
+
+`_escAttr` is worse, because the two implementations differ in *purpose*:
+
+```js
+// downloads.js  — escapes for a JS string literal (backslashes the quote)
+function _escAttr(s) { return _escToast(s).replace(/'/g, "\\'")... }
+
+// stats-automations.js — HTML-escapes instead (&#39;)
+function _escAttr(str) { if (!str) return ''; return String(str).replace(/&/g,'&amp;')... }
+```
+
+`downloads.js` calls `_escAttr` 14 times expecting the backslash behaviour and
+silently gets the HTML-entity one. The comment above the stats-automations
+version describes the exact bug this causes ("Road trip-The Rolfe's"
+delete-button SyntaxError) — so the two files have contradictory fixes for the
+same class of problem, and only one of them is in effect.
+
+## Why no test caught it
+
+Both are `function` declarations, so redeclaration is legal — no throw, no
+syntax error. `tests/test_vanilla_globals_resolve.py` sees the name resolve
+fine; it checks that names EXIST, not that they resolve to the one the author
+meant.
+
+## If fixing later
+
+1. Decide the canonical `_esc` (the falsy guard is almost certainly wrong —
+   `String(s ?? '')` is the intent).
+2. Decide whether `_escAttr` should be the JS-literal escaper or the HTML one,
+   then rename the loser: they do different jobs and both are needed.
+3. Delete the shadowed copies and re-run the full suite — ~245 call sites means
+   real render diffs, especially anywhere a legitimate 0 is displayed.
+4. Consider a lint rule for duplicate top-level declarations across the bundle;
+   the globals test could be extended to flag redeclarations, not just
+   unresolved names.

--- a/tests/test_artist_detail_cross_file_contract.py
+++ b/tests/test_artist_detail_cross_file_contract.py
@@ -1,0 +1,126 @@
+"""What other files borrow from library.js — pinned BEFORE the artist-detail port.
+
+The automations migration taught this lesson once: the page being replaced was
+not the only consumer of the code behind it, and the cleanup PR nearly deleted
+things the video side still called. The library-list cleanup then taught it
+again the hard way, by deleting four declarations that the artist-detail page
+still needed.
+
+So this file records, up front, every name that leaves library.js. When the
+artist-detail cleanup eventually runs, anything listed here MUST survive it, or
+be migrated deliberately along with its callers.
+
+The surprising ones, which is exactly why this is written down:
+
+  * `artistDetailPageState` is read by **stats-automations.js**. Two of the
+    artist-detail page's own buttons -- Play Artist Radio, and writing the
+    artist photo to disk -- are implemented over there and reach back into this
+    page's state. The page's behaviour is split across two files.
+
+  * `playLibraryTrack` (144 lines, and on the shared spine of the artist-detail
+    call graph) is called by five other files. It cannot move into a React
+    component; it has to stay reachable as a global.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_STATIC = _ROOT / "webui" / "static"
+_LIBRARY_JS = (_STATIC / "library.js").read_text(encoding="utf-8")
+
+# name -> the files that reach for it. Hardcoded on purpose: deriving this from
+# the current source would shrink whenever a consumer is deleted, and the test
+# would pass vacuously at exactly the moment it should fail.
+_CONTRACT = {
+    "_esc": {
+        "stats-automations.js", "auto-sync.js", "discover.js",
+        "pages-extra.js", "label-detail.js", "wishlist-tools.js",
+    },
+    "playLibraryTrack": {
+        "stats-automations.js", "shell-bridge.js", "downloads.js",
+        "enrichment.js", "search.js",
+    },
+    "navigateToArtistDetail": {
+        "label-detail.js", "shell-bridge.js", "enrichment.js", "search.js",
+    },
+    "artistDetailPageState": {"stats-automations.js"},
+    "_updateSidebarLibraryBreadcrumb": {"shell-bridge.js"},
+    "_handoffLibrarySearchToEnhancedSearch": {"label-detail.js"},
+}
+
+
+def _strip_comments(source: str) -> str:
+    """Length-preserving, so a name only mentioned in a comment does not count
+    as a real reference -- the mistake that made a dead modal look alive."""
+    out = list(source)
+    i, n, mode = 0, len(source), None
+    while i < n:
+        char, pair = source[i], source[i : i + 2]
+        if mode is None:
+            if pair == "//":
+                mode = "line"; out[i] = out[i + 1] = " "; i += 2; continue
+            if pair == "/*":
+                mode = "block"; out[i] = out[i + 1] = " "; i += 2; continue
+            if char in "\"'`":
+                mode = char; i += 1; continue
+            i += 1
+        elif mode == "line":
+            if char == "\n": mode = None
+            else: out[i] = " "
+            i += 1
+        elif mode == "block":
+            if pair == "*/":
+                out[i] = out[i + 1] = " "; mode = None; i += 2; continue
+            if char != "\n": out[i] = " "
+            i += 1
+        else:
+            if char == "\\": i += 2; continue
+            if char == mode: mode = None
+            i += 1
+    return "".join(out)
+
+
+@pytest.mark.parametrize("name", sorted(_CONTRACT))
+def test_library_js_still_declares_the_name(name):
+    """It must exist. This is the check the library-list cleanup did not have:
+    `artistDetailPageState` was deleted as collateral and 177 references were
+    left pointing at nothing, while the file still parsed cleanly."""
+    assert re.search(rf"^(?:async )?function {re.escape(name)}\b", _LIBRARY_JS, re.M) or re.search(
+        rf"^(?:const|let|var)\s+{re.escape(name)}\b", _LIBRARY_JS, re.M
+    ), f"library.js no longer declares {name}, which other files still call"
+
+
+@pytest.mark.parametrize("name,consumers", sorted((k, v) for k, v in _CONTRACT.items()))
+def test_every_recorded_consumer_still_uses_it(name, consumers):
+    """The other half: if a consumer stops needing a name, this fails and the
+    contract shrinks DELIBERATELY rather than the entry quietly going stale."""
+    still_using = set()
+    for filename in consumers:
+        path = _STATIC / filename
+        if not path.exists():
+            continue
+        source = _strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+        if re.search(rf"\b{re.escape(name)}\b", source):
+            still_using.add(filename)
+
+    assert still_using == consumers, (
+        f"{name}: recorded consumers {sorted(consumers)}, actually using "
+        f"{sorted(still_using)}. Update _CONTRACT deliberately."
+    )
+
+
+def test_artist_detail_state_is_reached_from_stats_automations():
+    """Spelled out separately because it is the least obvious coupling in the
+    codebase: the artist-detail page's Radio and artist-photo buttons live in
+    stats-automations.js and read this page's module state directly. Porting
+    the page to React without rehoming these leaves them reading a state object
+    nothing updates any more."""
+    source = _strip_comments((_STATIC / "stats-automations.js").read_text(encoding="utf-8"))
+    assert "artistDetailPageState.currentArtistId" in source
+    for fn in ("playArtistRadio",):
+        assert re.search(rf"function {fn}\b", source), f"{fn} moved; recheck the coupling"

--- a/webui/src/routes/artist-detail/-artist-detail.api.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.test.ts
@@ -133,15 +133,15 @@ describe('needsCompletionStream', () => {
   const library = { artist: { server_source: 'plex' } };
 
   it('runs when a library discography still has unknown ownership', () => {
-    expect(
-      needsCompletionStream({ ...library, discography: { albums: [{ owned: null }] } }),
-    ).toBe(true);
+    expect(needsCompletionStream({ ...library, discography: { albums: [{ owned: null }] } })).toBe(
+      true,
+    );
   });
 
   it('does not run once everything is resolved', () => {
-    expect(
-      needsCompletionStream({ ...library, discography: { albums: [{ owned: true }] } }),
-    ).toBe(false);
+    expect(needsCompletionStream({ ...library, discography: { albums: [{ owned: true }] } })).toBe(
+      false,
+    );
   });
 
   it('finds unknowns in eps and singles too, not just albums', () => {

--- a/webui/src/routes/artist-detail/-artist-detail.api.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  artistDetailQueryOptions,
+  isSourceOnlyArtist,
+  needsCompletionStream,
+  readArtistDetail,
+  settleOwnershipForSourceArtist,
+} from './-artist-detail.api';
+import { artistDetailSearchSchema, normalizeSource } from './-artist-detail.types';
+
+describe('normalizeSource', () => {
+  it("treats 'library' as no source, since that means the local DB", () => {
+    expect(normalizeSource('library')).toBeNull();
+    expect(normalizeSource('LIBRARY')).toBeNull();
+    expect(normalizeSource('')).toBeNull();
+  });
+
+  it('lowercases a real metadata source', () => {
+    expect(normalizeSource('Spotify')).toBe('spotify');
+  });
+});
+
+describe('artistDetailSearchSchema', () => {
+  it('coerces an all-digits artist name back to a string', () => {
+    // TanStack JSON-parses search values, so "311" arrives as a NUMBER and a
+    // bare z.string() throws SearchParamError — the route dies and clicking
+    // the artist appears to do nothing. This has regressed once before.
+    expect(artistDetailSearchSchema.parse({ name: 311 })).toEqual({ name: '311' });
+  });
+
+  it('defaults to an empty name when absent', () => {
+    expect(artistDetailSearchSchema.parse({})).toEqual({ name: '' });
+  });
+});
+
+describe('artistDetailQueryOptions', () => {
+  it('sends no query params at all for a library artist', () => {
+    // The vanilla loader only set() source/name when non-empty, so a library
+    // request carried no query string. Sending empties would also fragment
+    // the cache key.
+    const opts = artistDetailQueryOptions('library', '42', '');
+    expect(opts.queryKey).toEqual(['artist-detail', 'library', '42', '']);
+  });
+
+  it('omits empty source and name from the REQUEST, not just the key', async () => {
+    // The query key is derived separately, so it cannot detect this — the URL
+    // has to be observed. The vanilla loader built its params with conditional
+    // set() calls and sent no query string for a plain library artist.
+    const seen: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        seen.push(input instanceof Request ? input.url : String(input));
+        return new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+    try {
+      await artistDetailQueryOptions('library', '42', '').queryFn!({} as never);
+      expect(new URL(seen[0]).search).toBe('');
+
+      await artistDetailQueryOptions('spotify', 'abc', '311').queryFn!({} as never);
+      const params = new URL(seen[1]).searchParams;
+      expect(params.get('source')).toBe('spotify');
+      expect(params.get('name')).toBe('311');
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('keys separately per source, id and name', () => {
+    const a = artistDetailQueryOptions('spotify', 'abc', 'Aphex Twin');
+    const b = artistDetailQueryOptions('deezer', 'abc', 'Aphex Twin');
+    expect(a.queryKey).not.toEqual(b.queryKey);
+  });
+});
+
+describe('readArtistDetail', () => {
+  it('surfaces the server reason on success:false', () => {
+    expect(() => readArtistDetail({ success: false, error: 'Artist not found' })).toThrow(
+      'Artist not found',
+    );
+  });
+
+  it('falls back to a generic message when no reason is given', () => {
+    expect(() => readArtistDetail({ success: false })).toThrow('Failed to load artist data');
+    expect(() => readArtistDetail(undefined)).toThrow('Failed to load artist data');
+  });
+
+  it('passes a successful payload straight through', () => {
+    const payload = { success: true, artist: { name: 'Aphex Twin' } };
+    expect(readArtistDetail(payload)).toBe(payload);
+  });
+});
+
+describe('settleOwnershipForSourceArtist', () => {
+  it('turns unknown ownership into false across every bucket', () => {
+    // A source-only artist has no library to check against, so anything left
+    // as null would render as "checking" forever.
+    const settled = settleOwnershipForSourceArtist({
+      albums: [{ owned: null }, { owned: true }],
+      eps: [{}],
+      singles: [{ owned: false }],
+    });
+    expect(settled.albums?.map((r) => r.owned)).toEqual([false, true]);
+    expect(settled.eps?.map((r) => r.owned)).toEqual([false]);
+    expect(settled.singles?.map((r) => r.owned)).toEqual([false]);
+  });
+
+  it('does not mutate the cached response', () => {
+    const original = { albums: [{ owned: null }] };
+    settleOwnershipForSourceArtist(original);
+    expect(original.albums[0].owned).toBeNull();
+  });
+
+  it('leaves a missing bucket missing rather than inventing an empty one', () => {
+    expect(settleOwnershipForSourceArtist({ albums: [] }).eps).toBeUndefined();
+  });
+});
+
+describe('isSourceOnlyArtist', () => {
+  it('keys off server_source, which is what the backend omits for source artists', () => {
+    expect(isSourceOnlyArtist({ artist: { name: 'x' } })).toBe(true);
+    expect(isSourceOnlyArtist({ artist: { name: 'x', server_source: 'plex' } })).toBe(false);
+    expect(isSourceOnlyArtist({})).toBe(true);
+  });
+});
+
+describe('needsCompletionStream', () => {
+  const library = { artist: { server_source: 'plex' } };
+
+  it('runs when a library discography still has unknown ownership', () => {
+    expect(
+      needsCompletionStream({ ...library, discography: { albums: [{ owned: null }] } }),
+    ).toBe(true);
+  });
+
+  it('does not run once everything is resolved', () => {
+    expect(
+      needsCompletionStream({ ...library, discography: { albums: [{ owned: true }] } }),
+    ).toBe(false);
+  });
+
+  it('finds unknowns in eps and singles too, not just albums', () => {
+    expect(
+      needsCompletionStream({
+        ...library,
+        discography: { albums: [{ owned: true }], singles: [{ owned: null }] },
+      }),
+    ).toBe(true);
+  });
+
+  it('never runs for a source-only artist', () => {
+    // There is no library to check against — the stream could never report.
+    expect(needsCompletionStream({ discography: { albums: [{ owned: null }] } })).toBe(false);
+  });
+
+  it('does not run when the discography has no albums key at all', () => {
+    expect(needsCompletionStream({ ...library, discography: { singles: [{ owned: null }] } })).toBe(
+      false,
+    );
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.api.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.ts
@@ -70,7 +70,9 @@ export function settleOwnershipForSourceArtist(discography: Discography): Discog
     const releases = discography[bucket];
     if (!releases) continue;
     settled[bucket] = releases.map((release) =>
-      release.owned === null || release.owned === undefined ? { ...release, owned: false } : release,
+      release.owned === null || release.owned === undefined
+        ? { ...release, owned: false }
+        : release,
     );
   }
   return settled;

--- a/webui/src/routes/artist-detail/-artist-detail.api.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.ts
@@ -1,0 +1,98 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { apiClient, readJson } from '@/app/api-client';
+
+import {
+  type ArtistDetailResponse,
+  type Discography,
+  normalizeSource,
+} from './-artist-detail.types';
+
+export const ARTIST_DETAIL_QUERY_KEY = ['artist-detail'] as const;
+
+/**
+ * The one call that backs first paint.
+ *
+ * Everything else on the page (gap-fill, the completion stream, enhance
+ * eligibility) is fire-and-forget AFTER this resolves — the vanilla loader
+ * never awaited any of them, and neither should the route.
+ *
+ * `source` and `name` are only sent when present, matching the vanilla
+ * URLSearchParams build: it set() them conditionally, so a library artist's
+ * request carries no query string at all and does not fragment the cache.
+ */
+export function artistDetailQueryOptions(source: string, id: string, name: string) {
+  const normalized = normalizeSource(source);
+  const params: Record<string, string> = {};
+  if (normalized) params.source = normalized;
+  if (name) params.name = name;
+
+  return queryOptions({
+    queryKey: [...ARTIST_DETAIL_QUERY_KEY, normalized ?? 'library', id, name] as const,
+    queryFn: () =>
+      readJson<ArtistDetailResponse>(
+        apiClient.get(`artist-detail/${encodeURIComponent(id)}`, {
+          searchParams: params,
+          // A source artist with a cold provider can take a while; the vanilla
+          // fetch had no timeout at all, and ky's default 10s would surface as
+          // a spurious failure the old page never had.
+          timeout: false,
+        }),
+      ),
+  });
+}
+
+/**
+ * Unwrap the payload the way the vanilla loader did.
+ *
+ * It threw on `!response.ok || !data.success`, preferring the server's own
+ * `error` string. The status-text half of that message has no equivalent here
+ * — readJson already throws on a non-2xx — so only the body case is rebuilt.
+ */
+export function readArtistDetail(payload: ArtistDetailResponse | undefined): ArtistDetailResponse {
+  if (!payload || payload.success === false) {
+    throw new Error(payload?.error || 'Failed to load artist data');
+  }
+  return payload;
+}
+
+/**
+ * A source-only artist has no library to check ownership against, so the
+ * vanilla loader rewrote every null/undefined `owned` to false before render.
+ * Without it those releases sit in the "checking" state forever, because
+ * nothing will ever stream a result for them.
+ *
+ * Returns a new object; the response from the cache is not mutated.
+ */
+export function settleOwnershipForSourceArtist(discography: Discography): Discography {
+  const settled: Discography = { ...discography };
+  for (const bucket of ['albums', 'eps', 'singles'] as const) {
+    const releases = discography[bucket];
+    if (!releases) continue;
+    settled[bucket] = releases.map((release) =>
+      release.owned === null || release.owned === undefined ? { ...release, owned: false } : release,
+    );
+  }
+  return settled;
+}
+
+/** True when the artist has no library record — drives several UI gates. */
+export function isSourceOnlyArtist(payload: ArtistDetailResponse): boolean {
+  return !payload.artist?.server_source;
+}
+
+/**
+ * Whether the completion stream should run.
+ *
+ * The vanilla loader started it only for a LIBRARY artist whose discography
+ * still had at least one `owned === null`. Starting it otherwise opens an SSE
+ * connection that can never report anything.
+ */
+export function needsCompletionStream(payload: ArtistDetailResponse): boolean {
+  if (isSourceOnlyArtist(payload)) return false;
+  const disc = payload.discography;
+  if (!disc?.albums) return false;
+  return [...(disc.albums ?? []), ...(disc.eps ?? []), ...(disc.singles ?? [])].some(
+    (release) => release.owned === null,
+  );
+}

--- a/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyMusicBrainzDeclutter,
+  defaultFilterState,
+  isMusicBrainzDiscography,
+  isReleaseHidden,
+  liveToggleLabel,
+  NON_STUDIO_SECONDARY,
+  releaseFlags,
+  sectionCounts,
+} from './-artist-detail.filters';
+
+const mb = () => applyMusicBrainzDeclutter(defaultFilterState(), 'musicbrainz');
+
+describe('defaultFilterState', () => {
+  it('starts neutral — show everything', () => {
+    // The declutter is applied LATER, once the discography's real source is
+    // known; the initial state must not assume MusicBrainz.
+    const s = defaultFilterState();
+    expect(s.categories).toEqual({ albums: true, eps: true, singles: true });
+    expect(s.content).toEqual({ live: true, compilations: true, featured: true });
+    expect(s.ownership).toBe('all');
+    expect(s.mbDeclutter).toBe(false);
+  });
+});
+
+describe('applyMusicBrainzDeclutter', () => {
+  it('hides non-studio for MusicBrainz only', () => {
+    expect(mb().content.live).toBe(false);
+    expect(mb().mbDeclutter).toBe(true);
+  });
+
+  it('leaves every other source untouched', () => {
+    for (const source of ['spotify', 'deezer', 'itunes', '', null, undefined]) {
+      const s = applyMusicBrainzDeclutter(defaultFilterState(), source);
+      expect(s.content.live).toBe(true);
+      expect(s.mbDeclutter).toBe(false);
+    }
+  });
+
+  it('never hides compilations — they have their own toggle', () => {
+    expect(mb().content.compilations).toBe(true);
+  });
+
+  it('matches the source case-insensitively', () => {
+    expect(isMusicBrainzDiscography('MusicBrainz')).toBe(true);
+  });
+});
+
+describe('liveToggleLabel', () => {
+  it('renames the toggle honestly on MusicBrainz', () => {
+    // It governs the broader non-studio set there, not just live albums.
+    expect(liveToggleLabel(mb())).toBe('Non-Studio');
+    expect(liveToggleLabel(defaultFilterState())).toBe('Live');
+  });
+});
+
+describe('releaseFlags', () => {
+  it('uses the backend flags off MusicBrainz', () => {
+    const flags = releaseFlags({ is_live: true, is_compilation: true }, false);
+    expect(flags).toEqual({ isLive: true, isCompilation: true, isFeatured: false });
+  });
+
+  it('lets secondary_types OVERRIDE the live guess on MusicBrainz', () => {
+    // The whole point: a studio album titled "Live Through This" is flagged
+    // is_live by the title guess, and MB's secondary_types say otherwise.
+    const flags = releaseFlags(
+      { name: 'Live Through This', is_live: true, secondary_types: [] },
+      true,
+    );
+    expect(flags.isLive).toBe(false);
+  });
+
+  it('catches soundtrack/remix/demo, which a title guess never would', () => {
+    for (const type of ['Soundtrack', 'Remix', 'Demo', 'Live']) {
+      expect(releaseFlags({ secondary_types: [type] }, true).isLive).toBe(true);
+    }
+  });
+
+  it('ignores a secondary type that is not in the non-studio set', () => {
+    // Compilation is deliberately excluded — it has its own toggle.
+    expect(releaseFlags({ secondary_types: ['Compilation'] }, true).isLive).toBe(false);
+    expect(NON_STUDIO_SECONDARY.has('compilation')).toBe(false);
+  });
+
+  it('survives a non-array secondary_types', () => {
+    expect(releaseFlags({ secondary_types: 'live' as never }, true).isLive).toBe(false);
+  });
+});
+
+describe('isReleaseHidden — content filters', () => {
+  it('hides by each content flag when its toggle is off', () => {
+    const s = defaultFilterState();
+    s.content.live = false;
+    expect(isReleaseHidden({}, { isLive: true, isCompilation: false, isFeatured: false }, s)).toBe(
+      true,
+    );
+
+    const c = defaultFilterState();
+    c.content.compilations = false;
+    expect(isReleaseHidden({}, { isLive: false, isCompilation: true, isFeatured: false }, c)).toBe(
+      true,
+    );
+
+    const f = defaultFilterState();
+    f.content.featured = false;
+    expect(isReleaseHidden({}, { isLive: false, isCompilation: false, isFeatured: true }, f)).toBe(
+      true,
+    );
+  });
+
+  it('never hides an OWNED release under the MB auto-declutter', () => {
+    // The user did not choose that hide, so it must not bury their own music.
+    const hidden = isReleaseHidden(
+      { owned: true },
+      { isLive: true, isCompilation: false, isFeatured: false },
+      mb(),
+    );
+    expect(hidden).toBe(false);
+  });
+
+  it('DOES hide an owned release when the user turned the toggle off themselves', () => {
+    // Off MusicBrainz there is no exemption — the toggle is user-driven, and
+    // this keeps non-MB behaviour identical to before the exemption existed.
+    const s = defaultFilterState();
+    s.content.live = false;
+    const hidden = isReleaseHidden(
+      { owned: true },
+      { isLive: true, isCompilation: false, isFeatured: false },
+      s,
+    );
+    expect(hidden).toBe(true);
+  });
+});
+
+describe('isReleaseHidden — ownership filter', () => {
+  const plain = { isLive: false, isCompilation: false, isFeatured: false };
+
+  it('filters to owned / missing', () => {
+    const owned = { ...defaultFilterState(), ownership: 'owned' as const };
+    expect(isReleaseHidden({ owned: true }, plain, owned)).toBe(false);
+    expect(isReleaseHidden({ owned: false }, plain, owned)).toBe(true);
+
+    const missing = { ...defaultFilterState(), ownership: 'missing' as const };
+    expect(isReleaseHidden({ owned: false }, plain, missing)).toBe(false);
+    expect(isReleaseHidden({ owned: true }, plain, missing)).toBe(true);
+  });
+
+  it('never hides a release whose ownership check is still running', () => {
+    // owned === null means pending; the filter re-runs when the stream resolves.
+    for (const ownership of ['owned', 'missing'] as const) {
+      expect(isReleaseHidden({ owned: null }, plain, { ...defaultFilterState(), ownership })).toBe(
+        false,
+      );
+    }
+  });
+
+  it('is not consulted at all once a content filter already hid the card', () => {
+    const s = { ...defaultFilterState(), ownership: 'owned' as const };
+    s.content.live = false;
+    // owned:true would PASS the ownership filter, but live is off, so it stays hidden.
+    expect(isReleaseHidden({ owned: true }, { ...plain, isLive: true }, s)).toBe(true);
+  });
+});
+
+describe('sectionCounts', () => {
+  it('counts only what is visible, so stats track the filtered view', () => {
+    const s = { ...defaultFilterState(), ownership: 'owned' as const };
+    const counts = sectionCounts([{ owned: true }, { owned: false }, { owned: true }], false, s);
+    expect(counts).toEqual({ visible: 2, owned: 2, missing: 0 });
+  });
+
+  it('counts a pending release as visible but neither owned nor missing', () => {
+    // So owned + missing does not necessarily equal visible.
+    const counts = sectionCounts([{ owned: null }, { owned: true }], false, defaultFilterState());
+    expect(counts).toEqual({ visible: 2, owned: 1, missing: 0 });
+  });
+
+  it('recomputes live-ness from secondary_types when the source is MusicBrainz', () => {
+    const releases = [{ name: 'Live Through This', is_live: true, secondary_types: [] }];
+    expect(sectionCounts(releases, true, mb()).visible).toBe(1);
+    // ...and the same release IS hidden when the title guess is trusted.
+    expect(sectionCounts(releases, false, { ...mb(), mbDeclutter: false }).visible).toBe(0);
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.filters.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.ts
@@ -1,0 +1,168 @@
+import type { DiscographyBucket, DiscographyRelease } from './-artist-detail.types';
+
+/**
+ * Discography filter state, ported 1:1 from `discographyFilterState`.
+ *
+ * The vanilla version filtered by mutating `card.style.display` on DOM nodes it
+ * had already rendered, reading `data-is-live` / `data-is-compilation` /
+ * `data-is-featured` attributes back off them. Here the same decisions are made
+ * on the release objects before render, which is why the flags are recomputed
+ * rather than read from markup — see releaseFlags().
+ */
+export interface DiscographyFilterState {
+  categories: Record<DiscographyBucket, boolean>;
+  content: { live: boolean; compilations: boolean; featured: boolean };
+  ownership: 'all' | 'owned' | 'missing';
+  /**
+   * True only when the automatic MusicBrainz declutter is in effect. It is NOT
+   * a user setting, and it changes the rules: see ownedExempt below.
+   */
+  mbDeclutter: boolean;
+}
+
+/**
+ * Non-studio MusicBrainz release-group secondary types, EXCLUDING Compilation
+ * (which has its own toggle). Mirrors `_NON_STUDIO_SECONDARY_TYPES` in
+ * core/musicbrainz_search so the backend and UI agree — keep them in step.
+ */
+export const NON_STUDIO_SECONDARY = new Set([
+  'live',
+  'soundtrack',
+  'remix',
+  'demo',
+  'mixtape/street',
+  'interview',
+  'audiobook',
+  'audio drama',
+]);
+
+/** Neutral show-all. The MB declutter is applied AFTER, once the source is known. */
+export function defaultFilterState(): DiscographyFilterState {
+  return {
+    categories: { albums: true, eps: true, singles: true },
+    content: { live: true, compilations: true, featured: true },
+    ownership: 'all',
+    mbDeclutter: false,
+  };
+}
+
+export function isMusicBrainzDiscography(source: string | null | undefined): boolean {
+  return String(source ?? '').toLowerCase() === 'musicbrainz';
+}
+
+/**
+ * MusicBrainz lists an artist's WHOLE catalogue (live, soundtracks, remixes),
+ * which buries the studio albums — so non-studio content is hidden by default
+ * there and ONLY there. Every other source is already a clean commercial
+ * catalogue, so its default is untouched.
+ *
+ * Compilations deliberately stay shown; they have their own toggle.
+ */
+export function applyMusicBrainzDeclutter(
+  state: DiscographyFilterState,
+  source: string | null | undefined,
+): DiscographyFilterState {
+  if (!isMusicBrainzDiscography(source)) return state;
+  return { ...state, content: { ...state.content, live: false }, mbDeclutter: true };
+}
+
+/** The toggle governs the broader non-studio set on MB, so it is relabelled. */
+export function liveToggleLabel(state: DiscographyFilterState): string {
+  return state.mbDeclutter ? 'Non-Studio' : 'Live';
+}
+
+export interface ReleaseFlags {
+  isLive: boolean;
+  isCompilation: boolean;
+  isFeatured: boolean;
+}
+
+/**
+ * The three content flags for one release.
+ *
+ * On MusicBrainz, `secondary_types` is authoritative and REPLACES the
+ * title-based guess — that is what stops a studio album called "Live Through
+ * This" being hidden, and it also catches soundtrack/remix/demo which a title
+ * guess never would. Off MusicBrainz there are no secondary types, so the
+ * flags the backend already set on the release stand.
+ */
+export function releaseFlags(release: DiscographyRelease, isMusicBrainz: boolean): ReleaseFlags {
+  const base: ReleaseFlags = {
+    isLive: release.is_live === true,
+    isCompilation: release.is_compilation === true,
+    isFeatured: release.is_featured === true,
+  };
+  if (!isMusicBrainz) return base;
+
+  const secondary = Array.isArray(release.secondary_types)
+    ? (release.secondary_types as unknown[]).map((s) => String(s).trim().toLowerCase())
+    : [];
+  return { ...base, isLive: secondary.some((s) => NON_STUDIO_SECONDARY.has(s)) };
+}
+
+/**
+ * Whether one release is hidden. Mirrors the vanilla order exactly: content
+ * filters first, then ownership, and ownership is only consulted when the
+ * content filters did not already hide it.
+ */
+export function isReleaseHidden(
+  release: DiscographyRelease,
+  flags: ReleaseFlags,
+  state: DiscographyFilterState,
+): boolean {
+  // On MB the non-studio hide is an automatic default the user never chose, so
+  // it must never bury something they OWN. Off MB every toggle is user-driven
+  // and is respected as-is — no exemption, which keeps non-MB behaviour
+  // byte-identical to before this rule existed.
+  const ownedExempt = state.mbDeclutter && release.owned === true;
+
+  let hidden = false;
+  if (!ownedExempt) {
+    if (!state.content.live && flags.isLive) hidden = true;
+    if (!state.content.compilations && flags.isCompilation) hidden = true;
+    if (!state.content.featured && flags.isFeatured) hidden = true;
+  }
+
+  // `owned === null` means the completion check is still running. Those cards
+  // are never hidden by the ownership filter — the filter re-runs when the
+  // stream resolves them.
+  //
+  // The `!hidden` short-circuit mirrors the vanilla shape but is not
+  // observable: this block only ever SETS hidden to true, so entering it while
+  // already hidden cannot change the answer. Removing it survives mutation
+  // testing for that reason — an equivalent mutant, not a missing test.
+  if (!hidden && state.ownership !== 'all' && release.owned !== null) {
+    if (state.ownership === 'owned' && !release.owned) hidden = true;
+    if (state.ownership === 'missing' && release.owned) hidden = true;
+  }
+
+  return hidden;
+}
+
+export interface SectionCounts {
+  visible: number;
+  owned: number;
+  missing: number;
+}
+
+/**
+ * The per-section counts, computed over VISIBLE cards only — the vanilla stats
+ * line reflected the filtered view, not the whole bucket.
+ *
+ * A release still being checked (`owned === null`) counts toward `visible` but
+ * toward neither owned nor missing, so the two do not necessarily sum.
+ */
+export function sectionCounts(
+  releases: DiscographyRelease[],
+  isMusicBrainz: boolean,
+  state: DiscographyFilterState,
+): SectionCounts {
+  const counts: SectionCounts = { visible: 0, owned: 0, missing: 0 };
+  for (const release of releases) {
+    if (isReleaseHidden(release, releaseFlags(release, isMusicBrainz), state)) continue;
+    counts.visible += 1;
+    if (release.owned === true) counts.owned += 1;
+    else if (release.owned === false) counts.missing += 1;
+  }
+  return counts;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.types.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.types.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+
+/**
+ * URL contract for /artist-detail/$source/$id.
+ *
+ * `source` is a PATH param, not a search param: 'library' means the id is the
+ * local DB primary key, anything else ('spotify', 'deezer', ...) means the id
+ * belongs to that metadata source and the backend synthesizes a response from
+ * it. buildArtistDetailPath() normalizes an absent source to the literal
+ * 'library', so the path always carries one.
+ *
+ * `name` travels in the query string because some sources (Bandcamp) have no
+ * numeric-ID lookup at all. The preprocess is load-bearing: TanStack
+ * JSON-parses search values, so an all-digits artist name ("311", "702")
+ * arrives as a NUMBER and a bare z.string() throws SearchParamError, killing
+ * the route. That bug has been fixed once already — keep the coercion.
+ */
+export const artistDetailSearchSchema = z.object({
+  name: z
+    .preprocess((v) => (v == null ? '' : String(v)), z.string())
+    .optional()
+    .default(''),
+});
+
+export type ArtistDetailSearch = z.infer<typeof artistDetailSearchSchema>;
+
+/** 'library' addresses the local DB; anything else is a metadata source. */
+export const LIBRARY_SOURCE = 'library';
+
+export function normalizeSource(source: string): string | null {
+  const value = source.trim().toLowerCase();
+  return !value || value === LIBRARY_SOURCE ? null : value;
+}
+
+/**
+ * One release in a discography bucket.
+ *
+ * `owned` is TRI-STATE and the distinction matters:
+ *   true  — confirmed in the library
+ *   false — confirmed absent
+ *   null  — still being checked; the completion stream fills these in
+ * A source-only artist has no library to check against, so the loader coerces
+ * every null to false before render (there is nothing to stream).
+ */
+export interface DiscographyRelease {
+  id?: string | number;
+  name?: string;
+  album_type?: string;
+  release_date?: string;
+  year?: number | string | null;
+  image_url?: string | null;
+  track_count?: number;
+  owned?: boolean | null;
+  owned_track_count?: number;
+  total_track_count?: number;
+  [key: string]: unknown;
+}
+
+export type DiscographyBucket = 'albums' | 'eps' | 'singles';
+
+export interface Discography {
+  albums?: DiscographyRelease[];
+  eps?: DiscographyRelease[];
+  singles?: DiscographyRelease[];
+  /** Which metadata source produced this list; drives album-track lookups. */
+  source?: string | null;
+  [key: string]: unknown;
+}
+
+export interface ArtistInfo {
+  id?: string | number;
+  name?: string;
+  image_url?: string | null;
+  /** Absent => source-only artist: no library record, no ownership, no Enhanced view. */
+  server_source?: string | null;
+  source?: string | null;
+  musicbrainz_id?: string | null;
+  spotify_artist_id?: string | null;
+  [key: string]: unknown;
+}
+
+/** Non-fatal: the page still renders, but the vanilla page toasted a warning. */
+export interface ProviderError {
+  state?: string;
+  error?: string;
+  source?: string;
+  status_code?: number;
+}
+
+export interface ArtistDetailResponse {
+  success?: boolean;
+  error?: string;
+  artist?: ArtistInfo;
+  discography?: Discography;
+  enrichment_coverage?: Record<string, unknown>;
+  provider_error?: ProviderError;
+}


### PR DESCRIPTION
# artist detail — groundwork (nothing renders yet)

first slice of the artist-detail port. **deliberately dormant** — the manifest still says `legacy`, nothing outside the artist-detail folder imports any of it, and the route component is the same handoff shim it was before. merging this changes nothing you can see.

posting it now rather than banking it, because the page is big enough that one PR at the end would be unreviewable.

## the headline: this page is 4x what i thought

my earlier estimate was wrong. it came from splitting `library.js` by *region*; the actual call graph says otherwise:

| | i said | actually |
|---|---|---|
| functions | 32 | **161** (203 with the modals) |
| lines | ~1,900 | **~8,000** |
| endpoints | ~39 | **78** |
| ids | — | **156** across three places |

after the list cleanup, `library.js` is basically artist detail and its modals.

**and it doesn't split by feature.** i checked whether "core page first, modals later" was possible — it isn't. enhanced view and reorganize have *zero* functions of their own; they're entry points into the same 103-function spine the core page uses. so it ships as dormant slices behind the flag, then one small flip.

## what's in here

- **types + data layer** — the one call that backs first paint (`/api/artist-detail/<id>`) and the four rules the vanilla loader applied to its response
- **discography filters** — `discographyFilterState` / `applyDiscographyFilters` lifted to pure functions
- **a cross-file contract test** — see below
- one `style:` commit fixing two files i committed unformatted (CI would've caught it, but still)

## two things worth knowing

**the page isn't contained in `library.js`.** two of its own buttons — play artist radio, and writing the artist photo to disk — are implemented in `stats-automations.js` and read `artistDetailPageState` directly. they never showed up in the 161-function closure because that was computed from `library.js` alone.

if we port the page without rehoming those, they keep rendering and silently act on a stale artist. no error, no failing test. the plan is to leave both functions where they are and feed them the artist id through `shell-bridge.js`, which already re-exports three other `library.js` functions to react.

that's what the contract test pins — six names that leave `library.js`, both halves asserted (the name still exists **and** every recorded consumer still uses it), so a stale entry fails instead of rotting.

**a vanilla bug, reproduced 1:1 on purpose.** the completion stream only starts if `discography.albums` exists, so an artist whose *singles* have unknown ownership but who has no albums bucket never gets checked. left exactly as-is with a test that says out loud it's deliberate. fixing it is a separate call.

## also found, not fixed

`_esc` is declared in **both** `library.js` and `stats-automations.js`, and the latter loads second so it wins app-wide. the two differ: the winner has an `if (!str) return ''` guard, so `_esc(0)` renders as blank instead of "0". `_escAttr` has the same problem across `downloads.js` and `stats-automations.js`, with implementations that do genuinely different jobs.

pre-existing, nothing to do with this migration. written up in `known_issues_esc_shadowing.md` rather than fixed under a 1:1 instruction.

## tests

68 new tests on the branch, 470 webui total, 0 type errors. every behaviour mutation-tested — one documented equivalent mutant survives (the `!hidden` short-circuit can't change the outcome), everything else dies when broken.
