### PR TITLE
React migration artist detail hero

### DIFF
--- a/scripts/artist_detail_css_audit.py
+++ b/scripts/artist_detail_css_audit.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""CSS scoped to the vanilla page container must also reach the React page.
+
+The React artist-detail page renders inside #webui-react-root, not inside
+#artist-detail-page. Any rule written against the old container silently stops
+applying — no error, no failing test, jsdom cannot see it at all. That is how a
+SOURCE artist ended up offering Artist Radio and Enhance Quality: the rules that
+hid them were scoped to a container the page no longer lives in.
+
+Every such rule must name the React page's own hook (.artist-detail-page) too.
+"""
+import re, sys
+from pathlib import Path
+
+ROOT = Path("/mnt/e/Broque Projects/Github Projects/SoulSync")
+css = (ROOT / "webui/static/style.css").read_text(encoding="utf-8", errors="replace")
+page = (ROOT / "webui/src/routes/artist-detail/-ui/artist-detail-page.tsx").read_text(
+    encoding="utf-8"
+)
+
+REACT_HOOK = "artist-detail-page"
+
+if f'className="{REACT_HOOK}"' not in page:
+    print("CSS AUDIT — issues:")
+    print(f"   the page component no longer renders className=\"{REACT_HOOK}\";")
+    print("   every rule scoped to the artist-detail container is now dead")
+    sys.exit(1)
+
+problems = []
+for match in re.finditer(r"[^}]*#artist-detail-page[^{]*\{", css):
+    selector = " ".join(match.group(0).rstrip("{").split())
+    if f".{REACT_HOOK}" in selector:
+        continue
+    problems.append(selector[:150])
+
+if problems:
+    print("CSS AUDIT — issues:")
+    print(f"  {len(problems)} rule(s) scoped to #artist-detail-page that the React page cannot match:")
+    for selector in problems:
+        print("   ", selector)
+    sys.exit(1)
+
+total = css.count("#artist-detail-page")
+print("CSS AUDIT — clean")
+print(f"  ({total} selector(s) scoped to the artist-detail container, all reaching the React page)")

--- a/scripts/artist_detail_markup_audit.py
+++ b/scripts/artist_detail_markup_audit.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Every element the vanilla artist-detail page rendered must exist in the port.
+
+The parity audit checks LOGIC — which fields the vanilla reads and which
+cross-file functions it calls. It cannot see a whole section that was simply
+never rendered, which is how the Back button and the entire Similar Artists
+block went missing: no test asked for them, so nothing failed.
+
+This walks the vanilla `#artist-detail-page` subtree in index.html and requires
+every id and every class to appear somewhere in the React port.
+"""
+import re, sys
+from pathlib import Path
+
+ROOT = Path("/mnt/e/Broque Projects/Github Projects/SoulSync")
+html = (ROOT / "webui/index.html").read_text(encoding="utf-8")
+
+start = html.index('<div class="page" id="artist-detail-page">')
+depth, end = 0, start
+for m in re.finditer(r"<(/?)div\b[^>]*>", html[start:]):
+    depth += 1 if m.group(1) == "" else -1
+    if depth == 0:
+        end = start + m.end()
+        break
+page = html[start:end]
+
+port = "\n".join(
+    p.read_text(encoding="utf-8")
+    for p in (ROOT / "webui/src/routes/artist-detail").rglob("*.ts*")
+    if ".test." not in p.name
+)
+
+# Ids the port builds from a template literal rather than a string constant.
+TEMPLATED = re.compile(r"^(albums|eps|singles)-(section|grid|stats|completion-fill|owned-count|missing-count)$")
+
+# Rendered by the vanilla page only, with a reason.
+ALLOWED_MISSING = {
+    "artist-detail-page": "the React host IS the page container",
+    "artist-detail-retry-btn": "the retry button is wired by onClick, not by id lookup",
+}
+
+problems = []
+for el_id in sorted(set(re.findall(r'id="([^"]+)"', page))):
+    if el_id in ALLOWED_MISSING or TEMPLATED.match(el_id) or el_id in port:
+        continue
+    problems.append(f"id #{el_id} is rendered by the vanilla page but appears nowhere in the port")
+
+for cls in sorted({c for a in re.findall(r'class="([^"]+)"', page) for c in a.split()}):
+    if cls in ("hidden", "page") or cls in port:
+        continue
+    problems.append(f"class .{cls} is rendered by the vanilla page but appears nowhere in the port")
+
+if problems:
+    print("MARKUP AUDIT — issues:")
+    for p in problems:
+        print("  ", p)
+    sys.exit(1)
+print("MARKUP AUDIT — clean")
+print(f"  (every id and class in the vanilla page is present in the port; "
+      f"{len(ALLOWED_MISSING)} documented exceptions)")

--- a/scripts/artist_detail_parity_audit.py
+++ b/scripts/artist_detail_parity_audit.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Continuous parity audit: the port vs library.js. Run after every change."""
+import re, sys
+from pathlib import Path
+
+ROOT = Path("/mnt/e/Broque Projects/Github Projects/SoulSync")
+
+def strip(s):
+    out=list(s); i,n,mode=0,len(s),None
+    while i<n:
+        c=s[i]; two=s[i:i+2]
+        if mode is None:
+            if two=='//': mode='line'; out[i]=out[i+1]=' '; i+=2; continue
+            if two=='/*': mode='block'; out[i]=out[i+1]=' '; i+=2; continue
+            if c in '"\'`': mode=c; i+=1; continue
+            i+=1
+        elif mode=='line':
+            if c=='\n': mode=None
+            else: out[i]=' '
+            i+=1
+        elif mode=='block':
+            if two=='*/': out[i]=out[i+1]=' '; mode=None; i+=2; continue
+            if c!='\n': out[i]=' '
+            i+=1
+        else:
+            if c=='\\': i+=2; continue
+            if c==mode: mode=None
+            i+=1
+    return ''.join(out)
+
+VANILLA = strip((ROOT/"webui/static/library.js").read_text(encoding="utf-8"))
+PORT = "\n".join(p.read_text(encoding="utf-8")
+                 for p in (ROOT/"webui/src/routes/artist-detail").rglob("*.ts*"))
+
+def body(name):
+    try: i = VANILLA.index(f"function {name}(")
+    except ValueError: return None
+    rest = VANILLA[i:]
+    m = re.search(r"\n(?:async )?function ", rest[1:])
+    return rest[:m.start()+1] if m else rest
+
+# functions claimed ported -> (their vanilla name)
+PORTED = ["loadArtistDetailData","populateArtistDetailPage","updateArtistHeroSection",
+          "updateArtistDetailPageHeaderWithData","renderArtistEnrichmentCoverage",
+          "updateArtistSummaryStats","updateCategoryStats","updateArtistGenres",
+          "createReleaseCard","populateReleaseSection","populateDiscographySections",
+          "applyDiscographyFilters","_classifyReleaseContent","resetDiscographyFilters",
+          "initializeDiscographyFilters"]
+
+SKIP_FIELDS = {"map","filter","some","forEach","length","push","find","join","split","replace",
+               "trim","toString","toLowerCase","includes","slice","concat","every","sort","style",
+               "classList","dataset","textContent","innerHTML","appendChild","querySelector",
+               "querySelectorAll","remove","src","alt","onclick","onerror","onload","id","className",
+               "title","type","parentElement","closest","value","checked","disabled","display"}
+
+# Cross-file globals that are NOT gaps. Each needs a reason; an audit that is
+# permanently red gets ignored, and "deferred" must mean deferred-with-a-plan.
+DEFERRED = {
+    "_esc": "createReleaseCard uses a LOCAL _esc; React escapes text automatically",
+    "showToast": "invoked via window.showToast from the page component (not yet built)",
+    "hideLoadingOverlay": "release-open flow, page component",
+    "showLoadingOverlay": "release-open flow, page component",
+    "openAddToWishlistModal": "stays vanilla; invoked from the page component",
+    "lazyLoadTrackOwnership": "stays vanilla; invoked after the modal opens",
+    "checkArtistEnhanceEligibility": "fire-and-forget after load, page component",
+    "loadSimilarArtists": "stays vanilla; invoked from the page component",
+    "getAudioDBLogoURL": "deferred to via window in audioDbLogoUrl()",
+}
+
+problems = []
+
+# 1. fields the vanilla reads that the port never mentions
+fields = {}
+for name in PORTED:
+    b = body(name)
+    if b is None:
+        problems.append(f"vanilla function vanished: {name}")
+        continue
+    for obj in ("artist","data","discography","release","enrichment"):
+        for f in re.findall(rf"\b{obj}\.(\w+)", b):
+            if f not in SKIP_FIELDS:
+                fields.setdefault(f"{obj}.{f}", set()).add(name)
+missing = {k: v for k, v in fields.items() if k.split(".")[1] not in PORT}
+if missing:
+    problems.append(f"{len(missing)} field(s) read by the vanilla, absent from the port:")
+    for k, v in sorted(missing.items()):
+        problems.append(f"    {k:34} read in {', '.join(sorted(v))}")
+
+# 2. globals the vanilla calls that live OUTSIDE library.js and the port must invoke
+OTHER = strip("\n".join(p.read_text(encoding="utf-8", errors="replace")
+              for p in (ROOT/"webui/static").glob("*.js") if p.name != "library.js"))
+other_fns = set(re.findall(r"^(?:async )?function ([A-Za-z_$][\w$]*)", OTHER, re.M))
+for name in PORTED:
+    b = body(name)
+    if not b: continue
+    for called in set(re.findall(r"\b([a-zA-Z_$][\w$]*)\(", b)):
+        if called in DEFERRED: continue
+        if called in other_fns and called not in PORT and called not in SKIP_FIELDS:
+            problems.append(f"    calls {called}() from another static file — not referenced in the port ({name})")
+
+if problems:
+    print("PARITY AUDIT — issues:")
+    for p in problems: print(" ", p)
+    sys.exit(1)
+print("PARITY AUDIT — clean")
+print(f"  ({len(DEFERRED)} cross-file calls deferred with reasons — see DEFERRED)")

--- a/scripts/artist_detail_parity_audit.py
+++ b/scripts/artist_detail_parity_audit.py
@@ -45,7 +45,23 @@ PORTED = ["loadArtistDetailData","populateArtistDetailPage","updateArtistHeroSec
           "updateArtistSummaryStats","updateCategoryStats","updateArtistGenres",
           "createReleaseCard","populateReleaseSection","populateDiscographySections",
           "applyDiscographyFilters","_classifyReleaseContent","resetDiscographyFilters",
-          "initializeDiscographyFilters"]
+          "initializeDiscographyFilters",
+          # Enhanced Management view
+          "toggleEnhancedView","loadEnhancedViewData","renderEnhancedView","renderEnhancedStatsBar",
+          "renderEnhancedSection","renderAlbumRow","renderExpandedAlbumHeader","renderAlbumMetaRow",
+          "renderTrackTable","_buildTrackRow","_attachTableDelegation","_getEnhancedAlbumTrackRows",
+          "_normalizeExpectedMissingTrack","_deriveEnhancedMissingTracks","sortEnhancedTracks",
+          "saveAlbumMetadata","startInlineEdit","saveInlineEdit","updateBulkBar",
+          "showBulkEditModal","executeBulkEdit","batchAnalyzeReplayGainSelected",
+          "batchWriteTagsSelected","clearTrackSelection","extractFormat","formatDurationMs",
+          "getServiceUrl","makeClickableBadge","_getEnhancedAlbumCanonicalSource",
+          # DB record inspector + top tracks + gap-fill
+          "setupArtistRecordButton","_arecRenderFields","_arecApplyFilter",
+          "_loadArtistTopTracks","playTrackByMetadata","_topTrackDownloadOne","_topTrackDownloadAll",
+          "_gapFillEnabled","_gapNorm","_gapYear","_gapSameRelease","_loadDiscographyGapFill",
+          "_streamGapOwnership","checkLibraryCompletion","updateLibraryReleaseCard",
+          "updateCategoryStatsFromStream","recalculateSummaryStats","_libraryViewModeKey",
+          "isEnhancedAdmin","_trackSlotKey","_normTitleForMatch"]
 
 SKIP_FIELDS = {"map","filter","some","forEach","length","push","find","join","split","replace",
                "trim","toString","toLowerCase","includes","slice","concat","every","sort","style",
@@ -65,6 +81,8 @@ DEFERRED = {
     "checkArtistEnhanceEligibility": "fire-and-forget after load, page component",
     "loadSimilarArtists": "stays vanilla; invoked from the page component",
     "getAudioDBLogoURL": "deferred to via window in audioDbLogoUrl()",
+    "escapeHtml": "only used to escape an error message into innerHTML; React escapes text",
+    "_escAttr": "only used to escape values into an innerHTML string; React escapes attributes",
 }
 
 problems = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1190,6 +1190,109 @@ def _video_db_assignment_tripwire():
         videoapi.__class__ = base
 
 
+@pytest.fixture()
+def video_wishlist_forensics():
+    """Make the rotating video-wishlist flake name its own cause.
+
+    The family's signature never varies: the endpoint reports it WROTE rows
+    (``wished == 2``, ``success: True``), ``wishlist_counts()`` reads back
+    zero, and the assignment tripwire above is clean — the global pointed at
+    the test's own handle the whole time. Three explanations survive that
+    evidence, and a row count taken after the fact cannot separate them:
+
+      1. the write landed in a DIFFERENT database,
+      2. the rows were inserted and then deleted by something else,
+      3. the rows were never inserted at all.
+
+    ``arm(db)`` hangs an AFTER DELETE trigger on video_wishlist, so a delete
+    from ANY connection — a daemon thread outliving its test, calling the live
+    get_video_db(), is the standing suspect — leaves a permanent record in the
+    file itself. The report then prints that record beside the identity and
+    path of both handles, the WAL, and the live thread list.
+
+    Rows present in the delete log => (2), and the log says what was removed.
+    Log empty with the wishlist empty => (3), or (1) if the paths differ.
+
+    Used by the known family members; add it to the next one that flakes
+    rather than re-rolling a 45-minute suite. Diagnostic only — the trigger
+    lives on a per-test tmp database and no production code is touched.
+    """
+    import sqlite3
+    from pathlib import Path
+
+    class _Forensics:
+        def arm(self, db):
+            """Start recording deletes on this database. Call once, early."""
+            conn = sqlite3.connect(str(db.database_path))
+            try:
+                conn.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS _diag_wishlist_deletes (
+                        kind TEXT, tmdb_id INTEGER, season_number INTEGER,
+                        episode_number INTEGER, at TEXT DEFAULT CURRENT_TIMESTAMP);
+                    CREATE TRIGGER IF NOT EXISTS _diag_wishlist_del
+                    AFTER DELETE ON video_wishlist BEGIN
+                        INSERT INTO _diag_wishlist_deletes
+                            (kind, tmdb_id, season_number, episode_number)
+                        VALUES (old.kind, old.tmdb_id, old.season_number, old.episode_number);
+                    END;
+                    """)
+                conn.commit()
+            finally:
+                conn.close()
+
+        def __call__(self, db, note=""):
+            import threading
+
+            import api.video as videoapi
+            import core.video.download_events as events
+            import core.video.download_monitor as monitor
+
+            out = ["[wishlist forensics] %s" % note]
+
+            def describe(label, handle):
+                if handle is None:
+                    out.append("  %-17s: None" % label)
+                    return
+                path = Path(handle.database_path)
+                out.append("  %-17s: id=%s exists=%s size=%s path=%s"
+                           % (label, hex(id(handle)), path.exists(),
+                              path.stat().st_size if path.exists() else "-", path))
+
+            describe("test handle", db)
+            describe("api.video global", videoapi._video_db)
+            out.append("  %-17s: %s" % ("same handle", videoapi._video_db is db))
+
+            conn = sqlite3.connect(str(db.database_path))
+            try:
+                rows = conn.execute(
+                    "SELECT kind, tmdb_id, season_number, episode_number "
+                    "FROM video_wishlist ORDER BY rowid").fetchall()
+                out.append("  %-17s: %s" % ("wishlist rows", rows or "EMPTY"))
+                try:
+                    gone = conn.execute(
+                        "SELECT kind, tmdb_id, season_number, episode_number, at "
+                        "FROM _diag_wishlist_deletes ORDER BY rowid").fetchall()
+                    out.append("  %-17s: %s" % (
+                        "deletes recorded",
+                        gone or "NONE - nothing was ever deleted from THIS file"))
+                except sqlite3.Error:
+                    out.append("  %-17s: (not armed)" % "deletes recorded")
+            finally:
+                conn.close()
+
+            wal = Path(str(db.database_path) + "-wal")
+            out.append("  %-17s: exists=%s size=%s"
+                       % ("wal", wal.exists(), wal.stat().st_size if wal.exists() else "-"))
+            out.append("  %-17s: %s" % ("live threads", [
+                t.name for t in threading.enumerate() if t is not threading.main_thread()]))
+            out.append("  %-17s: forwarders=%d monitor._started=%s"
+                       % ("leak guards", len(events._forwarders), monitor._started))
+            return "\n".join(out)
+
+    return _Forensics()
+
+
 @pytest.fixture(autouse=True)
 def reset_state(_inert_video_enrichment_engine, _inert_video_download_monitor):
     """Reset all mutable state between tests."""

--- a/tests/test_artist_detail_cross_file_contract.py
+++ b/tests/test_artist_detail_cross_file_contract.py
@@ -124,3 +124,71 @@ def test_artist_detail_state_is_reached_from_stats_automations():
     assert "artistDetailPageState.currentArtistId" in source
     for fn in ("playArtistRadio",):
         assert re.search(rf"function {fn}\b", source), f"{fn} moved; recheck the coupling"
+
+
+# ---------------------------------------------------------------------------
+# The flip: only ONE page may load
+# ---------------------------------------------------------------------------
+
+
+def test_navigate_to_artist_detail_stops_before_the_legacy_load_when_react_owns_it():
+    """`navigateToArtistDetail` must not run the vanilla page load under React.
+
+    Search, label-detail and enrichment still call this function, and it used to
+    fall straight through into `loadArtistDetailData`. With artist-detail
+    React-owned that meant two pages loading over each other: the legacy load
+    targets DOM by id and class, the React page reuses those same ids, and
+    `applyDiscographyFilters` hides every `.release-card` on the document using
+    the legacy filter state -- so the whole discography vanished on any artist
+    reached from Search.
+
+    The state assignments above the guard are deliberate: React reads
+    currentArtistId / currentArtistName / currentArtistSource back out of them.
+    """
+    source = (Path(__file__).resolve().parents[1] / "webui/static/library.js").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("function navigateToArtistDetail(")
+    end = source.index("\nfunction ", start + 1)
+    body = source[start:end]
+
+    guard = body.index("routeManifest")
+    guard_return = body.index("return;", guard)
+    legacy_load = body.index("loadArtistDetailData(")
+
+    assert guard_return < legacy_load, (
+        "navigateToArtistDetail reaches loadArtistDetailData even when the React "
+        "page owns the route — two pages will load over each other"
+    )
+    assert "kind === 'react'" in body[guard:guard_return]
+
+
+def test_the_label_stack_is_cleared_in_place_not_reassigned():
+    """React holds a reference to the same array via window.artistDetailLabelStack.
+
+    Reassigning `_artistDetailLabelStack = []` would leave React reading a
+    detached copy, and the Back button would keep naming a page you had already
+    left.
+    """
+    source = (Path(__file__).resolve().parents[1] / "webui/static/library.js").read_text(
+        encoding="utf-8"
+    )
+    assert "_artistDetailLabelStack.length = 0" in source
+    assert not re.search(r"_artistDetailLabelStack\s*=\s*\[\]\s*;(?!\s*//\s*declaration)", 
+                         source.split("let _artistDetailLabelStack")[1])
+
+
+def test_selected_tracks_set_identity_survives_navigation():
+    """The vanilla deletes from this Set after a track delete.
+
+    React mirrors its selection into the SAME object, so replacing it here would
+    leave those writes landing on a Set nobody reads.
+    """
+    source = (Path(__file__).resolve().parents[1] / "webui/static/library.js").read_text(
+        encoding="utf-8"
+    )
+    start = source.index("function navigateToArtistDetail(")
+    end = source.index("\nfunction ", start + 1)
+    body = source[start:end]
+    assert "selectedTracks.clear()" in body
+    assert "selectedTracks = new Set()" not in body

--- a/tests/test_release_classifier_parity.py
+++ b/tests/test_release_classifier_parity.py
@@ -1,0 +1,86 @@
+"""The React release classifier must stay identical to the vanilla one.
+
+`_classifyReleaseContent` in library.js is deliberately SHARED between the
+artist-detail page and the Download Discography modal (#877) so the two can
+never disagree about what counts as live / compilation / featured. The React
+port adds a third consumer, so "identical" now spans two languages.
+
+Why this test exists: the first version of the port invented its own contract.
+It read `release.is_live` / `is_compilation` / `is_featured` — fields the
+backend never sends — instead of classifying by title. Every release came back
+unclassified, so the Live / Compilations / Featured toggles would have done
+nothing off MusicBrainz. The unit tests passed because they asserted the
+invented contract rather than the real one. A test comparing the two sources
+directly is the only kind that could have caught it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_VANILLA = (_ROOT / "webui" / "static" / "library.js").read_text(encoding="utf-8")
+_PORT = (
+    _ROOT / "webui" / "src" / "routes" / "artist-detail" / "-artist-detail.filters.ts"
+).read_text(encoding="utf-8")
+
+_PAIRS = [
+    ("livePattern", "LIVE_PATTERN"),
+    ("compilationPattern", "COMPILATION_PATTERN"),
+    ("featuredPattern", "FEATURED_PATTERN"),
+]
+
+
+def _vanilla_classifier() -> str:
+    start = _VANILLA.index("function _classifyReleaseContent")
+    return _VANILLA[start : _VANILLA.index("\nfunction ", start + 5)]
+
+
+def _regexes(source: str) -> dict[str, str]:
+    return dict(re.findall(r"const (\w+) = (/.*/i);", source))
+
+
+def test_vanilla_classifier_still_exists():
+    """If it is renamed or inlined, everything below silently stops checking."""
+    fn = _vanilla_classifier()
+    assert "livePattern" in fn and "compilationPattern" in fn and "featuredPattern" in fn
+
+
+@pytest.mark.parametrize("vanilla_name,port_name", _PAIRS)
+def test_regex_is_byte_identical(vanilla_name, port_name):
+    vanilla = _regexes(_vanilla_classifier())
+    port = _regexes(_PORT)
+    assert vanilla_name in vanilla, f"{vanilla_name} vanished from library.js"
+    assert port_name in port, f"{port_name} vanished from the React port"
+    assert vanilla[vanilla_name] == port[port_name], (
+        f"classifier drift: library.js has {vanilla[vanilla_name]}, "
+        f"the React port has {port[port_name]}"
+    )
+
+
+def test_compilation_also_keys_off_album_type():
+    """The one rule that is not a regex — a release is a compilation if its
+    album_type says so, REGARDLESS of title."""
+    fn = _vanilla_classifier()
+    assert "album_type === 'compilation'" in fn
+    assert "album_type === 'compilation'" in _PORT
+
+
+def test_port_does_not_invent_backend_fields():
+    """The specific mistake this file was written for. The backend sends no
+    is_live/is_compilation/is_featured; reading them classifies nothing."""
+    for field in ("is_live", "is_compilation", "is_featured"):
+        assert f"release.{field}" not in _PORT, (
+            f"the port reads release.{field}, which the backend never sends — "
+            "classification is title-based, see _classifyReleaseContent"
+        )
+
+
+def test_title_and_name_are_both_read():
+    """artist detail passes `title`, the download modal passes `name`."""
+    fn = _vanilla_classifier()
+    assert "release.title || release.name" in fn
+    assert "release.title ?? release.name" in _PORT

--- a/tests/test_video_quality_profiles.py
+++ b/tests/test_video_quality_profiles.py
@@ -217,14 +217,21 @@ def test_policy_engine_failure_degrades_to_empty():
     assert episodes_for_policy(_Boom(), 1, "all", "2026-07-16") == []
 
 
-def test_follow_with_policy_wishes_the_back_catalog(client, db, monkeypatch):
+def test_follow_with_policy_wishes_the_back_catalog(client, db, monkeypatch,
+                                                   video_wishlist_forensics):
+    # This test joined the rotating video-wishlist flake family on CI
+    # (2026-07-28): the endpoint reported wished=2 and the wishlist read back
+    # empty, with the _video_db tripwire clean. It has never reproduced
+    # locally, so it records deletes instead — see the fixture.
+    video_wishlist_forensics.arm(db)
     import core.video.enrichment.engine as eng_mod
     monkeypatch.setattr(eng_mod, "get_video_enrichment_engine", lambda: _FakeEngine())
     out = client.post("/api/video/watchlist/add",
                       json={"kind": "show", "tmdb_id": 42, "title": "Poker Face",
                             "monitor": "first_season"}).get_json()
     assert out["success"] is True and out["wished"] == 2
-    assert db.wishlist_counts().get("episode") == 2
+    assert db.wishlist_counts().get("episode") == 2, video_wishlist_forensics(
+        db, "follow reported wished=%r" % out.get("wished"))
     # default follow stays exactly as before
     out2 = client.post("/api/video/watchlist/add",
                        json={"kind": "show", "tmdb_id": 43, "title": "Slow Horses"}).get_json()

--- a/tests/test_video_requests.py
+++ b/tests/test_video_requests.py
@@ -69,8 +69,9 @@ def test_member_files_and_sees_only_their_own(app_db):
     assert len(rows) == 1 and rows[0]["requester_name"] == "Kid" and rows[0]["note"] == "please!"
 
 
-def test_approve_movie_lands_on_the_wishlist(app_db):
+def test_approve_movie_lands_on_the_wishlist(app_db, video_wishlist_forensics):
     client, db, persona = app_db
+    video_wishlist_forensics.arm(db)
     _as_member(persona)
     rid = client.post("/api/video/requests",
                       json={"kind": "movie", "tmdb_id": 603, "title": "The Matrix",
@@ -107,12 +108,14 @@ def test_approve_movie_lands_on_the_wishlist(app_db):
         raise AssertionError(
             "approve said %r but wishlist_counts()=%r\n"
             "  request rows   : %r          <- kind here decides movie-vs-show branch\n"
-            "  wishlist rows  : %r          <- empty + approved => inserted then removed\n"
+            "  wishlist rows  : %r\n"
             "  watchlist rows : %r          <- populated => the SHOW branch ran\n"
             "  db path        : %s\n"
-            "  fixture db %s / api._video_db %s / same object: %s"
+            "  fixture db %s / api._video_db %s / same object: %s\n"
+            "%s"
             % (out, counts, rq, wl, wa, db.database_path,
-               hex(id(db)), hex(id(videoapi._video_db)), db is videoapi._video_db))
+               hex(id(db)), hex(id(videoapi._video_db)), db is videoapi._video_db,
+               video_wishlist_forensics(db, "approve said %r" % out)))
     assert counts.get("movie") == 1
     req = db.get_video_request(rid)
     assert req["status"] == "approved" and req["admin_response"] == "enjoy"

--- a/tests/video/test_wishlist_forensics.py
+++ b/tests/video/test_wishlist_forensics.py
@@ -1,0 +1,65 @@
+"""The forensics fixture is only worth having if it can tell the two failure
+modes apart, so prove that it does.
+
+The rotating video-wishlist flake always presents the same way — the write
+path says it wrote, the read path sees nothing — and the whole point of
+``video_wishlist_forensics`` is to separate "inserted, then something deleted
+it" from "never inserted here at all". A diagnostic that quietly reported
+neither would be worse than none, because the next red CI run would look
+explained.
+"""
+
+from database.video_database import VideoDatabase
+
+EP = [{"season_number": 1, "episode_number": 1}]
+
+
+def _db(tmp_path):
+    return VideoDatabase(database_path=str(tmp_path / "video_library.db"))
+
+
+def test_a_delete_is_recorded_and_named(tmp_path, video_wishlist_forensics):
+    db = _db(tmp_path)
+    video_wishlist_forensics.arm(db)
+    db.add_episodes_to_wishlist(42, "Poker Face", EP)
+
+    armed = video_wishlist_forensics(db, "after the insert")
+    assert "('episode', 42, 1, 1)" in armed          # the row is there
+    assert "NONE" in armed                            # and nothing was deleted
+
+    db.remove_from_wishlist("show", tmdb_id=42)
+    after = video_wishlist_forensics(db, "after the delete")
+    # Empty wishlist AND a named delete: the row existed and was removed.
+    assert "wishlist rows    : EMPTY" in after
+    assert "NONE" not in after
+    assert "'episode', 42, 1, 1" in after
+
+
+def test_an_empty_log_means_the_row_never_landed_here(tmp_path, video_wishlist_forensics):
+    db = _db(tmp_path)
+    video_wishlist_forensics.arm(db)
+
+    report = video_wishlist_forensics(db, "nothing written")
+    # The distinction the flake turns on: empty wishlist, empty delete log.
+    assert "wishlist rows    : EMPTY" in report
+    assert "NONE - nothing was ever deleted from THIS file" in report
+
+
+def test_an_unarmed_database_says_so_rather_than_lying(tmp_path, video_wishlist_forensics):
+    report = video_wishlist_forensics(_db(tmp_path), "never armed")
+    # Silence here would read as "no deletes happened", which is not known.
+    assert "deletes recorded : (not armed)" in report
+
+
+def test_the_report_names_both_handles_and_the_live_threads(tmp_path, video_wishlist_forensics):
+    import api.video as videoapi
+
+    db = _db(tmp_path)
+    videoapi._video_db = db
+    try:
+        report = video_wishlist_forensics(db, "identity")
+        assert "same handle      : True" in report
+    finally:
+        videoapi._video_db = None
+    assert "same handle      : False" in video_wishlist_forensics(db, "identity")
+    assert "live threads" in video_wishlist_forensics(db, "threads")

--- a/webui/src/app/router.test.tsx
+++ b/webui/src/app/router.test.tsx
@@ -57,7 +57,16 @@ describe('createAppRouter', () => {
     expect(router.options.context?.queryClient).toBe(queryClient);
     expect(router.options.defaultPreload).toBe('intent');
     expect(router.options.defaultPreloadStaleTime).toBe(0);
-    expect(router.options.scrollRestoration).toBe(true);
+    // A predicate now, not a flag: every route restores scroll EXCEPT artist
+    // detail, which always opens at the top. Its similar-artist row sits at the
+    // very bottom, so the position worth saving there is the footer.
+    const shouldRestore = router.options.scrollRestoration as (opts: {
+      location: { pathname: string };
+    }) => boolean;
+    expect(typeof shouldRestore).toBe('function');
+    expect(shouldRestore({ location: { pathname: '/library' } })).toBe(true);
+    expect(shouldRestore({ location: { pathname: '/wishlist' } })).toBe(true);
+    expect(shouldRestore({ location: { pathname: '/artist-detail/library/42' } })).toBe(false);
     expect(router.options.defaultErrorComponent).toBeDefined();
     expect(router.options.defaultNotFoundComponent).toBeDefined();
   });

--- a/webui/src/app/router.tsx
+++ b/webui/src/app/router.tsx
@@ -37,7 +37,18 @@ export function createAppRouter(
     context,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
-    scrollRestoration: true,
+    /**
+     * Restoring scroll is right for the long list pages — go back to the
+     * library and you are where you left off. It reads wrong on artist detail:
+     * the similar-artist bubbles are at the very bottom, so the position it
+     * saves is the footer, and going back drops you there instead of at the
+     * artist you just returned to.
+     *
+     * Returning false makes the router leave scroll ALONE for that route (it
+     * bails before both the restore and the scroll-to-top), so the page can own
+     * it with no race between the two.
+     */
+    scrollRestoration: ({ location }) => !location.pathname.startsWith('/artist-detail'),
     defaultErrorComponent: DefaultErrorComponent,
     defaultNotFoundComponent: DefaultNotFoundComponent,
   });

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -126,6 +126,23 @@ declare global {
     hideLoadingOverlay?: () => void;
     /** library.js — quality-enhance eligibility probe (library artists only). */
     checkArtistEnhanceEligibility?: (artistId: unknown) => void;
+    /** stats-automations.js — the Enhance Quality modal, opened from the hero. */
+    openEnhanceQualityModal?: () => void;
+    /**
+     * shared-helpers.js — the download-missing modal. Called directly rather
+     * than through the shell bridge because the bridge wrapper fixes the last
+     * two arguments, and the top-tracks bulk download needs contextType
+     * 'playlist' to render the playlist hero and route per-track album folders.
+     */
+    openDownloadMissingModalForArtistAlbum?: (
+      virtualPlaylistId: string,
+      playlistName: string,
+      tracks: unknown[],
+      album: unknown,
+      artist: unknown,
+      showLoadingOverlay?: boolean,
+      contextType?: string,
+    ) => void | Promise<void>;
     /** library.js — wires the hero watchlist button to an identity. */
     initializeLibraryWatchlistButton?: (artistId: unknown, artistName: string) => void;
     /** downloads.js — the Add to Wishlist modal, opened from a release card. */

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -118,6 +118,30 @@ declare global {
     openArtistArtPicker?: () => void;
     /** library.js — the Download Discography modal. */
     openDiscographyModal?: () => void;
+    /** shared-helpers.js / core.js — similar-artists section + its abort. */
+    loadSimilarArtists?: (artistName: string) => void;
+    cancelSimilarArtistsLoad?: () => void;
+    /** core.js — full-page loading overlay used while a release opens. */
+    showLoadingOverlay?: (message?: string) => void;
+    hideLoadingOverlay?: () => void;
+    /** library.js — quality-enhance eligibility probe (library artists only). */
+    checkArtistEnhanceEligibility?: (artistId: unknown) => void;
+    /** library.js — wires the hero watchlist button to an identity. */
+    initializeLibraryWatchlistButton?: (artistId: unknown, artistName: string) => void;
+    /** downloads.js — the Add to Wishlist modal, opened from a release card. */
+    openAddToWishlistModal?: (
+      album: unknown,
+      artist: unknown,
+      tracks: unknown[],
+      albumType: unknown,
+    ) => Promise<void> | void;
+    /** shared-helpers.js — backfills per-track ownership behind the modal. */
+    lazyLoadTrackOwnership?: (
+      artistName: string,
+      tracks: unknown[],
+      card: unknown,
+      albumName: unknown,
+    ) => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -102,6 +102,9 @@ declare global {
     showLibraryDownloadsSection?: () => void;
     currentMusicSourceName?: string;
     updateWatchlistCount?: () => void;
+    /** shared-helpers.js — drops JioSaavn entries unless the experimental
+     *  source is enabled. Kept as the single source of truth for that flag. */
+    filterJiosaavnServiceEntries?: <T>(items: T[], idKey?: string) => T[];
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -105,6 +105,10 @@ declare global {
     /** shared-helpers.js — drops JioSaavn entries unless the experimental
      *  source is enabled. Kept as the single source of truth for that flag. */
     filterJiosaavnServiceEntries?: <T>(items: T[], idKey?: string) => T[];
+    /** core.js — points the shared IntersectionObserver at every [data-bg-src]
+     *  inside a container. Cards render the attribute; without this call the
+     *  artwork is never fetched and every tile stays blank. */
+    observeLazyBackgrounds?: (container: Element | null) => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -109,6 +109,8 @@ declare global {
      *  inside a container. Cards render the attribute; without this call the
      *  artwork is never fetched and every tile stays blank. */
     observeLazyBackgrounds?: (container: Element | null) => void;
+    /** core.js — reads the AudioDB logo off an existing img.audiodb-logo. */
+    getAudioDBLogoURL?: () => string | null;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -160,7 +160,31 @@ declare global {
       entityId: unknown,
       title: string,
       artistName: string,
+      /** Track reports add the album name; album reports omit it. */
+      albumName?: string,
     ) => void;
+    /**
+     * The Enhanced view's per-track actions, still in library.js. The mobile
+     * popover keeps its underscore name: it is a private helper being called
+     * across the boundary until the popover itself is ported.
+     */
+    showTagPreview?: (trackId: unknown) => void;
+    analyzeTrackReplayGain?: (trackId: unknown, button: HTMLElement) => void;
+    showTrackSourceInfo?: (track: unknown, button: HTMLElement) => void;
+    openReidentifyModal?: (
+      trackId: unknown,
+      trackTitle: string,
+      artistName: string,
+      albumTitle: string,
+      albumArt: string,
+    ) => void;
+    showTrackRedownloadModal?: (track: unknown, album: unknown) => void;
+    deleteLibraryTrack?: (trackId: unknown, albumId: unknown) => void;
+    openMissingTrackManageModal?: (track: unknown, album: unknown) => void;
+    _showMobileTrackActions?: (track: unknown, album: unknown) => void;
+    /** media-player.js — the play queue. */
+    addToQueue?: (payload: unknown) => void;
+    playNext?: (payload: unknown) => void;
     /**
      * shared-helpers.js — the download-missing modal. Called directly rather
      * than through the shell bridge because the bridge wrapper fixes the last

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -129,6 +129,39 @@ declare global {
     /** stats-automations.js — the Enhance Quality modal, opened from the hero. */
     openEnhanceQualityModal?: () => void;
     /**
+     * The Enhanced view's album actions. All of these still live in library.js
+     * (showReportIssueModal in stats-automations.js) and are invoked through
+     * window until the modals slice ports them; two of them take the button
+     * element itself, because they render progress onto it.
+     */
+    openAlbumArtPicker?: (album: unknown) => void;
+    openManualMatchModal?: (
+      entityType: string,
+      entityId: unknown,
+      service: string,
+      title: string,
+      artistId: unknown,
+    ) => void;
+    runEnrichment?: (
+      entityType: string,
+      entityId: unknown,
+      service: string,
+      title: string,
+      artistName: string,
+      artistId: unknown,
+    ) => void;
+    writeAlbumTags?: (albumId: unknown) => void;
+    analyzeAlbumReplayGain?: (albumId: unknown, button: HTMLElement) => void;
+    showReorganizeModal?: (albumId: unknown) => void;
+    redownloadLibraryAlbum?: (album: unknown, artistName: string, button: HTMLElement) => void;
+    deleteLibraryAlbum?: (albumId: unknown) => void;
+    showReportIssueModal?: (
+      entityType: string,
+      entityId: unknown,
+      title: string,
+      artistName: string,
+    ) => void;
+    /**
      * shared-helpers.js — the download-missing modal. Called directly rather
      * than through the shell bridge because the bridge wrapper fixes the last
      * two arguments, and the top-tracks bulk download needs contextType

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -111,6 +111,13 @@ declare global {
     observeLazyBackgrounds?: (container: Element | null) => void;
     /** core.js — reads the AudioDB logo off an existing img.audiodb-logo. */
     getAudioDBLogoURL?: () => string | null;
+    /** stats-automations.js — reads artistDetailPageState for the artist id.
+     *  Must be given the id explicitly once React owns the page. */
+    playArtistRadio?: (artistId?: string | number, artistName?: string) => void;
+    /** library.js — artist photo picker, opened from the hero image. */
+    openArtistArtPicker?: () => void;
+    /** library.js — the Download Discography modal. */
+    openDiscographyModal?: () => void;
     openWatchlistHistoryModal?: () => void;
     openBlocklistModal?: (initialType: string) => void;
     SoulSyncIssueDomain?: IssueDomainBridge;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -182,6 +182,14 @@ declare global {
     deleteLibraryTrack?: (trackId: unknown, albumId: unknown) => void;
     openMissingTrackManageModal?: (track: unknown, album: unknown) => void;
     _showMobileTrackActions?: (track: unknown, album: unknown) => void;
+    /**
+     * library.js — the batch tag-preview modal. Safe to call across the
+     * boundary because it takes the track ids explicitly rather than reading
+     * the vanilla's selection state.
+     */
+    showBatchTagPreview?: (trackIds: unknown[], albumId: unknown) => void;
+    /** library.js — polls the batch ReplayGain job this page just started. */
+    _pollBatchRgStatus?: () => void;
     /** media-player.js — the play queue. */
     addToQueue?: (payload: unknown) => void;
     playNext?: (payload: unknown) => void;

--- a/webui/src/platform/shell/route-manifest.test.ts
+++ b/webui/src/platform/shell/route-manifest.test.ts
@@ -59,12 +59,14 @@ describe('shellRouteManifest', () => {
     expect(getShellRouteByPageId('wishlist')?.kind).toBe('react');
     expect(getShellRouteByPageId('automations')?.kind).toBe('react');
     expect(getShellRouteByPageId('library')?.kind).toBe('react');
+    expect(getShellRouteByPageId('artist-detail')?.kind).toBe('react');
     expect(reactShellRoutes.map((route) => route.pageId)).toEqual([
       'watchlist',
       'wishlist',
       'automations',
       'import',
       'library',
+      'artist-detail',
       'stats',
       'issues',
     ]);

--- a/webui/src/platform/shell/route-manifest.ts
+++ b/webui/src/platform/shell/route-manifest.ts
@@ -43,7 +43,7 @@ export const shellRouteManifest: readonly ShellRouteDefinition[] = [
   { pageId: 'import', path: '/import', kind: 'react' },
   { pageId: 'library', path: '/library', kind: 'react' },
   { pageId: 'tools', path: '/tools', kind: 'legacy' },
-  { pageId: 'artist-detail', path: '/artist-detail', kind: 'legacy' },
+  { pageId: 'artist-detail', path: '/artist-detail', kind: 'react' },
   { pageId: 'label-detail', path: '/label-detail', kind: 'legacy' },
   { pageId: 'stats', path: '/stats', kind: 'react' },
   { pageId: 'settings', path: '/settings', kind: 'legacy' },

--- a/webui/src/routes/artist-detail/$source/$id.tsx
+++ b/webui/src/routes/artist-detail/$source/$id.tsx
@@ -1,34 +1,47 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { useLayoutEffect } from 'react';
-import { z } from 'zod';
 
 import { useShellBridge } from '@/platform/shell/route-controllers';
+import { getShellRouteByPageId } from '@/platform/shell/route-manifest';
 
-// Some metadata sources (Bandcamp) have no numeric-ID lookup API at all —
-// they're addressed entirely by URL/name — so the artist's display name has
-// to travel as a search param. Sources that can resolve by ID alone just
-// don't need it; this is a no-op for them.
-//
-// TanStack's search parser JSON-parses param values, so an all-digits artist
-// name ("311", "702") arrives as a NUMBER — a bare z.string() then throws
-// SearchParamError and the whole route dies in the error boundary (clicking
-// the artist did nothing). Coerce whatever arrives back to a string.
-const artistDetailSearchSchema = z.object({
-  name: z
-    .preprocess((v) => (v == null ? '' : String(v)), z.string())
-    .optional()
-    .default(''),
-});
+import { artistDetailSearchSchema } from '../-artist-detail.types';
+import { ArtistDetailPage } from '../-ui/artist-detail-page';
+
+/**
+ * Whether the shell has handed artist detail over to React yet.
+ *
+ * TanStack matches from the generated route tree, not the manifest, so this
+ * route matches the moment the file exists. Without this guard the React page
+ * and the vanilla page would both activate on the same URL. Delete the
+ * indirection once the vanilla artist-detail page is gone.
+ *
+ * The search schema moved to -artist-detail.types.ts, where its preprocess is
+ * unit-tested: TanStack JSON-parses search values, so an all-digits artist
+ * name ("311", "702") arrives as a NUMBER and a bare z.string() throws
+ * SearchParamError, killing the route. That has regressed once already.
+ */
+function isReactOwned(): boolean {
+  return getShellRouteByPageId('artist-detail')?.kind === 'react';
+}
 
 export const Route = createFileRoute('/artist-detail/$source/$id')({
   validateSearch: artistDetailSearchSchema,
-  component: ArtistDetailPage,
+  component: ArtistDetailRouteComponent,
 });
 
-// Thin legacy handoff: TanStack owns the URL shape here, but the vanilla JS
-// artist-detail page still renders the actual experience for now. The route
-// owns cancellation so similar-artist loading stops when this page changes.
-function ArtistDetailPage() {
+function ArtistDetailRouteComponent() {
+  if (!isReactOwned()) {
+    return <LegacyArtistDetailHandoff />;
+  }
+  return <ArtistDetailPage />;
+}
+
+/**
+ * Thin legacy handoff: TanStack owns the URL shape, but the vanilla JS page
+ * still renders the experience. The route owns cancellation so similar-artist
+ * loading stops when this page changes.
+ */
+function LegacyArtistDetailHandoff() {
   const bridge = useShellBridge();
   const { source, id } = Route.useParams();
   const { name } = Route.useSearch();

--- a/webui/src/routes/artist-detail/-artist-detail.api.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.test.ts
@@ -6,6 +6,7 @@ import {
   needsCompletionStream,
   readArtistDetail,
   settleOwnershipForSourceArtist,
+  watchlistIdentity,
 } from './-artist-detail.api';
 import { artistDetailSearchSchema, normalizeSource } from './-artist-detail.types';
 
@@ -162,5 +163,42 @@ describe('needsCompletionStream', () => {
     expect(needsCompletionStream({ ...library, discography: { singles: [{ owned: null }] } })).toBe(
       false,
     );
+  });
+});
+
+describe('watchlistIdentity', () => {
+  it('prefers the canonical Spotify identity over the library record', () => {
+    // The watchlist is keyed on Spotify ids; using the library PK would create
+    // a second row for an artist already watched from the Watchlist page.
+    const identity = watchlistIdentity({
+      artist: { id: 42, name: 'Aphex Twin (library)' },
+      spotify_artist: { spotify_artist_id: 'sp1', spotify_artist_name: 'Aphex Twin' },
+    });
+    expect(identity).toEqual({ id: 'sp1', name: 'Aphex Twin' });
+  });
+
+  it('falls back to the arriving id for a source artist', () => {
+    // Deezer/iTunes/Discogs artists have no Spotify id at all.
+    expect(watchlistIdentity({ artist: { id: 'dz-9', name: 'Boards of Canada' } })).toEqual({
+      id: 'dz-9',
+      name: 'Boards of Canada',
+    });
+  });
+
+  it('falls back per FIELD, not all-or-nothing', () => {
+    // A half-populated spotify_artist still contributes what it has.
+    expect(
+      watchlistIdentity({
+        artist: { id: 42, name: 'From Library' },
+        spotify_artist: { spotify_artist_id: 'sp1' },
+      }),
+    ).toEqual({ id: 'sp1', name: 'From Library' });
+  });
+
+  it('returns null unless BOTH halves resolve', () => {
+    // The vanilla required id AND name before initialising the button.
+    expect(watchlistIdentity({ artist: { id: 42 } })).toBeNull();
+    expect(watchlistIdentity({ artist: { name: 'No id' } })).toBeNull();
+    expect(watchlistIdentity({})).toBeNull();
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.api.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.api.ts
@@ -98,3 +98,28 @@ export function needsCompletionStream(payload: ArtistDetailResponse): boolean {
     (release) => release.owned === null,
   );
 }
+
+export interface WatchlistIdentity {
+  id: string;
+  name: string;
+}
+
+/**
+ * Which identity the watchlist button acts on.
+ *
+ * A library artist that has been enriched gets the CANONICAL Spotify identity,
+ * because the watchlist is keyed on Spotify ids — otherwise the same artist
+ * watched from here and from the Watchlist page would be two different rows.
+ * Source artists (Deezer/iTunes/Discogs) have no Spotify id and fall back to
+ * whatever id they arrived with.
+ *
+ * Returns null when neither half resolves; the vanilla required BOTH before
+ * initialising the button.
+ */
+export function watchlistIdentity(payload: ArtistDetailResponse): WatchlistIdentity | null {
+  const spotify = payload.spotify_artist;
+  const id = spotify?.spotify_artist_id || payload.artist?.id;
+  const name = spotify?.spotify_artist_name || payload.artist?.name;
+  if (!id || !name) return null;
+  return { id: String(id), name: String(name) };
+}

--- a/webui/src/routes/artist-detail/-artist-detail.back-label.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.back-label.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type BackLabelEntry,
+  backButtonLabel,
+  backLabelStack,
+  popBackOrigin,
+  pushArtistOrigin,
+  resetGoingBackForTests,
+} from './-artist-detail.back-label';
+
+type W = {
+  artistDetailLabelStack?: BackLabelEntry[];
+  artistDetailBackLabels?: Record<string, string>;
+};
+
+const install = (stack: BackLabelEntry[] = []) => {
+  (window as W).artistDetailLabelStack = stack;
+  return stack;
+};
+
+beforeEach(() => resetGoingBackForTests());
+
+afterEach(() => {
+  delete (window as W).artistDetailLabelStack;
+  delete (window as W).artistDetailBackLabels;
+});
+
+describe('backButtonLabel', () => {
+  it('names the page you came from', () => {
+    install([{ type: 'page', pageId: 'search' }]);
+    expect(backButtonLabel()).toBe('← Back to Search');
+  });
+
+  it('names the ARTIST you came from', () => {
+    install([{ type: 'artist', name: 'Aphex Twin' }]);
+    expect(backButtonLabel()).toBe('← Back to Aphex Twin');
+  });
+
+  it('reads the TOP of the stack, not the bottom', () => {
+    install([
+      { type: 'page', pageId: 'search' },
+      { type: 'artist', name: 'Boards of Canada' },
+    ]);
+    expect(backButtonLabel()).toBe('← Back to Boards of Canada');
+  });
+
+  it('is a plain Back on a cold load', () => {
+    install([]);
+    expect(backButtonLabel()).toBe('← Back');
+  });
+
+  it('falls back to Library for an unrecognised page', () => {
+    install([{ type: 'page', pageId: 'something-new' }]);
+    expect(backButtonLabel()).toBe('← Back to Library');
+  });
+
+  it('prefers the vanilla label map when library.js exported one', () => {
+    // Keeps the two in step if Boulder renames a page label there.
+    (window as W).artistDetailBackLabels = { search: 'Back to Finder' };
+    install([{ type: 'page', pageId: 'search' }]);
+    expect(backButtonLabel()).toBe('← Back to Finder');
+  });
+
+  it('works with no exported stack at all', () => {
+    expect(backButtonLabel()).toBe('← Back');
+  });
+});
+
+describe('the stack across hops', () => {
+  it('pushes the previous artist on a forward hop', () => {
+    const stack = install([{ type: 'page', pageId: 'search' }]);
+    pushArtistOrigin('Aphex Twin');
+    expect(stack).toHaveLength(2);
+    expect(backButtonLabel()).toBe('← Back to Aphex Twin');
+  });
+
+  it('pops on a back navigation', () => {
+    install([
+      { type: 'page', pageId: 'search' },
+      { type: 'artist', name: 'Aphex Twin' },
+    ]);
+    popBackOrigin();
+    expect(backButtonLabel()).toBe('← Back to Search');
+  });
+
+  it('does NOT re-push when the back navigation re-renders the old artist', () => {
+    // Going back looks exactly like a forward hop to the page effect; without
+    // the guard the pop and the push cancel and the label never moves.
+    const stack = install([
+      { type: 'page', pageId: 'search' },
+      { type: 'artist', name: 'A' },
+    ]);
+    popBackOrigin();
+    pushArtistOrigin('A');
+    expect(stack).toEqual([{ type: 'page', pageId: 'search' }]);
+    expect(backButtonLabel()).toBe('← Back to Search');
+  });
+
+  it('only swallows ONE push after a back', () => {
+    const stack = install([
+      { type: 'page', pageId: 'search' },
+      { type: 'artist', name: 'A' },
+    ]);
+    popBackOrigin();
+    pushArtistOrigin('A');
+    pushArtistOrigin('B');
+    expect(stack).toHaveLength(2);
+    expect(backButtonLabel()).toBe('← Back to B');
+  });
+
+  it('ignores a push with no artist name', () => {
+    const stack = install([]);
+    pushArtistOrigin(null);
+    pushArtistOrigin('');
+    expect(stack).toHaveLength(0);
+  });
+
+  it('shares the SAME array the vanilla pushes into', () => {
+    // library.js clears it in place for exactly this reason; a reassignment
+    // there would leave React reading a detached copy.
+    const stack = install([]);
+    stack.push({ type: 'page', pageId: 'search' });
+    expect(backLabelStack()).toBe(stack);
+    expect(backButtonLabel()).toBe('← Back to Search');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.back-label.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.back-label.ts
@@ -1,0 +1,96 @@
+/**
+ * The Back button's label, from _updateArtistDetailBackButtonLabel
+ * (library.js:464).
+ *
+ * The vanilla kept a stack of where you came from — a page id, or the name of
+ * the previous artist when you chained artist → similar artist → artist — and
+ * labelled the button from its top entry. Arrivals from a still-vanilla page
+ * (search, label detail, enrichment) go through navigateToArtistDetail, which
+ * pushes onto that stack, so React reads the SAME array rather than guessing.
+ */
+
+export interface BackLabelEntry {
+  type: 'page' | 'artist';
+  pageId?: string;
+  name?: string;
+}
+
+/** Mirrors _ARTIST_DETAIL_BACK_LABELS; unknown pages fall back to Library. */
+const FALLBACK_LABELS: Record<string, string> = {
+  library: 'Back to Library',
+  search: 'Back to Search',
+  discover: 'Back to Discover',
+  watchlist: 'Back to Watchlist',
+  wishlist: 'Back to Wishlist',
+  stats: 'Back to Stats',
+  'playlist-explorer': 'Back to Explorer',
+  automations: 'Back to Automations',
+  dashboard: 'Back to Dashboard',
+  sync: 'Back to Sync',
+  'active-downloads': 'Back to Downloads',
+};
+
+function labels(): Record<string, string> {
+  return (
+    (window as { artistDetailBackLabels?: Record<string, string> }).artistDetailBackLabels ??
+    FALLBACK_LABELS
+  );
+}
+
+export function backLabelStack(): BackLabelEntry[] {
+  return (window as { artistDetailLabelStack?: BackLabelEntry[] }).artistDetailLabelStack ?? [];
+}
+
+/**
+ * "← Back to Search" / "← Back to Aphex Twin" / "← Back".
+ *
+ * An empty stack gives the plain "← Back", which is what the vanilla showed on
+ * a cold load straight onto an artist url.
+ */
+export function backButtonLabel(stack: BackLabelEntry[] = backLabelStack()): string {
+  const top = stack[stack.length - 1];
+  if (!top) return '← Back';
+  if (top.type === 'artist') return `← Back to ${top.name}`;
+  return `← ${labels()[top.pageId ?? ''] ?? labels().library ?? FALLBACK_LABELS.library}`;
+}
+
+/**
+ * Mirrors the vanilla's _artistDetailGoingBack.
+ *
+ * Going back re-renders the page with the PREVIOUS artist, which looks exactly
+ * like a forward hop to the effect below. Without this flag the pop and the
+ * push cancel out and the label never changes.
+ */
+let goingBack = false;
+
+export function markGoingBack(): void {
+  goingBack = true;
+}
+
+/**
+ * Record an artist → artist hop, as navigateToArtistDetail did for the vanilla.
+ *
+ * Similar-artist bubbles are plain links, and with artist-detail React-owned
+ * they route through TanStack without ever reaching navigateToArtistDetail — so
+ * nothing else pushes for these hops, and after three of them the button would
+ * still be offering the page you originally came from.
+ */
+export function pushArtistOrigin(previousArtistName: string | null | undefined): void {
+  if (goingBack) {
+    goingBack = false;
+    return;
+  }
+  if (!previousArtistName) return;
+  backLabelStack().push({ type: 'artist', name: previousArtistName });
+}
+
+/** Back navigation pops, so the label follows you back down the chain. */
+export function popBackOrigin(): BackLabelEntry | undefined {
+  markGoingBack();
+  return backLabelStack().pop();
+}
+
+/** Test seam: the flag is module state and has to be resettable. */
+export function resetGoingBackForTests(): void {
+  goingBack = false;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.card.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.card.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  completionOverlay,
+  isExplicit,
+  musicbrainzReleaseUrl,
+  releaseBackgroundSrc,
+  releaseCardClassName,
+  releaseYearText,
+} from './-artist-detail.card';
+
+describe('releaseCardClassName', () => {
+  it('keeps BOTH classes — .release-card for the filters, .album-card for the look', () => {
+    expect(releaseCardClassName({ owned: true })).toBe('release-card album-card');
+  });
+
+  it('adds checking while ownership is unresolved, missing when absent', () => {
+    expect(releaseCardClassName({ owned: null })).toBe('release-card album-card checking');
+    expect(releaseCardClassName({ owned: false })).toBe('release-card album-card missing');
+  });
+});
+
+describe('completionOverlay', () => {
+  it('is omitted entirely for a source artist', () => {
+    // No library to be complete against — the card is just artwork + title.
+    expect(completionOverlay({ owned: true }, true)).toBeNull();
+    expect(completionOverlay({ owned: null }, true)).toBeNull();
+  });
+
+  it('shows Checking while ownership is unresolved', () => {
+    expect(completionOverlay({ owned: null }, false)).toEqual({
+      className: 'checking',
+      label: 'Checking...',
+    });
+  });
+
+  it('also shows Checking when track_completion says so, even if owned', () => {
+    expect(completionOverlay({ owned: true, track_completion: 'checking' }, false)?.className).toBe(
+      'checking',
+    );
+  });
+
+  it('shows Missing when not owned', () => {
+    expect(completionOverlay({ owned: false }, false)).toEqual({
+      className: 'missing',
+      label: 'Missing',
+    });
+  });
+
+  describe('object track_completion', () => {
+    it('is complete only when NOTHING is missing', () => {
+      const overlay = completionOverlay(
+        {
+          owned: true,
+          track_completion: { owned_tracks: 12, total_tracks: 12, missing_tracks: 0 },
+        },
+        false,
+      );
+      expect(overlay).toEqual({ className: 'completed', label: '✓ Owned' });
+    });
+
+    it('shows owned/total and splits nearly_complete at 75%', () => {
+      const near = completionOverlay(
+        { owned: true, track_completion: { owned_tracks: 9, total_tracks: 12, missing_tracks: 3 } },
+        false,
+      );
+      expect(near).toEqual({ className: 'nearly_complete', label: '9/12' }); // 75%
+
+      const partial = completionOverlay(
+        { owned: true, track_completion: { owned_tracks: 8, total_tracks: 12, missing_tracks: 4 } },
+        false,
+      );
+      expect(partial).toEqual({ className: 'partial', label: '8/12' }); // 67%
+    });
+
+    it('does not divide by zero when total_tracks is 0', () => {
+      const overlay = completionOverlay(
+        { owned: true, track_completion: { owned_tracks: 0, total_tracks: 0, missing_tracks: 2 } },
+        false,
+      );
+      expect(overlay).toEqual({ className: 'partial', label: '0/0' });
+    });
+
+    it('stays partial when total is 0 but owned is not — Infinity must not pass 75%', () => {
+      // 0/0 is NaN and fails >= 75 anyway, so it cannot detect a missing guard.
+      // owned/0 is Infinity, which WOULD pass and mislabel this as nearly complete.
+      const overlay = completionOverlay(
+        { owned: true, track_completion: { owned_tracks: 5, total_tracks: 0, missing_tracks: 1 } },
+        false,
+      );
+      expect(overlay).toEqual({ className: 'partial', label: '5/0' });
+    });
+  });
+
+  describe('numeric track_completion', () => {
+    it('treats 100 as complete', () => {
+      expect(completionOverlay({ owned: true, track_completion: 100 }, false)).toEqual({
+        className: 'completed',
+        label: '✓ Owned',
+      });
+    });
+
+    it('treats a missing completion on an owned release as complete', () => {
+      // `|| 100` in the vanilla — absence means "no partial info", not "0%".
+      expect(completionOverlay({ owned: true }, false)).toEqual({
+        className: 'completed',
+        label: '✓ Owned',
+      });
+      expect(completionOverlay({ owned: true, track_completion: 0 }, false)?.className).toBe(
+        'completed',
+      );
+    });
+
+    it('splits nearly_complete at 75% and labels with a percent', () => {
+      expect(completionOverlay({ owned: true, track_completion: 75 }, false)).toEqual({
+        className: 'nearly_complete',
+        label: '75%',
+      });
+      expect(completionOverlay({ owned: true, track_completion: 74 }, false)).toEqual({
+        className: 'partial',
+        label: '74%',
+      });
+    });
+  });
+});
+
+describe('releaseYearText', () => {
+  const now = new Date('2026-07-27T00:00:00Z');
+
+  it('takes a leading 4-digit year from release_date', () => {
+    expect(releaseYearText({ release_date: '1994-04-08' }, now)).toBe('1994');
+  });
+
+  it('parses a non-leading-year date format', () => {
+    expect(releaseYearText({ release_date: 'April 8, 1994' }, now)).toBe('1994');
+  });
+
+  it('rejects a year outside 1900 < y <= currentYear + 1', () => {
+    expect(releaseYearText({ release_date: '1899-01-01' }, now)).toBe('');
+    expect(releaseYearText({ release_date: '2099-01-01' }, now)).toBe('');
+    // next year IS allowed — announced but unreleased
+    expect(releaseYearText({ release_date: '2027-01-01' }, now)).toBe('2027');
+  });
+
+  it('falls back to the year field when the date is unusable', () => {
+    expect(releaseYearText({ release_date: 'nonsense', year: 1994 }, now)).toBe('1994');
+    expect(releaseYearText({ year: 1994 }, now)).toBe('1994');
+  });
+
+  it('renders nothing when there is neither', () => {
+    expect(releaseYearText({}, now)).toBe('');
+  });
+
+  it('does NOT range-check the year fallback', () => {
+    // Matches the vanilla: `if (!yearText && release.year) yearText = release.year.toString()`
+    // is unguarded. Reproduced 1:1 rather than tightened.
+    expect(releaseYearText({ year: 3000 }, now)).toBe('3000');
+  });
+});
+
+describe('releaseBackgroundSrc', () => {
+  it('skips empty and whitespace-only urls so no observer work is queued', () => {
+    expect(releaseBackgroundSrc({ image_url: '  ' })).toBeNull();
+    expect(releaseBackgroundSrc({ image_url: '' })).toBeNull();
+    expect(releaseBackgroundSrc({})).toBeNull();
+    expect(releaseBackgroundSrc({ image_url: 'a.jpg' })).toBe('a.jpg');
+  });
+});
+
+describe('isExplicit', () => {
+  it('requires exactly true, not merely truthy', () => {
+    expect(isExplicit({ explicit: true })).toBe(true);
+    expect(isExplicit({ explicit: 1 as never })).toBe(false);
+    expect(isExplicit({})).toBe(false);
+  });
+});
+
+describe('musicbrainzReleaseUrl', () => {
+  it('links to the RELEASE, not the release-group', () => {
+    expect(musicbrainzReleaseUrl({ musicbrainz_release_id: 'abc' })).toBe(
+      'https://musicbrainz.org/release/abc',
+    );
+    expect(musicbrainzReleaseUrl({})).toBeNull();
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.card.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.card.ts
@@ -1,0 +1,120 @@
+import type { DiscographyRelease } from './-artist-detail.types';
+
+/**
+ * Release-card derivations, ported from `createReleaseCard` (library.js:1683).
+ *
+ * Kept as pure functions so each branch is testable without a DOM — the vanilla
+ * built this by hand with createElement and innerHTML.
+ */
+
+export type CompletionClass = 'checking' | 'completed' | 'nearly_complete' | 'partial' | 'missing';
+
+export interface CompletionOverlay {
+  className: CompletionClass;
+  label: string;
+}
+
+/** `release-card album-card` plus a state suffix. Both classes matter:
+ *  `.release-card` keeps the existing filter/state CSS and JS queries working,
+ *  `.album-card` carries the big-photo visual treatment. */
+export function releaseCardClassName(release: DiscographyRelease): string {
+  if (release.owned === null) return 'release-card album-card checking';
+  if (release.owned === false) return 'release-card album-card missing';
+  return 'release-card album-card';
+}
+
+/**
+ * The top-right completion badge.
+ *
+ * Returns null for a SOURCE artist — the vanilla omitted the overlay entirely
+ * there (`document.body.dataset.artistSource === 'source'`), because there is
+ * no library to be complete against; the card is just artwork + title.
+ *
+ * `track_completion` arrives in two shapes, and both are handled:
+ *   - an OBJECT {owned_tracks,total_tracks,missing_tracks} -> "3/12" style
+ *   - a NUMBER percentage -> "75%" style
+ * The 75% threshold splits 'nearly_complete' from 'partial' in both.
+ */
+export function completionOverlay(
+  release: DiscographyRelease,
+  isSourceArtist: boolean,
+): CompletionOverlay | null {
+  if (isSourceArtist) return null;
+
+  const completion = release.track_completion;
+
+  if (release.owned === null || completion === 'checking') {
+    return { className: 'checking', label: 'Checking...' };
+  }
+
+  if (!release.owned) {
+    return { className: 'missing', label: 'Missing' };
+  }
+
+  if (completion && typeof completion === 'object') {
+    const tc = completion as {
+      owned_tracks?: number;
+      total_tracks?: number;
+      missing_tracks?: number;
+    };
+    const ownedTracks = tc.owned_tracks || 0;
+    const totalTracks = tc.total_tracks || 0;
+    const missingTracks = tc.missing_tracks || 0;
+    if (missingTracks === 0) return { className: 'completed', label: '✓ Owned' };
+    const pct = totalTracks > 0 ? Math.round((ownedTracks / totalTracks) * 100) : 0;
+    return {
+      className: pct >= 75 ? 'nearly_complete' : 'partial',
+      label: `${ownedTracks}/${totalTracks}`,
+    };
+  }
+
+  // Percentage form. `|| 100` is deliberate: a missing/zero completion on an
+  // owned release is treated as fully owned, matching the vanilla.
+  const pct = (completion as number) || 100;
+  if (pct === 100) return { className: 'completed', label: '✓ Owned' };
+  return { className: pct >= 75 ? 'nearly_complete' : 'partial', label: `${pct}%` };
+}
+
+/**
+ * Display year.
+ *
+ * Prefers a leading 4-digit year in `release_date`, else parses the date, else
+ * falls back to `release.year`. Both parsed paths are sanity-bounded to
+ * 1900 < year <= currentYear + 1 — a nonsense date renders no year rather than
+ * a wrong one. The +1 allows announced-but-unreleased records.
+ */
+export function releaseYearText(release: DiscographyRelease, now: Date = new Date()): string {
+  const limit = now.getFullYear() + 1;
+  const inRange = (y: number) => Boolean(y) && !Number.isNaN(y) && y > 1900 && y <= limit;
+
+  const raw = release.release_date;
+  if (typeof raw === 'string' && raw) {
+    const match = /^(\d{4})/.exec(raw);
+    if (match) {
+      const year = parseInt(match[1], 10);
+      if (inRange(year)) return String(year);
+    } else {
+      const year = new Date(raw).getFullYear();
+      if (inRange(year)) return String(year);
+    }
+  }
+
+  return release.year ? String(release.year) : '';
+}
+
+/** Lazy background: the vanilla set data-bg-src and let an IntersectionObserver
+ *  swap it in. Empty/whitespace urls are skipped so no observer work is queued. */
+export function releaseBackgroundSrc(release: DiscographyRelease): string | null {
+  const url = release.image_url;
+  return typeof url === 'string' && url.trim() !== '' ? url : null;
+}
+
+/** Only `true` shows the badge — not any truthy value. */
+export function isExplicit(release: DiscographyRelease): boolean {
+  return release.explicit === true;
+}
+
+export function musicbrainzReleaseUrl(release: DiscographyRelease): string | null {
+  const id = release.musicbrainz_release_id;
+  return id ? `https://musicbrainz.org/release/${id}` : null;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.completion.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.completion.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyCompletionEvent,
+  completionFromEvent,
+  completionStreamPayload,
+  emptyStreamCounts,
+  isEventOwned,
+  parseSseFrames,
+  tallyEvent,
+} from './-artist-detail.completion';
+
+describe('isEventOwned', () => {
+  it('treats anything but missing/error as owned, partials included', () => {
+    expect(isEventOwned({ status: 'partial' })).toBe(true);
+    expect(isEventOwned({ status: 'completed' })).toBe(true);
+    expect(isEventOwned({ status: 'missing' })).toBe(false);
+    expect(isEventOwned({ status: 'error' })).toBe(false);
+  });
+});
+
+describe('completionFromEvent', () => {
+  it('returns the NUMBER 0 when not owned, not an object', () => {
+    // Downstream branches on typeof; an empty object would take the wrong path.
+    expect(completionFromEvent({ status: 'missing', owned_tracks: 0 })).toBe(0);
+    expect(completionFromEvent({ status: 'error' })).toBe(0);
+  });
+
+  it('clamps a library with MORE tracks than expected to 100%', () => {
+    // Bonus tracks would otherwise render "13/12" and 108%.
+    expect(completionFromEvent({ status: 'ok', owned_tracks: 13, expected_tracks: 12 })).toEqual({
+      owned_tracks: 13,
+      total_tracks: 13,
+      percentage: 100,
+      missing_tracks: -1,
+    });
+  });
+
+  it('reports a genuine partial with the server percentage', () => {
+    expect(
+      completionFromEvent({
+        status: 'partial',
+        owned_tracks: 9,
+        expected_tracks: 12,
+        completion_percentage: 75,
+      }),
+    ).toEqual({ owned_tracks: 9, total_tracks: 12, percentage: 75, missing_tracks: 3 });
+  });
+
+  it('is complete at exactly the expected count', () => {
+    const c = completionFromEvent({ status: 'ok', owned_tracks: 12, expected_tracks: 12 });
+    expect(c).toMatchObject({ total_tracks: 12, percentage: 100, missing_tracks: 0 });
+  });
+
+  it('treats 0 owned as NOT complete even when 0 were expected', () => {
+    // `owned > 0` guards this: 0 >= 0 would otherwise read as complete.
+    expect(completionFromEvent({ status: 'ok', owned_tracks: 0, expected_tracks: 0 })).toEqual({
+      owned_tracks: 0,
+      total_tracks: 0,
+      percentage: 100,
+      missing_tracks: 0,
+    });
+  });
+
+  it('falls back to owned/owned when nothing is expected', () => {
+    expect(completionFromEvent({ status: 'ok', owned_tracks: 5 })).toEqual({
+      owned_tracks: 5,
+      total_tracks: 5,
+      percentage: 100,
+      missing_tracks: 0,
+    });
+  });
+});
+
+describe('applyCompletionEvent', () => {
+  const disc = {
+    albums: [
+      { id: 1, title: 'A', owned: null },
+      { id: 2, title: 'B', owned: null },
+    ],
+    singles: [{ id: 3, title: 'C', owned: null }],
+  };
+
+  it('updates only the matching release', () => {
+    const next = applyCompletionEvent(disc, {
+      id: 2,
+      status: 'ok',
+      owned_tracks: 5,
+      expected_tracks: 5,
+    });
+    expect(next.albums?.[0].owned).toBeNull();
+    expect(next.albums?.[1].owned).toBe(true);
+  });
+
+  it('matches a numeric id against its string form', () => {
+    // The vanilla looked the card up with a [data-release-id="..."] selector,
+    // so 1 and "1" were the same card.
+    const next = applyCompletionEvent(
+      { albums: [{ id: '1', owned: null }] },
+      { id: 1, status: 'ok' },
+    );
+    expect(next.albums?.[0].owned).toBe(true);
+  });
+
+  it('searches every bucket, not just albums', () => {
+    const next = applyCompletionEvent(disc, { id: 3, status: 'missing' });
+    expect(next.singles?.[0].owned).toBe(false);
+  });
+
+  it('returns the SAME object when nothing matched, so React does not re-render', () => {
+    expect(applyCompletionEvent(disc, { id: 999, status: 'ok' })).toBe(disc);
+    expect(applyCompletionEvent(disc, {})).toBe(disc);
+  });
+
+  it('does not mutate the input', () => {
+    applyCompletionEvent(disc, { id: 1, status: 'ok', owned_tracks: 1, expected_tracks: 1 });
+    expect(disc.albums[0].owned).toBeNull();
+  });
+});
+
+describe('tallyEvent', () => {
+  it('counts every event in total but only owned ones in owned', () => {
+    const counts = emptyStreamCounts();
+    tallyEvent(counts, { category: 'albums', status: 'ok' });
+    tallyEvent(counts, { category: 'albums', status: 'missing' });
+    expect(counts.total.albums).toBe(2);
+    expect(counts.owned.albums).toBe(1);
+    // "missing" is derived, never counted separately.
+    expect(counts.total.albums - counts.owned.albums).toBe(1);
+  });
+
+  it('accumulates formats from owned releases only', () => {
+    const counts = emptyStreamCounts();
+    tallyEvent(counts, { category: 'albums', status: 'ok', formats: ['FLAC', 'MP3'] });
+    tallyEvent(counts, { category: 'albums', status: 'missing', formats: ['WAV'] });
+    expect([...counts.formats].sort()).toEqual(['FLAC', 'MP3']);
+  });
+
+  it('ignores an event with no or unknown category', () => {
+    const counts = emptyStreamCounts();
+    tallyEvent(counts, { status: 'ok' });
+    tallyEvent(counts, { category: 'bogus' as never, status: 'ok' });
+    expect(counts.total).toEqual({ albums: 0, eps: 0, singles: 0 });
+  });
+});
+
+describe('parseSseFrames', () => {
+  it('carries an incomplete trailing line forward', () => {
+    // A frame split across two chunks is otherwise dropped silently.
+    const first = parseSseFrames('data: {"id":1}\ndata: {"id":2');
+    expect(first.events).toEqual([{ id: 1 }]);
+    expect(first.rest).toBe('data: {"id":2');
+
+    const second = parseSseFrames(first.rest + '}\n');
+    expect(second.events).toEqual([{ id: 2 }]);
+  });
+
+  it('ignores lines that are not data frames', () => {
+    expect(parseSseFrames(': keep-alive\nevent: ping\ndata: {"id":1}\n').events).toEqual([
+      { id: 1 },
+    ]);
+  });
+
+  it('ignores a non-data line even when its tail happens to parse as JSON', () => {
+    // Dropping the prefix check and relying on JSON.parse throwing is not
+    // enough: `event: 1`.slice(6) is " 1", which parses to the number 1 and
+    // would be emitted as an event.
+    expect(parseSseFrames('event: 1\nretry: 500\ndata: {"id":2}\n').events).toEqual([{ id: 2 }]);
+  });
+
+  it('skips a malformed frame instead of stalling the stream', () => {
+    const { events } = parseSseFrames('data: {bad json\ndata: {"id":2}\n');
+    expect(events).toEqual([{ id: 2 }]);
+  });
+});
+
+describe('completionStreamPayload', () => {
+  it('sends every bucket and the source, defaulting empties', () => {
+    expect(
+      completionStreamPayload('Aphex Twin', { albums: [{ id: 1 }], source: 'spotify' }),
+    ).toEqual({
+      artist_name: 'Aphex Twin',
+      albums: [{ id: 1 }],
+      eps: [],
+      singles: [],
+      source: 'spotify',
+    });
+    expect(completionStreamPayload('X', {}).source).toBeNull();
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.completion.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.completion.ts
@@ -1,0 +1,163 @@
+import type { Discography, DiscographyBucket, DiscographyRelease } from './-artist-detail.types';
+
+/**
+ * The library completion stream, ported from checkLibraryCompletion and
+ * updateLibraryReleaseCard (library.js:1918-2088).
+ *
+ * The vanilla mutated `card._releaseData` in place and rewrote the overlay by
+ * hand. Here each event produces a NEW release object and React re-renders,
+ * which is why the merge is a pure function.
+ */
+
+export interface CompletionEvent {
+  type?: string;
+  id?: string | number;
+  category?: DiscographyBucket;
+  status?: string;
+  owned_tracks?: number;
+  expected_tracks?: number;
+  completion_percentage?: number;
+  formats?: string[];
+  processed_count?: number;
+}
+
+/** Anything but 'missing' or 'error' counts as owned — including partials. */
+export function isEventOwned(event: CompletionEvent): boolean {
+  return event.status !== 'missing' && event.status !== 'error';
+}
+
+/**
+ * The track_completion an event implies.
+ *
+ * Three shapes, matching the vanilla exactly:
+ *   - owned with a known expectation -> the object form. When the library has
+ *     at least as many tracks as expected, `total_tracks` is clamped to the
+ *     OWNED count and the percentage forced to 100, so an album with bonus
+ *     tracks does not render as "13/12" or 108%.
+ *   - owned with no expectation -> owned/owned at 100%
+ *   - not owned -> the NUMBER 0, not an object. Downstream code branches on
+ *     typeof, so this distinction matters.
+ */
+export function completionFromEvent(
+  event: CompletionEvent,
+): { owned_tracks: number; total_tracks: number; percentage: number; missing_tracks: number } | 0 {
+  const owned = event.owned_tracks ?? 0;
+  const expected = event.expected_tracks ?? 0;
+
+  if (!isEventOwned(event)) return 0;
+
+  if (expected > 0) {
+    // `owned > 0` is redundant inside this branch — expected is already > 0,
+    // so owned >= expected implies owned > 0. Kept verbatim because it is what
+    // the vanilla wrote; it survives mutation for that reason, not for lack of
+    // a test.
+    const complete = owned >= expected && owned > 0;
+    return {
+      owned_tracks: owned,
+      total_tracks: complete ? owned : expected,
+      percentage: complete ? 100 : (event.completion_percentage ?? 0),
+      missing_tracks: expected - owned,
+    };
+  }
+
+  return { owned_tracks: owned, total_tracks: owned, percentage: 100, missing_tracks: 0 };
+}
+
+/**
+ * Apply one event to a discography, returning a new object.
+ *
+ * Matching is by release id as a STRING: the vanilla looked the card up with
+ * a `[data-release-id="..."]` selector, so a numeric id and its string form
+ * were the same card.
+ */
+export function applyCompletionEvent(
+  discography: Discography,
+  event: CompletionEvent,
+): Discography {
+  const targetId = String(event.id ?? '');
+  if (!targetId) return discography;
+
+  let changed = false;
+  const next: Discography = { ...discography };
+
+  for (const bucket of ['albums', 'eps', 'singles'] as const) {
+    const releases = discography[bucket];
+    if (!releases) continue;
+    const updated = releases.map((release) => {
+      if (String(release.id ?? '') !== targetId) return release;
+      changed = true;
+      return {
+        ...release,
+        owned: isEventOwned(event),
+        track_completion: completionFromEvent(event),
+      } as DiscographyRelease;
+    });
+    if (updated !== releases) next[bucket] = updated;
+  }
+
+  return changed ? next : discography;
+}
+
+export interface StreamCounts {
+  owned: Record<DiscographyBucket, number>;
+  total: Record<DiscographyBucket, number>;
+  formats: Set<string>;
+}
+
+export function emptyStreamCounts(): StreamCounts {
+  return {
+    owned: { albums: 0, eps: 0, singles: 0 },
+    total: { albums: 0, eps: 0, singles: 0 },
+    formats: new Set(),
+  };
+}
+
+/**
+ * Running tallies, mutated in place as the vanilla did.
+ *
+ * `total` counts EVERY completion event; `owned` only the owned ones — so
+ * "missing" for a category is total minus owned, never a separate counter.
+ * Formats accumulate from owned releases only.
+ */
+export function tallyEvent(counts: StreamCounts, event: CompletionEvent): StreamCounts {
+  const category = event.category;
+  if (!category || !(category in counts.total)) return counts;
+
+  counts.total[category] += 1;
+  if (isEventOwned(event)) {
+    counts.owned[category] += 1;
+    for (const format of event.formats ?? []) counts.formats.add(format);
+  }
+  return counts;
+}
+
+/** Parse the `data: ` frames out of an SSE chunk buffer. */
+export function parseSseFrames(buffer: string): { events: CompletionEvent[]; rest: string } {
+  const lines = buffer.split('\n');
+  // The last element is an INCOMPLETE line and must be carried forward, or a
+  // frame split across two chunks is silently dropped.
+  const rest = lines.pop() ?? '';
+  const events: CompletionEvent[] = [];
+
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue;
+    try {
+      events.push(JSON.parse(line.slice(6)) as CompletionEvent);
+    } catch {
+      // A malformed frame is skipped, not fatal — the vanilla warned and
+      // carried on so one bad event could not stall the whole stream.
+    }
+  }
+  return { events, rest };
+}
+
+/** The request body the stream endpoint expects. */
+export function completionStreamPayload(artistName: string, discography: Discography) {
+  return {
+    artist_name: artistName,
+    albums: discography.albums ?? [],
+    eps: discography.eps ?? [],
+    singles: discography.singles ?? [],
+    source: discography.source ?? null,
+  };
+}

--- a/webui/src/routes/artist-detail/-artist-detail.db-record.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.db-record.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  copyRecordText,
+  downloadRecord,
+  jsonHighlightTokens,
+  matchesRecordFilter,
+  recordFileName,
+  recordFooterStats,
+  recordRows,
+  showsDbRecordButton,
+} from './-artist-detail.db-record';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('showsDbRecordButton', () => {
+  it('is library-artists-only', () => {
+    expect(showsDbRecordButton({ id: 42 }, false)).toBe(true);
+    // No DB row to inspect for an artist that only exists on a source.
+    expect(showsDbRecordButton({ id: 'sp1' }, true)).toBe(false);
+    expect(showsDbRecordButton({}, false)).toBe(false);
+    expect(showsDbRecordButton(undefined, false)).toBe(false);
+  });
+});
+
+describe('recordRows', () => {
+  it('renders every empty shape as a single "null" row', () => {
+    const rows = recordRows({ a: null, b: undefined, c: '' });
+    expect(rows.every((r) => r.isEmpty && r.text === 'null')).toBe(true);
+  });
+
+  it('copies an EMPTY value as empty, not as the word null', () => {
+    // Copying "null" would be a lie about what the column holds.
+    expect(recordRows({ a: null })[0].copyValue).toBe('');
+  });
+
+  it('shows objects as compact JSON and copies the same string', () => {
+    const [row] = recordRows({ meta: { x: 1 } });
+    expect(row.isJson).toBe(true);
+    expect(row.text).toBe('{"x":1}');
+    expect(row.copyValue).toBe('{"x":1}');
+  });
+
+  it('stringifies scalars, including a falsy 0 and false', () => {
+    const rows = recordRows({ n: 0, b: false });
+    expect(rows.map((r) => [r.text, r.isEmpty])).toEqual([
+      ['0', false],
+      ['false', false],
+    ]);
+  });
+
+  it('indexes both the field NAME and its value for filtering', () => {
+    const [row] = recordRows({ Spotify_ID: 'ABC123' });
+    expect(row.filterKey).toBe('spotify_id abc123');
+  });
+});
+
+describe('matchesRecordFilter', () => {
+  const [row] = recordRows({ spotify_id: 'ABC123' });
+
+  it('matches on the field name or the value, case-insensitively', () => {
+    expect(matchesRecordFilter(row, 'SPOT')).toBe(true);
+    expect(matchesRecordFilter(row, 'abc')).toBe(true);
+    expect(matchesRecordFilter(row, 'deezer')).toBe(false);
+  });
+
+  it('shows everything for an empty or whitespace query', () => {
+    expect(matchesRecordFilter(row, '')).toBe(true);
+    expect(matchesRecordFilter(row, '   ')).toBe(true);
+  });
+});
+
+describe('recordFooterStats', () => {
+  it('counts fields, and sources by match_status === matched', () => {
+    const stats = recordFooterStats({
+      artist_id: 42,
+      counts: { albums: 12, tracks: 140 },
+      record: {
+        spotify_match_status: 'matched',
+        deezer_match_status: 'unmatched',
+        itunes_match_status: 'matched',
+        name: 'Aphex Twin',
+      },
+    });
+    expect(stats.fields).toBe(4);
+    expect(stats.matched).toBe(2);
+    expect(stats.albums).toBe('12');
+    expect(stats.tracks).toBe('140');
+    expect(stats.id).toBe('42');
+  });
+
+  it('counts only match_status FIELDS, not any field whose value is "matched"', () => {
+    // A free-text column that happens to say "matched" is not a matched source.
+    expect(
+      recordFooterStats({
+        record: {
+          spotify_artist_id: 'abc',
+          spotify_match_status: 'pending',
+          notes: 'matched',
+          last_action: 'matched',
+        },
+      }).matched,
+    ).toBe(0);
+  });
+
+  it('shows an en dash for an unknown count, not zero', () => {
+    const stats = recordFooterStats({ record: {} });
+    expect(stats.albums).toBe('–');
+    expect(stats.tracks).toBe('–');
+  });
+
+  it('keeps a real zero as zero', () => {
+    expect(recordFooterStats({ counts: { albums: 0 }, record: {} }).albums).toBe('0');
+  });
+});
+
+describe('jsonHighlightTokens', () => {
+  const tokens = jsonHighlightTokens({ name: 'Aphex', count: 12, ok: true, missing: null });
+  const classOf = (text: string) => tokens.find((t) => t.text === text)?.className;
+
+  it('classes keys apart from string values', () => {
+    // A key is a string token FOLLOWED by a colon — that colon is part of the
+    // match, which is why the two look different.
+    expect(classOf('"name":')).toBe('tok-key');
+    expect(classOf('"Aphex"')).toBe('tok-str');
+  });
+
+  it('classes numbers, booleans and nulls', () => {
+    expect(classOf('12')).toBe('tok-num');
+    expect(classOf('true')).toBe('tok-bool');
+    expect(classOf('null')).toBe('tok-null');
+  });
+
+  it('loses nothing — the tokens rejoin into the original JSON', () => {
+    const value = { a: [1, 2], b: 'x"y', c: -1.5e3 };
+    expect(
+      jsonHighlightTokens(value)
+        .map((t) => t.text)
+        .join(''),
+    ).toBe(JSON.stringify(value, null, 2));
+  });
+
+  it('survives an empty record', () => {
+    expect(
+      jsonHighlightTokens({})
+        .map((t) => t.text)
+        .join(''),
+    ).toBe('{}');
+  });
+});
+
+describe('recordFileName', () => {
+  it('replaces unsafe characters with underscores', () => {
+    expect(recordFileName('AC/DC: Live!')).toBe('AC_DC_Live__db_record.json');
+  });
+
+  it('caps the artist part at 60 characters', () => {
+    const name = recordFileName('a'.repeat(200));
+    expect(name).toBe(`${'a'.repeat(60)}_db_record.json`);
+  });
+
+  it('falls back to "artist" for an empty name', () => {
+    expect(recordFileName('')).toBe('artist_db_record.json');
+  });
+
+  it('does NOT fall back for a name that sanitises to punctuation', () => {
+    // '!!!' collapses to a single underscore, which is truthy, so the vanilla's
+    // `|| 'artist'` never fires. Reproduced rather than tidied.
+    expect(recordFileName('!!!')).toBe('__db_record.json');
+  });
+});
+
+describe('copyRecordText', () => {
+  it('uses the async clipboard in a secure context', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('isSecureContext', true);
+
+    await copyRecordText('hello');
+    expect(writeText).toHaveBeenCalledWith('hello');
+  });
+
+  it('falls back to a textarea over plain http EVEN WITH a clipboard available', async () => {
+    // SoulSync is usually served over http on a LAN, so this is the COMMON
+    // path. The browser still exposes navigator.clipboard there — it just
+    // rejects — so the secure-context check is what actually routes this.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('isSecureContext', false);
+    const exec = vi.fn().mockReturnValue(true);
+    document.execCommand = exec as never;
+
+    await copyRecordText('hello');
+    expect(writeText).not.toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith('copy');
+    // The textarea is removed again rather than left in the DOM.
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+
+  it('falls back when the clipboard write REJECTS', async () => {
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+    });
+    vi.stubGlobal('isSecureContext', true);
+    const exec = vi.fn().mockReturnValue(true);
+    document.execCommand = exec as never;
+
+    await copyRecordText('hello');
+    expect(exec).toHaveBeenCalledWith('copy');
+  });
+
+  it('copies an empty string rather than the text "null"', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('isSecureContext', true);
+
+    await copyRecordText(null);
+    expect(writeText).toHaveBeenCalledWith('');
+  });
+});
+
+describe('downloadRecord', () => {
+  it('saves pretty-printed JSON under the safe name and cleans up', () => {
+    const createObjectURL = vi.fn().mockReturnValue('blob:x');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+    vi.useFakeTimers();
+
+    const name = downloadRecord({ a: 1 }, 'Aphex Twin');
+
+    expect(name).toBe('Aphex_Twin_db_record.json');
+    expect(createObjectURL).toHaveBeenCalled();
+    // The anchor is not left behind in the body.
+    expect(document.querySelector('a[download]')).toBeNull();
+
+    vi.advanceTimersByTime(1000);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:x');
+    vi.useRealTimers();
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.db-record.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.db-record.ts
@@ -1,0 +1,215 @@
+/**
+ * The artist "DB Record" inspector, ported from setupArtistRecordButton /
+ * openArtistRecordModal and the _arec* helpers (library.js:9171-9300).
+ *
+ * The helpers stay in library.js as well: the watchlist/library Export modal
+ * reuses _arecEsc / _arecCopy / _jsonSyntaxHighlight, so the vanilla copies are
+ * still load-bearing for a page this migration has not reached.
+ */
+
+export interface ArtistRecordPayload {
+  success?: boolean;
+  error?: string;
+  artist_id?: string | number;
+  counts?: { albums?: number; tracks?: number };
+  record?: Record<string, unknown>;
+}
+
+export interface RecordRow {
+  key: string;
+  /** Empty values render as a dimmed literal "null", whatever their real type. */
+  isEmpty: boolean;
+  /** Objects are shown as compact JSON; everything else as its string form. */
+  isJson: boolean;
+  /** What the row displays, and what its copy button puts on the clipboard. */
+  text: string;
+  copyValue: string;
+  /** Lowercased "key value" haystack the filter matches against. */
+  filterKey: string;
+}
+
+export function recordRows(record: Record<string, unknown>): RecordRow[] {
+  return Object.entries(record).map(([key, value]) => {
+    const isEmpty = value === null || value === undefined || value === '';
+    if (isEmpty) {
+      // Copying an empty row yields '' — not the string "null", which would be
+      // a lie about what the column holds.
+      return {
+        key,
+        isEmpty,
+        isJson: false,
+        text: 'null',
+        copyValue: '',
+        filterKey: filterKeyFor(key, ''),
+      };
+    }
+    if (typeof value === 'object') {
+      const json = JSON.stringify(value);
+      return {
+        key,
+        isEmpty,
+        isJson: true,
+        text: json,
+        copyValue: json,
+        filterKey: filterKeyFor(key, json),
+      };
+    }
+    const text = String(value);
+    return {
+      key,
+      isEmpty,
+      isJson: false,
+      text,
+      copyValue: text,
+      filterKey: filterKeyFor(key, text),
+    };
+  });
+}
+
+function filterKeyFor(key: string, value: string): string {
+  return `${key.toLowerCase()} ${value.toLowerCase()}`;
+}
+
+/** The filter searches field NAMES and values alike, so "spotify" finds both. */
+export function matchesRecordFilter(row: RecordRow, query: string): boolean {
+  const q = (query || '').trim().toLowerCase();
+  return !q || row.filterKey.includes(q);
+}
+
+export interface RecordFooterStats {
+  fields: number;
+  albums: string;
+  tracks: string;
+  matched: number;
+  id: string;
+}
+
+/**
+ * The footer stat line.
+ *
+ * "sources matched" counts fields whose NAME ends in match_status and whose
+ * value is exactly 'matched' — a per-source enrichment tally, not a count of
+ * non-empty ids.
+ */
+export function recordFooterStats(payload: ArtistRecordPayload): RecordFooterStats {
+  const record = payload.record ?? {};
+  const counts = payload.counts ?? {};
+  return {
+    fields: Object.keys(record).length,
+    // An en dash, not 0: a missing count is unknown, not zero albums.
+    albums: counts.albums != null ? String(counts.albums) : '–',
+    tracks: counts.tracks != null ? String(counts.tracks) : '–',
+    matched: Object.entries(record).filter(
+      ([key, value]) => /match_status$/.test(key) && value === 'matched',
+    ).length,
+    id: String(payload.artist_id),
+  };
+}
+
+export interface JsonToken {
+  text: string;
+  /** null for the structural whitespace and punctuation between tokens. */
+  className: string | null;
+}
+
+const JSON_TOKEN =
+  /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false)\b|\bnull\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g;
+
+/**
+ * Split pretty-printed JSON into highlight tokens.
+ *
+ * The vanilla built an HTML string; this returns segments so React can render
+ * spans without dangerouslySetInnerHTML. The regex and the class names are
+ * verbatim — a key is a string token that is FOLLOWED by a colon, which is why
+ * the colon is captured as part of the match.
+ */
+export function jsonHighlightTokens(value: unknown): JsonToken[] {
+  const json = JSON.stringify(value, null, 2) ?? '';
+  const tokens: JsonToken[] = [];
+  let lastIndex = 0;
+
+  for (const match of json.matchAll(JSON_TOKEN)) {
+    const text = match[0];
+    const index = match.index ?? 0;
+    if (index > lastIndex) tokens.push({ text: json.slice(lastIndex, index), className: null });
+
+    let className = 'tok-num';
+    if (/^"/.test(text)) className = /:$/.test(text) ? 'tok-key' : 'tok-str';
+    else if (/true|false/.test(text)) className = 'tok-bool';
+    else if (/null/.test(text)) className = 'tok-null';
+
+    tokens.push({ text, className });
+    lastIndex = index + text.length;
+  }
+
+  if (lastIndex < json.length) tokens.push({ text: json.slice(lastIndex), className: null });
+  return tokens;
+}
+
+/** Filesystem-safe download name, capped at 60 characters. */
+export function recordFileName(artistName: string | undefined): string {
+  const safe = String(artistName || 'artist')
+    .replace(/[^a-z0-9._-]+/gi, '_')
+    .slice(0, 60);
+  return `${safe || 'artist'}_db_record.json`;
+}
+
+/**
+ * Copy text, falling back to a hidden textarea.
+ *
+ * navigator.clipboard only exists in a secure context, and SoulSync is very
+ * often served over plain http on a LAN — so the fallback is the common path,
+ * not an edge case.
+ */
+export async function copyRecordText(text: string | null | undefined): Promise<void> {
+  const value = text == null ? '' : String(text);
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return;
+    } catch {
+      // Permission denied or a detached document — fall through.
+    }
+  }
+  copyViaTextarea(value);
+}
+
+function copyViaTextarea(value: string): void {
+  const textarea = document.createElement('textarea');
+  textarea.value = value;
+  textarea.style.cssText = 'position:fixed;left:-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    document.execCommand('copy');
+  } catch {
+    // Nothing left to try; the toast still fires, as it did in the vanilla.
+  }
+  document.body.removeChild(textarea);
+}
+
+/** Save the record as a .json file. */
+export function downloadRecord(
+  record: Record<string, unknown>,
+  artistName: string | undefined,
+): string {
+  const fileName = recordFileName(artistName);
+  const blob = new Blob([JSON.stringify(record, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  return fileName;
+}
+
+/** The button only exists for LIBRARY artists — there is no row to inspect otherwise. */
+export function showsDbRecordButton(
+  artist: { id?: unknown } | undefined,
+  isSourceArtist: boolean,
+): boolean {
+  return Boolean(artist?.id) && !isSourceArtist;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  albumEnrichServices,
+  albumIdBadges,
+  albumMatchChips,
+  expandedHeaderDetails,
+  getAlbumTrackRows,
+  getServiceUrl,
+  normalizeExpectedMissingTrack,
+  serviceBadgeClass,
+  trackSlotKey,
+} from './-artist-detail.enhanced-album';
+
+afterEach(() => {
+  delete window.filterJiosaavnServiceEntries;
+});
+
+describe('getServiceUrl', () => {
+  it('builds a url per service and entity type', () => {
+    expect(getServiceUrl('spotify', 'album', 'abc')).toBe('https://open.spotify.com/album/abc');
+    expect(getServiceUrl('musicbrainz', 'album', 'x')).toBe('https://musicbrainz.org/release/x');
+    expect(getServiceUrl('discogs', 'album', '9')).toBe('https://www.discogs.com/release/9');
+  });
+
+  it('returns the value ITSELF for services that store a full url', () => {
+    // lastfm_url / genius_url / bandcamp_url are already complete links.
+    expect(getServiceUrl('lastfm', 'album', 'https://last.fm/x')).toBe('https://last.fm/x');
+    expect(getServiceUrl('bandcamp', 'album', 'https://x.bandcamp.com')).toBe(
+      'https://x.bandcamp.com',
+    );
+  });
+
+  it('is null for a service/entity pair that has no page', () => {
+    expect(getServiceUrl('discogs', 'track', '9')).toBeNull();
+    expect(getServiceUrl('amazon', 'artist', '9')).toBeNull();
+    expect(getServiceUrl('genius', 'album', '9')).toBeNull();
+  });
+
+  it('is null for an unknown service or a missing id', () => {
+    expect(getServiceUrl('napster', 'album', '1')).toBeNull();
+    expect(getServiceUrl('spotify', 'album', '')).toBeNull();
+    expect(getServiceUrl('spotify', 'album', null)).toBeNull();
+  });
+});
+
+describe('serviceBadgeClass', () => {
+  it('abbreviates only MusicBrainz', () => {
+    expect(serviceBadgeClass('musicbrainz')).toBe('mb');
+    expect(serviceBadgeClass('spotify')).toBe('spotify');
+  });
+});
+
+describe('albumIdBadges', () => {
+  it('emits a badge only for ids the album actually has', () => {
+    const badges = albumIdBadges({ spotify_album_id: 'sp1', deezer_id: '' });
+    expect(badges.map((b) => b.service)).toEqual(['spotify']);
+    expect(badges[0].url).toBe('https://open.spotify.com/album/sp1');
+    expect(badges[0].title).toBe('Spotify: sp1 (click to open)');
+    expect(badges[0].className).toBe('enhanced-id-badge spotify');
+  });
+
+  it('drops the click hint from a badge that is not a link', () => {
+    // JioSaavn is the one album service with no public page, so it is also the
+    // only way to reach the unlinked branch — and it only renders at all when
+    // the shared helper enables it.
+    window.filterJiosaavnServiceEntries = (entries) => entries as never[];
+    const [badge] = albumIdBadges({ jiosaavn_id: 'js1' });
+    expect(badge.url).toBeNull();
+    expect(badge.title).toBe('JioSaavn: js1');
+  });
+
+  it('hides JioSaavn unless the shared helper enables it', () => {
+    expect(albumIdBadges({ jiosaavn_id: 'js1' })).toEqual([]);
+    window.filterJiosaavnServiceEntries = (entries) => entries as never[];
+    expect(albumIdBadges({ jiosaavn_id: 'js1' }).map((b) => b.service)).toEqual(['jiosaavn']);
+  });
+
+  it('keeps the vanilla badge order', () => {
+    const badges = albumIdBadges({
+      itunes_album_id: 'i',
+      spotify_album_id: 's',
+      musicbrainz_release_id: 'm',
+    });
+    expect(badges.map((b) => b.service)).toEqual(['spotify', 'musicbrainz', 'itunes']);
+  });
+});
+
+describe('albumMatchChips', () => {
+  it('shows a chip for EVERY service, even an unmatched one', () => {
+    // "we never matched this" is the information the row carries.
+    const chips = albumMatchChips({});
+    expect(chips).toHaveLength(9);
+    expect(chips[0].status).toBe('—');
+    expect(chips[0].className).toContain('pending');
+  });
+
+  it('classes matched, not_found and anything else apart', () => {
+    const chips = albumMatchChips({
+      spotify_match_status: 'matched',
+      musicbrainz_match_status: 'not_found',
+      deezer_match_status: 'queued',
+    });
+    expect(chips[0].className).toContain('matched');
+    expect(chips[1].className).toContain('not-found');
+    expect(chips[2].className).toContain('pending');
+  });
+
+  it('mentions the last attempt in the tooltip when there was one', () => {
+    const [chip] = albumMatchChips({ spotify_last_attempted: '2026-01-02T03:04:05Z' });
+    expect(chip.title).toContain('Last:');
+    expect(chip.title).toContain('Click to rematch');
+  });
+
+  it('says only "Click to rematch" when it has never been attempted', () => {
+    expect(albumMatchChips({})[0].title).toBe('Click to rematch');
+  });
+});
+
+describe('albumEnrichServices', () => {
+  it('lists the enrichment sources, JioSaavn excluded by default', () => {
+    expect(albumEnrichServices().map((s) => s.id)).toEqual([
+      'spotify',
+      'musicbrainz',
+      'deezer',
+      'discogs',
+      'audiodb',
+      'itunes',
+      'lastfm',
+      'genius',
+      'bandcamp',
+    ]);
+  });
+});
+
+describe('trackSlotKey', () => {
+  it('defaults disc 1 and track 0', () => {
+    expect(trackSlotKey({})).toBe('1:0');
+    expect(trackSlotKey({ disc_number: 2, track_number: 5 })).toBe('2:5');
+  });
+
+  it('falls back to the expected_* fields of a missing row', () => {
+    expect(trackSlotKey({ expected_disc_number: 2, expected_track_number: 3 })).toBe('2:3');
+  });
+});
+
+describe('normalizeExpectedMissingTrack', () => {
+  const album = { id: 42 };
+
+  it('flattens a source row into the shape a track row expects', () => {
+    const row = normalizeExpectedMissingTrack(
+      { title: 'Xtal', track_number: 1, disc_number: 1, source: 'spotify', track_id: 'sp9' },
+      album,
+    );
+    expect(row.id).toBe('missing-42-1-1');
+    expect(row.spotify_track_id).toBe('sp9');
+    expect(row._missingExpected).toBe(true);
+    expect(row._hasActionableContext).toBe(true);
+  });
+
+  it('routes the source id to the field for its own source only', () => {
+    const row = normalizeExpectedMissingTrack(
+      { title: 'X', track_number: 1, source: 'deezer', track_id: 'dz1' },
+      album,
+    );
+    expect(row.deezer_id).toBe('dz1');
+    expect(row.spotify_track_id).toBe('');
+  });
+
+  it('is NOT actionable without a track number or any source id', () => {
+    // Nothing the row's buttons could act on; the row is dropped rather than
+    // rendered inert.
+    expect(
+      normalizeExpectedMissingTrack({ title: 'X', track_number: 1 }, album)._hasActionableContext,
+    ).toBe(false);
+    expect(
+      normalizeExpectedMissingTrack({ title: 'X', track_id: 'a' }, album)._hasActionableContext,
+    ).toBe(false);
+  });
+
+  it('names an untitled row by its track number', () => {
+    expect(normalizeExpectedMissingTrack({ track_number: 3 }, album).title).toBe('Track 3');
+    expect(normalizeExpectedMissingTrack({}, album).title).toBe('Track ?');
+  });
+});
+
+describe('getAlbumTrackRows', () => {
+  it('keys owned tracks by ID, so a shared disc:track slot cannot eat one', () => {
+    // #1051: multi-disc albums whose tags all claim disc 1 make disc1-track1
+    // and disc2-track1 share a slot. Keying by slot dropped one of them.
+    const rows = getAlbumTrackRows({
+      tracks: [
+        { id: 1, track_number: 1, disc_number: 1, title: 'A' },
+        { id: 2, track_number: 1, disc_number: 1, title: 'B' },
+      ],
+    });
+    expect(rows).toHaveLength(2);
+  });
+
+  it('merges expected-missing tracks that are not already owned', () => {
+    const rows = getAlbumTrackRows({
+      id: 42,
+      tracks: [{ id: 1, track_number: 1, disc_number: 1, title: 'Owned' }],
+      missing_tracks: [
+        { title: 'Missing', track_number: 2, disc_number: 1, source: 'spotify', track_id: 's2' },
+      ],
+    });
+    expect(rows.map((r) => r.title)).toEqual(['Owned', 'Missing']);
+  });
+
+  it('does NOT re-add a missing track whose slot is already owned', () => {
+    const rows = getAlbumTrackRows({
+      id: 42,
+      tracks: [{ id: 1, track_number: 1, disc_number: 1, title: 'Owned' }],
+      missing_tracks: [
+        { title: 'Dup', track_number: 1, disc_number: 1, source: 'spotify', track_id: 's1' },
+      ],
+    });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('drops a missing track with no actionable context', () => {
+    const rows = getAlbumTrackRows({
+      id: 42,
+      tracks: [],
+      missing_tracks: [{ title: 'Nothing to do', track_number: 2 }],
+    });
+    expect(rows).toEqual([]);
+  });
+
+  it('sorts by disc, then track, then title', () => {
+    const rows = getAlbumTrackRows({
+      tracks: [
+        { id: 1, disc_number: 2, track_number: 1, title: 'D2T1' },
+        { id: 2, disc_number: 1, track_number: 2, title: 'D1T2' },
+        { id: 3, disc_number: 1, track_number: 1, title: 'B' },
+        { id: 4, disc_number: 1, track_number: 1, title: 'A' },
+      ],
+    });
+    expect(rows.map((r) => r.title)).toEqual(['A', 'B', 'D1T2', 'D2T1']);
+  });
+
+  it('survives an album with no tracks at all', () => {
+    expect(getAlbumTrackRows({})).toEqual([]);
+  });
+});
+
+describe('expandedHeaderDetails', () => {
+  it('builds the full detail line in order', () => {
+    const album = {
+      year: 1992,
+      label: 'Apollo',
+      record_type: 'album',
+      tracks: [{ duration: 300_000 }, { duration: 60_000 }],
+    };
+    expect(expandedHeaderDetails(album, getAlbumTrackRows(album))).toBe(
+      '1992 · 2 tracks · 6:00 · Apollo · ALBUM',
+    );
+  });
+
+  it('reads owned/expected only when the album is INCOMPLETE', () => {
+    const incomplete = { tracks: [{ id: 1 }], api_track_count: 12 };
+    expect(expandedHeaderDetails(incomplete, getAlbumTrackRows(incomplete))).toBe('1/12 tracks');
+
+    const complete = { tracks: [{ id: 1 }], api_track_count: 1 };
+    expect(expandedHeaderDetails(complete, getAlbumTrackRows(complete))).toBe('1 track');
+  });
+
+  it('never lets an under-reporting source make an album look over-full', () => {
+    // Expected is the LARGEST of owned / rendered / claimed.
+    const album = { tracks: [{ id: 1 }, { id: 2 }], api_track_count: 1 };
+    expect(expandedHeaderDetails(album, getAlbumTrackRows(album))).toBe('2 tracks');
+  });
+
+  it('counts the missing rows separately', () => {
+    const album = {
+      id: 42,
+      tracks: [{ id: 1, track_number: 1 }],
+      api_track_count: 2,
+      missing_tracks: [{ title: 'M', track_number: 2, source: 'spotify', track_id: 's' }],
+    };
+    expect(expandedHeaderDetails(album, getAlbumTrackRows(album))).toBe('1/2 tracks · 1 missing');
+  });
+
+  it('counts the RENDERED rows toward expected, even with no claimed count', () => {
+    // A source that never reported a track count still has its missing rows
+    // shown, and those rows are part of what the album is expected to contain.
+    const album = {
+      id: 42,
+      tracks: [{ id: 1, track_number: 1 }],
+      missing_tracks: [{ title: 'M', track_number: 2, source: 'spotify', track_id: 's' }],
+    };
+    expect(expandedHeaderDetails(album, getAlbumTrackRows(album))).toBe('1/2 tracks · 1 missing');
+  });
+
+  it('says so while the canonical tracklist is still loading', () => {
+    expect(expandedHeaderDetails({ _canonicalTracksLoading: true, tracks: [] }, [])).toBe(
+      'checking tracklist · 0 tracks',
+    );
+  });
+
+  it('omits a zero duration rather than printing the dash sentinel', () => {
+    expect(expandedHeaderDetails({ tracks: [{ id: 1 }] }, [])).toBe('1 track');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   albumEnrichServices,
+  sortedTrackRows,
   inlineEditDisplay,
   inlineEditInput,
   inlineEditUrl,
@@ -603,5 +604,43 @@ describe('inlineEditUrl', () => {
   it('routes each entity to its own endpoint', () => {
     expect(inlineEditUrl('track', 5)).toBe('/api/library/track/5');
     expect(inlineEditUrl('album', 9)).toBe('/api/library/album/9');
+  });
+});
+
+describe('sortedTrackRows', () => {
+  const owned = (id: number, title: string, bpm?: number) => ({ id, title, bpm });
+  const missing = (id: string, title: string) => ({ id, title, _missingExpected: true });
+
+  it('is the input, untouched, with no active sort', () => {
+    const rows = [owned(1, 'B'), owned(2, 'A')];
+    expect(sortedTrackRows(rows, undefined)).toBe(rows);
+  });
+
+  it('sorts the owned rows', () => {
+    const sorted = sortedTrackRows([owned(1, 'B'), owned(2, 'A')], {
+      field: 'title',
+      ascending: true,
+    });
+    expect(sorted.map((r) => r.title)).toEqual(['A', 'B']);
+  });
+
+  it('sinks missing rows in BOTH directions', () => {
+    const rows = [missing('m1', 'AAA'), owned(1, 'B'), owned(2, 'C')];
+    for (const ascending of [true, false]) {
+      const sorted = sortedTrackRows(rows, { field: 'title', ascending });
+      expect(sorted.at(-1)?.title).toBe('AAA');
+    }
+  });
+
+  it('keeps missing rows in their own order among themselves', () => {
+    const rows = [missing('m1', 'first'), missing('m2', 'second')];
+    const sorted = sortedTrackRows(rows, { field: 'title', ascending: false });
+    expect(sorted.map((r) => r.title)).toEqual(['first', 'second']);
+  });
+
+  it('does not mutate the input', () => {
+    const rows = [owned(1, 'B'), owned(2, 'A')];
+    sortedTrackRows(rows, { field: 'title', ascending: true });
+    expect(rows.map((r) => r.title)).toEqual(['B', 'A']);
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
@@ -2,6 +2,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   albumEnrichServices,
+  albumMetaFields,
+  albumMetaUpdates,
+  deriveMissingTracks,
+  getAlbumCanonicalSource,
+  normalizeCanonicalTracks,
+  normTitleForMatch,
   albumIdBadges,
   albumMatchChips,
   expandedHeaderDetails,
@@ -301,5 +307,244 @@ describe('expandedHeaderDetails', () => {
 
   it('omits a zero duration rather than printing the dash sentinel', () => {
     expect(expandedHeaderDetails({ tracks: [{ id: 1 }] }, [])).toBe('1 track');
+  });
+});
+
+describe('albumMetaFields', () => {
+  it('joins genres into one comma string for the form', () => {
+    const fields = albumMetaFields({ genres: ['ambient', 'idm'] });
+    expect(fields.find((f) => f.key === 'genres')?.value).toBe('ambient, idm');
+  });
+
+  it('keeps a non-array genres value as-is', () => {
+    expect(albumMetaFields({ genres: 'ambient' }).find((f) => f.key === 'genres')?.value).toBe(
+      'ambient',
+    );
+  });
+
+  it('renders explicit as the string 1 or 0, not a boolean', () => {
+    expect(albumMetaFields({ explicit: true }).find((f) => f.key === 'explicit')?.value).toBe('1');
+    expect(albumMetaFields({}).find((f) => f.key === 'explicit')?.value).toBe('0');
+  });
+
+  it('defaults the type to album, and everything else to empty', () => {
+    const fields = albumMetaFields({});
+    expect(fields.find((f) => f.key === 'record_type')?.value).toBe('album');
+    expect(fields.find((f) => f.key === 'title')?.value).toBe('');
+  });
+
+  it('keeps the vanilla field order', () => {
+    expect(albumMetaFields({}).map((f) => f.key)).toEqual([
+      'title',
+      'year',
+      'release_date',
+      'genres',
+      'label',
+      'style',
+      'mood',
+      'record_type',
+      'explicit',
+    ]);
+  });
+});
+
+describe('albumMetaUpdates', () => {
+  const album = { title: 'SAW', year: 1992, genres: ['ambient'], label: 'Apollo' };
+
+  it('sends ONLY the fields that changed', () => {
+    // Sending everything would clobber columns another process touched between
+    // load and save.
+    const { updates } = albumMetaUpdates(album, { title: 'SAW', label: 'Warp' });
+    expect(updates).toEqual({ label: 'Warp' });
+  });
+
+  it('ALWAYS reports explicit:0 for a non-explicit album', () => {
+    // `album.explicit || null` reads a falsy 0 as null, so 0 !== null every
+    // time. Verbatim vanilla — a save on such an album is never a no-op.
+    expect(albumMetaUpdates({ explicit: 0 }, { explicit: '0' }).updates).toEqual({ explicit: 0 });
+    expect(albumMetaUpdates({}, { explicit: '0' }).updates).toEqual({ explicit: 0 });
+    // An album that IS explicit compares cleanly.
+    expect(albumMetaUpdates({ explicit: 1 }, { explicit: '1' }).updates).toEqual({});
+  });
+
+  it('sends null — not an empty string — for a cleared field', () => {
+    expect(albumMetaUpdates(album, { label: '' }).updates).toEqual({ label: null });
+  });
+
+  it('parses numeric fields, and nulls an emptied one', () => {
+    expect(albumMetaUpdates(album, { year: '1993' }).updates).toEqual({ year: 1993 });
+    expect(albumMetaUpdates(album, { year: '' }).updates).toEqual({ year: null });
+    expect(albumMetaUpdates(album, { year: '1992' }).updates).toEqual({});
+  });
+
+  it('compares genres as a LIST, not as the joined string', () => {
+    expect(albumMetaUpdates(album, { genres: 'ambient' }).updates).toEqual({});
+    expect(albumMetaUpdates(album, { genres: 'ambient, idm' }).updates).toEqual({
+      genres: ['ambient', 'idm'],
+    });
+    expect(albumMetaUpdates(album, { genres: '' }).updates).toEqual({ genres: [] });
+  });
+
+  it('drops blank entries from a sloppy genre list', () => {
+    expect(albumMetaUpdates(album, { genres: 'ambient, , idm,' }).updates).toEqual({
+      genres: ['ambient', 'idm'],
+    });
+  });
+
+  it('accepts a year, a year-month or a full release date (#824)', () => {
+    for (const value of ['1992', '1992-11', '1992-11-08']) {
+      expect(albumMetaUpdates(album, { release_date: value }).invalidDate).toBe(false);
+    }
+  });
+
+  it('flags a malformed release date and saves NOTHING from that field', () => {
+    const result = albumMetaUpdates(album, { release_date: '08/11/1992', label: 'Warp' });
+    expect(result.invalidDate).toBe(true);
+    expect(result.updates.release_date).toBeUndefined();
+  });
+
+  it('accepts an EMPTY release date as a clear', () => {
+    const result = albumMetaUpdates({ release_date: '1992' }, { release_date: '' });
+    expect(result.invalidDate).toBe(false);
+    expect(result.updates).toEqual({ release_date: null });
+  });
+
+  it('trims before comparing, so whitespace alone is not a change', () => {
+    expect(albumMetaUpdates(album, { title: '  SAW  ' }).updates).toEqual({});
+  });
+});
+
+describe('normTitleForMatch', () => {
+  it('collapses different separators to the same key', () => {
+    expect(normTitleForMatch('X (Main Theme)')).toBe(normTitleForMatch('X - Main Theme'));
+  });
+
+  it('KEEPS bracket content — that is what makes editions line up', () => {
+    expect(normTitleForMatch('X (Main Theme)')).toBe('x main theme');
+  });
+
+  it('removes a featured credit in brackets or trailing', () => {
+    expect(normTitleForMatch('Song (feat. Y)')).toBe('song');
+    expect(normTitleForMatch('Song [ft Y]')).toBe('song');
+    expect(normTitleForMatch('Song feat. Y and Z')).toBe('song');
+  });
+
+  it('is empty for junk', () => {
+    expect(normTitleForMatch(null)).toBe('');
+    expect(normTitleForMatch('!!!')).toBe('');
+  });
+});
+
+describe('getAlbumCanonicalSource', () => {
+  it('prefers Spotify, then Deezer, then iTunes', () => {
+    expect(getAlbumCanonicalSource({ deezer_id: 'd', spotify_album_id: 's' })).toEqual({
+      source: 'spotify',
+      id: 's',
+    });
+    expect(getAlbumCanonicalSource({ itunes_album_id: 'i', deezer_id: 'd' })).toEqual({
+      source: 'deezer',
+      id: 'd',
+    });
+  });
+
+  it('is null when the album is matched to nothing', () => {
+    expect(getAlbumCanonicalSource({})).toBeNull();
+  });
+});
+
+describe('deriveMissingTracks', () => {
+  const canonical = (n: number, title: string, disc = 1) => ({
+    track_number: n,
+    disc_number: disc,
+    title,
+    name: title,
+    source: 'spotify',
+    track_id: `s${n}`,
+  });
+
+  it('matches by disc:track slot first', () => {
+    const album = { id: 1, tracks: [{ id: 1, track_number: 1, disc_number: 1, title: 'Owned' }] };
+    expect(deriveMissingTracks(album, [canonical(1, 'Different Title')])).toEqual([]);
+  });
+
+  it('falls back to TITLE when every owned track claims disc 1 (#916)', () => {
+    // The scanner does not split discs, so a strict slot match would report
+    // every canonical disc-2 track as missing.
+    const album = {
+      id: 1,
+      tracks: [{ id: 1, track_number: 1, disc_number: 1, title: 'Disc Two Opener' }],
+    };
+    expect(deriveMissingTracks(album, [canonical(1, 'Disc Two Opener', 2)])).toEqual([]);
+  });
+
+  it('consumes each owned track once, so a duplicate title still counts missing', () => {
+    const album = { id: 1, tracks: [{ id: 1, track_number: 9, disc_number: 1, title: 'Same' }] };
+    const missing = deriveMissingTracks(album, [canonical(1, 'Same'), canonical(2, 'Same')]);
+    expect(missing).toHaveLength(1);
+  });
+
+  it('does NOT let two untitled tracks match each other', () => {
+    // Both normalise to an empty key; matching on that would silently mark a
+    // missing track as owned.
+    const album = { id: 1, tracks: [{ id: 1, track_number: 9, disc_number: 1, title: '!!!' }] };
+    const missing = deriveMissingTracks(album, [
+      {
+        track_number: 1,
+        disc_number: 1,
+        title: '???',
+        name: '???',
+        source: 'spotify',
+        track_id: 's1',
+      },
+    ]);
+    expect(missing).toHaveLength(1);
+  });
+
+  it('reports a genuinely absent track', () => {
+    const album = { id: 1, tracks: [] };
+    const missing = deriveMissingTracks(album, [canonical(1, 'Gone')]);
+    expect(missing[0].name).toBe('Gone');
+  });
+
+  it('skips a canonical track with no usable slot or context', () => {
+    const album = { id: 1, tracks: [] };
+    expect(deriveMissingTracks(album, [{ title: 'No number' }])).toEqual([]);
+  });
+
+  it('carries a duration through under duration_ms', () => {
+    const album = { id: 1, tracks: [] };
+    const [row] = deriveMissingTracks(album, [{ ...canonical(1, 'X'), duration: 1234 }]);
+    expect(row.duration_ms).toBe(1234);
+  });
+});
+
+describe('normalizeCanonicalTracks', () => {
+  it('fills in title, name, numbers and duration', () => {
+    const [row] = normalizeCanonicalTracks(
+      [{ id: 'a', name: 'X', duration_ms: 500 }],
+      'spotify',
+      'al1',
+    );
+    expect(row.title).toBe('X');
+    expect(row.track_number).toBe(1);
+    expect(row.disc_number).toBe(1);
+    expect(row.duration).toBe(500);
+    expect(row.track_id).toBe('a');
+  });
+
+  it('SYNTHESISES an id when the source gives none', () => {
+    // Without a stable key the row cannot be tracked across a re-render.
+    const [row] = normalizeCanonicalTracks([{ name: 'X', track_number: 4 }], 'deezer', 'al1');
+    expect(row.id).toBe('deezer:al1:1:4');
+  });
+
+  it('names an untitled track by its position', () => {
+    const rows = normalizeCanonicalTracks([{}, {}], 'spotify', 'al1');
+    expect(rows.map((r) => r.title)).toEqual(['Track 1', 'Track 2']);
+  });
+
+  it('prefers the source the PAYLOAD reports over the one we asked for', () => {
+    const [row] = normalizeCanonicalTracks([{ id: 'a' }], 'spotify', 'al1', 'spotify_free');
+    expect(row.source).toBe('spotify_free');
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   albumEnrichServices,
+  inlineEditDisplay,
+  inlineEditInput,
+  inlineEditUrl,
+  inlineEditValue,
   albumMetaFields,
   albumMetaUpdates,
   deriveMissingTracks,
@@ -546,5 +550,58 @@ describe('normalizeCanonicalTracks', () => {
   it('prefers the source the PAYLOAD reports over the one we asked for', () => {
     const [row] = normalizeCanonicalTracks([{ id: 'a' }], 'spotify', 'al1', 'spotify_free');
     expect(row.source).toBe('spotify_free');
+  });
+});
+
+describe('inlineEditValue', () => {
+  it('parses whole numbers for the track and disc slots', () => {
+    expect(inlineEditValue('track_number', '7.9')).toBe(7);
+    expect(inlineEditValue('disc_number', '2')).toBe(2);
+  });
+
+  it('keeps BPM fractional', () => {
+    expect(inlineEditValue('bpm', '128.5')).toBe(128.5);
+  });
+
+  it('CLEARS a number to null so the field can be emptied', () => {
+    expect(inlineEditValue('bpm', '')).toBeNull();
+    expect(inlineEditValue('track_number', 'abc')).toBeNull();
+  });
+
+  it('floors explicit to 0, never null — the column is a flag', () => {
+    // A flag has no "unknown" state, so an empty input means "not explicit".
+    expect(inlineEditValue('explicit', '')).toBe(0);
+    expect(inlineEditValue('explicit', 'x')).toBe(0);
+    expect(inlineEditValue('explicit', '1')).toBe(1);
+  });
+
+  it('passes text through untouched', () => {
+    expect(inlineEditValue('title', '  Xtal ')).toBe('  Xtal ');
+  });
+});
+
+describe('inlineEditDisplay', () => {
+  it('shows a dash for a cleared value', () => {
+    expect(inlineEditDisplay(null)).toBe('-');
+    expect(inlineEditDisplay('')).toBe('-');
+  });
+
+  it('shows a real zero rather than a dash', () => {
+    expect(inlineEditDisplay(0)).toBe('0');
+  });
+});
+
+describe('inlineEditInput', () => {
+  it('is a number box for the numeric fields only', () => {
+    expect(inlineEditInput('bpm').type).toBe('number');
+    expect(inlineEditInput('title').type).toBe('text');
+    expect(inlineEditInput('title').className).not.toContain('num');
+  });
+});
+
+describe('inlineEditUrl', () => {
+  it('routes each entity to its own endpoint', () => {
+    expect(inlineEditUrl('track', 5)).toBe('/api/library/track/5');
+    expect(inlineEditUrl('album', 9)).toBe('/api/library/album/9');
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -701,3 +701,50 @@ export function trackFileName(track: EnhancedTrack): string {
   if ((track as { _missingExpected?: boolean })._missingExpected) return 'Missing from library';
   return path !== '-' ? String(path).split(/[\\/]/).pop() || '-' : '-';
 }
+
+/**
+ * The queue payload for a library track.
+ *
+ * `is_library: true` is what tells the player this is a local file rather than
+ * something to stream, and the art falls back to the ARTIST thumbnail so a
+ * queued track from an album with no cover still shows something.
+ */
+export function queueTrackPayload(
+  track: EnhancedTrack,
+  album: EnhancedAlbum,
+  artist: Record<string, unknown> | undefined,
+) {
+  return {
+    title: track.title || 'Unknown Track',
+    artist: String(artist?.name || '') || 'Unknown Artist',
+    album: album.title || 'Unknown Album',
+    file_path: track.file_path,
+    filename: track.file_path,
+    is_library: true,
+    image_url: album.thumb_url || artist?.thumb_url || null,
+    id: track.id,
+    artist_id: artist?.id ?? null,
+    album_id: album.id,
+    bitrate: track.bitrate,
+    sample_rate: track.sample_rate,
+  };
+}
+
+/**
+ * The default search text when re-matching a TRACK.
+ *
+ * Bandcamp alone gets the album name alongside the title: it searches release
+ * pages, and a bare track title is ambiguous across compilations, remixes and
+ * covers. Every other service takes an id directly and searched better with the
+ * bare title.
+ */
+export function trackMatchQuery(
+  service: string,
+  track: EnhancedTrack,
+  album: EnhancedAlbum,
+): string {
+  if (service === 'bandcamp') {
+    return [album.title, track.title].filter(Boolean).join(' ');
+  }
+  return String(track.title || '');
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -1,0 +1,357 @@
+import type { EnhancedAlbum, EnhancedTrack } from './-artist-detail.enhanced';
+
+import { formatDurationMs } from './-artist-detail.enhanced';
+import { filterJiosaavnEntries } from './-artist-detail.enrichment';
+
+/**
+ * The expanded album header, ported from renderExpandedAlbumHeader,
+ * _getEnhancedAlbumTrackRows, _trackSlotKey, _normalizeExpectedMissingTrack,
+ * getServiceUrl and makeClickableBadge (library.js:3783-4012, 5917).
+ */
+
+/** External links per service and entity type; null when the service has none. */
+export function getServiceUrl(service: string, entityType: string, id: unknown): string | null {
+  if (!id) return null;
+  const urls: Record<string, Record<string, string>> = {
+    spotify: {
+      artist: `https://open.spotify.com/artist/${id}`,
+      album: `https://open.spotify.com/album/${id}`,
+      track: `https://open.spotify.com/track/${id}`,
+    },
+    musicbrainz: {
+      artist: `https://musicbrainz.org/artist/${id}`,
+      album: `https://musicbrainz.org/release/${id}`,
+      track: `https://musicbrainz.org/recording/${id}`,
+    },
+    deezer: {
+      artist: `https://www.deezer.com/artist/${id}`,
+      album: `https://www.deezer.com/album/${id}`,
+      track: `https://www.deezer.com/track/${id}`,
+    },
+    audiodb: {
+      artist: `https://www.theaudiodb.com/artist/${id}`,
+      album: `https://www.theaudiodb.com/album/${id}`,
+      track: `https://www.theaudiodb.com/track/${id}`,
+    },
+    itunes: {
+      artist: `https://music.apple.com/artist/${id}`,
+      album: `https://music.apple.com/album/${id}`,
+      track: `https://music.apple.com/song/${id}`,
+    },
+    // Last.fm, Genius and Bandcamp store a FULL url rather than an id, so the
+    // "url" here is the value itself.
+    lastfm: { artist: String(id), album: String(id), track: String(id) },
+    genius: { artist: String(id), track: String(id) },
+    tidal: {
+      artist: `https://tidal.com/browse/artist/${id}`,
+      album: `https://tidal.com/browse/album/${id}`,
+      track: `https://tidal.com/browse/track/${id}`,
+    },
+    qobuz: {
+      artist: `https://www.qobuz.com/artist/${id}`,
+      album: `https://www.qobuz.com/album/${id}`,
+      track: `https://www.qobuz.com/track/${id}`,
+    },
+    // Discogs has no per-track page, and Amazon no artist page.
+    discogs: {
+      artist: `https://www.discogs.com/artist/${id}`,
+      album: `https://www.discogs.com/release/${id}`,
+    },
+    amazon: {
+      album: `https://music.amazon.com/albums/${id}`,
+      track: `https://music.amazon.com/tracks/${id}`,
+    },
+    bandcamp: { artist: String(id), album: String(id), track: String(id) },
+  };
+  return urls[service]?.[entityType] || null;
+}
+
+/** MusicBrainz's badge class is abbreviated; everything else uses its own name. */
+export function serviceBadgeClass(service: string): string {
+  return service === 'musicbrainz' ? 'mb' : service;
+}
+
+export interface AlbumIdBadge {
+  service: string;
+  label: string;
+  id: string;
+  url: string | null;
+  className: string;
+  title: string;
+}
+
+const ALBUM_ID_FIELDS = [
+  { key: 'spotify_album_id', label: 'Spotify', svc: 'spotify' },
+  { key: 'musicbrainz_release_id', label: 'MusicBrainz', svc: 'musicbrainz' },
+  { key: 'deezer_id', label: 'Deezer', svc: 'deezer' },
+  { key: 'jiosaavn_id', label: 'JioSaavn', svc: 'jiosaavn' },
+  { key: 'audiodb_id', label: 'AudioDB', svc: 'audiodb' },
+  { key: 'discogs_id', label: 'Discogs', svc: 'discogs' },
+  { key: 'itunes_album_id', label: 'iTunes', svc: 'itunes' },
+  { key: 'lastfm_url', label: 'Last.fm', svc: 'lastfm' },
+  { key: 'bandcamp_url', label: 'Bandcamp', svc: 'bandcamp' },
+];
+
+/** One badge per id the album actually has; a service with no id is skipped. */
+export function albumIdBadges(album: EnhancedAlbum): AlbumIdBadge[] {
+  return filterJiosaavnEntries(ALBUM_ID_FIELDS, 'svc')
+    .filter((field) => album[field.key])
+    .map((field) => {
+      const id = String(album[field.key]);
+      const url = getServiceUrl(field.svc, 'album', id);
+      return {
+        service: field.svc,
+        label: field.label,
+        id,
+        url,
+        className: `enhanced-id-badge ${serviceBadgeClass(field.svc)}`,
+        // A badge with no link says so by omitting the "click to open" hint.
+        title: url ? `${field.label}: ${id} (click to open)` : `${field.label}: ${id}`,
+      };
+    });
+}
+
+export interface AlbumMatchChip {
+  service: string;
+  label: string;
+  status: string;
+  className: string;
+  title: string;
+}
+
+const ALBUM_MATCH_SERVICES = [
+  {
+    key: 'spotify_match_status',
+    label: 'Spotify',
+    attempted: 'spotify_last_attempted',
+    svc: 'spotify',
+  },
+  {
+    key: 'musicbrainz_match_status',
+    label: 'MB',
+    attempted: 'musicbrainz_last_attempted',
+    svc: 'musicbrainz',
+  },
+  {
+    key: 'deezer_match_status',
+    label: 'Deezer',
+    attempted: 'deezer_last_attempted',
+    svc: 'deezer',
+  },
+  {
+    key: 'jiosaavn_match_status',
+    label: 'JioSaavn',
+    attempted: 'jiosaavn_last_attempted',
+    svc: 'jiosaavn',
+  },
+  {
+    key: 'audiodb_match_status',
+    label: 'AudioDB',
+    attempted: 'audiodb_last_attempted',
+    svc: 'audiodb',
+  },
+  {
+    key: 'discogs_match_status',
+    label: 'Discogs',
+    attempted: 'discogs_last_attempted',
+    svc: 'discogs',
+  },
+  {
+    key: 'itunes_match_status',
+    label: 'iTunes',
+    attempted: 'itunes_last_attempted',
+    svc: 'itunes',
+  },
+  {
+    key: 'lastfm_match_status',
+    label: 'Last.fm',
+    attempted: 'lastfm_last_attempted',
+    svc: 'lastfm',
+  },
+  {
+    key: 'amazon_match_status',
+    label: 'Amazon',
+    attempted: 'amazon_last_attempted',
+    svc: 'amazon',
+  },
+  {
+    key: 'bandcamp_match_status',
+    label: 'Bandcamp',
+    attempted: 'bandcamp_last_attempted',
+    svc: 'bandcamp',
+  },
+];
+
+/**
+ * A chip per service, ALWAYS — an unmatched service shows an em dash rather
+ * than disappearing, because "we never matched this" is the information.
+ */
+export function albumMatchChips(album: EnhancedAlbum): AlbumMatchChip[] {
+  return filterJiosaavnEntries(ALBUM_MATCH_SERVICES, 'svc').map((service) => {
+    const status = album[service.key] as string | undefined;
+    const attempted = album[service.attempted];
+    const state =
+      status === 'matched' ? 'matched' : status === 'not_found' ? 'not-found' : 'pending';
+    const tip: string[] = [];
+    if (attempted) tip.push(`Last: ${new Date(String(attempted)).toLocaleString()}`);
+    tip.push('Click to rematch');
+    return {
+      service: service.svc,
+      label: service.label,
+      status: status || '—',
+      className: `enhanced-match-chip clickable ${state}`,
+      title: tip.join(' · '),
+    };
+  });
+}
+
+export const ALBUM_ENRICH_SERVICES = [
+  { id: 'spotify', label: 'Spotify', icon: '🟢' },
+  { id: 'musicbrainz', label: 'MusicBrainz', icon: '🟠' },
+  { id: 'deezer', label: 'Deezer', icon: '🟣' },
+  { id: 'jiosaavn', label: 'JioSaavn', icon: '🎵' },
+  { id: 'discogs', label: 'Discogs', icon: '🟤' },
+  { id: 'audiodb', label: 'AudioDB', icon: '🔵' },
+  { id: 'itunes', label: 'iTunes', icon: '🔴' },
+  { id: 'lastfm', label: 'Last.fm', icon: '⚪' },
+  { id: 'genius', label: 'Genius', icon: '🟡' },
+  { id: 'bandcamp', label: 'Bandcamp', icon: '🔹' },
+];
+
+export function albumEnrichServices() {
+  return filterJiosaavnEntries(ALBUM_ENRICH_SERVICES, 'id');
+}
+
+/**
+ * The disc:track slot a row occupies.
+ *
+ * Used ONLY to decide whether an expected-missing track is already owned —
+ * never as a render key. See getAlbumTrackRows.
+ */
+export function trackSlotKey(track: Record<string, unknown>): string {
+  const disc = Number(track.disc_number || track.expected_disc_number || 1);
+  const num = Number(track.track_number || track.expected_track_number || 0);
+  return `${disc}:${num}`;
+}
+
+export interface MissingTrackRow extends EnhancedTrack {
+  _hasActionableContext: boolean;
+  _missingExpected: true;
+  _sourceTrack: Record<string, unknown>;
+}
+
+/**
+ * An expected-but-missing track, flattened into the shape a track row expects.
+ *
+ * `_hasActionableContext` is the gate: without a title, a track number and SOME
+ * source id there is nothing the row's actions could act on, so the row is
+ * dropped rather than rendered as an inert placeholder.
+ */
+export function normalizeExpectedMissingTrack(
+  source: Record<string, unknown>,
+  album: EnhancedAlbum,
+): MissingTrackRow {
+  const title = (source.title || source.name || `Track ${source.track_number || '?'}`) as string;
+  const sourceTrackId = (source.track_id || source.id || source.source_track_id || '') as string;
+  const hasActionableContext = Boolean(
+    title &&
+    source.track_number &&
+    (sourceTrackId ||
+      source.spotify_track_id ||
+      source.deezer_id ||
+      source.itunes_track_id ||
+      source.musicbrainz_recording_id),
+  );
+  return {
+    id: `missing-${album.id}-${source.disc_number || 1}-${source.track_number || ''}`,
+    title,
+    track_number: (source.track_number || source.position || '') as string,
+    disc_number: (source.disc_number || 1) as number,
+    duration: (source.duration || source.duration_ms || 0) as number,
+    spotify_track_id: source.spotify_track_id || (source.source === 'spotify' ? sourceTrackId : ''),
+    deezer_id: source.deezer_id || (source.source === 'deezer' ? sourceTrackId : ''),
+    itunes_track_id: source.itunes_track_id || (source.source === 'itunes' ? sourceTrackId : ''),
+    musicbrainz_recording_id:
+      source.musicbrainz_recording_id || (source.source === 'musicbrainz' ? sourceTrackId : ''),
+    source: (source.source || source.metadata_source || '') as string,
+    track_id: sourceTrackId,
+    album_id: (source.album_id || source.source_album_id || '') as string,
+    artists: (source.artists || source.artist_names || []) as unknown,
+    _hasActionableContext: hasActionableContext,
+    _missingExpected: true,
+    _sourceTrack: source,
+  };
+}
+
+/**
+ * Owned tracks merged with expected-missing ones, sorted disc then track.
+ *
+ * Owned rows are keyed by track ID, NEVER by disc:track slot (#1051). Multi-disc
+ * albums whose tags all claim disc 1 make disc1-trackN and disc2-trackN share a
+ * slot; keying the map by slot silently overwrote one with the other and tracks
+ * vanished from the table. The slot set is still what decides whether an
+ * expected-missing row is already owned.
+ */
+export function getAlbumTrackRows(album: EnhancedAlbum): EnhancedTrack[] {
+  const owned = Array.isArray(album.tracks) ? album.tracks : [];
+  const rows = new Map<string, EnhancedTrack>();
+  const ownedSlots = new Set<string>();
+
+  for (const track of owned) {
+    rows.set(`owned:${track.id}`, track);
+    ownedSlots.add(trackSlotKey(track));
+  }
+
+  const explicitMissing = Array.isArray(album.missing_tracks) ? album.missing_tracks : [];
+  for (const missing of explicitMissing) {
+    const row = normalizeExpectedMissingTrack(missing as Record<string, unknown>, album);
+    const key = trackSlotKey(row as Record<string, unknown>);
+    if (row._hasActionableContext && !ownedSlots.has(key) && !rows.has(`missing:${key}`)) {
+      rows.set(`missing:${key}`, row);
+    }
+  }
+
+  return [...rows.values()].sort((a, b) => {
+    const discDelta = Number(a.disc_number || 1) - Number(b.disc_number || 1);
+    if (discDelta !== 0) return discDelta;
+    const trackDelta = Number(a.track_number || 0) - Number(b.track_number || 0);
+    if (trackDelta !== 0) return trackDelta;
+    return String(a.title || '').localeCompare(String(b.title || ''));
+  });
+}
+
+/**
+ * The header's meta line.
+ *
+ * The track count reads "owned/expected" only when the album is INCOMPLETE;
+ * a complete album shows a plain count rather than "12/12 tracks". Expected is
+ * the largest of what we own, what we can show, and what the source claims — so
+ * a source under-reporting its own tracklist cannot make a complete album look
+ * over-full.
+ */
+export function expandedHeaderDetails(album: EnhancedAlbum, rows: EnhancedTrack[]): string {
+  const details: string[] = [];
+  if (album.year) details.push(String(album.year));
+
+  const ownedCount = album.tracks ? album.tracks.length : 0;
+  const expectedCount = Math.max(
+    ownedCount,
+    rows.length,
+    Number(album.api_track_count || album.track_count || 0),
+  );
+  const missingCount = rows.filter((row) => (row as MissingTrackRow)._missingExpected).length;
+
+  if (album._canonicalTracksLoading) details.push('checking tracklist');
+  if (expectedCount > ownedCount) details.push(`${ownedCount}/${expectedCount} tracks`);
+  else details.push(`${ownedCount} track${ownedCount !== 1 ? 's' : ''}`);
+  if (missingCount > 0) details.push(`${missingCount} missing`);
+
+  let durationMs = 0;
+  for (const track of album.tracks ?? []) durationMs += track.duration || 0;
+  if (durationMs > 0) details.push(formatDurationMs(durationMs));
+
+  if (album.label) details.push(String(album.label));
+  if (album.record_type) details.push(String(album.record_type).toUpperCase());
+
+  return details.join(' · ');
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -656,14 +656,10 @@ export function sortIndicator(column: TrackColumn, sort: TrackSort | undefined):
 const NUMERIC_SORT_FIELDS = ['track_number', 'disc_number', 'bpm', 'bitrate', 'duration'];
 
 /**
- * Sort the album's OWNED tracks, as sortEnhancedTracks did.
+ * Sort tracks by a column, as sortEnhancedTracks did.
  *
- * NOTE: this does not change the rendered order. The vanilla sorted
- * album.tracks and then fed the table from _getEnhancedAlbumTrackRows, which
- * re-sorts by disc, then track, then title — so a column click updates the
- * arrow and nothing else. Reproduced verbatim rather than "fixed", because
- * making the columns actually sort is a behaviour change, not a port. See the
- * note in enhanced-track-table.tsx.
+ * A null always sinks, whichever direction the sort runs — the vanilla's rule,
+ * and the reason an unset BPM never floats to the top of an ascending sort.
  */
 export function sortTracks(
   tracks: EnhancedTrack[],
@@ -792,4 +788,30 @@ export function inlineEditDisplay(value: string | number | null): string {
 /** Track edits hit the track endpoint, album edits the album one. */
 export function inlineEditUrl(type: 'track' | 'album', id: unknown): string {
   return type === 'track' ? `/api/library/track/${id}` : `/api/library/album/${id}`;
+}
+
+/**
+ * The rows a sorted table renders.
+ *
+ * Missing rows always sink, in BOTH directions, and keep their own disc/track
+ * order among themselves. They are not data for these columns — a row you do
+ * not own has no bitrate, no format and no file — so interleaving them with
+ * real tracks would sort on absence. Sinking them matches how sortTracks
+ * already treats a null.
+ *
+ * With no active sort this is exactly getAlbumTrackRows: disc, then track,
+ * then title. An untouched table looks the way it always has.
+ */
+export function sortedTrackRows(
+  rows: EnhancedTrack[],
+  sort: TrackSort | undefined,
+): EnhancedTrack[] {
+  if (!sort) return rows;
+
+  const owned: EnhancedTrack[] = [];
+  const missing: EnhancedTrack[] = [];
+  for (const row of rows) {
+    ((row as { _missingExpected?: boolean })._missingExpected ? missing : owned).push(row);
+  }
+  return [...sortTracks(owned, sort.field, sort.ascending), ...missing];
 }

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -355,3 +355,216 @@ export function expandedHeaderDetails(album: EnhancedAlbum, rows: EnhancedTrack[
 
   return details.join(' · ');
 }
+
+export interface AlbumMetaField {
+  key: string;
+  label: string;
+  value: string;
+  type?: string;
+  placeholder?: string;
+}
+
+/**
+ * The editable album metadata fields, in the vanilla's order.
+ *
+ * `genres` is a comma-joined string in the form and an ARRAY on the record;
+ * `explicit` is the string '1'/'0' rather than a checkbox.
+ */
+export function albumMetaFields(album: EnhancedAlbum): AlbumMetaField[] {
+  return [
+    { key: 'title', label: 'Title', value: String(album.title || '') },
+    { key: 'year', label: 'Year', value: String(album.year || ''), type: 'number' },
+    {
+      key: 'release_date',
+      label: 'Release Date',
+      value: String(album.release_date || ''),
+      placeholder: 'YYYY-MM-DD',
+    },
+    {
+      key: 'genres',
+      label: 'Genres',
+      value: Array.isArray(album.genres) ? album.genres.join(', ') : String(album.genres || ''),
+    },
+    { key: 'label', label: 'Label', value: String(album.label || '') },
+    { key: 'style', label: 'Style', value: String(album.style || '') },
+    { key: 'mood', label: 'Mood', value: String(album.mood || '') },
+    { key: 'record_type', label: 'Type', value: String(album.record_type || 'album') },
+    { key: 'explicit', label: 'Explicit', value: album.explicit ? '1' : '0' },
+  ];
+}
+
+/** #824: a release date may be just the year, year-month, or the full date. */
+export const RELEASE_DATE_PATTERN = /^\d{4}(-\d{2}(-\d{2})?)?$/;
+
+export interface AlbumMetaDiff {
+  updates: Record<string, unknown>;
+  /** True when a non-empty release date does not parse; nothing is saved. */
+  invalidDate: boolean;
+}
+
+/**
+ * Only what CHANGED, per field type.
+ *
+ * The diff matters: sending every field would overwrite columns another process
+ * touched between load and save, and the empty-vs-null distinction is what
+ * lets a user clear a field rather than merely blank the input.
+ */
+export function albumMetaUpdates(
+  album: EnhancedAlbum,
+  values: Record<string, string>,
+): AlbumMetaDiff {
+  const updates: Record<string, unknown> = {};
+  let invalidDate = false;
+
+  for (const [field, raw] of Object.entries(values)) {
+    const value = String(raw ?? '').trim();
+
+    if (field === 'genres') {
+      const next = value
+        ? value
+            .split(',')
+            .map((g) => g.trim())
+            .filter(Boolean)
+        : [];
+      const original = Array.isArray(album.genres) ? album.genres : [];
+      if (JSON.stringify(next) !== JSON.stringify(original)) updates[field] = next;
+    } else if (field === 'year' || field === 'explicit' || field === 'track_count') {
+      const numeric = value !== '' ? parseInt(value, 10) : null;
+      // `|| null` treats a stored 0 (or an absent field) as null, so a
+      // non-explicit album ALWAYS reports explicit:0 as a change. Verbatim
+      // vanilla: it means a save on such an album is never a no-op, and the
+      // "no changes" branch is only reachable for an explicit album. Fixing it
+      // would change what gets written on every save.
+      if (numeric !== (album[field] || null)) updates[field] = numeric;
+    } else if (field === 'release_date') {
+      if (value && !RELEASE_DATE_PATTERN.test(value)) {
+        invalidDate = true;
+        continue;
+      }
+      if ((value || '') !== (album.release_date || '')) updates[field] = value || null;
+    } else if ((value || '') !== (album[field] || '')) {
+      updates[field] = value || null;
+    }
+  }
+
+  return { updates, invalidDate };
+}
+
+/**
+ * Loose title key for owned-to-canonical matching.
+ *
+ * Mirrors core.library_reorganize._normalize_title: drop only the featured
+ * credit, then treat every OTHER separator as whitespace. Keeping bracket
+ * CONTENT rather than deleting it is what makes "X (Main Theme)" and
+ * "X - Main Theme" line up.
+ */
+export function normTitleForMatch(value: unknown): string {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[([]\s*(?:feat|ft|featuring)\b[^)\]]*[)\]]/g, ' ')
+    .replace(/\s+(?:feat|ft|featuring)\b\.?\s.*$/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Which source's tracklist counts as canonical, in priority order. */
+export function getAlbumCanonicalSource(
+  album: EnhancedAlbum,
+): { source: string; id: string } | null {
+  const priority: [string, string][] = [
+    ['spotify', 'spotify_album_id'],
+    ['deezer', 'deezer_id'],
+    ['itunes', 'itunes_album_id'],
+    ['musicbrainz', 'musicbrainz_release_id'],
+    ['discogs', 'discogs_id'],
+    ['tidal', 'tidal_id'],
+    ['qobuz', 'qobuz_id'],
+  ];
+  for (const [source, key] of priority) {
+    if (album[key]) return { source, id: String(album[key]) };
+  }
+  return null;
+}
+
+/**
+ * Which canonical tracks we do not own.
+ *
+ * #916: multi-disc albums store disc_number = 1 for EVERY track (the scanner
+ * does not split discs), so a strict slot match flags every canonical disc-2+
+ * track as missing. Each canonical track matches by SLOT first, then falls back
+ * to a normalised TITLE against any unused owned track — consuming each owned
+ * track once, so genuine missings and duplicate titles still count correctly.
+ */
+export function deriveMissingTracks(
+  album: EnhancedAlbum,
+  canonicalTracks: Record<string, unknown>[],
+): Record<string, unknown>[] {
+  const owned = (album.tracks ?? []).map((track) => ({
+    slot: trackSlotKey(track as Record<string, unknown>),
+    title: normTitleForMatch(track.title || track.name),
+    used: false,
+  }));
+
+  // '1:0' is the "no slot at all" key; indexing it would match everything.
+  const slotIndex = new Map<string, number>();
+  owned.forEach((entry, index) => {
+    if (entry.slot !== '1:0' && !slotIndex.has(entry.slot)) slotIndex.set(entry.slot, index);
+  });
+
+  const missing: Record<string, unknown>[] = [];
+  for (const track of canonicalTracks ?? []) {
+    // Indexing the slotless '1:0' key above is dead defensively — a canonical
+    // track with that key is skipped below, so the entry could never be looked
+    // up. Kept because the vanilla wrote it.
+    const key = trackSlotKey(track);
+    const normalized = normalizeExpectedMissingTrack(track, album);
+    if (key === '1:0' || !normalized._hasActionableContext) continue;
+
+    const slotMatch = slotIndex.get(key);
+    if (slotMatch != null && !owned[slotMatch].used) {
+      owned[slotMatch].used = true;
+      continue;
+    }
+
+    const title = normTitleForMatch(track.name || track.title);
+    if (title) {
+      const match = owned.find((entry) => !entry.used && entry.title === title);
+      if (match) {
+        match.used = true;
+        continue;
+      }
+    }
+
+    missing.push({
+      ...track,
+      name: track.name || track.title,
+      duration_ms: track.duration_ms || track.duration || 0,
+    });
+  }
+  return missing;
+}
+
+/** Flatten an /api/album/<id>/tracks payload into canonical track rows. */
+export function normalizeCanonicalTracks(
+  tracks: Record<string, unknown>[],
+  source: string,
+  albumSourceId: string,
+  payloadSource?: string,
+): Record<string, unknown>[] {
+  return (tracks ?? []).map((track, index) => ({
+    ...track,
+    title: track.title || track.name || `Track ${track.track_number || index + 1}`,
+    name: track.name || track.title || `Track ${track.track_number || index + 1}`,
+    track_number: track.track_number || index + 1,
+    disc_number: track.disc_number || 1,
+    duration: track.duration || track.duration_ms || 0,
+    source: payloadSource || source,
+    track_id: track.id || track.track_id || '',
+    // A source with no per-track id still needs a stable key, so one is
+    // synthesised from the album and the slot.
+    id:
+      track.id ||
+      track.track_id ||
+      `${source}:${albumSourceId}:${track.disc_number || 1}:${track.track_number || index + 1}`,
+  }));
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -748,3 +748,48 @@ export function trackMatchQuery(
   }
   return String(track.title || '');
 }
+
+const NUMERIC_EDIT_FIELDS = ['track_number', 'disc_number', 'bpm'];
+
+export interface InlineEditInput {
+  type: 'number' | 'text';
+  className: string;
+  step?: string;
+  min?: string;
+}
+
+/** The input an inline-edited cell puts up, per field. */
+export function inlineEditInput(field: string): InlineEditInput {
+  const numeric = NUMERIC_EDIT_FIELDS.includes(field);
+  return {
+    type: numeric ? 'number' : 'text',
+    className: `enhanced-inline-input${numeric ? ' num' : ''}`,
+    // BPM is fractional; track and disc numbers are whole and start at 1.
+    step: field === 'bpm' ? '0.1' : numeric ? '1' : undefined,
+    min: field === 'track_number' || field === 'disc_number' ? '1' : undefined,
+  };
+}
+
+/**
+ * The value an inline edit sends.
+ *
+ * An unparseable number becomes NULL rather than NaN — which is how a user
+ * clears a field — except `explicit`, which floors to 0 because the column is
+ * a flag with no "unknown" state.
+ */
+export function inlineEditValue(field: string, raw: string): string | number | null {
+  if (field === 'track_number' || field === 'disc_number') return parseInt(raw, 10) || null;
+  if (field === 'bpm') return parseFloat(raw) || null;
+  if (field === 'explicit') return parseInt(raw, 10) || 0;
+  return raw;
+}
+
+/** What the cell shows once saved; an empty value reads as a dash. */
+export function inlineEditDisplay(value: string | number | null): string {
+  return value !== null && value !== '' ? String(value) : '-';
+}
+
+/** Track edits hit the track endpoint, album edits the album one. */
+export function inlineEditUrl(type: 'track' | 'album', id: unknown): string {
+  return type === 'track' ? `/api/library/track/${id}` : `/api/library/album/${id}`;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -1,6 +1,6 @@
 import type { EnhancedAlbum, EnhancedTrack } from './-artist-detail.enhanced';
 
-import { formatDurationMs } from './-artist-detail.enhanced';
+import { extractFormat, formatDurationMs } from './-artist-detail.enhanced';
 import { filterJiosaavnEntries } from './-artist-detail.enrichment';
 
 /**
@@ -567,4 +567,137 @@ export function normalizeCanonicalTracks(
       track.track_id ||
       `${source}:${albumSourceId}:${track.disc_number || 1}:${track.track_number || index + 1}`,
   }));
+}
+
+export interface TrackMatchChip {
+  service: string;
+  label: string;
+  matched: boolean;
+  className: string;
+  title: string;
+}
+
+const TRACK_MATCH_SERVICES = [
+  { svc: 'spotify', col: 'spotify_track_id', label: 'SP' },
+  { svc: 'musicbrainz', col: 'musicbrainz_recording_id', label: 'MB' },
+  { svc: 'deezer', col: 'deezer_id', label: 'Dz' },
+  { svc: 'jiosaavn', col: 'jiosaavn_id', label: 'JS' },
+  { svc: 'audiodb', col: 'audiodb_id', label: 'ADB' },
+  { svc: 'itunes', col: 'itunes_track_id', label: 'iT' },
+  { svc: 'lastfm', col: 'lastfm_url', label: 'LFM' },
+  { svc: 'genius', col: 'genius_id', label: 'Gen' },
+  { svc: 'bandcamp', col: 'bandcamp_url', label: 'BC' },
+];
+
+/** A chip per service, matched or not — the gaps are the point. */
+export function trackMatchChips(track: EnhancedTrack): TrackMatchChip[] {
+  return filterJiosaavnEntries(TRACK_MATCH_SERVICES, 'svc').map((service) => {
+    const id = track[service.col];
+    const matched = Boolean(id);
+    return {
+      service: service.svc,
+      label: service.label,
+      matched,
+      className: `enhanced-track-match-chip ${matched ? 'matched' : 'not-found'}`,
+      title: matched ? `${service.svc}: ${id}` : `${service.svc}: no match`,
+    };
+  });
+}
+
+export interface TrackColumn {
+  label: string;
+  cls: string;
+  sortField?: string;
+}
+
+/**
+ * The track table's columns.
+ *
+ * An admin gets a leading select-all cell (not in this list), write-tag and
+ * delete columns; everyone else gets a single report column instead.
+ *
+ * The header's admin `col-delete` does NOT match the body's
+ * `col-track-actions` — verbatim from the vanilla, where the two drifted.
+ */
+export function trackColumns(admin: boolean): TrackColumn[] {
+  return [
+    { label: '', cls: 'col-play' },
+    { label: '#', cls: 'col-num', sortField: 'track_number' },
+    { label: 'Disc', cls: 'col-disc', sortField: 'disc_number' },
+    { label: 'Title', cls: 'col-title', sortField: 'title' },
+    { label: 'Duration', cls: 'col-duration', sortField: 'duration' },
+    { label: 'Format', cls: 'col-format', sortField: 'format' },
+    { label: 'Bitrate', cls: 'col-bitrate', sortField: 'bitrate' },
+    { label: 'BPM', cls: 'col-bpm', sortField: 'bpm' },
+    { label: 'File', cls: 'col-path' },
+    { label: 'Match', cls: 'col-match' },
+    { label: '', cls: 'col-queue' },
+    ...(admin
+      ? [
+          { label: '', cls: 'col-writetag' },
+          { label: '', cls: 'col-delete' },
+        ]
+      : [{ label: '', cls: 'col-report' }]),
+    { label: '', cls: 'col-mobile-actions' },
+  ];
+}
+
+export interface TrackSort {
+  field: string;
+  ascending: boolean;
+}
+
+/** The sort arrow appended to a sorted column's label. */
+export function sortIndicator(column: TrackColumn, sort: TrackSort | undefined): string {
+  if (!sort || sort.field !== column.sortField) return column.label;
+  return `${column.label}${sort.ascending ? ' ▲' : ' ▼'}`;
+}
+
+const NUMERIC_SORT_FIELDS = ['track_number', 'disc_number', 'bpm', 'bitrate', 'duration'];
+
+/**
+ * Sort the album's OWNED tracks, as sortEnhancedTracks did.
+ *
+ * NOTE: this does not change the rendered order. The vanilla sorted
+ * album.tracks and then fed the table from _getEnhancedAlbumTrackRows, which
+ * re-sorts by disc, then track, then title — so a column click updates the
+ * arrow and nothing else. Reproduced verbatim rather than "fixed", because
+ * making the columns actually sort is a behaviour change, not a port. See the
+ * note in enhanced-track-table.tsx.
+ */
+export function sortTracks(
+  tracks: EnhancedTrack[],
+  field: string,
+  ascending: boolean,
+): EnhancedTrack[] {
+  return [...tracks].sort((a, b) => {
+    let valueA: unknown = field === 'format' ? extractFormat(a.file_path) : a[field];
+    let valueB: unknown = field === 'format' ? extractFormat(b.file_path) : b[field];
+
+    // A null always sinks, whichever direction the sort runs.
+    if (valueA == null) return 1;
+    if (valueB == null) return -1;
+
+    if (NUMERIC_SORT_FIELDS.includes(field)) {
+      return ascending ? Number(valueA) - Number(valueB) : Number(valueB) - Number(valueA);
+    }
+    valueA = String(valueA).toLowerCase();
+    valueB = String(valueB).toLowerCase();
+    return ascending
+      ? (valueA as string).localeCompare(valueB as string)
+      : (valueB as string).localeCompare(valueA as string);
+  });
+}
+
+/** 320+ is high, 192+ medium, anything else low. */
+export function bitrateClass(bitrate: unknown): string {
+  const value = Number(bitrate) || 0;
+  return value >= 320 ? 'high' : value >= 192 ? 'medium' : 'low';
+}
+
+/** The base name of the file, or a "missing" note for an unowned row. */
+export function trackFileName(track: EnhancedTrack): string {
+  const path = track.file_path || '-';
+  if ((track as { _missingExpected?: boolean })._missingExpected) return 'Missing from library';
+  return path !== '-' ? String(path).split(/[\\/]/).pop() || '-' : '-';
 }

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  enhancedStats,
+  extractFormat,
+  groupAlbumsByType,
+  libraryViewModeKey,
+  readEnhancedViewMode,
+  showsEnhancedToggle,
+  writeEnhancedViewMode,
+} from './-artist-detail.enhanced';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('the persisted view mode', () => {
+  it('scopes the key to the profile so two admins keep different defaults', () => {
+    expect(libraryViewModeKey(7)).toBe('soulsync-library-view-mode:7');
+  });
+
+  it('falls back to the UNSUFFIXED key with no profile', () => {
+    // That key is what pre-multi-profile installs already have saved.
+    expect(libraryViewModeKey(null)).toBe('soulsync-library-view-mode');
+    expect(libraryViewModeKey(undefined)).toBe('soulsync-library-view-mode');
+  });
+
+  it('keeps profile 0 scoped rather than treating it as absent', () => {
+    expect(libraryViewModeKey(0)).toBe('soulsync-library-view-mode:0');
+  });
+
+  it('round-trips both directions and writes "standard" explicitly', () => {
+    writeEnhancedViewMode(7, true);
+    expect(localStorage.getItem('soulsync-library-view-mode:7')).toBe('enhanced');
+    expect(readEnhancedViewMode(7)).toBe(true);
+
+    writeEnhancedViewMode(7, false);
+    expect(localStorage.getItem('soulsync-library-view-mode:7')).toBe('standard');
+    expect(readEnhancedViewMode(7)).toBe(false);
+  });
+
+  it("does not leak one profile's choice to another", () => {
+    writeEnhancedViewMode(1, true);
+    expect(readEnhancedViewMode(2)).toBe(false);
+  });
+
+  it('defaults to Standard when nothing is stored', () => {
+    expect(readEnhancedViewMode(7)).toBe(false);
+  });
+});
+
+describe('showsEnhancedToggle', () => {
+  it('is admin-only and library-only', () => {
+    expect(showsEnhancedToggle(true, false)).toBe(true);
+    expect(showsEnhancedToggle(false, false)).toBe(false);
+    // Forcing it on a source artist showed an empty pane and hid the
+    // discography — there is no DB record behind it to edit.
+    expect(showsEnhancedToggle(true, true)).toBe(false);
+  });
+});
+
+describe('extractFormat', () => {
+  it('maps the known extensions, m4a and aac both to AAC', () => {
+    expect(extractFormat('/m/a.flac')).toBe('FLAC');
+    expect(extractFormat('/m/a.mp3')).toBe('MP3');
+    expect(extractFormat('/m/a.m4a')).toBe('AAC');
+    expect(extractFormat('/m/a.aac')).toBe('AAC');
+    expect(extractFormat('/m/a.opus')).toBe('OPUS');
+  });
+
+  it('is case-insensitive about the extension', () => {
+    expect(extractFormat('/m/a.FLAC')).toBe('FLAC');
+  });
+
+  it('uppercases an unmapped extension rather than dropping it', () => {
+    expect(extractFormat('/m/a.aiff')).toBe('AIFF');
+  });
+
+  it('returns a dash — not a format — when there is no path', () => {
+    expect(extractFormat('')).toBe('-');
+    expect(extractFormat(null)).toBe('-');
+    expect(extractFormat(undefined)).toBe('-');
+  });
+
+  it('uses the LAST dot, so a dotted directory does not confuse it', () => {
+    expect(extractFormat('/m/v1.0/track.flac')).toBe('FLAC');
+  });
+});
+
+describe('groupAlbumsByType', () => {
+  it('always returns the three known buckets, even when empty', () => {
+    expect(groupAlbumsByType([])).toEqual({ album: [], ep: [], single: [] });
+  });
+
+  it('treats a missing record_type as an album', () => {
+    expect(groupAlbumsByType([{ title: 'X' }]).album).toHaveLength(1);
+  });
+
+  it('LOWERCASES the type, so "EP" lands in the EPs section', () => {
+    expect(groupAlbumsByType([{ record_type: 'EP' }]).ep).toHaveLength(1);
+  });
+
+  it('gives an unknown type its own bucket, and accumulates into it', () => {
+    const grouped = groupAlbumsByType([{ record_type: 'live' }, { record_type: 'live' }]);
+    expect(grouped.live).toHaveLength(2);
+  });
+});
+
+describe('enhancedStats', () => {
+  const DATA = {
+    albums: [
+      { record_type: 'album', tracks: [{ duration: 200000, file_path: 'a.flac' }] },
+      { tracks: [{ duration: 100000, file_path: 'b.flac' }, { file_path: 'c.mp3' }] },
+      { record_type: 'ep', tracks: [{ file_path: 'd.mp3' }] },
+      { record_type: 'single', tracks: [] },
+    ],
+  };
+
+  it('counts a MISSING record_type as an album', () => {
+    expect(enhancedStats(DATA).items[0]).toEqual({ value: 2, label: 'Albums' });
+  });
+
+  it('counts EPs and singles by strict equality', () => {
+    const stats = enhancedStats(DATA);
+    expect(stats.items[1].value).toBe(1);
+    expect(stats.items[2].value).toBe(1);
+  });
+
+  it('counts an uppercase "EP" as NONE of the three', () => {
+    // The stats bar does not lowercase, unlike groupAlbumsByType. Reproduced
+    // verbatim: the album shows in the EPs section but not in the EP count.
+    const stats = enhancedStats({ albums: [{ record_type: 'EP', tracks: [] }] });
+    expect(stats.items.slice(0, 3).map((s) => s.value)).toEqual([0, 0, 0]);
+    expect(groupAlbumsByType([{ record_type: 'EP' }]).ep).toHaveLength(1);
+  });
+
+  it('totals tracks across albums, tolerating an album with none', () => {
+    expect(enhancedStats(DATA).items[3].value).toBe(4);
+  });
+
+  it('formats the duration, dropping the hour part below an hour', () => {
+    expect(enhancedStats(DATA).items[4].value).toBe('5m');
+    expect(enhancedStats({ albums: [{ tracks: [{ duration: 3_900_000 }] }] }).items[4].value).toBe(
+      '1h 5m',
+    );
+  });
+
+  it('counts formats and puts the commonest first', () => {
+    const badges = enhancedStats(DATA).badges;
+    expect(badges).toEqual([
+      { format: 'FLAC', count: 2, className: 'flac' },
+      { format: 'MP3', count: 2, className: 'mp3' },
+    ]);
+  });
+
+  it('sorts by COUNT, not by the order the formats were first seen', () => {
+    // FLAC appears first but only once; MP3 must still lead the badge row.
+    const badges = enhancedStats({
+      albums: [
+        {
+          tracks: [{ file_path: 'a.flac' }, { file_path: 'b.mp3' }, { file_path: 'c.mp3' }],
+        },
+      ],
+    }).badges;
+    expect(badges.map((b) => [b.format, b.count])).toEqual([
+      ['MP3', 2],
+      ['FLAC', 1],
+    ]);
+  });
+
+  it('classes anything that is not FLAC or MP3 as other', () => {
+    const [badge] = enhancedStats({ albums: [{ tracks: [{ file_path: 'a.opus' }] }] }).badges;
+    expect(badge).toEqual({ format: 'OPUS', count: 1, className: 'other' });
+  });
+
+  it('does NOT badge a track with no file path', () => {
+    // '-' is the absence of a path, not a format called "-".
+    expect(enhancedStats({ albums: [{ tracks: [{ duration: 1 }] }] }).badges).toEqual([]);
+  });
+
+  it('survives a payload with no albums at all', () => {
+    const stats = enhancedStats({});
+    expect(stats.items.map((s) => s.value)).toEqual([0, 0, 0, 0, '0m']);
+    expect(stats.badges).toEqual([]);
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  albumRowMeta,
   enhancedStats,
   extractFormat,
   groupAlbumsByType,
   libraryViewModeKey,
   readEnhancedViewMode,
+  formatDurationMs,
+  sectionCountLabel,
+  sectionTrackTotal,
   showsEnhancedToggle,
   writeEnhancedViewMode,
 } from './-artist-detail.enhanced';
@@ -182,5 +186,76 @@ describe('enhancedStats', () => {
     const stats = enhancedStats({});
     expect(stats.items.map((s) => s.value)).toEqual([0, 0, 0, 0, '0m']);
     expect(stats.badges).toEqual([]);
+  });
+});
+
+describe('formatDurationMs', () => {
+  it('is m:ss with a zero-padded second', () => {
+    expect(formatDurationMs(65_000)).toBe('1:05');
+    expect(formatDurationMs(3_600_000)).toBe('60:00');
+  });
+
+  it('is a dash — NOT 0:00 — with no duration', () => {
+    expect(formatDurationMs(0)).toBe('-');
+    expect(formatDurationMs(undefined)).toBe('-');
+    expect(formatDurationMs(null)).toBe('-');
+  });
+});
+
+describe('sectionCountLabel', () => {
+  it('singularises exactly one release', () => {
+    expect(sectionCountLabel(1, 12)).toBe('1 release \u00B7 12 tracks');
+    expect(sectionCountLabel(3, 40)).toBe('3 releases \u00B7 40 tracks');
+  });
+
+  it('never singularises tracks, matching the vanilla', () => {
+    expect(sectionCountLabel(1, 1)).toBe('1 release \u00B7 1 tracks');
+  });
+});
+
+describe('sectionTrackTotal', () => {
+  it('sums tracks, tolerating an album with none', () => {
+    expect(sectionTrackTotal([{ tracks: [{}, {}] }, {}, { tracks: [] }])).toBe(2);
+  });
+});
+
+describe('albumRowMeta', () => {
+  it('builds the full meta line in order', () => {
+    const meta = albumRowMeta({
+      year: 1992,
+      label: 'Warp',
+      tracks: [
+        { duration: 200_000, file_path: 'a.flac' },
+        { duration: 100_000, file_path: 'b.flac' },
+      ],
+    });
+    expect(meta.metaLine).toBe('1992 \u00B7 2 tracks \u00B7 5:00 \u00B7 Warp');
+  });
+
+  it('SKIPS the duration rather than printing the dash sentinel', () => {
+    // A bare "-" between separators reads as a broken row.
+    const meta = albumRowMeta({ year: 1992, tracks: [{ file_path: 'a.flac' }] });
+    expect(meta.metaLine).toBe('1992 \u00B7 1 track');
+  });
+
+  it('drops the year and label when the album has none', () => {
+    expect(albumRowMeta({ tracks: [] }).metaLine).toBe('0 tracks');
+  });
+
+  it('singularises a single track', () => {
+    expect(albumRowMeta({ tracks: [{}] }).metaLine).toBe('1 track');
+  });
+
+  it('picks the album\u2019s commonest format for the badge', () => {
+    const meta = albumRowMeta({
+      tracks: [{ file_path: 'a.flac' }, { file_path: 'b.mp3' }, { file_path: 'c.mp3' }],
+    });
+    expect(meta.primaryFormat).toBe('MP3');
+    expect(meta.formatClass).toBe('mp3');
+  });
+
+  it('has no format badge when no track has a path', () => {
+    const meta = albumRowMeta({ tracks: [{ duration: 1 }] });
+    expect(meta.primaryFormat).toBe('');
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
@@ -1,0 +1,181 @@
+/**
+ * The Enhanced Management view's data layer, ported from toggleEnhancedView /
+ * _libraryViewModeKey / renderEnhancedView / renderEnhancedStatsBar /
+ * extractFormat (library.js:2785-2965, 5902).
+ *
+ * Enhanced is admin-only and library-only: it edits per-track metadata, which
+ * needs owned files and a DB row to write back to.
+ */
+
+export interface EnhancedTrack {
+  duration?: number;
+  file_path?: string;
+  [key: string]: unknown;
+}
+
+export interface EnhancedAlbum {
+  record_type?: string;
+  tracks?: EnhancedTrack[];
+  [key: string]: unknown;
+}
+
+export interface EnhancedData {
+  albums?: EnhancedAlbum[];
+  artist?: Record<string, unknown>;
+  server_type?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * The persisted Standard/Enhanced choice, scoped to the active profile so two
+ * admins can keep different defaults.
+ *
+ * The unsuffixed key is the fallback, not a bug: it is what pre-multi-profile
+ * installs already have in localStorage.
+ */
+export function libraryViewModeKey(profileId: number | string | null | undefined): string {
+  return profileId != null
+    ? `soulsync-library-view-mode:${profileId}`
+    : 'soulsync-library-view-mode';
+}
+
+export function readEnhancedViewMode(profileId: number | string | null | undefined): boolean {
+  try {
+    return localStorage.getItem(libraryViewModeKey(profileId)) === 'enhanced';
+  } catch {
+    return false;
+  }
+}
+
+export function writeEnhancedViewMode(
+  profileId: number | string | null | undefined,
+  enabled: boolean,
+): void {
+  try {
+    localStorage.setItem(libraryViewModeKey(profileId), enabled ? 'enhanced' : 'standard');
+  } catch {
+    // The toggle still works for this page view; it just will not persist.
+  }
+}
+
+/**
+ * Enhanced is offered only to an admin on a LIBRARY artist.
+ *
+ * Forcing it on a source-only artist showed an empty Enhanced pane and hid the
+ * discography — there is no DB record behind it to edit.
+ */
+export function showsEnhancedToggle(isAdmin: boolean, isSourceArtist: boolean): boolean {
+  return isAdmin && !isSourceArtist;
+}
+
+/** File extension to display format; anything unmapped is uppercased as-is. */
+export function extractFormat(filePath: unknown): string {
+  if (!filePath) return '-';
+  const ext = String(filePath).split('.').pop()?.toLowerCase() ?? '';
+  const map: Record<string, string> = {
+    mp3: 'MP3',
+    flac: 'FLAC',
+    m4a: 'AAC',
+    ogg: 'OGG',
+    opus: 'OPUS',
+    wav: 'WAV',
+    wma: 'WMA',
+    aac: 'AAC',
+  };
+  return map[ext] || ext.toUpperCase();
+}
+
+/**
+ * Albums grouped for the three Enhanced sections.
+ *
+ * record_type is lowercased HERE but not in the stats bar below — so an album
+ * typed "EP" lands in the EPs section while the stats bar still counts it as
+ * neither. Reproduced rather than harmonised; changing it would move counts
+ * Boulder has been reading for months.
+ */
+export function groupAlbumsByType(albums: EnhancedAlbum[] = []): Record<string, EnhancedAlbum[]> {
+  const grouped: Record<string, EnhancedAlbum[]> = { album: [], ep: [], single: [] };
+  for (const album of albums) {
+    const type = (album.record_type || 'album').toLowerCase();
+    if (grouped[type]) grouped[type].push(album);
+    else grouped[type] = [album];
+  }
+  return grouped;
+}
+
+/** Only these three render, in this order — any other bucket is grouped but unused. */
+export const ENHANCED_SECTIONS: { type: string; label: string }[] = [
+  { type: 'album', label: 'Albums' },
+  { type: 'ep', label: 'EPs' },
+  { type: 'single', label: 'Singles' },
+];
+
+export interface EnhancedStatItem {
+  value: string | number;
+  label: string;
+}
+
+export interface EnhancedFormatBadge {
+  format: string;
+  count: number;
+  /** flac / mp3 / other — drives the badge colour. */
+  className: string;
+}
+
+export interface EnhancedStats {
+  items: EnhancedStatItem[];
+  badges: EnhancedFormatBadge[];
+}
+
+/**
+ * The stats bar.
+ *
+ * Note the asymmetry in the counts, verbatim from the vanilla: an album with NO
+ * record_type counts as an album, but the EP and Single counts are strict
+ * equality, so a record_type of "EP" counts as none of the three.
+ *
+ * The vanilla's statsItems also carried an `icon` per row that its template
+ * never rendered. Dead data, so it is not carried over — emitting it would ADD
+ * icons the page has never shown.
+ */
+export function enhancedStats(data: EnhancedData): EnhancedStats {
+  const albums = data.albums ?? [];
+
+  const totalAlbums = albums.filter((a) => (a.record_type || 'album') === 'album').length;
+  const totalEps = albums.filter((a) => a.record_type === 'ep').length;
+  const totalSingles = albums.filter((a) => a.record_type === 'single').length;
+  const totalTracks = albums.reduce((sum, a) => sum + (a.tracks ? a.tracks.length : 0), 0);
+
+  let totalDurationMs = 0;
+  const formatCounts: Record<string, number> = {};
+  for (const album of albums) {
+    for (const track of album.tracks ?? []) {
+      totalDurationMs += track.duration || 0;
+      const format = extractFormat(track.file_path);
+      // '-' means the track has no path at all; it is not a format.
+      if (format !== '-') formatCounts[format] = (formatCounts[format] || 0) + 1;
+    }
+  }
+
+  const hours = Math.floor(totalDurationMs / 3600000);
+  const minutes = Math.floor((totalDurationMs % 3600000) / 60000);
+
+  return {
+    items: [
+      { value: totalAlbums, label: 'Albums' },
+      { value: totalEps, label: 'EPs' },
+      { value: totalSingles, label: 'Singles' },
+      { value: totalTracks, label: 'Tracks' },
+      { value: hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`, label: 'Duration' },
+    ],
+    badges: Object.entries(formatCounts)
+      // Commonest format first, so the badge row leads with what the library
+      // mostly is.
+      .sort((a, b) => b[1] - a[1])
+      .map(([format, count]) => ({
+        format,
+        count,
+        className: format === 'FLAC' ? 'flac' : format === 'MP3' ? 'mp3' : 'other',
+      })),
+  };
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
@@ -242,3 +242,43 @@ export function albumRowMeta(album: EnhancedAlbum): AlbumRowMeta {
     formatClass: primaryFormat === 'FLAC' ? 'flac' : primaryFormat === 'MP3' ? 'mp3' : 'other',
   };
 }
+
+export interface BulkEditValues {
+  track_number: string;
+  bpm: string;
+  style: string;
+  mood: string;
+  explicit: string;
+}
+
+export const EMPTY_BULK_EDIT: BulkEditValues = {
+  track_number: '',
+  bpm: '',
+  style: '',
+  mood: '',
+  explicit: '',
+};
+
+/**
+ * Only the fields the user actually filled in.
+ *
+ * Every field is "leave blank to skip" — a batch edit writes the same value to
+ * many tracks, so an empty box must mean "don't touch this column", never
+ * "clear it on all of them".
+ */
+export function bulkEditUpdates(values: BulkEditValues): Record<string, unknown> {
+  const updates: Record<string, unknown> = {};
+  if (values.track_number !== '') updates.track_number = parseInt(values.track_number, 10);
+  if (values.bpm !== '') updates.bpm = parseFloat(values.bpm);
+  if (values.style !== '') updates.style = values.style;
+  if (values.mood !== '') updates.mood = values.mood;
+  // `!== ''` rather than a truthiness check for intent, though the two agree
+  // here: the value is a STRING from a <select>, so '0' is already truthy.
+  if (values.explicit !== '') updates.explicit = parseInt(values.explicit, 10);
+  return updates;
+}
+
+/** "Batch Edit 3 Tracks" — singular for one. */
+export function bulkEditTitle(count: number): string {
+  return `Batch Edit ${count} Track${count !== 1 ? 's' : ''}`;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced.ts
@@ -179,3 +179,66 @@ export function enhancedStats(data: EnhancedData): EnhancedStats {
       })),
   };
 }
+
+/** m:ss, or a dash for a track with no known duration. */
+export function formatDurationMs(ms: unknown): string {
+  const value = Number(ms);
+  if (!value) return '-';
+  const totalSeconds = Math.floor(value / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** "3 releases · 40 tracks" — singular for exactly one release. */
+export function sectionCountLabel(albumCount: number, trackCount: number): string {
+  return `${albumCount} release${albumCount !== 1 ? 's' : ''} \u00B7 ${trackCount} tracks`;
+}
+
+export function sectionTrackTotal(albums: EnhancedAlbum[]): number {
+  return albums.reduce((sum, album) => sum + (album.tracks ? album.tracks.length : 0), 0);
+}
+
+export interface AlbumRowMeta {
+  trackCount: number;
+  /** "1992 · 12 tracks · 48:20 · Warp" — absent parts are simply skipped. */
+  metaLine: string;
+  /** The album's commonest format, or '' when no track has a path. */
+  primaryFormat: string;
+  formatClass: string;
+}
+
+/**
+ * The collapsed album row's derived fields.
+ *
+ * The meta line drops each part it has nothing for rather than printing a
+ * placeholder — including the duration, which is skipped when formatDurationMs
+ * returns its '-' sentinel rather than showing a bare dash between separators.
+ */
+export function albumRowMeta(album: EnhancedAlbum): AlbumRowMeta {
+  const tracks = album.tracks ?? [];
+  const trackCount = tracks.length;
+
+  let durationMs = 0;
+  const formats: Record<string, number> = {};
+  for (const track of tracks) {
+    durationMs += track.duration || 0;
+    const format = extractFormat(track.file_path);
+    if (format !== '-') formats[format] = (formats[format] || 0) + 1;
+  }
+  const duration = formatDurationMs(durationMs);
+  const primaryFormat = Object.keys(formats).sort((a, b) => formats[b] - formats[a])[0] || '';
+
+  const parts: string[] = [];
+  if (album.year) parts.push(String(album.year));
+  parts.push(`${trackCount} track${trackCount !== 1 ? 's' : ''}`);
+  if (duration !== '-') parts.push(duration);
+  if (album.label) parts.push(String(album.label));
+
+  return {
+    trackCount,
+    metaLine: parts.join(' \u00B7 '),
+    primaryFormat,
+    formatClass: primaryFormat === 'FLAC' ? 'flac' : primaryFormat === 'MP3' ? 'mp3' : 'other',
+  };
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enrichment.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enrichment.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildEnrichmentRings,
+  ENRICHMENT_SERVICES,
+  RING_CIRCUMFERENCE,
+  shouldShowEnrichment,
+  visibleEnrichmentServices,
+} from './-artist-detail.enrichment';
+
+afterEach(() => {
+  delete window.filterJiosaavnServiceEntries;
+});
+
+describe('shouldShowEnrichment', () => {
+  it('hides the panel without data, or with zero tracks', () => {
+    // A coverage ring over zero tracks means nothing.
+    expect(shouldShowEnrichment(undefined)).toBe(false);
+    expect(shouldShowEnrichment({})).toBe(false);
+    expect(shouldShowEnrichment({ total_tracks: 0 })).toBe(false);
+    expect(shouldShowEnrichment({ total_tracks: 12 })).toBe(true);
+  });
+});
+
+describe('visibleEnrichmentServices', () => {
+  it('defers to the shared helper when it exists', () => {
+    // shared-helpers.js owns the experimental-source flag; do not duplicate it.
+    window.filterJiosaavnServiceEntries = vi.fn((items) => items) as never;
+    expect(visibleEnrichmentServices().map((s) => s.key)).toContain('jiosaavn');
+    expect(window.filterJiosaavnServiceEntries).toHaveBeenCalled();
+  });
+
+  it('drops JioSaavn when the helper is unavailable — the safe default', () => {
+    expect(visibleEnrichmentServices().map((s) => s.key)).not.toContain('jiosaavn');
+  });
+
+  it('keeps every other service, in declaration order', () => {
+    expect(visibleEnrichmentServices().map((s) => s.key)).toEqual([
+      'spotify',
+      'musicbrainz',
+      'deezer',
+      'lastfm',
+      'itunes',
+      'audiodb',
+      'discogs',
+      'genius',
+      'tidal',
+      'qobuz',
+      'bandcamp',
+    ]);
+  });
+});
+
+describe('buildEnrichmentRings', () => {
+  const two = [
+    { name: 'Spotify', key: 'spotify', color: '#1db954' },
+    { name: 'Deezer', key: 'deezer', color: '#a238ff' },
+  ];
+
+  it('leaves a full ring at zero offset and an empty one at full circumference', () => {
+    const [full] = buildEnrichmentRings({ spotify: 100 }, [two[0]]);
+    expect(full.offset).toBe('0.0');
+    const [empty] = buildEnrichmentRings({ spotify: 0 }, [two[0]]);
+    expect(empty.offset).toBe(RING_CIRCUMFERENCE.toFixed(1));
+  });
+
+  it('offsets proportionally — half coverage leaves half the ring empty', () => {
+    const [half] = buildEnrichmentRings({ spotify: 50 }, [two[0]]);
+    expect(half.offset).toBe((RING_CIRCUMFERENCE / 2).toFixed(1));
+  });
+
+  it('treats a missing service as 0, not NaN', () => {
+    const [ring] = buildEnrichmentRings({}, [two[0]]);
+    expect(ring.pct).toBe(0);
+    expect(ring.label).toBe(0);
+    expect(ring.offset).not.toContain('NaN');
+  });
+
+  it('rounds the displayed number but keeps the raw pct for the geometry', () => {
+    const [ring] = buildEnrichmentRings({ spotify: 66.6 }, [two[0]]);
+    expect(ring.label).toBe(67);
+    expect(ring.pct).toBeCloseTo(66.6);
+  });
+
+  it('staggers by 0.08s, with the percentage text 0.3s behind its ring', () => {
+    const rings = buildEnrichmentRings({ spotify: 10, deezer: 20 }, two);
+    expect(rings.map((r) => r.delay)).toEqual(['0.00', '0.08']);
+    expect(rings.map((r) => r.pctDelay)).toEqual(['0.30', '0.38']);
+  });
+
+  it('uses one circumference for both the dash array and the offset', () => {
+    const [ring] = buildEnrichmentRings({ spotify: 25 }, [two[0]]);
+    expect(ring.dashArray).toBe(RING_CIRCUMFERENCE.toFixed(1));
+  });
+
+  it('covers every service the vanilla listed', () => {
+    expect(ENRICHMENT_SERVICES).toHaveLength(12);
+  });
+
+  it('pins the ring geometry to absolute numbers', () => {
+    // Everything else here is expressed RELATIVE to RING_CIRCUMFERENCE, so a
+    // wrong constant would move both sides of those assertions together and
+    // go unnoticed. r = 20 => 2*pi*20 = 125.66...
+    expect(RING_CIRCUMFERENCE.toFixed(1)).toBe('125.7');
+    const [quarter] = buildEnrichmentRings({ spotify: 25 }, [two[0]]);
+    expect(quarter.offset).toBe('94.2');
+    expect(quarter.dashArray).toBe('125.7');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.enrichment.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enrichment.ts
@@ -1,0 +1,93 @@
+/**
+ * Per-artist enrichment coverage rings, ported from
+ * `renderArtistEnrichmentCoverage` (library.js:730).
+ *
+ * Geometry and animation timings are computed here so the component is a plain
+ * render — the vanilla built the whole SVG as an innerHTML string.
+ */
+
+export interface EnrichmentService {
+  name: string;
+  key: string;
+  color: string;
+}
+
+/** Declaration order is the on-screen order, so it is part of the contract. */
+export const ENRICHMENT_SERVICES: readonly EnrichmentService[] = [
+  { name: 'Spotify', key: 'spotify', color: '#1db954' },
+  { name: 'MusicBrainz', key: 'musicbrainz', color: '#ba55d3' },
+  { name: 'Deezer', key: 'deezer', color: '#a238ff' },
+  { name: 'JioSaavn', key: 'jiosaavn', color: '#2bc5b4' },
+  { name: 'Last.fm', key: 'lastfm', color: '#d51007' },
+  { name: 'iTunes', key: 'itunes', color: '#fc3c44' },
+  { name: 'AudioDB', key: 'audiodb', color: '#1a9fff' },
+  { name: 'Discogs', key: 'discogs', color: '#D4A574' },
+  { name: 'Genius', key: 'genius', color: '#ffff64' },
+  { name: 'Tidal', key: 'tidal', color: '#00ffff' },
+  { name: 'Qobuz', key: 'qobuz', color: '#4285f4' },
+  { name: 'Bandcamp', key: 'bandcamp', color: '#1da0c3' },
+] as const;
+
+/** Ring radius, and the circumference every dash calculation is based on. */
+export const RING_RADIUS = 20;
+export const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+/**
+ * JioSaavn is experimental and hidden unless explicitly enabled. The vanilla
+ * routes this through `filterJiosaavnServiceEntries` in shared-helpers.js;
+ * that global stays the single source of truth, and this falls back to
+ * excluding JioSaavn when it is unavailable (the safe default — the same
+ * answer the helper gives when the flag is off).
+ */
+export function visibleEnrichmentServices(
+  services: readonly EnrichmentService[] = ENRICHMENT_SERVICES,
+): EnrichmentService[] {
+  const filter = window.filterJiosaavnServiceEntries;
+  if (typeof filter === 'function') {
+    return filter([...services], 'key') as EnrichmentService[];
+  }
+  return services.filter((s) => s.key !== 'jiosaavn');
+}
+
+export interface EnrichmentRing {
+  service: EnrichmentService;
+  /** Raw coverage percentage from the payload; 0 when the key is absent. */
+  pct: number;
+  /** Rounded value shown inside the ring. */
+  label: number;
+  /** stroke-dashoffset — how much of the ring is left EMPTY. */
+  offset: string;
+  dashArray: string;
+  /** Stagger, in seconds, as a fixed-2 string to match the vanilla exactly. */
+  delay: string;
+  /** The percentage text fades 0.3s after its ring starts. */
+  pctDelay: string;
+}
+
+/**
+ * The whole panel is hidden when there is no enrichment data at all, or when
+ * the artist has no tracks — a coverage ring over zero tracks is meaningless.
+ */
+export function shouldShowEnrichment(enrichment: Record<string, unknown> | undefined): boolean {
+  return Boolean(enrichment && enrichment.total_tracks);
+}
+
+export function buildEnrichmentRings(
+  enrichment: Record<string, unknown>,
+  services: EnrichmentService[] = visibleEnrichmentServices(),
+): EnrichmentRing[] {
+  return services.map((service, index) => {
+    const pct = Number(enrichment[service.key] ?? 0) || 0;
+    const offset = RING_CIRCUMFERENCE - (RING_CIRCUMFERENCE * pct) / 100;
+    const delay = (index * 0.08).toFixed(2);
+    return {
+      service,
+      pct,
+      label: Math.round(pct),
+      offset: offset.toFixed(1),
+      dashArray: RING_CIRCUMFERENCE.toFixed(1),
+      delay,
+      pctDelay: (parseFloat(delay) + 0.3).toFixed(2),
+    };
+  });
+}

--- a/webui/src/routes/artist-detail/-artist-detail.enrichment.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enrichment.ts
@@ -42,11 +42,19 @@ export const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 export function visibleEnrichmentServices(
   services: readonly EnrichmentService[] = ENRICHMENT_SERVICES,
 ): EnrichmentService[] {
+  return filterJiosaavnEntries(services, 'key');
+}
+
+/**
+ * The generic form, for the several other service lists on this page that key
+ * JioSaavn under a different property name ('svc', 'id', ...).
+ */
+export function filterJiosaavnEntries<T>(entries: readonly T[], key: string): T[] {
   const filter = window.filterJiosaavnServiceEntries;
   if (typeof filter === 'function') {
-    return filter([...services], 'key') as EnrichmentService[];
+    return filter([...entries] as never, key) as T[];
   }
-  return services.filter((s) => s.key !== 'jiosaavn');
+  return entries.filter((entry) => (entry as Record<string, unknown>)[key] !== 'jiosaavn');
 }
 
 export interface EnrichmentRing {

--- a/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   applyMusicBrainzDeclutter,
   classifyReleaseContent,
+  isSectionHidden,
+  sectionStatsLabels,
   defaultFilterState,
   isMusicBrainzDiscography,
   isReleaseHidden,
@@ -237,5 +239,37 @@ describe('sectionCounts', () => {
     expect(sectionCounts(releases, true, mb()).visible).toBe(1);
     // ...and the same release IS hidden when the title guess is trusted.
     expect(sectionCounts(releases, false, { ...mb(), mbDeclutter: false }).visible).toBe(0);
+  });
+});
+
+describe('section visibility and stats', () => {
+  const counts = (visible: number) => ({ visible, owned: 0, missing: 0 });
+
+  it('hides a section when its category toggle is off, even with visible cards', () => {
+    const s = defaultFilterState();
+    s.categories.eps = false;
+    expect(isSectionHidden('eps', counts(5), s)).toBe(true);
+    expect(isSectionHidden('albums', counts(5), s)).toBe(false);
+  });
+
+  it('hides a section when every card in it was filtered out', () => {
+    expect(isSectionHidden('albums', counts(0), defaultFilterState())).toBe(true);
+  });
+
+  it('labels with the FILTERED counts, not the bucket totals', () => {
+    expect(sectionStatsLabels({ visible: 3, owned: 2, missing: 1 })).toEqual({
+      owned: '2 owned',
+      missing: '1 missing',
+    });
+  });
+
+  it('shows 0 owned / 0 missing while ownership is still being checked', () => {
+    // NOT "Checking..." — populateReleaseSection writes that, then
+    // populateDiscographySections calls applyDiscographyFilters() in the same
+    // function with no early return, overwriting both labels before paint.
+    // Reproducing the label the user actually sees, not the one in the source.
+    const pending = sectionCounts([{ owned: null }, { owned: null }], false, defaultFilterState());
+    expect(pending).toEqual({ visible: 2, owned: 0, missing: 0 });
+    expect(sectionStatsLabels(pending)).toEqual({ owned: '0 owned', missing: '0 missing' });
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   applyMusicBrainzDeclutter,
+  classifyReleaseContent,
   defaultFilterState,
   isMusicBrainzDiscography,
   isReleaseHidden,
@@ -56,20 +57,74 @@ describe('liveToggleLabel', () => {
   });
 });
 
+describe('classifyReleaseContent — the shared title heuristic (#877)', () => {
+  // Must stay identical to _classifyReleaseContent in library.js: the same
+  // function classifies the Download Discography modal, and a release judged
+  // differently in the two places is exactly the drift it exists to prevent.
+  it('detects live by word, parens or brackets — not as a substring', () => {
+    for (const title of ['Live at Leeds', 'Alive (Live)', 'Whatever [Live 1994]']) {
+      expect(classifyReleaseContent({ title }).isLive).toBe(true);
+    }
+    // \b guards this: "Alive" and "Deliverance" contain "live" but are not live.
+    for (const title of ['Alive', 'Deliverance', 'Olive']) {
+      expect(classifyReleaseContent({ title }).isLive).toBe(false);
+    }
+  });
+
+  it('detects compilations by album_type OR title phrase', () => {
+    expect(classifyReleaseContent({ album_type: 'compilation', title: 'X' }).isCompilation).toBe(
+      true,
+    );
+    for (const title of [
+      'Greatest Hits',
+      'The Best of Blur',
+      'Anthology',
+      'Essential',
+      'The Collection',
+    ]) {
+      expect(classifyReleaseContent({ title }).isCompilation).toBe(true);
+    }
+    expect(classifyReleaseContent({ title: 'Kid A' }).isCompilation).toBe(false);
+  });
+
+  it('detects featured across feat. / ft. / featuring', () => {
+    for (const title of ['Song (feat. Someone)', 'Song ft. Someone', 'Song featuring Someone']) {
+      expect(classifyReleaseContent({ title }).isFeatured).toBe(true);
+    }
+    expect(classifyReleaseContent({ title: 'Feature Film' }).isFeatured).toBe(false);
+  });
+
+  it('reads `name` when there is no `title` — the download modal uses name', () => {
+    expect(classifyReleaseContent({ name: 'Live at Wembley' }).isLive).toBe(true);
+  });
+
+  it('survives a release with neither title nor name', () => {
+    expect(classifyReleaseContent({})).toEqual({
+      isLive: false,
+      isCompilation: false,
+      isFeatured: false,
+    });
+  });
+});
+
 describe('releaseFlags', () => {
-  it('uses the backend flags off MusicBrainz', () => {
-    const flags = releaseFlags({ is_live: true, is_compilation: true }, false);
-    expect(flags).toEqual({ isLive: true, isCompilation: true, isFeatured: false });
+  it('uses the title heuristic off MusicBrainz', () => {
+    const flags = releaseFlags({ title: 'Live at Leeds' }, false);
+    expect(flags.isLive).toBe(true);
   });
 
   it('lets secondary_types OVERRIDE the live guess on MusicBrainz', () => {
-    // The whole point: a studio album titled "Live Through This" is flagged
-    // is_live by the title guess, and MB's secondary_types say otherwise.
-    const flags = releaseFlags(
-      { name: 'Live Through This', is_live: true, secondary_types: [] },
-      true,
-    );
+    // The whole point: the title heuristic flags "Live Through This" as live,
+    // and MB's secondary_types say it is a studio album.
+    const flags = releaseFlags({ title: 'Live Through This', secondary_types: [] }, true);
     expect(flags.isLive).toBe(false);
+  });
+
+  it('keeps the title-derived compilation/featured flags on MusicBrainz', () => {
+    // secondary_types only overrides LIVE; the other two still come from title.
+    const flags = releaseFlags({ title: 'Greatest Hits (feat. X)', secondary_types: [] }, true);
+    expect(flags.isCompilation).toBe(true);
+    expect(flags.isFeatured).toBe(true);
   });
 
   it('catches soundtrack/remix/demo, which a title guess never would', () => {
@@ -178,7 +233,7 @@ describe('sectionCounts', () => {
   });
 
   it('recomputes live-ness from secondary_types when the source is MusicBrainz', () => {
-    const releases = [{ name: 'Live Through This', is_live: true, secondary_types: [] }];
+    const releases = [{ title: 'Live Through This', secondary_types: [] }];
     expect(sectionCounts(releases, true, mb()).visible).toBe(1);
     // ...and the same release IS hidden when the title guess is trusted.
     expect(sectionCounts(releases, false, { ...mb(), mbDeclutter: false }).visible).toBe(0);

--- a/webui/src/routes/artist-detail/-artist-detail.filters.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.ts
@@ -78,20 +78,43 @@ export interface ReleaseFlags {
 }
 
 /**
+ * Title-based classification, ported verbatim from `_classifyReleaseContent`.
+ *
+ * That function is deliberately SHARED between artist detail and the Download
+ * Discography modal (#877) so the two can never drift apart on what counts as
+ * live/compilation/featured. Keep these patterns identical to it — a release
+ * classified one way in the modal and another way on the page is the exact bug
+ * that shared classifier exists to prevent.
+ *
+ * Note there are no `is_live` / `is_compilation` fields on a release: the
+ * backend does not send them. Classification is entirely client-side, off the
+ * title, plus `album_type === 'compilation'`.
+ */
+const LIVE_PATTERN = /\b(live)\b|\(live[^)]*\)|\[live[^\]]*\]/i;
+const COMPILATION_PATTERN = /\b(greatest hits|best of|collection|anthology|essential)\b/i;
+const FEATURED_PATTERN = /\(?\bfeat\.?\s|\bft\.?\s|\bfeaturing\b/i;
+
+export function classifyReleaseContent(release: DiscographyRelease): ReleaseFlags {
+  // `title` on the artist page, `name` in the download modal — both are checked
+  // because the same classifier serves both shapes.
+  const title = String(release.title ?? release.name ?? '');
+  return {
+    isLive: LIVE_PATTERN.test(title),
+    isCompilation: release.album_type === 'compilation' || COMPILATION_PATTERN.test(title),
+    isFeatured: FEATURED_PATTERN.test(title),
+  };
+}
+
+/**
  * The three content flags for one release.
  *
  * On MusicBrainz, `secondary_types` is authoritative and REPLACES the
- * title-based guess — that is what stops a studio album called "Live Through
- * This" being hidden, and it also catches soundtrack/remix/demo which a title
- * guess never would. Off MusicBrainz there are no secondary types, so the
- * flags the backend already set on the release stand.
+ * title-based live guess — that is what stops a studio album called "Live
+ * Through This" being hidden, and it also catches soundtrack/remix/demo which a
+ * title guess never would. Off MusicBrainz the title heuristic governs.
  */
 export function releaseFlags(release: DiscographyRelease, isMusicBrainz: boolean): ReleaseFlags {
-  const base: ReleaseFlags = {
-    isLive: release.is_live === true,
-    isCompilation: release.is_compilation === true,
-    isFeatured: release.is_featured === true,
-  };
+  const base = classifyReleaseContent(release);
   if (!isMusicBrainz) return base;
 
   const secondary = Array.isArray(release.secondary_types)

--- a/webui/src/routes/artist-detail/-artist-detail.filters.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.filters.ts
@@ -175,6 +175,35 @@ export interface SectionCounts {
  * A release still being checked (`owned === null`) counts toward `visible` but
  * toward neither owned nor missing, so the two do not necessarily sum.
  */
+/**
+ * Whether a whole section is hidden.
+ *
+ * Two independent reasons, both from applyDiscographyFilters: its category
+ * toggle is off, or every card in it ended up filtered out.
+ */
+export function isSectionHidden(
+  bucket: DiscographyBucket,
+  counts: SectionCounts,
+  state: DiscographyFilterState,
+): boolean {
+  return !state.categories[bucket] || counts.visible === 0;
+}
+
+/**
+ * The "N owned" / "N missing" stats line.
+ *
+ * Always the FILTERED counts. `populateReleaseSection` first writes
+ * "Checking..." / "" when any ownership is still pending, but
+ * populateDiscographySections calls applyDiscographyFilters() immediately
+ * afterwards — in the same function, with no early return — which overwrites
+ * both labels before anything paints. So that "Checking..." state is
+ * unreachable in practice and is deliberately NOT reproduced here; during
+ * checking the user sees "0 owned" / "0 missing", exactly as they do today.
+ */
+export function sectionStatsLabels(counts: SectionCounts): { owned: string; missing: string } {
+  return { owned: `${counts.owned} owned`, missing: `${counts.missing} missing` };
+}
+
 export function sectionCounts(
   releases: DiscographyRelease[],
   isMusicBrainz: boolean,

--- a/webui/src/routes/artist-detail/-artist-detail.gap-fill.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.gap-fill.test.ts
@@ -1,0 +1,281 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  dedupeGaps,
+  gapFillEnabled,
+  gapFillUrl,
+  gapNorm,
+  gapReleasesFromResponse,
+  gapSameRelease,
+  gapSourceLabel,
+  gapStreamPayload,
+  gapYear,
+  mergeGapReleases,
+  SOURCE_LABEL_TEXT,
+  setGapFillEnabled,
+} from './-artist-detail.gap-fill';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('the gap-fill preference', () => {
+  it('is off until explicitly enabled, and persists as "1"', () => {
+    expect(gapFillEnabled()).toBe(false);
+    setGapFillEnabled(true);
+    expect(localStorage.getItem('discog_gapfill')).toBe('1');
+    expect(gapFillEnabled()).toBe(true);
+  });
+
+  it('writes "0" rather than removing the key when switched off', () => {
+    setGapFillEnabled(true);
+    setGapFillEnabled(false);
+    expect(localStorage.getItem('discog_gapfill')).toBe('0');
+    expect(gapFillEnabled()).toBe(false);
+  });
+});
+
+describe('gapNorm', () => {
+  it('KEEPS edition parentheses', () => {
+    // "Album" and "Album (Deluxe Edition)" are different releases; collapsing
+    // them would hide a real gap.
+    expect(gapNorm('Album (Deluxe Edition)')).toBe('album (deluxe edition)');
+    expect(gapNorm('Album')).not.toBe(gapNorm('Album (Deluxe Edition)'));
+  });
+
+  it('flattens punctuation and whitespace', () => {
+    expect(gapNorm('  Selected   Ambient-Works!  ')).toBe('selected ambient works');
+  });
+
+  it('is empty for junk input', () => {
+    expect(gapNorm(null)).toBe('');
+    expect(gapNorm(undefined)).toBe('');
+  });
+});
+
+describe('gapYear', () => {
+  it('prefers the year field, then the release date prefix', () => {
+    expect(gapYear({ year: 1992 })).toBe(1992);
+    expect(gapYear({ release_date: '1994-11-08' })).toBe(1994);
+  });
+
+  it('rejects out-of-range and unparseable values', () => {
+    expect(gapYear({ year: 12 })).toBeNull();
+    expect(gapYear({ year: 9999 })).toBeNull();
+    expect(gapYear({})).toBeNull();
+    expect(gapYear({ year: 'soon' })).toBeNull();
+  });
+});
+
+describe('gapSameRelease', () => {
+  it('matches on title plus a year within one', () => {
+    expect(gapSameRelease({ title: 'SAW', year: 1992 }, { title: 'saw', year: 1993 })).toBe(true);
+    expect(gapSameRelease({ title: 'SAW', year: 1992 }, { title: 'SAW', year: 1995 })).toBe(false);
+  });
+
+  it('treats an UNKNOWN year on either side as a match', () => {
+    // The alternative is rendering the same album twice.
+    expect(gapSameRelease({ title: 'SAW' }, { title: 'SAW', year: 1992 })).toBe(true);
+    expect(gapSameRelease({ title: 'SAW', year: 1992 }, { title: 'SAW' })).toBe(true);
+  });
+
+  it('reads either title or name', () => {
+    expect(gapSameRelease({ name: 'SAW', year: 1992 }, { title: 'SAW', year: 1992 })).toBe(true);
+  });
+
+  it('never matches on an empty title', () => {
+    expect(gapSameRelease({ title: '' }, { title: '' })).toBe(false);
+  });
+});
+
+describe('gapSourceLabel', () => {
+  it('names the source', () => {
+    expect(gapSourceLabel('itunes')).toBe('Apple Music');
+    expect(gapSourceLabel('musicbrainz')).toBe('MusicBrainz');
+  });
+
+  it('falls back to the raw key for an unknown source, as the vanilla did', () => {
+    expect(gapSourceLabel('newthing')).toBe('newthing');
+    expect(gapSourceLabel(undefined)).toBe('');
+  });
+});
+
+describe('SOURCE_LABEL_TEXT parity with shared-helpers.js', () => {
+  it('matches every label in the vanilla SOURCE_LABELS map', () => {
+    // SOURCE_LABELS is a top-level `const` in a classic script — a global
+    // LEXICAL binding that never lands on window, so a module cannot read it
+    // and this copy is the only option. This test is what keeps the copy from
+    // drifting: it parses the labels straight out of the vanilla source.
+    // vitest roots at webui/, and import.meta.url is not a file URL under the
+    // jsdom transform.
+    const source = readFileSync(resolve(process.cwd(), 'static/shared-helpers.js'), 'utf-8');
+    const start = source.indexOf('const SOURCE_LABELS = {');
+    expect(start).toBeGreaterThan(-1);
+    const block = source.slice(start, source.indexOf('\n};', start));
+
+    const vanilla: Record<string, string> = {};
+    let key: string | null = null;
+    for (const line of block.split('\n')) {
+      const keyMatch = line.match(/^\s{4}([a-z_]+):\s*\{/);
+      if (keyMatch) key = keyMatch[1];
+      const textMatch = line.match(/text:\s*'([^']*)'/);
+      if (key && textMatch) {
+        vanilla[key] = textMatch[1];
+        key = null;
+      }
+    }
+
+    expect(Object.keys(vanilla).length).toBeGreaterThan(5);
+    expect(SOURCE_LABEL_TEXT).toEqual(vanilla);
+  });
+});
+
+describe('gapReleasesFromResponse', () => {
+  const RESPONSE = {
+    success: true,
+    gaps: {
+      albums: [{ id: 'a1', title: 'Gap Album', gap_source: 'deezer', year: 2001, track_count: 12 }],
+      eps: [{ id: 'e1', name: 'Gap EP', gap_source: 'itunes' }],
+      singles: [],
+    },
+  };
+
+  it('flattens each bucket and tags it', () => {
+    const releases = gapReleasesFromResponse(RESPONSE);
+    expect(releases.map((r) => [r.title, r._bucket, r._gap_source])).toEqual([
+      ['Gap Album', 'albums', 'deezer'],
+      ['Gap EP', 'eps', 'itunes'],
+    ]);
+  });
+
+  it('starts them owned:false, never null', () => {
+    // A null would render as "checking" forever if the ownership stream never
+    // reached that release.
+    expect(gapReleasesFromResponse(RESPONSE).every((r) => r.owned === false)).toBe(true);
+  });
+
+  it('keeps the track count OFF track_count', () => {
+    // The vanilla's gap card carried no track count, so the download modal fell
+    // through to its "never 0" default of 1. Setting the real field would
+    // silently change what the modal opens with.
+    const [album] = gapReleasesFromResponse(RESPONSE);
+    expect(album.track_count).toBeUndefined();
+    expect(album._gap_track_count).toBe(12);
+  });
+
+  it('falls back to the bucket for a missing album_type, and names the unknown', () => {
+    const [, ep] = gapReleasesFromResponse(RESPONSE);
+    expect(ep.album_type).toBe('eps');
+    const [nameless] = gapReleasesFromResponse({ gaps: { albums: [{ id: 'x' }] } });
+    expect(nameless.title).toBe('Unknown Release');
+  });
+
+  it('survives a response with no gaps at all', () => {
+    expect(gapReleasesFromResponse({})).toEqual([]);
+    expect(gapReleasesFromResponse(null)).toEqual([]);
+  });
+});
+
+describe('dedupeGaps', () => {
+  const gaps = gapReleasesFromResponse({
+    gaps: { albums: [{ id: 'g1', title: 'SAW', year: 1992, gap_source: 'deezer' }] },
+  });
+
+  it('drops a gap the page already renders — even from another bucket', () => {
+    // The library-merged view can hold owned releases the base source never
+    // listed; those must not come back as "missing" gap cards.
+    expect(dedupeGaps(gaps, { eps: [{ title: 'SAW', year: 1992 }] })).toEqual([]);
+  });
+
+  it('keeps a gap that is genuinely absent', () => {
+    expect(dedupeGaps(gaps, { albums: [{ title: 'Drukqs', year: 2001 }] })).toHaveLength(1);
+  });
+});
+
+describe('mergeGapReleases', () => {
+  const gap = (id: string, year: number) =>
+    gapReleasesFromResponse({ gaps: { albums: [{ id, title: id, year }] } })[0];
+
+  it('slots a gap between the releases either side of it by year', () => {
+    const base = {
+      albums: [
+        { id: 'new', year: 2010 },
+        { id: 'old', year: 1990 },
+      ],
+    };
+    const merged = mergeGapReleases(base, [gap('mid', 2000)]);
+    expect(merged.albums?.map((r) => r.id)).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('sinks an unknown year to the end', () => {
+    const base = { albums: [{ id: 'a', year: 2010 }] };
+    const merged = mergeGapReleases(base, [gap('unknown', NaN)]);
+    expect(merged.albums?.map((r) => r.id)).toEqual(['a', 'unknown']);
+  });
+
+  it('is an insertion, not a re-sort — the base keeps its own order', () => {
+    // The scan stops at the FIRST older release, so against an out-of-order
+    // base the gap lands early rather than triggering a global sort. Verbatim
+    // vanilla behaviour: grids render newest-first, and re-sorting would
+    // rearrange releases the source deliberately ordered.
+    const base = {
+      albums: [
+        { id: 'a', year: 1990 },
+        { id: 'b', year: 2010 },
+      ],
+    };
+    const merged = mergeGapReleases(base, [gap('c', 1995)]);
+    expect(merged.albums?.map((r) => r.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('only touches the bucket a gap belongs to', () => {
+    const base = { albums: [{ id: 'a' }], eps: [{ id: 'e' }] };
+    const merged = mergeGapReleases(base, [gap('g', 2000)]);
+    expect(merged.eps).toBe(base.eps);
+    expect(merged.albums).not.toBe(base.albums);
+  });
+
+  it('returns the SAME object when there is nothing to merge', () => {
+    const base = { albums: [{ id: 'a' }] };
+    expect(mergeGapReleases(base, [])).toBe(base);
+  });
+});
+
+describe('gapStreamPayload', () => {
+  it('gives every entry its own source and leaves the top-level source null', () => {
+    // A gap id is only meaningful on the source that listed it, so these cannot
+    // ride the base artist's stream.
+    const gaps = gapReleasesFromResponse({
+      gaps: {
+        albums: [{ id: 'a', title: 'A', gap_source: 'deezer', track_count: 9 }],
+        singles: [{ id: 's', title: 'S', gap_source: 'itunes' }],
+      },
+    });
+    const payload = gapStreamPayload('Aphex Twin', gaps);
+
+    expect(payload.source).toBeNull();
+    expect(payload.albums).toEqual([
+      expect.objectContaining({ id: 'a', source: 'deezer', track_count: 9 }),
+    ]);
+    expect(payload.singles).toEqual([expect.objectContaining({ id: 's', source: 'itunes' })]);
+    expect(payload.eps).toEqual([]);
+  });
+});
+
+describe('gapFillUrl', () => {
+  it('passes the base source so the backend can exclude it', () => {
+    expect(gapFillUrl(42, 'Aphex Twin', 'spotify')).toBe(
+      '/api/artist/42/discography/gap-fill?artist_name=Aphex+Twin&base_source=spotify',
+    );
+  });
+
+  it('omits absent parameters rather than sending empties', () => {
+    expect(gapFillUrl(42, undefined, undefined)).toBe('/api/artist/42/discography/gap-fill?');
+  });
+
+  it('encodes an id with slashes', () => {
+    expect(gapFillUrl('a/b', undefined, undefined)).toContain('/api/artist/a%2Fb/');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.gap-fill.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.gap-fill.ts
@@ -1,0 +1,234 @@
+import type { Discography, DiscographyBucket, DiscographyRelease } from './-artist-detail.types';
+
+/**
+ * Discography gap-fill (#1067) — "show me what my OTHER sources know about".
+ *
+ * A view option, persisted per browser, that APPENDS releases the base source
+ * never listed. The base discography renders untouched; gap cards slot into the
+ * real Album/EP/Single grids at their year-sorted position (Boulder's live
+ * feedback: a separate section felt bolted-on) and carry a source badge, and
+ * each one keeps its owning source so clicks resolve from THERE — a gap
+ * release's id only means anything on the source that listed it.
+ */
+
+const STORAGE_KEY = 'discog_gapfill';
+
+export function gapFillEnabled(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    // Private-mode / disabled storage: treat as off rather than throwing.
+    return false;
+  }
+}
+
+export function setGapFillEnabled(on: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, on ? '1' : '0');
+  } catch {
+    // The chip still toggles for this page view; it just will not persist.
+  }
+}
+
+/**
+ * The client half of the backend's conservative same-release rule.
+ *
+ * Edition parens are KEPT — "Album" and "Album (Deluxe Edition)" are different
+ * releases and must not collapse into one.
+ */
+export function gapNorm(title: unknown): string {
+  return String(title || '')
+    .toLowerCase()
+    .replace(/[^\w\s()]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Year from `year` or the first four characters of `release_date`. */
+export function gapYear(release: { year?: unknown; release_date?: unknown }): number | null {
+  let raw: unknown = release?.year;
+  if (raw == null && release?.release_date) raw = String(release.release_date).slice(0, 4);
+  const year = parseInt(String(raw), 10);
+  return year >= 1000 && year <= 3000 ? year : null;
+}
+
+/**
+ * Same release? Titles must match exactly once normalised, and the years must
+ * be within one of each other — an UNKNOWN year on either side counts as a
+ * match, because the alternative is showing the same album twice.
+ */
+export function gapSameRelease(
+  a: { title?: unknown; name?: unknown; year?: unknown; release_date?: unknown },
+  b: { title?: unknown; name?: unknown; year?: unknown; release_date?: unknown },
+): boolean {
+  const ta = gapNorm(a.title ?? a.name);
+  const tb = gapNorm(b.title ?? b.name);
+  if (!ta || ta !== tb) return false;
+  const ya = gapYear(a);
+  const yb = gapYear(b);
+  if (ya == null || yb == null) return true;
+  return Math.abs(ya - yb) <= 1;
+}
+
+/**
+ * Badge text per source, mirroring SOURCE_LABELS in shared-helpers.js.
+ *
+ * That map is a top-level `const` in a classic script, so it is a global
+ * LEXICAL binding and never lands on `window` — a module cannot read it. The
+ * copy is kept honest by a differential parity test that extracts the labels
+ * from shared-helpers.js and requires them to match exactly.
+ */
+export const SOURCE_LABEL_TEXT: Record<string, string> = {
+  spotify: 'Spotify',
+  spotify_free: 'Spotify (no auth)',
+  itunes: 'Apple Music',
+  deezer: 'Deezer',
+  discogs: 'Discogs',
+  hydrabase: 'Hydrabase',
+  amazon: 'Amazon Music',
+  musicbrainz: 'MusicBrainz',
+  jiosaavn: 'JioSaavn',
+  bandcamp: 'Bandcamp',
+  youtube_videos: 'Music Videos',
+  soulseek: 'Basic Search',
+};
+
+/** An unknown source falls back to its raw key, exactly as the vanilla did. */
+export function gapSourceLabel(source: string | undefined): string {
+  return SOURCE_LABEL_TEXT[source ?? ''] ?? (source || '');
+}
+
+export interface GapRelease extends DiscographyRelease {
+  /** Which source listed this release — clicks and downloads resolve there. */
+  _gap_source?: string;
+  /** Which grid it belongs in. */
+  _bucket: DiscographyBucket;
+  /**
+   * Track count for the ownership stream ONLY.
+   *
+   * Deliberately not `track_count`: the vanilla's gap card carried no track
+   * count, so releaseToAlbumData fell through to its "never 0" default of 1.
+   * Setting the real field here would silently change what the download modal
+   * opens with.
+   */
+  _gap_track_count?: number;
+}
+
+const BUCKET_FOR: Record<string, DiscographyBucket> = {
+  albums: 'albums',
+  eps: 'eps',
+  singles: 'singles',
+};
+
+/**
+ * Flatten the gap-fill response into release objects.
+ *
+ * `owned` starts FALSE, not null: these are known-missing by definition, and a
+ * null would render them as permanently "checking" if the ownership stream
+ * never reached them.
+ */
+export function gapReleasesFromResponse(payload: unknown): GapRelease[] {
+  const gaps = (payload as { gaps?: Record<string, unknown[]> })?.gaps ?? {};
+  const releases: GapRelease[] = [];
+
+  for (const key of ['albums', 'eps', 'singles'] as const) {
+    for (const raw of gaps[key] ?? []) {
+      const gap = raw as Record<string, unknown>;
+      releases.push({
+        id: gap.id as string | number,
+        title: (gap.title as string) || (gap.name as string) || 'Unknown Release',
+        image_url: (gap.image_url as string) || '',
+        year: gap.year as number,
+        release_date: gap.release_date as string,
+        album_type: (gap.album_type as string) || key,
+        owned: false,
+        _gap_track_count: (gap.track_count as number) || (gap.total_tracks as number) || 0,
+        _gap_source: (gap.gap_source as string) || undefined,
+        _bucket: BUCKET_FOR[key],
+      });
+    }
+  }
+  return releases;
+}
+
+/**
+ * Drop gaps the page already shows.
+ *
+ * This runs against what was RENDERED, not against the base source's own list:
+ * the library-merged view can contain owned releases the base source never
+ * listed, and those must not come back as "missing" gap cards.
+ */
+export function dedupeGaps(gaps: GapRelease[], rendered: Discography): GapRelease[] {
+  const shown = [...(rendered.albums ?? []), ...(rendered.eps ?? []), ...(rendered.singles ?? [])];
+  return gaps.filter((gap) => !shown.some((release) => gapSameRelease(gap, release)));
+}
+
+/**
+ * Slot gap releases into the base buckets at their year-sorted position.
+ *
+ * Grids render newest-first and unknown years sink to the end, so each gap goes
+ * before the first release OLDER than it. The base order is otherwise left
+ * alone — this is an insertion, not a re-sort, so a source that lists releases
+ * in its own deliberate order keeps it.
+ */
+export function mergeGapReleases(base: Discography, gaps: GapRelease[]): Discography {
+  if (gaps.length === 0) return base;
+
+  const merged: Discography = { ...base };
+  for (const bucket of ['albums', 'eps', 'singles'] as const) {
+    const forBucket = gaps.filter((gap) => gap._bucket === bucket);
+    if (forBucket.length === 0) continue;
+
+    const releases = [...(base[bucket] ?? [])];
+    for (const gap of forBucket) {
+      const year = gapYear(gap) || 0;
+      const index = releases.findIndex((release) => (gapYear(release) || 0) < year);
+      if (index === -1) releases.push(gap);
+      else releases.splice(index, 0, gap);
+    }
+    merged[bucket] = releases;
+  }
+  return merged;
+}
+
+/**
+ * The completion-stream body for gap releases.
+ *
+ * Each entry carries its OWN `source` and the top-level source is null: a gap
+ * release's id is only meaningful on the source that listed it, so they cannot
+ * ride the base artist's stream.
+ */
+export function gapStreamPayload(artistName: string, gaps: GapRelease[]) {
+  const payload: {
+    artist_name: string;
+    albums: unknown[];
+    eps: unknown[];
+    singles: unknown[];
+    source: null;
+  } = { artist_name: artistName, albums: [], eps: [], singles: [], source: null };
+
+  for (const gap of gaps) {
+    payload[gap._bucket].push({
+      id: gap.id,
+      title: gap.title || '',
+      track_count: gap._gap_track_count || 0,
+      album_type: gap.album_type || gap._bucket,
+      year: gap.year,
+      release_date: gap.release_date,
+      source: gap._gap_source || null,
+    });
+  }
+  return payload;
+}
+
+/** The gap-fill request URL, with the base source so it can be excluded. */
+export function gapFillUrl(
+  artistId: unknown,
+  artistName: string | undefined,
+  baseSource: string | undefined,
+): string {
+  const params = new URLSearchParams();
+  if (artistName) params.set('artist_name', artistName);
+  if (baseSource) params.set('base_source', baseSource);
+  return `/api/artist/${encodeURIComponent(String(artistId))}/discography/gap-fill?${params}`;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildGenreChips,
   categoryStats,
   cleanArtistBio,
   formatHeroNumber,
@@ -191,5 +192,55 @@ describe('totalReleaseCount', () => {
     expect(totalReleaseCount({ albums: [{}, {}], eps: [{}], singles: [] })).toBe(3);
     expect(totalReleaseCount({})).toBe(0);
     expect(totalReleaseCount(undefined)).toBe(0);
+  });
+});
+
+describe('buildGenreChips', () => {
+  it("lists the artist's own genres first, undimmed", () => {
+    expect(buildGenreChips({ genres: ['IDM', 'Ambient'] })).toEqual([
+      { label: 'IDM', fromLastfm: false },
+      { label: 'Ambient', fromLastfm: false },
+    ]);
+  });
+
+  it('appends Last.fm tags as dimmed extras', () => {
+    const chips = buildGenreChips({ genres: ['IDM'], lastfm_tags: ['electronic'] });
+    expect(chips).toEqual([
+      { label: 'IDM', fromLastfm: false },
+      { label: 'electronic', fromLastfm: true },
+    ]);
+  });
+
+  it('parses lastfm_tags when it arrives as a JSON STRING', () => {
+    // The backend stores it serialised; a bare array check would drop them.
+    const chips = buildGenreChips({ lastfm_tags: '["techno","acid"]' });
+    expect(chips.map((c) => c.label)).toEqual(['techno', 'acid']);
+  });
+
+  it('swallows malformed tags rather than taking the hero down', () => {
+    expect(buildGenreChips({ genres: ['IDM'], lastfm_tags: '{not json' })).toEqual([
+      { label: 'IDM', fromLastfm: false },
+    ]);
+  });
+
+  it('dedups against existing genres case-INSENSITIVELY', () => {
+    // The tag must differ in case from the genre, or a case-SENSITIVE
+    // comparison gives the same answer and the test proves nothing: the
+    // existing-set is already lowercased, so a lowercase tag matches either way.
+    const chips = buildGenreChips({ genres: ['Techno'], lastfm_tags: ['TECHNO', 'acid'] });
+    expect(chips.map((c) => c.label)).toEqual(['Techno', 'acid']);
+  });
+
+  it('caps the Last.fm extras at 5, but does not cap real genres', () => {
+    const chips = buildGenreChips({
+      genres: ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      lastfm_tags: ['t1', 't2', 't3', 't4', 't5', 't6', 't7'],
+    });
+    expect(chips.filter((c) => !c.fromLastfm)).toHaveLength(7);
+    expect(chips.filter((c) => c.fromLastfm)).toHaveLength(5);
+  });
+
+  it('handles an artist with neither', () => {
+    expect(buildGenreChips({})).toEqual([]);
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
@@ -10,6 +10,9 @@ import {
   heroReleaseImage,
   isUsableHeroImageUrl,
   nextHeroImageStage,
+  artistFormatTags,
+  resolvedCategoryStats,
+  streamCategoryStats,
   summaryStats,
   totalReleaseCount,
 } from './-artist-detail.hero-stats';
@@ -242,5 +245,63 @@ describe('buildGenreChips', () => {
 
   it('handles an artist with neither', () => {
     expect(buildGenreChips({})).toEqual([]);
+  });
+});
+
+describe('streamCategoryStats', () => {
+  it('uses only RESOLVED releases as the denominator', () => {
+    // Three of twelve checked so far reads "2/3", not "2/12" — the bar tracks
+    // progress through the check, not the final answer.
+    expect(streamCategoryStats(2, 1)).toEqual({ text: '2/3', width: '67%', checking: false });
+  });
+
+  it('drops the checking state as soon as the first result lands', () => {
+    // categoryStats would still say "..." here because pending releases exist.
+    expect(streamCategoryStats(1, 0).checking).toBe(false);
+    expect(streamCategoryStats(1, 0).text).toBe('1/1');
+  });
+
+  it('treats nothing-resolved as 100%, like categoryStats not summaryStats', () => {
+    expect(streamCategoryStats(0, 0)).toEqual({ text: '0/0', width: '100%', checking: false });
+  });
+
+  it('reaches 100% when everything resolved is owned', () => {
+    expect(streamCategoryStats(5, 0).width).toBe('100%');
+    expect(streamCategoryStats(0, 5).width).toBe('0%');
+  });
+});
+
+describe('resolvedCategoryStats', () => {
+  it('drops unresolved releases from the denominator instead of showing "..."', () => {
+    // categoryStats would return '...' here; the vanilla's post-stream recount
+    // only ever saw resolved cards, so a release the backend never reported on
+    // simply is not counted.
+    const stats = resolvedCategoryStats([{ owned: true }, { owned: false }, { owned: null }]);
+    expect(stats).toEqual({ text: '1/2', width: '50%', checking: false });
+    expect(categoryStats([{ owned: true }, { owned: false }, { owned: null }]).text).toBe('...');
+  });
+
+  it('agrees with categoryStats once everything resolved', () => {
+    const releases = [{ owned: true }, { owned: true }, { owned: false }];
+    expect(resolvedCategoryStats(releases)).toEqual(categoryStats(releases));
+  });
+
+  it('reads 0/0 at 100% for a bucket with nothing resolved', () => {
+    expect(resolvedCategoryStats([{ owned: null }])).toEqual({
+      text: '0/0',
+      width: '100%',
+      checking: false,
+    });
+  });
+});
+
+describe('artistFormatTags', () => {
+  it('sorts the accumulated formats', () => {
+    expect(artistFormatTags(new Set(['MP3', 'FLAC', 'AAC']))).toEqual(['AAC', 'FLAC', 'MP3']);
+  });
+
+  it('renders nothing for an empty or absent set', () => {
+    expect(artistFormatTags(new Set())).toEqual([]);
+    expect(artistFormatTags(undefined)).toEqual([]);
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  categoryStats,
+  cleanArtistBio,
+  formatHeroNumber,
+  heroImage,
+  heroImageSrc,
+  heroReleaseImage,
+  isUsableHeroImageUrl,
+  nextHeroImageStage,
+  summaryStats,
+  totalReleaseCount,
+} from './-artist-detail.hero-stats';
+
+describe('isUsableHeroImageUrl', () => {
+  it('rejects the literal string "null", not just null', () => {
+    // The backend can serialise a missing image as the text "null", which
+    // would otherwise be fetched as a relative url and 404.
+    expect(isUsableHeroImageUrl('null')).toBe(false);
+    expect(isUsableHeroImageUrl(null)).toBe(false);
+    expect(isUsableHeroImageUrl('   ')).toBe(false);
+    expect(isUsableHeroImageUrl('')).toBe(false);
+    expect(isUsableHeroImageUrl('a.jpg')).toBe(true);
+  });
+});
+
+describe('heroReleaseImage', () => {
+  it('scans albums, then eps, then singles', () => {
+    expect(
+      heroReleaseImage({
+        albums: [{}],
+        eps: [{ image_url: 'ep.jpg' }],
+        singles: [{ image_url: 's.jpg' }],
+      }),
+    ).toBe('ep.jpg');
+  });
+
+  it('skips unusable urls rather than returning them', () => {
+    expect(heroReleaseImage({ albums: [{ image_url: 'null' }, { image_url: 'ok.jpg' }] })).toBe(
+      'ok.jpg',
+    );
+  });
+
+  it('returns empty when nothing has art', () => {
+    expect(heroReleaseImage({ albums: [{}] })).toBe('');
+    expect(heroReleaseImage(undefined)).toBe('');
+  });
+});
+
+describe('heroImage', () => {
+  it("prefers the artist's own photo", () => {
+    const img = heroImage({ image_url: 'artist.jpg' }, { albums: [{ image_url: 'rel.jpg' }] });
+    expect(img.primary).toBe('artist.jpg');
+    expect(img.artistImage).toBe('artist.jpg');
+  });
+
+  it('falls back to release art when the artist has none', () => {
+    const img = heroImage({}, { albums: [{ image_url: 'rel.jpg' }] });
+    expect(img.primary).toBe('rel.jpg');
+    expect(img.artistImage).toBe('');
+  });
+
+  it('has no primary at all when neither exists', () => {
+    expect(heroImage({}, {}).primary).toBe('');
+  });
+});
+
+describe('hero image fallback chain', () => {
+  it('tries Deezer first when there is a deezer id', () => {
+    const img = heroImage({ image_url: 'a.jpg', deezer_id: 7 }, {});
+    expect(nextHeroImageStage('primary', { deezer_id: 7 }, img)).toBe('deezer');
+    expect(heroImageSrc('deezer', { deezer_id: 7 }, img)).toBe(
+      'https://api.deezer.com/artist/7/image?size=big',
+    );
+  });
+
+  it('then falls to release art, then the icon', () => {
+    const img = heroImage(
+      { image_url: 'a.jpg', deezer_id: 7 },
+      { albums: [{ image_url: 'rel.jpg' }] },
+    );
+    expect(nextHeroImageStage('deezer', { deezer_id: 7 }, img)).toBe('release');
+    expect(nextHeroImageStage('release', { deezer_id: 7 }, img)).toBe('fallback');
+  });
+
+  it('does NOT retry release art when it was already the primary', () => {
+    // The artist had no photo, so the release cover IS the primary — retrying
+    // it would loop. This is what triedReleaseFallback pre-set guarded.
+    const img = heroImage({ deezer_id: 7 }, { albums: [{ image_url: 'rel.jpg' }] });
+    expect(nextHeroImageStage('deezer', { deezer_id: 7 }, img)).toBe('fallback');
+  });
+
+  it('skips Deezer entirely without a deezer id', () => {
+    const img = heroImage({ image_url: 'a.jpg' }, { albums: [{ image_url: 'rel.jpg' }] });
+    expect(nextHeroImageStage('primary', {}, img)).toBe('release');
+  });
+
+  it('goes straight to the icon with no deezer id and no release art', () => {
+    expect(nextHeroImageStage('primary', {}, heroImage({ image_url: 'a.jpg' }, {}))).toBe(
+      'fallback',
+    );
+  });
+});
+
+describe('categoryStats', () => {
+  it('shows owned/total and a proportional bar', () => {
+    expect(
+      categoryStats([{ owned: true }, { owned: false }, { owned: true }, { owned: false }]),
+    ).toEqual({
+      text: '2/4',
+      width: '50%',
+      checking: false,
+    });
+  });
+
+  it('treats an EMPTY category as 100% complete, not 0%', () => {
+    // You cannot be missing anything from a bucket with nothing in it.
+    expect(categoryStats([])).toEqual({ text: '0/0', width: '100%', checking: false });
+  });
+
+  it('shows a full animating bar while any check is pending', () => {
+    expect(categoryStats([{ owned: null }, { owned: true }])).toEqual({
+      text: '...',
+      width: '100%',
+      checking: true,
+    });
+  });
+});
+
+describe('summaryStats', () => {
+  it('counts ALBUMS only, but checks pending across every bucket', () => {
+    const stats = summaryStats({
+      albums: [{ owned: true }, { owned: false }],
+      eps: [{ owned: true }],
+      singles: [],
+    });
+    expect(stats).toEqual({ owned: '1', missing: '1', completion: '50%' });
+  });
+
+  it('goes to ... when a SINGLE is still checking, though singles are not counted', () => {
+    const stats = summaryStats({ albums: [{ owned: true }], singles: [{ owned: null }] });
+    expect(stats).toEqual({ owned: '...', missing: '...', completion: 'Checking...' });
+  });
+
+  it('uses 0% for an empty album list — unlike categoryStats, which uses 100%', () => {
+    expect(summaryStats({ albums: [] }).completion).toBe('0%');
+  });
+});
+
+describe('formatHeroNumber', () => {
+  it('abbreviates millions and thousands, trimming a trailing .0', () => {
+    expect(formatHeroNumber(1_200_000)).toBe('1.2M');
+    expect(formatHeroNumber(1_000_000)).toBe('1M');
+    expect(formatHeroNumber(3400)).toBe('3.4K');
+    expect(formatHeroNumber(1000)).toBe('1K');
+  });
+
+  it('leaves values under 1000 alone', () => {
+    expect(formatHeroNumber(999)).toBe('999');
+  });
+
+  it('renders 0 for absent or non-positive values', () => {
+    expect(formatHeroNumber(0)).toBe('0');
+    expect(formatHeroNumber(undefined)).toBe('0');
+    expect(formatHeroNumber(-5)).toBe('0');
+  });
+});
+
+describe('cleanArtistBio', () => {
+  it('removes anchors WHOLE, including their text', () => {
+    // Last.fm always appends a "Read more on Last.fm" link.
+    expect(cleanArtistBio('Great band. <a href="https://last.fm">Read more on Last.fm</a>')).toBe(
+      'Great band.',
+    );
+  });
+
+  it('strips other tags but keeps their text', () => {
+    expect(cleanArtistBio('<b>Bold</b> claim')).toBe('Bold claim');
+  });
+
+  it('returns empty when only a link remains, so the block hides', () => {
+    expect(cleanArtistBio('<a href="x">Read more</a>')).toBe('');
+    expect(cleanArtistBio('   ')).toBe('');
+    expect(cleanArtistBio(undefined)).toBe('');
+  });
+});
+
+describe('totalReleaseCount', () => {
+  it('sums every bucket — the Download Discography button keys off it', () => {
+    expect(totalReleaseCount({ albums: [{}, {}], eps: [{}], singles: [] })).toBe(3);
+    expect(totalReleaseCount({})).toBe(0);
+    expect(totalReleaseCount(undefined)).toBe(0);
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
@@ -1,0 +1,158 @@
+import type { ArtistInfo, Discography, DiscographyBucket } from './-artist-detail.types';
+
+/**
+ * Hero derivations from updateArtistHeroSection / updateCategoryStats /
+ * _isUsableArtistHeroImageUrl / _getArtistHeroReleaseImage (library.js 916-1060).
+ */
+
+/**
+ * The string 'null' is rejected explicitly, not just null: the backend can
+ * serialise a missing image as the literal text "null", which would otherwise
+ * be requested as a relative url and 404.
+ */
+export function isUsableHeroImageUrl(url: unknown): url is string {
+  return typeof url === 'string' && url.trim() !== '' && url !== 'null';
+}
+
+/** First usable release cover, scanned albums -> eps -> singles. */
+export function heroReleaseImage(discography: Discography | undefined): string {
+  for (const bucket of ['albums', 'eps', 'singles'] as const) {
+    for (const release of discography?.[bucket] ?? []) {
+      if (isUsableHeroImageUrl(release?.image_url)) return release.image_url as string;
+    }
+  }
+  return '';
+}
+
+export interface HeroImage {
+  /** What to show first; '' means go straight to the music-note fallback. */
+  primary: string;
+  /** The artist's own image, if usable — '' when we fell back to release art. */
+  artistImage: string;
+  /** Release cover used as a fallback, if any. */
+  releaseImage: string;
+}
+
+/**
+ * The artist's own photo wins; otherwise the first release cover stands in, and
+ * the blurred hero background uses whichever won.
+ */
+export function heroImage(artist: ArtistInfo, discography: Discography | undefined): HeroImage {
+  const artistImage = isUsableHeroImageUrl(artist.image_url) ? artist.image_url : '';
+  const releaseImage = heroReleaseImage(discography);
+  return { primary: artistImage || releaseImage, artistImage, releaseImage };
+}
+
+/**
+ * The image error chain: Deezer, then release art, then the icon.
+ *
+ * The vanilla tracked this with two dataset flags so neither hop could repeat
+ * (a failing Deezer url would otherwise loop forever). `triedReleaseFallback`
+ * starts already-set when the artist had no image of their own, because in
+ * that case the release cover IS the primary and re-trying it is pointless.
+ */
+export type HeroImageStage = 'primary' | 'deezer' | 'release' | 'fallback';
+
+export function nextHeroImageStage(
+  stage: HeroImageStage,
+  artist: ArtistInfo,
+  image: HeroImage,
+): HeroImageStage {
+  if (stage === 'primary' && artist.deezer_id) return 'deezer';
+  const releaseUsed = !image.artistImage;
+  if ((stage === 'primary' || stage === 'deezer') && image.releaseImage && !releaseUsed) {
+    return 'release';
+  }
+  return 'fallback';
+}
+
+export function heroImageSrc(stage: HeroImageStage, artist: ArtistInfo, image: HeroImage): string {
+  if (stage === 'deezer') return `https://api.deezer.com/artist/${artist.deezer_id}/image?size=big`;
+  if (stage === 'release') return image.releaseImage;
+  return image.primary;
+}
+
+export interface CategoryStats {
+  /** "3/12", or "..." while any ownership check is pending. */
+  text: string;
+  /** Bar width as a percentage string. */
+  width: string;
+  /** The bar animates instead of showing a real value while checking. */
+  checking: boolean;
+}
+
+/**
+ * Per-category completion bar.
+ *
+ * Note the default: an EMPTY category is 100%, not 0% — you cannot be missing
+ * anything from a bucket with nothing in it. That differs from
+ * updateArtistSummaryStats, which uses 0 for the same situation.
+ */
+export function categoryStats(releases: { owned?: boolean | null }[] = []): CategoryStats {
+  const checking = releases.some((r) => r.owned === null);
+  const owned = releases.filter((r) => r.owned === true).length;
+  const total = releases.length;
+  const completion = total > 0 ? Math.round((owned / total) * 100) : 100;
+
+  if (checking) return { text: '...', width: '100%', checking: true };
+  return { text: `${owned}/${total}`, width: `${completion}%`, checking: false };
+}
+
+export interface SummaryStats {
+  owned: string;
+  missing: string;
+  completion: string;
+}
+
+/**
+ * The album-only summary. Unlike categoryStats, an empty album list is 0% here
+ * — reproduced as-is rather than harmonised.
+ */
+export function summaryStats(discography: Discography): SummaryStats {
+  const all = [
+    ...(discography.albums ?? []),
+    ...(discography.eps ?? []),
+    ...(discography.singles ?? []),
+  ];
+  const checking = all.some((r) => r.owned === null);
+  const albums = discography.albums ?? [];
+  const owned = albums.filter((a) => a.owned === true).length;
+  const missing = albums.filter((a) => a.owned === false).length;
+  const pct = albums.length > 0 ? Math.round((owned / albums.length) * 100) : 0;
+
+  return {
+    owned: checking ? '...' : String(owned),
+    missing: checking ? '...' : String(missing),
+    completion: checking ? 'Checking...' : `${pct}%`,
+  };
+}
+
+/** Last.fm counts: 1.2M / 3.4K / 999, with a trailing ".0" trimmed. */
+export function formatHeroNumber(n: unknown): string {
+  const value = Number(n);
+  if (!value || value <= 0) return '0';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, '')}K`;
+  return value.toLocaleString();
+}
+
+/**
+ * Last.fm bios arrive as HTML and always carry a "Read more on Last.fm" link.
+ * Anchors are removed WHOLE (link text included), then any other tags are
+ * stripped. Returns '' when nothing readable is left, which hides the block.
+ */
+export function cleanArtistBio(bio: unknown): string {
+  if (typeof bio !== 'string' || !bio.trim()) return '';
+  return bio
+    .replace(/<a\b[^>]*>.*?<\/a>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .trim();
+}
+
+/** The Download Discography button appears only if there is anything to download. */
+export function totalReleaseCount(discography: Discography | undefined): number {
+  return (['albums', 'eps', 'singles'] as DiscographyBucket[]).reduce(
+    (sum, bucket) => sum + (discography?.[bucket]?.length ?? 0),
+    0,
+  );
+}

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
@@ -156,3 +156,46 @@ export function totalReleaseCount(discography: Discography | undefined): number 
     0,
   );
 }
+
+/**
+ * Genre chips: the artist's own genres, then up to 5 Last.fm tags that are not
+ * already present.
+ *
+ * Three things the vanilla does here that are easy to lose:
+ *   - `lastfm_tags` may arrive as a JSON STRING rather than an array, and a
+ *     parse failure is swallowed — bad tags must not take the hero down
+ *   - the dedup is case-INSENSITIVE against existing genres
+ *   - the extra tags are capped at 5 and rendered dimmed (opacity 0.6) so they
+ *     read as secondary to real genres
+ */
+export interface GenreChip {
+  label: string;
+  /** Last.fm tags render dimmed; the artist's own genres do not. */
+  fromLastfm: boolean;
+}
+
+export function buildGenreChips(artist: ArtistInfo): GenreChip[] {
+  const genres = Array.isArray(artist.genres) ? artist.genres : [];
+  const chips: GenreChip[] = genres.map((label) => ({ label: String(label), fromLastfm: false }));
+
+  let tags: unknown = artist.lastfm_tags;
+  if (typeof tags === 'string') {
+    try {
+      tags = JSON.parse(tags);
+    } catch {
+      // Malformed tags are ignored rather than thrown — the vanilla swallowed
+      // this too, and the hero must still render.
+      tags = null;
+    }
+  }
+  if (!Array.isArray(tags) || tags.length === 0) return chips;
+
+  const existing = new Set(genres.map((g) => String(g).toLowerCase()));
+  for (const tag of tags) {
+    if (chips.filter((c) => c.fromLastfm).length >= 5) break;
+    const label = String(tag);
+    if (existing.has(label.toLowerCase())) continue;
+    chips.push({ label, fromLastfm: true });
+  }
+  return chips;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero-stats.ts
@@ -199,3 +199,54 @@ export function buildGenreChips(artist: ArtistInfo): GenreChip[] {
   }
   return chips;
 }
+
+/**
+ * The completion bar WHILE the stream is running, from
+ * updateCategoryStatsFromStream (library.js:2090).
+ *
+ * Deliberately different from categoryStats: the denominator is only what has
+ * RESOLVED so far (owned + missing), not the whole bucket. So a 12-album
+ * discography reads "2/3" after three results, not "2/12" — the bar tracks
+ * progress through the check rather than the final answer, and the "checking"
+ * class is dropped as soon as the first result lands.
+ *
+ * An empty resolved set is 100%, matching categoryStats rather than
+ * summaryStats.
+ */
+export function streamCategoryStats(ownedCount: number, missingCount: number): CategoryStats {
+  const total = ownedCount + missingCount;
+  const completion = total > 0 ? Math.round((ownedCount / total) * 100) : 100;
+  return { text: `${ownedCount}/${total}`, width: `${completion}%`, checking: false };
+}
+
+/**
+ * The bars once the stream reports `complete`, from recalculateSummaryStats
+ * (library.js:2106).
+ *
+ * The vanilla recounted the CARDS rather than trusting its running tallies, and
+ * that recount excludes anything still unresolved — so a release the backend
+ * never reported on drops out of the denominator instead of pinning the bar
+ * back to "...". That is the only reason this is not just categoryStats: after
+ * a clean stream the two agree.
+ */
+export function resolvedCategoryStats(releases: { owned?: boolean | null }[] = []): CategoryStats {
+  let owned = 0;
+  let missing = 0;
+  for (const release of releases) {
+    if (release.owned === true) owned += 1;
+    else if (release.owned === false) missing += 1;
+  }
+  return streamCategoryStats(owned, missing);
+}
+
+/**
+ * Artist-level format tags, shown under the genre chips once the stream ends.
+ *
+ * Accumulated from OWNED releases only (tallyEvent), sorted, and rendered only
+ * when non-empty — the vanilla removed the block entirely rather than leaving
+ * an empty row.
+ */
+export function artistFormatTags(formats: Set<string> | undefined): string[] {
+  if (!formats || formats.size === 0) return [];
+  return [...formats].sort();
+}

--- a/webui/src/routes/artist-detail/-artist-detail.hero.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { audioDbLogoUrl, audioDbSlug, buildHeroBadges } from './-artist-detail.hero';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('buildHeroBadges', () => {
+  it('renders nothing for an unenriched artist', () => {
+    expect(buildHeroBadges({ name: 'Nobody' })).toEqual([]);
+  });
+
+  it('keeps the vanilla declaration order, which is visible in the hero', () => {
+    const artist = {
+      name: 'A',
+      spotify_artist_id: 's',
+      musicbrainz_id: 'm',
+      deezer_id: 1,
+      audiodb_id: 2,
+      itunes_artist_id: 3,
+      lastfm_url: 'https://last.fm/a',
+      genius_url: 'https://genius.com/a',
+      tidal_id: 4,
+      qobuz_id: 5,
+      discogs_id: 6,
+      amazon_id: 'az',
+      bandcamp_url: 'https://a.bandcamp.com',
+      soul_id: 'soul_123',
+    };
+    expect(buildHeroBadges(artist).map((b) => b.key)).toEqual([
+      'spotify',
+      'musicbrainz',
+      'deezer',
+      'audiodb',
+      'itunes',
+      'lastfm',
+      'genius',
+      'tidal',
+      'qobuz',
+      'discogs',
+      'amazon',
+      'bandcamp',
+      'soulsync',
+    ]);
+  });
+
+  it('includes Bandcamp — the library CARD badge list does not', () => {
+    // The two lists genuinely differ; merging them would change one page.
+    const badges = buildHeroBadges({ name: 'A', bandcamp_url: 'https://a.bandcamp.com' });
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toMatchObject({ key: 'bandcamp', fallback: 'BC', title: 'Bandcamp' });
+  });
+
+  it('deep-links each provider', () => {
+    const url = (artist: Parameters<typeof buildHeroBadges>[0]) => buildHeroBadges(artist)[0].url;
+    expect(url({ spotify_artist_id: 'sp' })).toBe('https://open.spotify.com/artist/sp');
+    expect(url({ musicbrainz_id: 'mb' })).toBe('https://musicbrainz.org/artist/mb');
+    expect(url({ deezer_id: 7 })).toBe('https://www.deezer.com/artist/7');
+    expect(url({ itunes_artist_id: 8 })).toBe('https://music.apple.com/artist/8');
+    expect(url({ tidal_id: 9 })).toBe('https://tidal.com/browse/artist/9');
+    expect(url({ qobuz_id: 10 })).toBe('https://www.qobuz.com/artist/10');
+    expect(url({ discogs_id: 11 })).toBe('https://www.discogs.com/artist/11');
+  });
+
+  it('passes Last.fm, Genius and Bandcamp urls through unchanged', () => {
+    // These are stored as full urls, not ids.
+    expect(buildHeroBadges({ lastfm_url: 'https://last.fm/x' })[0].url).toBe('https://last.fm/x');
+    expect(buildHeroBadges({ genius_url: 'https://genius.com/x' })[0].url).toBe(
+      'https://genius.com/x',
+    );
+    expect(buildHeroBadges({ bandcamp_url: 'https://x.bandcamp.com' })[0].url).toBe(
+      'https://x.bandcamp.com',
+    );
+  });
+
+  it('gives Amazon and SoulID no link — neither has a public artist page', () => {
+    expect(buildHeroBadges({ amazon_id: 'az' })[0].url).toBeNull();
+    expect(buildHeroBadges({ soul_id: 'soul_1' })[0].url).toBeNull();
+  });
+
+  it('titles the SoulID badge with the id itself', () => {
+    expect(buildHeroBadges({ soul_id: 'soul_42' })[0].title).toBe('SoulID: soul_42');
+  });
+
+  it('hides a placeholder soul id', () => {
+    expect(buildHeroBadges({ soul_id: 'soul_unnamed_9' })).toEqual([]);
+    expect(buildHeroBadges({ soul_id: 'soul_9' })).toHaveLength(1);
+  });
+
+  it('treats a zero id as absent', () => {
+    expect(buildHeroBadges({ deezer_id: 0, tidal_id: 0 })).toEqual([]);
+  });
+
+  it('builds the AudioDB url from the slugified name', () => {
+    const badge = buildHeroBadges({ name: 'Sigur Rós', audiodb_id: 5 })[0];
+    expect(badge.url).toBe('https://www.theaudiodb.com/artist/5-Sigur-Rs');
+  });
+});
+
+describe('audioDbSlug', () => {
+  it('hyphenates spaces BEFORE stripping non-alphanumerics', () => {
+    // Order matters: doing it the other way round gives "SigurRs".
+    expect(audioDbSlug('Sigur Rós')).toBe('Sigur-Rs');
+    expect(audioDbSlug('AC/DC')).toBe('ACDC');
+    expect(audioDbSlug('!!!')).toBe('');
+    expect(audioDbSlug(undefined)).toBe('');
+  });
+});
+
+describe('audioDbLogoUrl', () => {
+  it('reads the logo off an existing img.audiodb-logo', () => {
+    document.body.innerHTML = '<img class="audiodb-logo" src="/static/adb.png">';
+    expect(audioDbLogoUrl()).toContain('/static/adb.png');
+  });
+
+  it('returns empty when there is none, so the badge falls back to its text', () => {
+    expect(audioDbLogoUrl()).toBe('');
+    expect(buildHeroBadges({ audiodb_id: 1, name: 'A' })[0]).toMatchObject({
+      logo: '',
+      fallback: 'ADB',
+    });
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.hero.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero.test.ts
@@ -122,3 +122,26 @@ describe('audioDbLogoUrl', () => {
     });
   });
 });
+
+describe('audioDbLogoUrl defers to core.js', () => {
+  it('uses getAudioDBLogoURL when core.js provides it', () => {
+    // core.js owns this lookup; duplicating it means a change there stops
+    // applying here without anything failing.
+    window.getAudioDBLogoURL = () => '/from/core.png';
+    try {
+      expect(audioDbLogoUrl()).toBe('/from/core.png');
+    } finally {
+      delete window.getAudioDBLogoURL;
+    }
+  });
+
+  it('falls back to the DOM lookup when core.js returns nothing', () => {
+    window.getAudioDBLogoURL = () => null;
+    document.body.innerHTML = '<img class="audiodb-logo" src="/static/adb.png">';
+    try {
+      expect(audioDbLogoUrl()).toContain('/static/adb.png');
+    } finally {
+      delete window.getAudioDBLogoURL;
+    }
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.hero.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero.ts
@@ -1,0 +1,137 @@
+import type { ArtistInfo } from './-artist-detail.types';
+
+/**
+ * Hero provider badges, ported from `updateArtistDetailPageHeaderWithData`
+ * (library.js:690).
+ *
+ * NOTE this list is NOT the same as the library card's badge list, and the
+ * difference is real rather than an oversight in either place:
+ *   - the hero has **Bandcamp**, the library card does not
+ *   - the hero renders `.artist-hero-badge` anchors that open in a new tab;
+ *     the card renders `.source-card-icon` divs driven by a delegated handler
+ * They are kept separate deliberately — merging them would change one of the
+ * two pages.
+ */
+
+const LOGOS = {
+  musicbrainz: '/static/img/brands/musicbrainz.png',
+  deezer: '/static/img/brands/deezer.png',
+  spotify: '/static/img/brands/spotify.png',
+  itunes: '/static/img/brands/itunes.png',
+  lastfm: '/static/img/brands/lastfm.png',
+  genius: '/static/img/brands/genius.png',
+  tidal: '/static/img/brands/tidal.svg',
+  qobuz: '/static/img/brands/qobuz.svg',
+  discogs: '/static/img/brands/discogs.svg',
+  amazon: '/static/amazon.svg',
+  bandcamp: '/static/img/brands/bandcamp.svg',
+  soulsync: '/static/trans2.png',
+} as const;
+
+export interface HeroBadge {
+  key: string;
+  /** Empty string when there is no logo — the text fallback shows instead. */
+  logo: string;
+  /** Two/three-letter text shown when the logo is missing or fails to load. */
+  fallback: string;
+  title: string;
+  /** null renders a non-clickable div rather than an anchor. */
+  url: string | null;
+}
+
+/**
+ * AudioDB's logo is not a constant — the vanilla reads it off an existing
+ * `img.audiodb-logo` in the DOM and returns null when there isn't one. Ported
+ * as a lookup so the badge degrades to its 'ADB' text exactly as it does now.
+ */
+export function audioDbLogoUrl(): string {
+  const el = typeof document === 'undefined' ? null : document.querySelector('img.audiodb-logo');
+  return el instanceof HTMLImageElement ? el.src : '';
+}
+
+/**
+ * The AudioDB url slug: spaces become hyphens BEFORE non-alphanumerics are
+ * stripped, so "Sigur Rós" -> "Sigur-Rs" (the hyphen survives, the accent does
+ * not). Order matters and is easy to get backwards.
+ */
+export function audioDbSlug(name: string | undefined): string {
+  return (name ?? '').replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '');
+}
+
+/** A placeholder SoulID the backend uses for un-named artists; not shown. */
+function isPlaceholderSoulId(soulId: unknown): boolean {
+  return String(soulId ?? '').startsWith('soul_unnamed_');
+}
+
+/**
+ * Badges in the vanilla's declaration order — the order is visible in the hero,
+ * so it is part of the contract.
+ */
+export function buildHeroBadges(artist: ArtistInfo): HeroBadge[] {
+  const badges: HeroBadge[] = [];
+  const add = (key: string, logo: string, fallback: string, title: string, url: string | null) =>
+    badges.push({ key, logo, fallback, title, url });
+
+  if (artist.spotify_artist_id)
+    add(
+      'spotify',
+      LOGOS.spotify,
+      'SP',
+      'Spotify',
+      `https://open.spotify.com/artist/${artist.spotify_artist_id}`,
+    );
+  if (artist.musicbrainz_id)
+    add(
+      'musicbrainz',
+      LOGOS.musicbrainz,
+      'MB',
+      'MusicBrainz',
+      `https://musicbrainz.org/artist/${artist.musicbrainz_id}`,
+    );
+  if (artist.deezer_id)
+    add(
+      'deezer',
+      LOGOS.deezer,
+      'Dz',
+      'Deezer',
+      `https://www.deezer.com/artist/${artist.deezer_id}`,
+    );
+  if (artist.audiodb_id)
+    add(
+      'audiodb',
+      audioDbLogoUrl(),
+      'ADB',
+      'AudioDB',
+      `https://www.theaudiodb.com/artist/${artist.audiodb_id}-${audioDbSlug(artist.name)}`,
+    );
+  if (artist.itunes_artist_id)
+    add(
+      'itunes',
+      LOGOS.itunes,
+      'IT',
+      'Apple Music',
+      `https://music.apple.com/artist/${artist.itunes_artist_id}`,
+    );
+  if (artist.lastfm_url) add('lastfm', LOGOS.lastfm, 'LFM', 'Last.fm', String(artist.lastfm_url));
+  if (artist.genius_url) add('genius', LOGOS.genius, 'GEN', 'Genius', String(artist.genius_url));
+  if (artist.tidal_id)
+    add('tidal', LOGOS.tidal, 'TD', 'Tidal', `https://tidal.com/browse/artist/${artist.tidal_id}`);
+  if (artist.qobuz_id)
+    add('qobuz', LOGOS.qobuz, 'Qz', 'Qobuz', `https://www.qobuz.com/artist/${artist.qobuz_id}`);
+  if (artist.discogs_id)
+    add(
+      'discogs',
+      LOGOS.discogs,
+      'DC',
+      'Discogs',
+      `https://www.discogs.com/artist/${artist.discogs_id}`,
+    );
+  // Amazon and SoulID have no public artist page — rendered, but not linked.
+  if (artist.amazon_id) add('amazon', LOGOS.amazon, 'AMZ', 'Amazon Music', null);
+  if (artist.bandcamp_url)
+    add('bandcamp', LOGOS.bandcamp, 'BC', 'Bandcamp', String(artist.bandcamp_url));
+  if (artist.soul_id && !isPlaceholderSoulId(artist.soul_id))
+    add('soulsync', LOGOS.soulsync, 'SS', `SoulID: ${artist.soul_id}`, null);
+
+  return badges;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.hero.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.hero.ts
@@ -45,6 +45,12 @@ export interface HeroBadge {
  * as a lookup so the badge degrades to its 'ADB' text exactly as it does now.
  */
 export function audioDbLogoUrl(): string {
+  // Defer to core.js's getAudioDBLogoURL when it exists — it is the owner of
+  // this lookup, and duplicating it means a change there silently stops
+  // applying here. The inline fallback keeps the badge working in tests and
+  // if core.js has not loaded yet.
+  const fromCore = window.getAudioDBLogoURL?.();
+  if (fromCore) return fromCore;
   const el = typeof document === 'undefined' ? null : document.querySelector('img.audiodb-logo');
   return el instanceof HTMLImageElement ? el.src : '';
 }

--- a/webui/src/routes/artist-detail/-artist-detail.meta.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.meta.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  artistDisplayName,
+  buildIdBadges,
+  ID_BADGE_SOURCES,
+  visibleIdBadgeSources,
+} from './-artist-detail.meta';
+
+afterEach(() => {
+  delete window.filterJiosaavnServiceEntries;
+});
+
+describe('visibleIdBadgeSources', () => {
+  it('filters on svc, not key — the wrong id field silently disables it', () => {
+    const filter = vi.fn((items, idKey) => items);
+    window.filterJiosaavnServiceEntries = filter as never;
+    visibleIdBadgeSources();
+    expect(filter).toHaveBeenCalledWith(expect.anything(), 'svc');
+  });
+
+  it('drops JioSaavn when the shared helper is unavailable', () => {
+    expect(visibleIdBadgeSources().map((s) => s.svc)).not.toContain('jiosaavn');
+  });
+
+  it('keeps the rest in declaration order', () => {
+    expect(visibleIdBadgeSources().map((s) => s.svc)).toEqual([
+      'spotify',
+      'musicbrainz',
+      'deezer',
+      'audiodb',
+      'discogs',
+      'itunes',
+      'lastfm',
+      'genius',
+      'tidal',
+      'qobuz',
+      'amazon',
+    ]);
+  });
+});
+
+describe('buildIdBadges', () => {
+  it('is a THIRD provider list — no Bandcamp, no SoulID, but it has JioSaavn', () => {
+    // Deliberately different from buildHeroBadges; merging them would change
+    // what one of the two panels shows.
+    const keys = ID_BADGE_SOURCES.map((s) => s.svc);
+    expect(keys).toContain('jiosaavn');
+    expect(keys).not.toContain('bandcamp');
+    expect(keys).not.toContain('soulsync');
+  });
+
+  it('only badges ids the artist actually has', () => {
+    const badges = buildIdBadges({ spotify_artist_id: 'sp', tidal_id: 9 });
+    expect(badges.map((b) => b.svc)).toEqual(['spotify', 'tidal']);
+    expect(badges.map((b) => b.value)).toEqual(['sp', '9']);
+  });
+
+  it('treats a zero id as absent', () => {
+    expect(buildIdBadges({ deezer_id: 0, qobuz_id: 0 })).toEqual([]);
+  });
+
+  it('reads url fields as ids for Last.fm and Genius', () => {
+    const badges = buildIdBadges({ lastfm_url: 'https://last.fm/x' });
+    expect(badges[0]).toMatchObject({ svc: 'lastfm', value: 'https://last.fm/x' });
+  });
+
+  it('returns nothing for an unenriched artist', () => {
+    expect(buildIdBadges({ name: 'Nobody' })).toEqual([]);
+  });
+});
+
+describe('artistDisplayName', () => {
+  it('falls back rather than rendering an empty heading', () => {
+    expect(artistDisplayName({ name: 'Aphex Twin' })).toBe('Aphex Twin');
+    expect(artistDisplayName({})).toBe('Unknown Artist');
+    expect(artistDisplayName({ name: '' })).toBe('Unknown Artist');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.meta.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.meta.ts
@@ -1,0 +1,81 @@
+/**
+ * Enhanced-view artist meta panel, ported from `renderArtistMetaPanel`
+ * (library.js:2968).
+ *
+ * Only the data-shaped parts live here: which id badges exist and in what
+ * order. The panel's admin actions and the reorganize-status mount stay with
+ * the component, since they are behaviour rather than derivation.
+ */
+
+import type { ArtistInfo } from './-artist-detail.types';
+
+export interface IdBadgeSource {
+  /** Field on the artist record that holds the id or url. */
+  key: string;
+  label: string;
+  /** Service slug — drives the badge's icon and its deep link. */
+  svc: string;
+}
+
+/**
+ * Declaration order is the on-screen order.
+ *
+ * This is a THIRD provider list, and it is deliberately not the hero's:
+ *   - it has JioSaavn (experimental, filtered at runtime); the hero does not
+ *   - it has NO Bandcamp and NO SoulID; the hero has both
+ *   - it keys off `*_id` field names because the badges are built from the
+ *     artist record, not from a fixed set
+ * Do not merge with buildHeroBadges — they show different things.
+ */
+export const ID_BADGE_SOURCES: readonly IdBadgeSource[] = [
+  { key: 'spotify_artist_id', label: 'Spotify', svc: 'spotify' },
+  { key: 'musicbrainz_id', label: 'MusicBrainz', svc: 'musicbrainz' },
+  { key: 'deezer_id', label: 'Deezer', svc: 'deezer' },
+  { key: 'jiosaavn_id', label: 'JioSaavn', svc: 'jiosaavn' },
+  { key: 'audiodb_id', label: 'AudioDB', svc: 'audiodb' },
+  { key: 'discogs_id', label: 'Discogs', svc: 'discogs' },
+  { key: 'itunes_artist_id', label: 'iTunes', svc: 'itunes' },
+  { key: 'lastfm_url', label: 'Last.fm', svc: 'lastfm' },
+  { key: 'genius_url', label: 'Genius', svc: 'genius' },
+  { key: 'tidal_id', label: 'Tidal', svc: 'tidal' },
+  { key: 'qobuz_id', label: 'Qobuz', svc: 'qobuz' },
+  { key: 'amazon_id', label: 'Amazon Music', svc: 'amazon' },
+] as const;
+
+export interface IdBadge extends IdBadgeSource {
+  value: string;
+}
+
+/**
+ * JioSaavn is filtered by the SAME shared helper the enrichment rings use, but
+ * keyed on 'svc' here rather than 'key' — the vanilla passes a different id
+ * field for each list, and passing the wrong one silently disables the filter.
+ */
+export function visibleIdBadgeSources(
+  sources: readonly IdBadgeSource[] = ID_BADGE_SOURCES,
+): IdBadgeSource[] {
+  const filter = window.filterJiosaavnServiceEntries;
+  if (typeof filter === 'function') {
+    return filter([...sources], 'svc') as IdBadgeSource[];
+  }
+  return sources.filter((s) => s.svc !== 'jiosaavn');
+}
+
+/** Badges for the ids this artist actually has, in declaration order. */
+export function buildIdBadges(
+  artist: ArtistInfo,
+  sources: IdBadgeSource[] = visibleIdBadgeSources(),
+): IdBadge[] {
+  const badges: IdBadge[] = [];
+  for (const source of sources) {
+    const value = (artist as Record<string, unknown>)[source.key];
+    // Truthiness, matching the vanilla — a 0 id counts as absent.
+    if (value) badges.push({ ...source, value: String(value) });
+  }
+  return badges;
+}
+
+/** The panel falls back to this rather than rendering an empty heading. */
+export function artistDisplayName(artist: ArtistInfo): string {
+  return artist.name || 'Unknown Artist';
+}

--- a/webui/src/routes/artist-detail/-artist-detail.open-release.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.open-release.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  albumTracksParams,
+  isReleaseClickable,
+  openReleaseArtist,
+  releaseToAlbumData,
+  stillCheckingMessage,
+} from './-artist-detail.open-release';
+
+describe('isReleaseClickable', () => {
+  it('is inert only while ownership is unresolved', () => {
+    expect(isReleaseClickable({ owned: null })).toBe(false);
+    expect(isReleaseClickable({ owned: true })).toBe(true);
+    expect(isReleaseClickable({ owned: false })).toBe(true);
+    // A release with no ownership field at all is still clickable.
+    expect(isReleaseClickable({})).toBe(true);
+  });
+
+  it('names the release in the still-checking toast', () => {
+    expect(stillCheckingMessage({ title: 'Kid A' })).toBe('Still checking ownership for Kid A...');
+  });
+});
+
+describe('openReleaseArtist', () => {
+  it('uses the CURRENT artist id, not the one in the response', () => {
+    // loadArtistDetailData's library-upgrade branch can rewrite the id after
+    // the fetch; the modal must act on the upgraded one.
+    const artist = openReleaseArtist(
+      { artist: { id: 'source-9', name: 'Aphex Twin' } },
+      42,
+      'a.jpg',
+    );
+    expect(artist).toEqual({ id: 42, name: 'Aphex Twin', image_url: 'a.jpg', source: null });
+  });
+
+  it('prefers the discography source over the artist source', () => {
+    const artist = openReleaseArtist(
+      { artist: { name: 'X', source: 'itunes' }, discography: { source: 'musicbrainz' } },
+      1,
+      '',
+    );
+    expect(artist?.source).toBe('musicbrainz');
+  });
+
+  it('returns null without a name — the vanilla refused to open the modal', () => {
+    expect(openReleaseArtist({ artist: { id: 1 } }, 1, '')).toBeNull();
+    expect(openReleaseArtist({}, 1, '')).toBeNull();
+  });
+
+  it('falls back to an empty image rather than undefined', () => {
+    expect(openReleaseArtist({ artist: { name: 'X' } }, 1, '')?.image_url).toBe('');
+  });
+});
+
+describe('releaseToAlbumData', () => {
+  it('takes total_tracks from the object form of track_completion', () => {
+    const album = releaseToAlbumData({
+      id: 1,
+      title: 'Kid A',
+      track_completion: { total_tracks: 10, owned_tracks: 3 },
+    });
+    expect(album.total_tracks).toBe(10);
+  });
+
+  it('falls back to track_count, then to 1 — never 0', () => {
+    // The modal treats a zero-track album as empty and refuses to open.
+    expect(releaseToAlbumData({ id: 1, track_count: 7 }).total_tracks).toBe(7);
+    expect(releaseToAlbumData({ id: 1 }).total_tracks).toBe(1);
+    expect(releaseToAlbumData({ id: 1, track_count: 0 }).total_tracks).toBe(1);
+  });
+
+  it('synthesises a release_date from the year, and empty without one', () => {
+    expect(releaseToAlbumData({ id: 1, year: 1994 }).release_date).toBe('1994-01-01');
+    expect(releaseToAlbumData({ id: 1 }).release_date).toBe('');
+  });
+
+  it('defaults album_type through type, then album', () => {
+    expect(releaseToAlbumData({ id: 1, album_type: 'single' }).album_type).toBe('single');
+    expect(releaseToAlbumData({ id: 1, type: 'ep' }).album_type).toBe('ep');
+    expect(releaseToAlbumData({ id: 1 }).album_type).toBe('album');
+  });
+});
+
+describe('albumTracksParams', () => {
+  const artist = { id: 1, name: 'Aphex Twin', image_url: '', source: 'spotify' };
+
+  it('sends the album name and artist for Hydrabase lookups', () => {
+    expect(albumTracksParams({ title: 'Kid A' }, artist)).toEqual({
+      name: 'Kid A',
+      artist: 'Aphex Twin',
+      source: 'spotify',
+    });
+  });
+
+  it("uses a gap-fill card's OWN source, overriding the artist's", () => {
+    // #1067: the card belongs to another source; querying the artist's source
+    // returns no tracks at all.
+    const params = albumTracksParams({ title: 'X', _gap_source: 'deezer' }, artist);
+    expect(params.source).toBe('deezer');
+  });
+
+  it('omits source entirely when the artist has none', () => {
+    const params = albumTracksParams({ title: 'X' }, { ...artist, source: null });
+    expect('source' in params).toBe(false);
+  });
+
+  it('still sets a gap source when the artist has none', () => {
+    const params = albumTracksParams(
+      { title: 'X', _gap_source: 'qobuz' },
+      { ...artist, source: null },
+    );
+    expect(params.source).toBe('qobuz');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.open-release.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.open-release.ts
@@ -1,0 +1,93 @@
+import type { ArtistDetailResponse, DiscographyRelease } from './-artist-detail.types';
+
+/**
+ * Opening a release card, ported from the click handler inside
+ * createReleaseCard (library.js:1803-1878).
+ *
+ * The modal itself (openAddToWishlistModal) and the ownership backfill
+ * (lazyLoadTrackOwnership) stay vanilla — they are invoked, not reimplemented.
+ */
+
+export interface OpenReleaseArtist {
+  id: string | number | undefined;
+  name: string;
+  image_url: string;
+  source: string | null;
+}
+
+/**
+ * The artist payload the wishlist modal expects.
+ *
+ * Built from the CURRENT page state rather than the response, because the
+ * library-upgrade branch in loadArtistDetailData can rewrite the id after the
+ * fetch. Returns null when there is no artist name — the vanilla treated that
+ * as a hard error rather than opening a modal with no owner.
+ */
+export function openReleaseArtist(
+  payload: ArtistDetailResponse,
+  currentArtistId: string | number | undefined,
+  artistImageUrl: string,
+): OpenReleaseArtist | null {
+  const name = payload.artist?.name;
+  if (!name) return null;
+  return {
+    id: currentArtistId,
+    name: String(name),
+    image_url: artistImageUrl || '',
+    source: payload.discography?.source || payload.artist?.source || null,
+  };
+}
+
+/**
+ * The album shape the wishlist modal expects.
+ *
+ * `total_tracks` prefers the object form of track_completion, falls back to
+ * track_count, and finally to 1 — never 0, because the modal treats a
+ * zero-track album as empty and refuses to open.
+ */
+export function releaseToAlbumData(release: DiscographyRelease) {
+  const completion = release.track_completion;
+  const totalTracks =
+    completion && typeof completion === 'object'
+      ? (completion as { total_tracks?: number }).total_tracks
+      : (release.track_count as number | undefined) || 1;
+
+  return {
+    id: release.id,
+    name: release.title,
+    image_url: release.image_url,
+    // The modal wants a full date; the year is all we have on a release card.
+    release_date: release.year ? `${release.year}-01-01` : '',
+    album_type: release.album_type || release.type || 'album',
+    total_tracks: totalTracks,
+  };
+}
+
+/**
+ * Query string for the album-tracks lookup.
+ *
+ * `source` comes from the ARTIST, except for a gap-fill card (#1067) which
+ * belongs to a different source entirely and must be fetched from that one —
+ * otherwise its tracks come back empty.
+ */
+export function albumTracksParams(
+  release: DiscographyRelease,
+  artist: OpenReleaseArtist,
+): Record<string, string> {
+  const params: Record<string, string> = {
+    name: String(release.title ?? ''),
+    artist: artist.name || '',
+  };
+  if (artist.source) params.source = artist.source;
+  if (release._gap_source) params.source = String(release._gap_source);
+  return params;
+}
+
+/** Still-checking cards are inert; the vanilla toasted and returned. */
+export function isReleaseClickable(release: DiscographyRelease): boolean {
+  return release.owned !== null;
+}
+
+export function stillCheckingMessage(release: DiscographyRelease): string {
+  return `Still checking ownership for ${release.title ?? ''}...`;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.scroll.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.scroll.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { scrollArtistDetailToTop } from './-artist-detail.scroll';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('scrollArtistDetailToTop', () => {
+  it('scrolls the .main-content container, which is what actually scrolls', () => {
+    const main = document.createElement('div');
+    main.className = 'main-content';
+    document.body.appendChild(main);
+    main.scrollTop = 500;
+
+    scrollArtistDetailToTop();
+    expect(main.scrollTop).toBe(0);
+  });
+
+  it('does NOT rely on the window, which never scrolls here', () => {
+    // body is overflow:hidden; height:100vh — window.scrollTo is a no-op.
+    const main = document.createElement('div');
+    main.className = 'main-content';
+    document.body.appendChild(main);
+    const windowScroll = vi.spyOn(window, 'scrollTo');
+
+    scrollArtistDetailToTop();
+    expect(windowScroll).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the window with no shell around it', () => {
+    const windowScroll = vi.spyOn(window, 'scrollTo');
+    scrollArtistDetailToTop();
+    expect(windowScroll).toHaveBeenCalledWith(0, 0);
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.scroll.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.scroll.ts
@@ -1,0 +1,19 @@
+/**
+ * Artist detail always opens at the top.
+ *
+ * `body` is `overflow: hidden; height: 100vh`, so the WINDOW never scrolls —
+ * `.main-content` does, with the React host inside it. window.scrollTo(0, 0)
+ * would be a silent no-op here.
+ */
+export const SCROLL_CONTAINER_SELECTOR = '.main-content';
+
+export function scrollArtistDetailToTop(): void {
+  const container = document.querySelector(SCROLL_CONTAINER_SELECTOR);
+  if (container) {
+    container.scrollTop = 0;
+    return;
+  }
+  // No shell around us (a bare route render, or a test): fall back to the
+  // window so the behaviour is still "top" rather than "nothing happened".
+  window.scrollTo(0, 0);
+}

--- a/webui/src/routes/artist-detail/-artist-detail.top-tracks.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.top-tracks.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  EMPTY_TOP_TRACKS,
+  formatPlaycount,
+  loadTopTracks,
+  playTrackByMetadata,
+  topTracksBulkContext,
+  topTracksTitle,
+  trackArtistLabel,
+  wishlistTrackBody,
+} from './-artist-detail.top-tracks';
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+/** Route by URL so a test can fail one pass and answer the next. */
+function stubRoutes(routes: Record<string, () => Response | Promise<Response>>) {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      calls.push(url);
+      for (const [fragment, handler] of Object.entries(routes)) {
+        if (url.includes(fragment)) return handler();
+      }
+      throw new Error(`unstubbed ${url}`);
+    }),
+  );
+  return calls;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('topTracksTitle', () => {
+  it('labels the known sources', () => {
+    expect(topTracksTitle('spotify')).toBe('Top Tracks (Spotify)');
+    expect(topTracksTitle('deezer')).toBe('Top Tracks (Deezer)');
+    expect(topTracksTitle('lastfm')).toBe('Popular on Last.fm');
+  });
+
+  it('falls back for an unknown or missing source', () => {
+    expect(topTracksTitle('tidal')).toBe('Top Tracks');
+    expect(topTracksTitle(undefined)).toBe('Top Tracks');
+  });
+});
+
+describe('loadTopTracks', () => {
+  it('prefers the metadata source and marks it downloadable', async () => {
+    const calls = stubRoutes({
+      '/top-tracks': () => json({ success: true, source: 'spotify', tracks: [{ name: 'Xtal' }] }),
+    });
+    const state = await loadTopTracks(42, 'Aphex Twin');
+
+    expect(state).toEqual({
+      source: 'spotify',
+      title: 'Top Tracks (Spotify)',
+      tracks: [{ name: 'Xtal' }],
+      downloadable: true,
+    });
+    // Last.fm is never consulted when the source answered.
+    expect(calls.some((u) => u.includes('lastfm'))).toBe(false);
+  });
+
+  it('falls back to Last.fm when the source cannot rank by popularity', async () => {
+    // iTunes / Discogs / MusicBrainz answer success=false rather than 404,
+    // which is the only reason the second pass is reachable.
+    stubRoutes({
+      '/top-tracks': () => json({ success: false }),
+      'lastfm-top-tracks': () => json({ success: true, tracks: [{ name: 'Ageispolis' }] }),
+    });
+    const state = await loadTopTracks(42, 'Aphex Twin');
+
+    expect(state.source).toBe('lastfm');
+    expect(state.title).toBe('Popular on Last.fm');
+    // Display-only: Last.fm rows carry no metadata to download with.
+    expect(state.downloadable).toBe(false);
+  });
+
+  it('falls back when the source returns an EMPTY track list', async () => {
+    stubRoutes({
+      '/top-tracks': () => json({ success: true, source: 'deezer', tracks: [] }),
+      'lastfm-top-tracks': () => json({ success: true, tracks: [{ name: 'A' }] }),
+    });
+    expect((await loadTopTracks(42, 'X')).source).toBe('lastfm');
+  });
+
+  it('falls back on a non-ok source response', async () => {
+    stubRoutes({
+      '/top-tracks': () => json({ success: true, tracks: [{ name: 'ignored' }] }, 500),
+      'lastfm-top-tracks': () => json({ success: true, tracks: [{ name: 'A' }] }),
+    });
+    expect((await loadTopTracks(42, 'X')).source).toBe('lastfm');
+  });
+
+  it('skips the source pass entirely without an artist id', async () => {
+    const calls = stubRoutes({
+      'lastfm-top-tracks': () => json({ success: true, tracks: [{ name: 'A' }] }),
+    });
+    await loadTopTracks(null, 'X');
+    expect(calls.every((u) => !u.includes('/top-tracks?'))).toBe(true);
+  });
+
+  it('stays empty — so the sidebar stays hidden — when neither pass has rows', async () => {
+    stubRoutes({
+      '/top-tracks': () => json({ success: false }),
+      'lastfm-top-tracks': () => json({ success: true, tracks: [] }),
+    });
+    expect(await loadTopTracks(42, 'X')).toEqual(EMPTY_TOP_TRACKS);
+  });
+
+  it('swallows a thrown Last.fm request rather than failing the hero', async () => {
+    stubRoutes({
+      '/top-tracks': () => json({ success: false }),
+      'lastfm-top-tracks': () => {
+        throw new Error('offline');
+      },
+    });
+    expect(await loadTopTracks(42, 'X')).toEqual(EMPTY_TOP_TRACKS);
+  });
+});
+
+describe('trackArtistLabel', () => {
+  it('joins the track artists', () => {
+    expect(trackArtistLabel({ artists: [{ name: 'A' }, { name: 'B' }] }, 'Page')).toBe('A, B');
+  });
+
+  it('drops nameless entries instead of leaving empty separators', () => {
+    expect(trackArtistLabel({ artists: [{ name: 'A' }, {}] }, 'Page')).toBe('A');
+  });
+
+  it('falls back to the page artist when the track lists none', () => {
+    expect(trackArtistLabel({ artists: [] }, 'Page')).toBe('Page');
+    expect(trackArtistLabel({}, 'Page')).toBe('Page');
+  });
+});
+
+describe('formatPlaycount', () => {
+  it('abbreviates millions and thousands, trimming a trailing .0', () => {
+    expect(formatPlaycount(2_400_000)).toBe('2.4M');
+    expect(formatPlaycount(2_000_000)).toBe('2M');
+    expect(formatPlaycount(3400)).toBe('3.4K');
+    expect(formatPlaycount(1000)).toBe('1K');
+  });
+
+  it('leaves small counts alone and floors junk at 0', () => {
+    expect(formatPlaycount(999)).toBe('999');
+    expect(formatPlaycount(0)).toBe('0');
+    expect(formatPlaycount(undefined)).toBe('0');
+    expect(formatPlaycount(-5)).toBe('0');
+  });
+});
+
+describe('wishlistTrackBody', () => {
+  it('keeps the track artists when it has them', () => {
+    const body = wishlistTrackBody(
+      { name: 'Xtal', artists: [{ name: 'AFX' }], album: { name: 'SAW', album_type: 'album' } },
+      'Aphex Twin',
+      42,
+    );
+    expect(body.track.artists).toEqual([{ name: 'AFX' }]);
+    expect(body.source_context).toEqual({
+      artist_name: 'Aphex Twin',
+      album_name: 'SAW',
+      album_type: 'album',
+    });
+  });
+
+  it('substitutes the page artist when the track has none', () => {
+    const body = wishlistTrackBody({ name: 'X' }, 'Aphex Twin', 42);
+    expect(body.track.artists).toEqual([{ name: 'Aphex Twin' }]);
+  });
+
+  it('defaults the album to an object and the type to album', () => {
+    // The backend indexes into album.*; a null album would throw there.
+    const body = wishlistTrackBody({ name: 'X', album: null as never }, 'A', 42);
+    expect(body.album).toEqual({});
+    expect(body.source_context.album_type).toBe('album');
+  });
+
+  it('sends an empty id rather than the string "null"', () => {
+    expect(wishlistTrackBody({ name: 'X' }, 'A', null).artist.id).toBe('');
+  });
+});
+
+describe('topTracksBulkContext', () => {
+  it('builds a playlist id that does NOT trigger album-download mode', () => {
+    // downloads.js keys is_album_download off an `artist_album_` /
+    // `enhanced_search_album_` prefix; a top-tracks bundle must avoid it so
+    // each track lands in its own real album folder.
+    const context = topTracksBulkContext(
+      { source: 'spotify', title: '', tracks: [{ name: 'a' }, { name: 'b' }], downloadable: true },
+      'Aphex Twin',
+      42,
+    );
+    expect(context.virtualPlaylistId).toBe('top_tracks_spotify_42');
+    expect(context.virtualPlaylistId.startsWith('artist_album_')).toBe(false);
+    expect(context.virtualPlaylistId.startsWith('enhanced_search_album_')).toBe(false);
+    expect(context.playlistName).toBe('Aphex Twin — Top Tracks');
+    expect(context.wrapperAlbum.album_type).toBe('compilation');
+    expect(context.wrapperAlbum.total_tracks).toBe(2);
+  });
+
+  it('names the id "unknown" rather than "null" without an artist id', () => {
+    const context = topTracksBulkContext(EMPTY_TOP_TRACKS, 'A', null);
+    expect(context.virtualPlaylistId).toBe('top_tracks__unknown');
+  });
+});
+
+describe('playTrackByMetadata', () => {
+  const bridge = () =>
+    ({
+      playLibraryTrack: vi.fn(),
+      startStream: vi.fn(),
+      showLoadingOverlay: vi.fn(),
+      hideLoadingOverlay: vi.fn(),
+    }) as never;
+
+  it('plays the owned copy and never reaches the streamer', async () => {
+    const calls = stubRoutes({
+      'resolve-track': () =>
+        json({
+          success: true,
+          track: { id: 7, title: 'Xtal', file_path: '/x.flac', album_title: 'SAW' },
+        }),
+    });
+    const b = bridge();
+    await playTrackByMetadata(b, 'Xtal', 'Aphex Twin');
+
+    expect(
+      (b as never as { playLibraryTrack: ReturnType<typeof vi.fn> }).playLibraryTrack,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7, file_path: '/x.flac' }),
+      'SAW',
+      'Aphex Twin',
+    );
+    expect(calls.some((u) => u.includes('stream-track'))).toBe(false);
+  });
+
+  it('streams on a library MISS', async () => {
+    stubRoutes({
+      'resolve-track': () => json({ success: false }),
+      'stream-track': () => json({ success: true, result: { username: 'peer' } }),
+    });
+    const b = bridge() as never as { startStream: ReturnType<typeof vi.fn> };
+    await playTrackByMetadata(b as never, 'Xtal', 'Aphex Twin');
+    expect(b.startStream).toHaveBeenCalledWith({ username: 'peer' });
+  });
+
+  it('streams when the library resolve THROWS instead of surfacing an error', async () => {
+    stubRoutes({
+      'resolve-track': () => {
+        throw new Error('offline');
+      },
+      'stream-track': () => json({ success: true, result: { username: 'peer' } }),
+    });
+    const b = bridge() as never as { startStream: ReturnType<typeof vi.fn> };
+    await playTrackByMetadata(b as never, 'Xtal', 'A');
+    expect(b.startStream).toHaveBeenCalled();
+  });
+
+  it('reports the streamer error and clears the overlay', async () => {
+    window.showToast = vi.fn();
+    stubRoutes({
+      'resolve-track': () => json({ success: false }),
+      'stream-track': () => json({ success: false, error: 'nothing found' }),
+    });
+    const b = bridge() as never as {
+      hideLoadingOverlay: ReturnType<typeof vi.fn>;
+      startStream: ReturnType<typeof vi.fn>;
+    };
+    await playTrackByMetadata(b as never, 'Xtal', 'A');
+
+    expect(b.hideLoadingOverlay).toHaveBeenCalled();
+    expect(b.startStream).not.toHaveBeenCalled();
+    expect(window.showToast).toHaveBeenCalledWith('nothing found', 'error');
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.top-tracks.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.top-tracks.ts
@@ -1,0 +1,233 @@
+import type { ShellBridge } from '@/platform/shell/bridge';
+
+import type { ArtistDetailTrack } from './-artist-detail.types';
+
+/**
+ * The hero top-tracks sidebar, ported from `_loadArtistTopTracks`
+ * (library.js:1167) and its two download helpers.
+ *
+ * Two passes, in order:
+ *   1. the metadata source (Spotify / Deezer) via /api/artist/<id>/top-tracks,
+ *      which returns FULL track objects so each row gets a real download action
+ *   2. Last.fm playcount, which is display-only — the vanilla deliberately
+ *      offers no download there because the rows carry no usable metadata
+ *
+ * Sources that cannot rank by popularity (iTunes / Discogs / MusicBrainz)
+ * answer success=false, which is what makes pass 2 reachable at all.
+ */
+
+/** Sidebar heading per source. An unknown source falls back to "Top Tracks". */
+export const TOP_TRACKS_SOURCE_LABELS: Record<string, string> = {
+  spotify: 'Top Tracks (Spotify)',
+  deezer: 'Top Tracks (Deezer)',
+  lastfm: 'Popular on Last.fm',
+};
+
+export function topTracksTitle(source: string | undefined): string {
+  return (source && TOP_TRACKS_SOURCE_LABELS[source]) || 'Top Tracks';
+}
+
+export interface TopTracksState {
+  /** '' means the sidebar stays hidden — no source produced anything. */
+  source: string;
+  title: string;
+  tracks: ArtistDetailTrack[];
+  /**
+   * True only for the metadata-source pass. Last.fm rows show a playcount and
+   * no download button, matching the legacy display-only behaviour.
+   */
+  downloadable: boolean;
+}
+
+export const EMPTY_TOP_TRACKS: TopTracksState = {
+  source: '',
+  title: '',
+  tracks: [],
+  downloadable: false,
+};
+
+/** The row's artist label: the track's own artists, or the page artist. */
+export function trackArtistLabel(track: ArtistDetailTrack, artistName: string): string {
+  const names = (track.artists ?? [])
+    .map((a) => (a && a.name ? a.name : ''))
+    .filter(Boolean)
+    .join(', ');
+  return names || artistName;
+}
+
+/** Last.fm playcounts: 1.2M / 3.4K / 999, with a trailing ".0" trimmed. */
+export function formatPlaycount(n: unknown): string {
+  const value = Number(n);
+  if (!value || value <= 0) return '0';
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
+  if (value >= 1000) return `${(value / 1000).toFixed(1).replace(/\.0$/, '')}K`;
+  return value.toLocaleString();
+}
+
+/**
+ * Pass 1 then pass 2. Returns EMPTY_TOP_TRACKS when neither produced rows,
+ * which keeps the sidebar hidden rather than showing an empty panel.
+ *
+ * Every failure is swallowed: the sidebar is decoration on a page that must
+ * still render, and the vanilla only console.debug'd here.
+ */
+export async function loadTopTracks(
+  artistId: unknown,
+  artistName: string,
+  signal?: AbortSignal,
+): Promise<TopTracksState> {
+  if (artistId) {
+    try {
+      const params = new URLSearchParams({ limit: '10' });
+      const response = await fetch(
+        `/api/artist/${encodeURIComponent(String(artistId))}/top-tracks?${params}`,
+        { signal },
+      );
+      if (response.ok) {
+        const data = await response.json();
+        if (data?.success && Array.isArray(data.tracks) && data.tracks.length > 0) {
+          return {
+            source: data.source ?? '',
+            title: topTracksTitle(data.source),
+            tracks: data.tracks,
+            downloadable: true,
+          };
+        }
+      }
+    } catch {
+      // Fall through to Last.fm.
+    }
+  }
+
+  try {
+    // The literal `0` is the vanilla's placeholder — this endpoint keys off the
+    // ?name= query, not the path id.
+    const response = await fetch(
+      `/api/artist/0/lastfm-top-tracks?name=${encodeURIComponent(artistName)}`,
+      { signal },
+    );
+    const data = await response.json();
+    if (!data?.success || !data.tracks?.length) return EMPTY_TOP_TRACKS;
+    return {
+      source: 'lastfm',
+      title: TOP_TRACKS_SOURCE_LABELS.lastfm,
+      tracks: data.tracks,
+      downloadable: false,
+    };
+  } catch {
+    return EMPTY_TOP_TRACKS;
+  }
+}
+
+/** The body /api/add-album-to-wishlist expects for a single top track. */
+export function wishlistTrackBody(track: ArtistDetailTrack, artistName: string, artistId: unknown) {
+  const trackArtists = track.artists?.length ? track.artists : [{ name: artistName }];
+  const album = track.album && typeof track.album === 'object' ? track.album : {};
+  return {
+    track: { ...track, artists: trackArtists },
+    artist: { id: artistId || '', name: artistName },
+    album,
+    source_type: 'top_tracks',
+    source_context: {
+      artist_name: artistName,
+      album_name: album.name || '',
+      album_type: album.album_type || 'album',
+    },
+  };
+}
+
+/**
+ * The bulk-download wrapper.
+ *
+ * The virtual playlist id deliberately does NOT start with `artist_album_` /
+ * `enhanced_search_album_`: that prefix is what makes downloads.js set
+ * is_album_download=false, so each track downloads under its own real album
+ * metadata and lands in the proper per-album folder instead of one lump.
+ */
+export function topTracksBulkContext(state: TopTracksState, artistName: string, artistId: unknown) {
+  const virtualPlaylistId = `top_tracks_${state.source}_${artistId || 'unknown'}`;
+  const playlistName = `${artistName} — Top Tracks`;
+  return {
+    virtualPlaylistId,
+    playlistName,
+    wrapperAlbum: {
+      id: virtualPlaylistId,
+      name: playlistName,
+      album_type: 'compilation',
+      images: [],
+      total_tracks: state.tracks.length,
+      artists: [{ id: artistId || '', name: artistName }],
+    },
+    artist: { id: artistId || '', name: artistName, source: state.source },
+  };
+}
+
+/**
+ * Play one row: library first, streaming second (playTrackByMetadata,
+ * library.js:1209).
+ *
+ * The order is the point — an owned copy is faster and better quality than a
+ * stream, so /api/stats/resolve-track is always tried first and the streaming
+ * fallback only runs on a genuine library miss. A resolve FAILURE also falls
+ * through to streaming rather than surfacing an error.
+ */
+export async function playTrackByMetadata(
+  bridge: ShellBridge | null,
+  title: string,
+  artist: string,
+  album = '',
+): Promise<void> {
+  try {
+    const response = await fetch('/api/stats/resolve-track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, artist }),
+    });
+    const data = await response.json();
+    if (data?.success && data.track) {
+      const track = data.track;
+      bridge?.playLibraryTrack(
+        {
+          id: track.id,
+          title: track.title,
+          file_path: track.file_path,
+          bitrate: track.bitrate,
+          artist_id: track.artist_id,
+          album_id: track.album_id,
+          _stats_image: track.image_url || null,
+        },
+        track.album_title || album || '',
+        track.artist_name || artist || '',
+      );
+      return;
+    }
+  } catch {
+    // Library resolve failed — try streaming rather than giving up.
+  }
+
+  bridge?.showLoadingOverlay(`Searching for ${title}...`);
+  try {
+    const response = await fetch('/api/enhanced-search/stream-track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        track_name: title,
+        artist_name: artist,
+        album_name: album,
+        duration_ms: 0,
+      }),
+    });
+    const data = await response.json();
+    bridge?.hideLoadingOverlay();
+
+    if (data?.success && data.result) {
+      if (bridge) await bridge.startStream(data.result);
+      else window.showToast?.('Streaming not available', 'error');
+      return;
+    }
+    window.showToast?.(data?.error || 'Track not found in library or any source', 'error');
+  } catch {
+    bridge?.hideLoadingOverlay();
+    window.showToast?.('Failed to play track', 'error');
+  }
+}

--- a/webui/src/routes/artist-detail/-artist-detail.types.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.types.ts
@@ -90,10 +90,22 @@ export interface ProviderError {
   status_code?: number;
 }
 
+/**
+ * Present only when the artist has a spotify_artist_id (web_server.py:9765).
+ * It is the CANONICAL Spotify identity, and the watchlist is keyed on it —
+ * an artist enriched from Deezer still gets watched under their Spotify id.
+ */
+export interface SpotifyArtistIdentity {
+  spotify_artist_id?: string | null;
+  spotify_artist_name?: string | null;
+  artist_image?: string | null;
+}
+
 export interface ArtistDetailResponse {
   success?: boolean;
   error?: string;
   artist?: ArtistInfo;
+  spotify_artist?: SpotifyArtistIdentity;
   discography?: Discography;
   enrichment_coverage?: Record<string, unknown>;
   provider_error?: ProviderError;

--- a/webui/src/routes/artist-detail/-artist-detail.types.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.types.ts
@@ -44,6 +44,9 @@ export function normalizeSource(source: string): string | null {
  */
 export interface DiscographyRelease {
   id?: string | number;
+  /** The artist page uses `title`; the download modal's shape uses `name`.
+   *  Both are declared because _classifyReleaseContent reads either. */
+  title?: string;
   name?: string;
   album_type?: string;
   release_date?: string;

--- a/webui/src/routes/artist-detail/-artist-detail.types.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.types.ts
@@ -118,3 +118,17 @@ export interface ArtistDetailResponse {
   enrichment_coverage?: Record<string, unknown>;
   provider_error?: ProviderError;
 }
+
+/**
+ * A top-tracks row. The metadata-source pass returns full track objects (the
+ * download action needs `artists`/`album`); the Last.fm pass returns little
+ * more than a name and a playcount, which is why every field is optional.
+ */
+export interface ArtistDetailTrack {
+  id?: string | number;
+  name?: string;
+  playcount?: number | string;
+  artists?: { id?: string | number; name?: string }[];
+  album?: { name?: string; album_type?: string; [key: string]: unknown };
+  [key: string]: unknown;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.types.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.types.ts
@@ -79,6 +79,14 @@ export interface ArtistInfo {
   source?: string | null;
   musicbrainz_id?: string | null;
   spotify_artist_id?: string | null;
+  /** Enhanced-view meta panel image; distinct from image_url. */
+  thumb_url?: string | null;
+  genres?: string[];
+  /** Last.fm extras. `lastfm_tags` may arrive as a JSON STRING, not an array. */
+  lastfm_bio?: string | null;
+  lastfm_listeners?: number | null;
+  lastfm_playcount?: number | null;
+  lastfm_tags?: string | string[] | null;
   [key: string]: unknown;
 }
 

--- a/webui/src/routes/artist-detail/-artist-detail.use-completion.test.tsx
+++ b/webui/src/routes/artist-detail/-artist-detail.use-completion.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { emptyStreamCounts } from './-artist-detail.completion';
@@ -95,7 +95,11 @@ describe('useCompletionStream', () => {
       ok: false,
     });
     const { result } = renderHook(() => useCompletionStream('X', DISC, true));
-    await new Promise((r) => setTimeout(r, 30));
+    // The stream's state updates land on a timer, so the wait itself has to
+    // be inside act() — otherwise React warns they were never wrapped.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
     expect(result.current.discography.albums?.[0].owned).toBeNull();
     expect(result.current.streaming).toBe(false);
   });
@@ -111,7 +115,11 @@ describe('useCompletionStream', () => {
     // detect a missing type check. This one carries an id and a status.
     stubStream(['data: {"type":"complete","id":1,"category":"albums","status":"ok"}\n']);
     const { result } = renderHook(() => useCompletionStream('X', DISC, true));
-    await new Promise((r) => setTimeout(r, 30));
+    // The stream's state updates land on a timer, so the wait itself has to
+    // be inside act() — otherwise React warns they were never wrapped.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
     expect(result.current.discography.albums?.[0].owned).toBeNull();
     expect(result.current.counts?.total.albums ?? 0).toBe(0);
   });
@@ -153,6 +161,9 @@ describe('the terminal complete frame', () => {
     expect(result.current.discography).toBe(next);
     expect(result.current.counts).toBeNull();
     expect(result.current.completed).toBe(false);
+    // Let the remaining in-flight request settle inside act(), so its state
+    // update does not land after the test returns (React's act warning).
+    await act(async () => {});
   });
 });
 

--- a/webui/src/routes/artist-detail/-artist-detail.use-completion.test.tsx
+++ b/webui/src/routes/artist-detail/-artist-detail.use-completion.test.tsx
@@ -1,0 +1,170 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { emptyStreamCounts } from './-artist-detail.completion';
+import { bucketCounts, useCompletionStream } from './-artist-detail.use-completion';
+
+/** A stream that emits the given SSE text, then closes. */
+function stubStream(frames: string[], opts: { ok?: boolean } = {}) {
+  const aborted = { value: false };
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: unknown, init?: RequestInit) => {
+      init?.signal?.addEventListener('abort', () => {
+        aborted.value = true;
+      });
+      const encoder = new TextEncoder();
+      let i = 0;
+      const body = new ReadableStream({
+        pull(controller) {
+          if (i < frames.length) controller.enqueue(encoder.encode(frames[i++]));
+          else controller.close();
+        },
+      });
+      // A non-ok response still gets the FULL body: an empty error body reads
+      // as "done" immediately, so dropping the response.ok guard would look
+      // identical and the test would prove nothing.
+      return new Response(body, { status: opts.ok === false ? 500 : 200 });
+    }),
+  );
+  return aborted;
+}
+
+const DISC = {
+  albums: [
+    { id: 1, title: 'A', owned: null },
+    { id: 2, title: 'B', owned: null },
+  ],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useCompletionStream', () => {
+  it('merges each completion event into the discography', async () => {
+    stubStream([
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok","owned_tracks":5,"expected_tracks":5}\n',
+      'data: {"type":"completion","id":2,"category":"albums","status":"missing"}\n',
+    ]);
+    const { result } = renderHook(() => useCompletionStream('Aphex Twin', DISC, true));
+
+    await waitFor(() => expect(result.current.discography.albums?.[1].owned).toBe(false));
+    expect(result.current.discography.albums?.[0].owned).toBe(true);
+  });
+
+  it('tallies owned and missing per bucket', async () => {
+    stubStream([
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n',
+      'data: {"type":"completion","id":2,"category":"albums","status":"missing"}\n',
+    ]);
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+
+    await waitFor(() => expect(result.current.counts?.total.albums).toBe(2));
+    expect(bucketCounts(result.current.counts, 'albums')).toEqual({ owned: 1, missing: 1 });
+  });
+
+  it('does not open a stream when disabled', async () => {
+    stubStream([]);
+    renderHook(() => useCompletionStream('X', DISC, false));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not open a stream without an artist name', async () => {
+    stubStream([]);
+    renderHook(() => useCompletionStream(undefined, DISC, true));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('ABORTS on unmount so a stale stream cannot write into the next artist', async () => {
+    // The vanilla kept one AbortController and aborted it on navigation;
+    // without this two streams race and the slower one wins.
+    const aborted = stubStream([
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n',
+    ]);
+    const { result, unmount } = renderHook(() => useCompletionStream('X', DISC, true));
+    await waitFor(() => expect(result.current.discography.albums?.[0].owned).toBe(true));
+    unmount();
+    await waitFor(() => expect(aborted.value).toBe(true));
+  });
+
+  it('ignores a non-ok response even when it carries events', async () => {
+    stubStream(['data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n'], {
+      ok: false,
+    });
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(result.current.discography.albums?.[0].owned).toBeNull();
+    expect(result.current.streaming).toBe(false);
+  });
+
+  it('ignores a frame split across two chunks only once it completes', async () => {
+    stubStream(['data: {"type":"completion","id":1,"category":"albums"', ',"status":"ok"}\n']);
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+    await waitFor(() => expect(result.current.discography.albums?.[0].owned).toBe(true));
+  });
+
+  it('ignores non-completion events even when they LOOK mergeable', async () => {
+    // A terminal frame with no id merges to a no-op anyway, so it cannot
+    // detect a missing type check. This one carries an id and a status.
+    stubStream(['data: {"type":"complete","id":1,"category":"albums","status":"ok"}\n']);
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(result.current.discography.albums?.[0].owned).toBeNull();
+    expect(result.current.counts?.total.albums ?? 0).toBe(0);
+  });
+});
+
+describe('the terminal complete frame', () => {
+  it('marks the stream completed', async () => {
+    stubStream([
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n',
+      'data: {"type":"complete","processed_count":1}\n',
+    ]);
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+    await waitFor(() => expect(result.current.completed).toBe(true));
+  });
+
+  it('leaves a truncated stream NOT completed', async () => {
+    // The bars stay on the running tallies rather than recomputing from a
+    // discography that was never fully checked.
+    stubStream(['data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n']);
+    const { result } = renderHook(() => useCompletionStream('X', DISC, true));
+    await waitFor(() => expect(result.current.streaming).toBe(false));
+    expect(result.current.completed).toBe(false);
+  });
+
+  it('resets on a new discography without one stale committed frame', async () => {
+    stubStream([
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok"}\n',
+      'data: {"type":"complete"}\n',
+    ]);
+    const { result, rerender } = renderHook(({ disc }) => useCompletionStream('X', disc, true), {
+      initialProps: { disc: DISC },
+    });
+    await waitFor(() => expect(result.current.completed).toBe(true));
+
+    const next = { albums: [{ id: 9, title: 'Other', owned: null }] };
+    rerender({ disc: next });
+    // Synchronous: an effect-based reset would leave the previous artist's
+    // merged discography on screen for one frame.
+    expect(result.current.discography).toBe(next);
+    expect(result.current.counts).toBeNull();
+    expect(result.current.completed).toBe(false);
+  });
+});
+
+describe('bucketCounts', () => {
+  it('derives missing rather than reading a third counter', () => {
+    const counts = emptyStreamCounts();
+    counts.total.eps = 5;
+    counts.owned.eps = 2;
+    expect(bucketCounts(counts, 'eps')).toEqual({ owned: 2, missing: 3 });
+  });
+
+  it('is null before the stream starts', () => {
+    expect(bucketCounts(null, 'albums')).toBeNull();
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.use-completion.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.use-completion.ts
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { Discography, DiscographyBucket } from './-artist-detail.types';
+
+import {
+  applyCompletionEvent,
+  type CompletionEvent,
+  completionStreamPayload,
+  emptyStreamCounts,
+  parseSseFrames,
+  type StreamCounts,
+  tallyEvent,
+} from './-artist-detail.completion';
+
+export interface CompletionState {
+  /** The discography with every resolved ownership merged in. */
+  discography: Discography;
+  /** Per-bucket running tallies, or null before the stream starts. */
+  counts: StreamCounts | null;
+  /** True from the first event until the stream ends. */
+  streaming: boolean;
+  /**
+   * True only once the terminal `complete` frame arrives.
+   *
+   * This is what triggered recalculateSummaryStats in the vanilla, and it is
+   * deliberately NOT the same as "streaming stopped": an aborted or truncated
+   * stream leaves the bars showing the running tallies rather than recomputing
+   * them from a discography that was never fully checked.
+   */
+  completed: boolean;
+}
+
+/**
+ * Runs /api/library/completion-stream and merges results as they arrive.
+ *
+ * The abort contract is the load-bearing part: the vanilla kept ONE
+ * AbortController on artistDetailPageState and aborted it both when a new
+ * check started and when the user navigated away
+ * (clearArtistDetailPageState). Without that, switching artists quickly leaves
+ * two streams writing into the same page and the slower one wins.
+ *
+ * `enabled` is false for source artists and for a discography with nothing
+ * left to check — opening a stream that can never report anything.
+ */
+export function useCompletionStream(
+  artistName: string | undefined,
+  initial: Discography,
+  enabled: boolean,
+): CompletionState {
+  const [state, setState] = useState<CompletionState>({
+    discography: initial,
+    counts: null,
+    streaming: false,
+    completed: false,
+  });
+
+  // Kept in a ref so the merge always sees the latest merged copy rather than
+  // the value captured when the effect ran.
+  const discographyRef = useRef(initial);
+  const countsRef = useRef<StreamCounts | null>(null);
+  const completeRef = useRef(false);
+
+  /**
+   * Reset DURING render, not in an effect. An effect would leave one committed
+   * frame showing the previous artist's merged discography under the new
+   * artist's hero; adjusting state here re-renders before anything is shown.
+   */
+  const [seenInitial, setSeenInitial] = useState(initial);
+  if (initial !== seenInitial) {
+    setSeenInitial(initial);
+    discographyRef.current = initial;
+    countsRef.current = null;
+    completeRef.current = false;
+    setState({ discography: initial, counts: null, streaming: false, completed: false });
+  }
+
+  useEffect(() => {
+    if (!enabled || !artistName) return;
+
+    const controller = new AbortController();
+    countsRef.current = emptyStreamCounts();
+    completeRef.current = false;
+    let cancelled = false;
+
+    const run = async () => {
+      try {
+        const response = await fetch('/api/library/completion-stream', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(completionStreamPayload(artistName, discographyRef.current)),
+          signal: controller.signal,
+        });
+        if (!response.ok || !response.body) return;
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        setState((s) => ({ ...s, streaming: true }));
+
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done || cancelled) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const { events, rest } = parseSseFrames(buffer);
+          buffer = rest;
+
+          let touched = false;
+          for (const event of events as CompletionEvent[]) {
+            if (event.type === 'completion') {
+              discographyRef.current = applyCompletionEvent(discographyRef.current, event);
+              if (countsRef.current) tallyEvent(countsRef.current, event);
+              touched = true;
+            } else if (event.type === 'complete') {
+              completeRef.current = true;
+              touched = true;
+            }
+          }
+          if (touched && !cancelled) {
+            setState({
+              discography: discographyRef.current,
+              counts: countsRef.current,
+              streaming: true,
+              completed: completeRef.current,
+            });
+          }
+        }
+      } catch {
+        // AbortError on navigation is expected and silent, exactly as the
+        // vanilla treated it; any other failure leaves the page as-is rather
+        // than tearing it down over a background check.
+      } finally {
+        if (!cancelled) setState((s) => ({ ...s, streaming: false }));
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [artistName, enabled, initial]);
+
+  return state;
+}
+
+/** Resolved counts for one bucket, for the streaming hero bars. */
+export function bucketCounts(
+  counts: StreamCounts | null,
+  bucket: DiscographyBucket,
+): { owned: number; missing: number } | null {
+  if (!counts) return null;
+  return {
+    owned: counts.owned[bucket],
+    missing: counts.total[bucket] - counts.owned[bucket],
+  };
+}

--- a/webui/src/routes/artist-detail/-artist-detail.use-enhanced.test.tsx
+++ b/webui/src/routes/artist-detail/-artist-detail.use-enhanced.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useEnhancedData } from './-artist-detail.use-enhanced';
@@ -50,6 +50,9 @@ describe('useEnhancedData across artists', () => {
     // Synchronous: a stale payload must never render under a new artist, not
     // even for the frame before the new request lands.
     expect(result.current.data).toBeNull();
+    // Let the remaining in-flight request settle inside act(), so its state
+    // update does not land after the test returns (React's act warning).
+    await act(async () => {});
   });
 
   it('retries a FAILED artist once its id changes', async () => {

--- a/webui/src/routes/artist-detail/-artist-detail.use-enhanced.test.tsx
+++ b/webui/src/routes/artist-detail/-artist-detail.use-enhanced.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEnhancedData } from './-artist-detail.use-enhanced';
+
+let requested: string[] = [];
+
+function stubEnhanced(body: unknown = { success: true, albums: [] }) {
+  requested = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      requested.push(String(input));
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+beforeEach(() => stubEnhanced());
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('useEnhancedData across artists', () => {
+  it('refetches when the SAME hook is handed a new artist', async () => {
+    // TanStack keeps this component mounted when only the route params change,
+    // so the artist swap arrives as a prop — not a remount.
+    const { result, rerender } = renderHook(({ id }) => useEnhancedData(id, true), {
+      initialProps: { id: 42 as unknown },
+    });
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(requested).toHaveLength(1);
+
+    rerender({ id: 99 });
+    await waitFor(() => expect(requested).toHaveLength(2));
+    expect(requested[1]).toContain('/artist/99/');
+  });
+
+  it('drops the previous payload the moment the id changes', async () => {
+    const { result, rerender } = renderHook(({ id }) => useEnhancedData(id, true), {
+      initialProps: { id: 42 as unknown },
+    });
+    // Wait for a real payload first — otherwise data is null either way and the
+    // assertion below proves nothing.
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+
+    rerender({ id: 99 });
+    // Synchronous: a stale payload must never render under a new artist, not
+    // even for the frame before the new request lands.
+    expect(result.current.data).toBeNull();
+  });
+
+  it('retries a FAILED artist once its id changes', async () => {
+    stubEnhanced({ success: false, error: 'nope' });
+    const { result, rerender } = renderHook(({ id }) => useEnhancedData(id, true), {
+      initialProps: { id: 42 as unknown },
+    });
+    await waitFor(() => expect(result.current.status.error).toBe('nope'));
+
+    stubEnhanced();
+    rerender({ id: 99 });
+    await waitFor(() => expect(result.current.data).not.toBeNull());
+    expect(result.current.status.error).toBe('');
+  });
+
+  it('does not retry the SAME artist after a failure', async () => {
+    stubEnhanced({ success: false, error: 'nope' });
+    const { result, rerender } = renderHook(({ enabled }) => useEnhancedData(42, enabled), {
+      initialProps: { enabled: true },
+    });
+    await waitFor(() => expect(result.current.status.error).toBe('nope'));
+
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(requested).toHaveLength(1);
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.use-enhanced.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.use-enhanced.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { EnhancedData } from './-artist-detail.enhanced';
+
+export interface EnhancedState {
+  data: EnhancedData | null;
+  status: { loading: boolean; error: string };
+}
+
+const IDLE: EnhancedState = { data: null, status: { loading: false, error: '' } };
+
+/**
+ * Loads /api/library/artist/<id>/enhanced (loadEnhancedViewData, library.js:2857).
+ *
+ * Fetched lazily — only once the user actually switches to Enhanced — and kept
+ * afterwards, because the vanilla only re-fetched when it had no data.
+ * Switching back to Standard and returning must not re-request a payload that
+ * carries every track of every album.
+ *
+ * "Already attempted" is a REF, not state. Putting it in the effect's deps made
+ * the effect re-run the moment it set `loading`, and the re-run's cleanup
+ * aborted the request it had just started — leaving the view on "Loading..."
+ * forever, or resolving first and passing by luck.
+ */
+export function useEnhancedData(artistId: unknown, enabled: boolean): EnhancedState {
+  const [state, setState] = useState<EnhancedState>(IDLE);
+  const attemptedRef = useRef<unknown>(undefined);
+
+  /**
+   * A new artist invalidates the payload; kept across a Standard/Enhanced
+   * toggle, never across an artist change.
+   *
+   * Not test-observable: when Enhanced is on, the effect below re-runs on the
+   * id change and clears the state itself, and when it is off nothing renders
+   * the payload anyway. Kept so the invariant holds independently of effect
+   * ordering rather than as a consequence of it.
+   */
+  const [seenArtist, setSeenArtist] = useState(artistId);
+  if (artistId !== seenArtist) {
+    setSeenArtist(artistId);
+    // Belt and braces: the guard below compares the ref against the CURRENT
+    // artist, so a stale id would not block the new fetch anyway. Clearing it
+    // survives mutation for that reason.
+    attemptedRef.current = undefined;
+    setState(IDLE);
+  }
+
+  useEffect(() => {
+    if (!enabled || !artistId) return;
+    // One attempt per artist — the vanilla did not retry a failure either.
+    if (attemptedRef.current === artistId) return;
+    attemptedRef.current = artistId;
+
+    const controller = new AbortController();
+    setState({ data: null, status: { loading: true, error: '' } });
+
+    void (async () => {
+      try {
+        const response = await fetch(`/api/library/artist/${artistId}/enhanced`, {
+          signal: controller.signal,
+        });
+        const data = await response.json();
+        if (!data.success) throw new Error(data.error || 'Failed to load enhanced data');
+        setState({ data, status: { loading: false, error: '' } });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setState({
+          data: null,
+          status: { loading: false, error: (error as Error).message || String(error) },
+        });
+      }
+    })();
+
+    return () => controller.abort();
+  }, [artistId, enabled]);
+
+  return state;
+}

--- a/webui/src/routes/artist-detail/-artist-detail.use-gap-fill.test.tsx
+++ b/webui/src/routes/artist-detail/-artist-detail.use-gap-fill.test.tsx
@@ -1,0 +1,151 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useGapFill } from './-artist-detail.use-gap-fill';
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function sse(frames: string[]) {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (i < frames.length) controller.enqueue(encoder.encode(frames[i++]));
+        else controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+let requested: string[] = [];
+
+function stubRoutes(routes: Record<string, () => Response>) {
+  requested = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requested.push(url);
+      for (const [fragment, handler] of Object.entries(routes)) {
+        if (url.includes(fragment)) return handler();
+      }
+      return json({ success: false });
+    }),
+  );
+}
+
+const GAPS = {
+  success: true,
+  gaps: { albums: [{ id: 'g1', title: 'Gap Album', gap_source: 'deezer', year: 2001 }] },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('useGapFill', () => {
+  it('fetches nothing while the chip is off', async () => {
+    stubRoutes({ 'gap-fill': () => json(GAPS) });
+    const { result } = renderHook(() => useGapFill(42, 'Aphex Twin', 'spotify', {}));
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.releases).toEqual([]);
+    expect(requested).toEqual([]);
+  });
+
+  it('loads and exposes gaps once enabled', async () => {
+    stubRoutes({ 'gap-fill': () => json(GAPS) });
+    const { result } = renderHook(() => useGapFill(42, 'Aphex Twin', 'spotify', {}));
+
+    act(() => result.current.toggle());
+    await waitFor(() => expect(result.current.releases).toHaveLength(1));
+    expect(result.current.releases[0].title).toBe('Gap Album');
+    expect(requested[0]).toContain('base_source=spotify');
+  });
+
+  it('persists the toggle so the next page load keeps it on', async () => {
+    stubRoutes({ 'gap-fill': () => json({ success: true, gaps: {} }) });
+    const { result } = renderHook(() => useGapFill(42, 'A', 'spotify', {}));
+    act(() => result.current.toggle());
+    expect(localStorage.getItem('discog_gapfill')).toBe('1');
+
+    const second = renderHook(() => useGapFill(42, 'A', 'spotify', {}));
+    expect(second.result.current.enabled).toBe(true);
+  });
+
+  it('drops gaps the page already renders', async () => {
+    stubRoutes({ 'gap-fill': () => json(GAPS) });
+    const { result } = renderHook(() =>
+      useGapFill(42, 'A', 'spotify', { albums: [{ title: 'Gap Album', year: 2001 }] }),
+    );
+
+    act(() => result.current.toggle());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.releases).toEqual([]);
+    // Nothing survived the dedup, so no ownership stream is opened for it.
+    expect(requested.some((u) => u.includes('completion-stream'))).toBe(false);
+  });
+
+  it('streams ownership for the gaps on their OWN sources', async () => {
+    stubRoutes({
+      'gap-fill': () => json(GAPS),
+      'completion-stream': () =>
+        sse(['data: {"type":"completion","id":"g1","category":"albums","status":"ok"}\n']),
+    });
+    const { result } = renderHook(() => useGapFill(42, 'Aphex Twin', 'spotify', {}));
+
+    act(() => result.current.toggle());
+    // #1071: an album bought on another platform must light up OWNED here too.
+    await waitFor(() => expect(result.current.releases[0]?.owned).toBe(true));
+  });
+
+  it('clears the gaps when switched back off', async () => {
+    stubRoutes({ 'gap-fill': () => json(GAPS) });
+    const { result } = renderHook(() => useGapFill(42, 'A', 'spotify', {}));
+
+    act(() => result.current.toggle());
+    await waitFor(() => expect(result.current.releases).toHaveLength(1));
+    act(() => result.current.toggle());
+    expect(result.current.releases).toEqual([]);
+  });
+
+  it('leaves the page alone when the request fails', async () => {
+    stubRoutes({ 'gap-fill': () => json({ success: false }, 500) });
+    const { result } = renderHook(() => useGapFill(42, 'A', 'spotify', {}));
+
+    act(() => result.current.toggle());
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.releases).toEqual([]);
+  });
+
+  it('aborts in flight when the artist changes', async () => {
+    let aborted = false;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (_url: unknown, init?: RequestInit) => {
+        init?.signal?.addEventListener('abort', () => {
+          aborted = true;
+        });
+        return new Promise<Response>(() => {});
+      }),
+    );
+    localStorage.setItem('discog_gapfill', '1');
+    const { rerender } = renderHook(({ id }) => useGapFill(id, 'A', 'spotify', {}), {
+      initialProps: { id: 42 as unknown },
+    });
+
+    rerender({ id: 99 });
+    // The vanilla used a request sequence number to ignore stale responses;
+    // aborting stops the request itself.
+    await waitFor(() => expect(aborted).toBe(true));
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.use-gap-fill.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.use-gap-fill.ts
@@ -1,0 +1,143 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { Discography } from './-artist-detail.types';
+
+import {
+  applyCompletionEvent,
+  type CompletionEvent,
+  parseSseFrames,
+} from './-artist-detail.completion';
+import {
+  dedupeGaps,
+  gapFillEnabled,
+  type GapRelease,
+  gapFillUrl,
+  gapReleasesFromResponse,
+  gapStreamPayload,
+  setGapFillEnabled,
+} from './-artist-detail.gap-fill';
+
+export interface GapFillState {
+  enabled: boolean;
+  toggle: () => void;
+  /** Already deduped against what the page renders. */
+  releases: GapRelease[];
+}
+
+/**
+ * Loads gap-fill releases and streams their ownership (#1067, #1071).
+ *
+ * Gap cards get REAL ownership checks like every other card — an album bought
+ * on another platform must light up OWNED here too — but on their OWN stream,
+ * because each gap id is only meaningful on the source that listed it.
+ *
+ * The vanilla guarded both requests with a request sequence number so a slow
+ * response for a previous artist could not land in the current page; here that
+ * is an AbortController per load, which also stops the stream itself rather
+ * than just ignoring its results.
+ */
+export function useGapFill(
+  artistId: unknown,
+  artistName: string | undefined,
+  baseSource: string | undefined,
+  rendered: Discography,
+): GapFillState {
+  const [enabled, setEnabled] = useState(gapFillEnabled);
+  const [releases, setReleases] = useState<GapRelease[]>([]);
+  const releasesRef = useRef<GapRelease[]>([]);
+
+  // Read through a ref so the ownership stream does not have to re-run every
+  // time the base discography's ownership settles.
+  const renderedRef = useRef(rendered);
+  renderedRef.current = rendered;
+
+  const toggle = useCallback(() => {
+    setEnabled((on) => {
+      setGapFillEnabled(!on);
+      return !on;
+    });
+  }, []);
+
+  useEffect(() => {
+    releasesRef.current = [];
+    setReleases([]);
+    if (!enabled || !artistId) return;
+
+    const controller = new AbortController();
+
+    const run = async () => {
+      const response = await fetch(gapFillUrl(artistId, artistName, baseSource), {
+        signal: controller.signal,
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data.success) return;
+
+      const fresh = dedupeGaps(gapReleasesFromResponse(data), renderedRef.current);
+      if (fresh.length === 0) return;
+      releasesRef.current = fresh;
+      setReleases(fresh);
+
+      await streamGapOwnership(artistName ?? '', fresh, controller.signal, (next) => {
+        releasesRef.current = next;
+        setReleases(next);
+      });
+    };
+
+    void run().catch(() => {
+      // Gap-fill is additive: a failure leaves the base discography alone
+      // rather than taking the page down.
+    });
+
+    return () => controller.abort();
+  }, [enabled, artistId, artistName, baseSource]);
+
+  return { enabled, toggle, releases };
+}
+
+/**
+ * Run the gap ownership stream, merging each result into the gap list.
+ *
+ * The merge reuses applyCompletionEvent by wrapping the flat list in a
+ * one-bucket discography, so gap cards and base cards resolve ownership through
+ * exactly the same code — the vanilla routed both through
+ * updateLibraryReleaseCard for the same reason.
+ */
+async function streamGapOwnership(
+  artistName: string,
+  gaps: GapRelease[],
+  signal: AbortSignal,
+  onUpdate: (releases: GapRelease[]) => void,
+): Promise<void> {
+  const response = await fetch('/api/library/completion-stream', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(gapStreamPayload(artistName, gaps)),
+    signal,
+  });
+  if (!response.ok || !response.body) return;
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let current = gaps;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done || signal.aborted) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const { events, rest } = parseSseFrames(buffer);
+    buffer = rest;
+
+    let touched = false;
+    for (const event of events as CompletionEvent[]) {
+      if (event.type !== 'completion') continue;
+      const merged = applyCompletionEvent({ albums: current }, event);
+      if (merged.albums && merged.albums !== current) {
+        current = merged.albums as GapRelease[];
+        touched = true;
+      }
+    }
+    if (touched && !signal.aborted) onUpdate(current);
+  }
+}

--- a/webui/src/routes/artist-detail/-artist-detail.vanilla-state.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.vanilla-state.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  clearVanillaArtist,
+  syncVanillaArtist,
+  syncVanillaEnhancedData,
+  syncVanillaSelection,
+  type VanillaArtistState,
+} from './-artist-detail.vanilla-state';
+
+/** The shape library.js declares, defaults and all. */
+function installVanillaState(): VanillaArtistState {
+  const state: VanillaArtistState = {
+    currentArtistId: null,
+    currentArtistName: null,
+    currentArtistSource: null,
+    enhancedData: null,
+    selectedTracks: new Set<string>(),
+  };
+  (window as { artistDetailPageState?: VanillaArtistState }).artistDetailPageState = state;
+  return state;
+}
+
+afterEach(() => {
+  delete (window as { artistDetailPageState?: VanillaArtistState }).artistDetailPageState;
+});
+
+describe('syncVanillaArtist', () => {
+  it('writes the artist through to the vanilla page state', () => {
+    const state = installVanillaState();
+    syncVanillaArtist({ id: 42, name: 'Aphex Twin', source: 'spotify' });
+
+    expect(state.currentArtistId).toBe(42);
+    expect(state.currentArtistName).toBe('Aphex Twin');
+    expect(state.currentArtistSource).toBe('spotify');
+  });
+
+  it('leaves fields it was not given alone', () => {
+    const state = installVanillaState();
+    syncVanillaArtist({ id: 42, name: 'A', source: 'spotify' });
+    syncVanillaArtist({ name: 'B' });
+
+    expect(state.currentArtistName).toBe('B');
+    expect(state.currentArtistId).toBe(42);
+  });
+
+  it('normalises undefined to null rather than leaving it undefined', () => {
+    // The vanilla treats null as "no artist"; undefined would read the same
+    // way to a truthiness check but not to `=== null`.
+    const state = installVanillaState();
+    syncVanillaArtist({ id: undefined, name: undefined, source: undefined });
+    expect(state.currentArtistId).toBeNull();
+    expect(state.currentArtistName).toBeNull();
+  });
+
+  it('clears everything on teardown', () => {
+    const state = installVanillaState();
+    syncVanillaArtist({ id: 42, name: 'A', source: 'spotify' });
+    clearVanillaArtist();
+
+    expect(state.currentArtistId).toBeNull();
+    expect(state.currentArtistName).toBeNull();
+    expect(state.currentArtistSource).toBeNull();
+  });
+
+  it('is a no-op when library.js is not loaded', () => {
+    // The React page must not require the vanilla bundle to exist.
+    expect(() => syncVanillaArtist({ id: 1 })).not.toThrow();
+    expect(() => clearVanillaArtist()).not.toThrow();
+    expect(() => syncVanillaEnhancedData(null)).not.toThrow();
+    expect(() => syncVanillaSelection(new Set())).not.toThrow();
+  });
+});
+
+describe('syncVanillaEnhancedData', () => {
+  it('hands the payload over and takes it back', () => {
+    const state = installVanillaState();
+    const data = { albums: [{ id: 1 }] };
+
+    syncVanillaEnhancedData(data);
+    expect(state.enhancedData).toBe(data);
+
+    syncVanillaEnhancedData(null);
+    expect(state.enhancedData).toBeNull();
+  });
+});
+
+describe('syncVanillaSelection', () => {
+  it('MUTATES the existing Set rather than replacing it', () => {
+    // deleteLibraryTrack deletes from this Set after a delete; swapping the
+    // object out would leave those writes landing on a Set nobody reads.
+    const state = installVanillaState();
+    const original = state.selectedTracks;
+
+    syncVanillaSelection(new Set(['1', '2']));
+
+    expect(state.selectedTracks).toBe(original);
+    expect([...state.selectedTracks]).toEqual(['1', '2']);
+  });
+
+  it('replaces the contents, dropping ids that are no longer ticked', () => {
+    const state = installVanillaState();
+    syncVanillaSelection(new Set(['1', '2']));
+    syncVanillaSelection(new Set(['3']));
+    expect([...state.selectedTracks]).toEqual(['3']);
+  });
+
+  it('survives a state object with no Set at all', () => {
+    const state = installVanillaState();
+    (state as { selectedTracks?: Set<string> }).selectedTracks = undefined;
+    expect(() => syncVanillaSelection(new Set(['1']))).not.toThrow();
+  });
+});

--- a/webui/src/routes/artist-detail/-artist-detail.vanilla-state.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.vanilla-state.ts
@@ -1,0 +1,78 @@
+import type { EnhancedData } from './-artist-detail.enhanced';
+
+/**
+ * Keeps the vanilla artistDetailPageState in step with the React page.
+ *
+ * This is not bookkeeping — it is load-bearing. A dozen functions the React
+ * page invokes through window read this object rather than taking arguments:
+ *
+ *   playArtistRadio / openArtistArtPicker / openDiscographyModal
+ *       read currentArtistId + currentArtistName. Without them they bail out
+ *       with "No artist selected" and the button does nothing at all.
+ *   deleteLibraryAlbum / deleteLibraryTrack / runEnrichment / showReorganizeModal
+ *   / _showMobileTrackActions / showTrackRedownloadModal /
+ *   openMissingTrackManageModal / openManualMatchModal / redownloadLibraryAlbum
+ *       read enhancedData for the artist name and to patch their own copy of
+ *       the album list, and selectedTracks to drop ids they just deleted.
+ *
+ * library.js exports the object onto window for exactly this reason: a
+ * top-level `let` in a classic script is a global LEXICAL binding that no
+ * module can reach.
+ */
+export interface VanillaArtistState {
+  currentArtistId: unknown;
+  currentArtistName: string | null;
+  currentArtistSource: string | null;
+  enhancedData: EnhancedData | null;
+  selectedTracks: Set<string>;
+  [key: string]: unknown;
+}
+
+function vanillaState(): VanillaArtistState | null {
+  return (window as { artistDetailPageState?: VanillaArtistState }).artistDetailPageState ?? null;
+}
+
+/**
+ * Which artist the page is showing.
+ *
+ * Mirrors what populateArtistDetailPage set, including the library-upgrade
+ * case: when the backend resolves a source-artist click to an existing library
+ * record, the id it hands back is the library primary key, and the library-only
+ * endpoints need THAT id rather than the one in the URL.
+ */
+export function syncVanillaArtist(patch: {
+  id?: unknown;
+  name?: string | null;
+  source?: string | null;
+}): void {
+  const state = vanillaState();
+  if (!state) return;
+  if ('id' in patch) state.currentArtistId = patch.id ?? null;
+  if ('name' in patch) state.currentArtistName = patch.name ?? null;
+  if ('source' in patch) state.currentArtistSource = patch.source ?? null;
+}
+
+/** The vanilla's own teardown (clearArtistDetailPageState), for unmount. */
+export function clearVanillaArtist(): void {
+  syncVanillaArtist({ id: null, name: null, source: null });
+}
+
+/** The Enhanced payload, so album/track actions can read and patch it. */
+export function syncVanillaEnhancedData(data: EnhancedData | null): void {
+  const state = vanillaState();
+  if (state) state.enhancedData = data;
+}
+
+/**
+ * The ticked track ids.
+ *
+ * The Set is MUTATED rather than replaced: the vanilla deletes from it after a
+ * track delete, and swapping the object out would leave those writes landing on
+ * a Set nobody reads.
+ */
+export function syncVanillaSelection(selected: Set<string>): void {
+  const state = vanillaState();
+  if (!state?.selectedTracks) return;
+  state.selectedTracks.clear();
+  for (const id of selected) state.selectedTracks.add(id);
+}

--- a/webui/src/routes/artist-detail/-route.test.tsx
+++ b/webui/src/routes/artist-detail/-route.test.tsx
@@ -1,10 +1,23 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
 import { createTestQueryClient } from '@/test/query-client';
 import { createShellBridge } from '@/test/shell-bridge';
+
+function stubDetail(body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    ),
+  );
+}
 
 function renderArtistDetailRoute(initialEntries = ['/artist-detail/library/42']) {
   const queryClient = createTestQueryClient();
@@ -18,103 +31,90 @@ function renderArtistDetailRoute(initialEntries = ['/artist-detail/library/42'])
   };
 }
 
+/**
+ * Every URL the page requested, so the source/name round-trip can be checked.
+ *
+ * ky hands fetch a Request object rather than a string, so the url has to be
+ * read off it — String() would give "[object Request]" and every assertion
+ * below would pass vacuously.
+ */
+const requestedUrls = () =>
+  (fetch as unknown as { mock: { calls: unknown[][] } }).mock.calls.map((call) =>
+    call[0] instanceof Request ? call[0].url : String(call[0]),
+  );
+
+const detailUrl = () => requestedUrls().find((url) => url.includes('/api/artist-detail')) ?? '';
+
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  window.showToast = vi.fn();
+  window.loadSimilarArtists = vi.fn();
+  window.cancelSimilarArtistsLoad = vi.fn();
+  window.checkArtistEnhanceEligibility = vi.fn();
+  window.initializeLibraryWatchlistButton = vi.fn();
+  window.observeLazyBackgrounds = vi.fn();
+  stubDetail({
+    success: true,
+    artist: { id: 42, name: 'Aphex Twin', server_source: 'plex' },
+    discography: { albums: [{ id: 1, title: 'SAW', owned: true }], source: 'spotify' },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.SoulSyncWebShellBridge = undefined;
+  delete document.body.dataset.artistSource;
+});
+
 describe('artist-detail route', () => {
-  beforeEach(() => {
-    window.SoulSyncWebShellBridge = createShellBridge();
-  });
-
-  afterEach(() => {
-    window.SoulSyncWebShellBridge = undefined;
-  });
-
-  it('hands off canonical artist-detail URLs to the legacy shell', async () => {
+  it('renders the React page rather than handing off to the legacy shell', async () => {
     renderArtistDetailRoute(['/artist-detail/spotify/2YZyLoL8N0Wb9xBt1NhZWg']);
 
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '2YZyLoL8N0Wb9xBt1NhZWg',
-        '',
-        'spotify',
-        {
-          skipRouteChange: true,
-        },
-      );
-    });
+    await screen.findByText('Aphex Twin');
+    expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).not.toHaveBeenCalled();
   });
 
   it('survives an all-digits artist name (311) in ?name=', async () => {
-    // TanStack's search parser JSON-parses param values, so name=311 arrives
-    // as a NUMBER. A bare z.string() schema threw SearchParamError, the route
-    // died in its error boundary, and clicking the artist "did nothing".
+    // TanStack's search parser JSON-parses param values, so name=311 arrives as
+    // a NUMBER. A bare z.string() schema threw SearchParamError, the route died
+    // in its error boundary, and clicking the artist "did nothing". This has
+    // regressed once already.
     renderArtistDetailRoute(['/artist-detail/deezer/2481?name=311']);
 
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '2481',
-        '311',
-        'deezer',
-        {
-          skipRouteChange: true,
-        },
-      );
-    });
+    await screen.findByText('Aphex Twin');
+    await waitFor(() => expect(detailUrl()).toContain('name=311'));
   });
 
-  it('passes the ?name= search param through to the legacy shell', async () => {
+  it('round-trips the ?name= search param into the request', async () => {
     // Bandcamp (and any other source with no numeric-ID lookup API) can only
-    // resolve an artist by name — the URL is the only channel that survives
-    // a page load / browser-back, so this must round-trip correctly.
+    // resolve an artist by name — the URL is the only channel that survives a
+    // page load or a browser-back.
     renderArtistDetailRoute(['/artist-detail/bandcamp/3957198221?name=Radiohead']);
 
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '3957198221',
-        'Radiohead',
-        'bandcamp',
-        {
-          skipRouteChange: true,
-        },
-      );
-    });
+    await screen.findByText('Aphex Twin');
+    expect(detailUrl()).toContain('name=Radiohead');
+    expect(detailUrl()).toContain('source=bandcamp');
   });
 
-  it('normalizes library sources before handing off', async () => {
+  it('normalizes a library source away rather than sending it', async () => {
+    // "library" is not a metadata source; sending it would ask the backend to
+    // resolve the artist somewhere it does not exist.
     renderArtistDetailRoute(['/artist-detail/library/42']);
 
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '42',
-        '',
-        null,
-        {
-          skipRouteChange: true,
-        },
-      );
-    });
+    await screen.findByText('Aphex Twin');
+    // Assert the request was found first — a missing url would make the
+    // not.toContain below pass for the wrong reason.
+    expect(detailUrl()).toContain('/api/artist-detail/42');
+    expect(detailUrl()).not.toContain('source=library');
   });
 
-  it('cancels the similar artists stream when the route unmounts', async () => {
+  it('cancels the similar-artists stream when the route unmounts', async () => {
     const { unmount } = renderArtistDetailRoute(['/artist-detail/spotify/2YZyLoL8N0Wb9xBt1NhZWg']);
 
-    await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '2YZyLoL8N0Wb9xBt1NhZWg',
-        '',
-        'spotify',
-        {
-          skipRouteChange: true,
-        },
-      );
-    });
-
-    const cancelSimilarArtistsLoad = window.SoulSyncWebShellBridge
-      ?.cancelSimilarArtistsLoad as ReturnType<typeof vi.fn>;
-    cancelSimilarArtistsLoad.mockClear();
+    await waitFor(() => expect(window.loadSimilarArtists).toHaveBeenCalledWith('Aphex Twin'));
+    (window.cancelSimilarArtistsLoad as ReturnType<typeof vi.fn>).mockClear();
 
     unmount();
-
-    await waitFor(() => {
-      expect(cancelSimilarArtistsLoad).toHaveBeenCalledTimes(1);
-    });
+    expect(window.cancelSimilarArtistsLoad).toHaveBeenCalled();
   });
 });

--- a/webui/src/routes/artist-detail/-ui/album-meta-row.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/album-meta-row.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnhancedAlbum } from '../-artist-detail.enhanced';
+
+import { AlbumMetaRow } from './album-meta-row';
+
+const ALBUM: EnhancedAlbum = {
+  id: 7,
+  title: 'SAW 85-92',
+  year: 1992,
+  genres: ['ambient'],
+  label: 'Apollo',
+  record_type: 'album',
+};
+
+let body: unknown = null;
+
+function stubPut(result: unknown = { success: true, updated_fields: ['label'] }) {
+  body = null;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      body = init?.body ? JSON.parse(String(init.body)) : null;
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderRow(album: EnhancedAlbum = ALBUM, isAdmin = true) {
+  const onSaved = vi.fn();
+  const view = render(<AlbumMetaRow album={album} isAdmin={isAdmin} onSaved={onSaved} />);
+  return { onSaved, ...view };
+}
+
+const input = (field: string) =>
+  document.querySelector(`[data-field="${field}"]`) as HTMLInputElement;
+
+beforeEach(() => {
+  window.showToast = vi.fn();
+  stubPut();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+describe('the read-only row', () => {
+  it('shows values as text for a non-admin, with no inputs or Save', () => {
+    renderRow(ALBUM, false);
+    expect(document.querySelector('.enhanced-album-meta-input')).toBeNull();
+    expect(document.querySelector('.enhanced-album-save-btn')).toBeNull();
+    expect(document.querySelector('.enhanced-album-meta-value')?.textContent).toBe('SAW 85-92');
+  });
+
+  it('shows an em dash for an empty value rather than a blank gap', () => {
+    renderRow({ id: 7 }, false);
+    const values = [...document.querySelectorAll('.enhanced-album-meta-value')].map(
+      (n) => n.textContent,
+    );
+    expect(values[0]).toBe('—');
+  });
+});
+
+describe('the editable row', () => {
+  it('seeds each input from the album', () => {
+    renderRow();
+    expect(input('title').value).toBe('SAW 85-92');
+    expect(input('year').value).toBe('1992');
+    expect(input('genres').value).toBe('ambient');
+    expect(input('explicit').value).toBe('0');
+  });
+
+  it('does not let a click in a field collapse the album', () => {
+    const onRowClick = vi.fn();
+    render(
+      <div onClick={onRowClick}>
+        <AlbumMetaRow album={ALBUM} isAdmin onSaved={vi.fn()} />
+      </div>,
+    );
+    fireEvent.click(input('title'));
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('PUTs only the changed fields', () => {
+    renderRow();
+    fireEvent.change(input('label'), { target: { value: 'Warp' } });
+    fireEvent.click(document.querySelector('.enhanced-album-save-btn') as HTMLElement);
+    // explicit:0 rides along on every save for a non-explicit album — see
+    // albumMetaUpdates.
+    expect(body).toEqual({ label: 'Warp', explicit: 0 });
+  });
+
+  it('applies the update so the row above it follows', async () => {
+    const { onSaved } = renderRow();
+    fireEvent.change(input('label'), { target: { value: 'Warp' } });
+    fireEvent.click(document.querySelector('.enhanced-album-save-btn') as HTMLElement);
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith({ label: 'Warp', explicit: 0 }));
+    expect(window.showToast).toHaveBeenCalledWith('Album metadata saved (label)', 'success');
+  });
+
+  it('refuses a malformed release date without sending anything', () => {
+    renderRow();
+    fireEvent.change(input('release_date'), { target: { value: '08/11/1992' } });
+    fireEvent.click(document.querySelector('.enhanced-album-save-btn') as HTMLElement);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(window.showToast).toHaveBeenCalledWith(
+      'Release Date must be YYYY-MM-DD (or just YYYY)',
+      'error',
+    );
+  });
+
+  it('says so — as an ERROR — when nothing changed', () => {
+    // Silence would read as a save that quietly failed. Only reachable for an
+    // EXPLICIT album: otherwise explicit:0 always counts as a change.
+    renderRow({ ...ALBUM, explicit: 1 });
+    fireEvent.click(document.querySelector('.enhanced-album-save-btn') as HTMLElement);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(window.showToast).toHaveBeenCalledWith('No album changes to save', 'error');
+  });
+
+  it('surfaces a rejected save instead of claiming success', async () => {
+    stubPut({ success: false, error: 'locked' });
+    const { onSaved } = renderRow();
+    fireEvent.change(input('label'), { target: { value: 'Warp' } });
+    fireEvent.click(document.querySelector('.enhanced-album-save-btn') as HTMLElement);
+
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Failed to save: locked', 'error'),
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('reseeds the inputs when a refetch replaces the album', () => {
+    const { rerender } = renderRow();
+    fireEvent.change(input('label'), { target: { value: 'typing…' } });
+
+    rerender(<AlbumMetaRow album={{ ...ALBUM, label: 'Rephlex' }} isAdmin onSaved={vi.fn()} />);
+    // Stale edits must not survive a real refetch.
+    expect(input('label').value).toBe('Rephlex');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/album-meta-row.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/album-meta-row.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { EnhancedAlbum } from '../-artist-detail.enhanced';
@@ -46,7 +46,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('the read-only row', () => {

--- a/webui/src/routes/artist-detail/-ui/album-meta-row.tsx
+++ b/webui/src/routes/artist-detail/-ui/album-meta-row.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+
+import type { EnhancedAlbum } from '../-artist-detail.enhanced';
+
+import { albumMetaFields, albumMetaUpdates } from '../-artist-detail.enhanced-album';
+
+interface Props {
+  album: EnhancedAlbum;
+  /** Non-admins get a read-only row; the inputs and Save button are admin-only. */
+  isAdmin: boolean;
+  /** Applied to the album after a successful PUT, so the row above updates. */
+  onSaved: (updates: Record<string, unknown>) => void;
+}
+
+/**
+ * The editable album metadata row (renderAlbumMetaRow, library.js:4012).
+ *
+ * Every input stops its own click: the whole album row is a toggle, and typing
+ * in a field must not collapse the panel you are typing into.
+ */
+export function AlbumMetaRow({ album, isAdmin, onSaved }: Props) {
+  const fields = albumMetaFields(album);
+
+  // Seeded from the album and reset when the album object itself changes —
+  // a refetch replaces the record, and stale edits must not survive it.
+  const [seenAlbum, setSeenAlbum] = useState(album);
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(fields.map((field) => [field.key, field.value])),
+  );
+  if (album !== seenAlbum) {
+    setSeenAlbum(album);
+    setValues(Object.fromEntries(albumMetaFields(album).map((f) => [f.key, f.value])));
+  }
+
+  const save = async () => {
+    const { updates, invalidDate } = albumMetaUpdates(album, values);
+    if (invalidDate) {
+      window.showToast?.('Release Date must be YYYY-MM-DD (or just YYYY)', 'error');
+      return;
+    }
+    if (Object.keys(updates).length === 0) {
+      // Reported as an error, not a no-op: the vanilla did, and silence would
+      // read as a save that quietly failed.
+      window.showToast?.('No album changes to save', 'error');
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/library/album/${album.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      });
+      const result = await response.json();
+      if (!result.success) throw new Error(result.error);
+
+      onSaved(updates);
+      window.showToast?.(
+        `Album metadata saved (${(result.updated_fields || []).join(', ')})`,
+        'success',
+      );
+    } catch (error) {
+      window.showToast?.(`Failed to save: ${(error as Error).message}`, 'error');
+    }
+  };
+
+  return (
+    <div className="enhanced-album-meta-row" id={`enhanced-album-meta-${album.id}`}>
+      {fields.map((field) => (
+        <div className="enhanced-album-meta-field" key={field.key}>
+          <label className="enhanced-album-meta-label">{field.label}</label>
+          {isAdmin ? (
+            <input
+              className="enhanced-album-meta-input"
+              type={field.type || 'text'}
+              placeholder={field.placeholder}
+              data-album-id={String(album.id)}
+              data-field={field.key}
+              value={values[field.key] ?? ''}
+              onClick={(e) => e.stopPropagation()}
+              onChange={(e) => setValues((v) => ({ ...v, [field.key]: e.target.value }))}
+            />
+          ) : (
+            <span className="enhanced-album-meta-value">{field.value || '—'}</span>
+          )}
+        </div>
+      ))}
+
+      {isAdmin ? (
+        <div className="enhanced-album-meta-field">
+          {/* An empty label, so the button lines up with the inputs. */}
+          <label className="enhanced-album-meta-label">&nbsp;</label>
+          <button
+            type="button"
+            className="enhanced-album-save-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              void save();
+            }}
+          >
+            Save Album
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/artist-db-record.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-db-record.test.tsx
@@ -1,0 +1,202 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ArtistDbRecord } from './artist-db-record';
+
+const RECORD = {
+  success: true,
+  artist_id: 42,
+  counts: { albums: 3, tracks: 40 },
+  record: {
+    name: 'Aphex Twin',
+    spotify_match_status: 'matched',
+    deezer_artist_id: null,
+    meta: { a: 1 },
+  },
+};
+
+function stubRecord(body: unknown = RECORD) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    ),
+  );
+}
+
+const openModal = async () => {
+  fireEvent.click(document.getElementById('artist-db-record-btn') as HTMLElement);
+  await screen.findByText('Aphex Twin', { selector: '.arec-sub' });
+};
+
+beforeEach(() => {
+  window.showToast = vi.fn();
+  stubRecord();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+describe('the DB Record button', () => {
+  it('is there for a library artist', () => {
+    render(<ArtistDbRecord artist={{ id: 42, name: 'Aphex Twin' }} isSourceArtist={false} />);
+    expect(document.getElementById('artist-db-record-btn')).not.toBeNull();
+  });
+
+  it('is absent for a source artist and for an artist with no id', () => {
+    const { rerender } = render(
+      <ArtistDbRecord artist={{ id: 'sp1', name: 'X' }} isSourceArtist={true} />,
+    );
+    expect(document.getElementById('artist-db-record-btn')).toBeNull();
+    rerender(<ArtistDbRecord artist={{ name: 'X' }} isSourceArtist={false} />);
+    expect(document.getElementById('artist-db-record-btn')).toBeNull();
+  });
+
+  it('does not fetch the record until it is clicked', async () => {
+    render(<ArtistDbRecord artist={{ id: 42, name: 'Aphex Twin' }} isSourceArtist={false} />);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('the record modal', () => {
+  beforeEach(() => {
+    render(<ArtistDbRecord artist={{ id: 42, name: 'Aphex Twin' }} isSourceArtist={false} />);
+  });
+
+  it('lists every field, with empty values marked', async () => {
+    await openModal();
+    const rows = [...document.querySelectorAll('.arec-row')];
+    expect(rows).toHaveLength(4);
+    const empty = rows.find((r) => r.className.includes('is-empty'));
+    expect(empty?.querySelector('.arec-key')?.textContent).toBe('deezer_artist_id');
+    expect(empty?.querySelector('.arec-null')?.textContent).toBe('null');
+    // Objects render as compact JSON.
+    expect(document.querySelector('.arec-json')?.textContent).toBe('{"a":1}');
+  });
+
+  it('summarises the record in the footer', async () => {
+    await openModal();
+    const footer = document.getElementById('arec-footer') as HTMLElement;
+    expect(footer.textContent).toContain('4 fields');
+    expect(footer.textContent).toContain('3 albums');
+    expect(footer.textContent).toContain('1 sources matched');
+    expect(footer.textContent).toContain('id 42');
+  });
+
+  it('filters rows by field name, hiding rather than removing them', async () => {
+    await openModal();
+    fireEvent.change(document.getElementById('arec-filter') as HTMLElement, {
+      target: { value: 'deezer' },
+    });
+    const rows = [...document.querySelectorAll('.arec-row')] as HTMLElement[];
+    expect(rows).toHaveLength(4);
+    expect(rows.filter((r) => r.style.display !== 'none')).toHaveLength(1);
+  });
+
+  it('switches to a highlighted JSON view and hides the filter box', async () => {
+    await openModal();
+    fireEvent.click(document.querySelector('[data-tab="json"]') as HTMLElement);
+
+    expect(document.querySelector('.arec-code .tok-key')?.textContent).toBe('"name":');
+    expect(document.querySelector('.arec-row')).toBeNull();
+    // visibility, not display — the action buttons must not shift.
+    expect((document.getElementById('arec-filter') as HTMLElement).style.visibility).toBe('hidden');
+  });
+
+  it('keeps the typed filter when coming back from the JSON tab', async () => {
+    await openModal();
+    fireEvent.change(document.getElementById('arec-filter') as HTMLElement, {
+      target: { value: 'deezer' },
+    });
+    fireEvent.click(document.querySelector('[data-tab="json"]') as HTMLElement);
+    fireEvent.click(document.querySelector('[data-tab="fields"]') as HTMLElement);
+
+    const rows = [...document.querySelectorAll('.arec-row')] as HTMLElement[];
+    expect(rows.filter((r) => r.style.display !== 'none')).toHaveLength(1);
+  });
+
+  it('shows an error instead of an empty record when the request fails', async () => {
+    stubRecord({ success: false, error: 'no such artist' });
+    fireEvent.click(document.getElementById('artist-db-record-btn') as HTMLElement);
+    await screen.findByText('Could not load record: no such artist');
+  });
+
+  it('closes on the close button, on Escape, and on a backdrop click', async () => {
+    await openModal();
+    fireEvent.click(document.getElementById('arec-close') as HTMLElement);
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).toBeNull());
+
+    await openModal();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).toBeNull());
+
+    await openModal();
+    fireEvent.click(document.getElementById('artist-record-overlay') as HTMLElement);
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).toBeNull());
+  });
+
+  it('does NOT close on a click inside the card', async () => {
+    await openModal();
+    fireEvent.click(document.querySelector('.arec-card') as HTMLElement);
+    expect(document.getElementById('artist-record-overlay')).not.toBeNull();
+  });
+
+  it('stops listening for Escape once closed', async () => {
+    // Counted rather than observed through behaviour: a leaked handler still
+    // closes the modal (same onClose identity), so only the listener balance
+    // shows the leak — and it accumulates one per open across a session.
+    const added = vi.spyOn(document, 'addEventListener');
+    const removed = vi.spyOn(document, 'removeEventListener');
+    const keydowns = (spy: typeof added) =>
+      spy.mock.calls.filter(([type]) => type === 'keydown').length;
+
+    await openModal();
+    expect(keydowns(added)).toBe(1);
+
+    fireEvent.click(document.getElementById('arec-close') as HTMLElement);
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).toBeNull());
+    expect(keydowns(removed)).toBe(1);
+
+    added.mockRestore();
+    removed.mockRestore();
+  });
+
+  it('copies the whole record as pretty JSON', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('isSecureContext', true);
+    await openModal();
+
+    fireEvent.click(document.getElementById('arec-copy') as HTMLElement);
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(JSON.stringify(RECORD.record, null, 2)),
+    );
+    expect(window.showToast).toHaveBeenCalledWith('Full record copied as JSON', 'success');
+  });
+
+  it('copies a single row value', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    vi.stubGlobal('isSecureContext', true);
+    await openModal();
+
+    fireEvent.click(document.querySelectorAll('.arec-rowcopy')[0]);
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('Aphex Twin'));
+    expect(window.showToast).toHaveBeenCalledWith('Value copied', 'success');
+  });
+
+  it('reports the saved filename', async () => {
+    vi.stubGlobal('URL', { createObjectURL: () => 'blob:x', revokeObjectURL: vi.fn() });
+    await openModal();
+
+    fireEvent.click(document.getElementById('arec-download') as HTMLElement);
+    expect(window.showToast).toHaveBeenCalledWith('Saved Aphex_Twin_db_record.json', 'success');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-db-record.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-db-record.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ArtistDbRecord } from './artist-db-record';
@@ -40,7 +40,11 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': these render through a portal, and
+  // wiping the body out from under Testing Library's own cleanup makes it throw
+  // "The node to be removed is not a child of this node". cleanup() unmounts
+  // the tree, which takes the portal with it.
+  cleanup();
 });
 
 describe('the DB Record button', () => {

--- a/webui/src/routes/artist-detail/-ui/artist-db-record.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-db-record.tsx
@@ -12,6 +12,7 @@ import {
   recordRows,
   showsDbRecordButton,
 } from '../-artist-detail.db-record';
+import { BodyPortal } from './portal';
 
 interface Props {
   artist: ArtistInfo;
@@ -119,157 +120,159 @@ function ArtistRecordModal({
   const stats = payload ? recordFooterStats(payload) : null;
 
   return (
-    <div
-      id="artist-record-overlay"
-      className={`arec-overlay${visible ? ' visible' : ''}`}
-      // Only a click on the backdrop itself closes; a click that started inside
-      // the card must not.
-      onClick={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="arec-card" role="dialog" aria-label="Artist database record">
-        <div className="arec-header">
-          <div className="arec-title-wrap">
-            <div className="arec-title">
-              <span className="arec-dot" />
-              Artist DB Record
+    <BodyPortal>
+      <div
+        id="artist-record-overlay"
+        className={`arec-overlay${visible ? ' visible' : ''}`}
+        // Only a click on the backdrop itself closes; a click that started inside
+        // the card must not.
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="arec-card" role="dialog" aria-label="Artist database record">
+          <div className="arec-header">
+            <div className="arec-title-wrap">
+              <div className="arec-title">
+                <span className="arec-dot" />
+                Artist DB Record
+              </div>
+              <div className="arec-sub" id="arec-sub">
+                {artistName}
+              </div>
             </div>
-            <div className="arec-sub" id="arec-sub">
-              {artistName}
+            <button className="arec-close" id="arec-close" title="Close (Esc)" onClick={onClose}>
+              ×
+            </button>
+          </div>
+
+          <div className="arec-toolbar">
+            <div className="arec-tabs">
+              <button
+                className={`arec-tab${tab === 'fields' ? ' active' : ''}`}
+                data-tab="fields"
+                onClick={() => setTab('fields')}
+              >
+                Fields
+              </button>
+              <button
+                className={`arec-tab${tab === 'json' ? ' active' : ''}`}
+                data-tab="json"
+                onClick={() => setTab('json')}
+              >
+                JSON
+              </button>
+            </div>
+            {/* Hidden with visibility, not display: the toolbar keeps its layout
+                so the action buttons do not shift when you switch tabs. */}
+            <input
+              id="arec-filter"
+              className="arec-filter"
+              type="text"
+              placeholder="filter fields…"
+              autoComplete="off"
+              spellCheck={false}
+              style={{ visibility: tab === 'json' ? 'hidden' : undefined }}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <div className="arec-actions">
+              <button
+                className="arec-btn"
+                id="arec-copy"
+                onClick={() => {
+                  void copyRecordText(JSON.stringify(record, null, 2));
+                  window.showToast?.('Full record copied as JSON', 'success');
+                }}
+              >
+                Copy JSON
+              </button>
+              <button
+                className="arec-btn"
+                id="arec-download"
+                onClick={() =>
+                  window.showToast?.(`Saved ${downloadRecord(record, artistName)}`, 'success')
+                }
+              >
+                Save .json
+              </button>
             </div>
           </div>
-          <button className="arec-close" id="arec-close" title="Close (Esc)" onClick={onClose}>
-            ×
-          </button>
-        </div>
 
-        <div className="arec-toolbar">
-          <div className="arec-tabs">
-            <button
-              className={`arec-tab${tab === 'fields' ? ' active' : ''}`}
-              data-tab="fields"
-              onClick={() => setTab('fields')}
-            >
-              Fields
-            </button>
-            <button
-              className={`arec-tab${tab === 'json' ? ' active' : ''}`}
-              data-tab="json"
-              onClick={() => setTab('json')}
-            >
-              JSON
-            </button>
-          </div>
-          {/* Hidden with visibility, not display: the toolbar keeps its layout
-              so the action buttons do not shift when you switch tabs. */}
-          <input
-            id="arec-filter"
-            className="arec-filter"
-            type="text"
-            placeholder="filter fields…"
-            autoComplete="off"
-            spellCheck={false}
-            style={{ visibility: tab === 'json' ? 'hidden' : undefined }}
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-          />
-          <div className="arec-actions">
-            <button
-              className="arec-btn"
-              id="arec-copy"
-              onClick={() => {
-                void copyRecordText(JSON.stringify(record, null, 2));
-                window.showToast?.('Full record copied as JSON', 'success');
-              }}
-            >
-              Copy JSON
-            </button>
-            <button
-              className="arec-btn"
-              id="arec-download"
-              onClick={() =>
-                window.showToast?.(`Saved ${downloadRecord(record, artistName)}`, 'success')
-              }
-            >
-              Save .json
-            </button>
-          </div>
-        </div>
-
-        <div className="arec-body" id="arec-body">
-          {error ? (
-            <div className="arec-error">Could not load record: {error}</div>
-          ) : !payload ? (
-            <div className="arec-loading">Loading record…</div>
-          ) : tab === 'json' ? (
-            <pre className="arec-code">
-              {jsonHighlightTokens(record).map((token, index) =>
-                token.className ? (
-                  <span className={token.className} key={index}>
-                    {token.text}
-                  </span>
-                ) : (
-                  token.text
-                ),
-              )}
-            </pre>
-          ) : (
-            <div className="arec-fields">
-              {recordRows(record).map((row) => (
-                <div
-                  className={`arec-row${row.isEmpty ? ' is-empty' : ''}`}
-                  key={row.key}
-                  data-field={row.filterKey}
-                  style={{ display: matchesRecordFilter(row, filter) ? undefined : 'none' }}
-                >
-                  <span className="arec-key">{row.key}</span>
-                  <span className="arec-val">
-                    {row.isEmpty ? (
-                      <span className="arec-null">null</span>
-                    ) : row.isJson ? (
-                      <span className="arec-json">{row.text}</span>
-                    ) : (
-                      row.text
-                    )}
-                  </span>
-                  <button
-                    className="arec-rowcopy"
-                    title="Copy value"
-                    data-copy={row.copyValue}
-                    onClick={() => {
-                      void copyRecordText(row.copyValue);
-                      window.showToast?.('Value copied', 'success');
-                    }}
+          <div className="arec-body" id="arec-body">
+            {error ? (
+              <div className="arec-error">Could not load record: {error}</div>
+            ) : !payload ? (
+              <div className="arec-loading">Loading record…</div>
+            ) : tab === 'json' ? (
+              <pre className="arec-code">
+                {jsonHighlightTokens(record).map((token, index) =>
+                  token.className ? (
+                    <span className={token.className} key={index}>
+                      {token.text}
+                    </span>
+                  ) : (
+                    token.text
+                  ),
+                )}
+              </pre>
+            ) : (
+              <div className="arec-fields">
+                {recordRows(record).map((row) => (
+                  <div
+                    className={`arec-row${row.isEmpty ? ' is-empty' : ''}`}
+                    key={row.key}
+                    data-field={row.filterKey}
+                    style={{ display: matchesRecordFilter(row, filter) ? undefined : 'none' }}
                   >
-                    ⧉
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+                    <span className="arec-key">{row.key}</span>
+                    <span className="arec-val">
+                      {row.isEmpty ? (
+                        <span className="arec-null">null</span>
+                      ) : row.isJson ? (
+                        <span className="arec-json">{row.text}</span>
+                      ) : (
+                        row.text
+                      )}
+                    </span>
+                    <button
+                      className="arec-rowcopy"
+                      title="Copy value"
+                      data-copy={row.copyValue}
+                      onClick={() => {
+                        void copyRecordText(row.copyValue);
+                        window.showToast?.('Value copied', 'success');
+                      }}
+                    >
+                      ⧉
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
 
-        <div className="arec-footer" id="arec-footer">
-          {stats ? (
-            <>
-              <span>
-                <b>{stats.fields}</b> fields
-              </span>
-              <span>
-                <b>{stats.albums}</b> albums
-              </span>
-              <span>
-                <b>{stats.tracks}</b> tracks
-              </span>
-              <span>
-                <b>{stats.matched}</b> sources matched
-              </span>
-              <span className="arec-id">id {stats.id}</span>
-            </>
-          ) : null}
+          <div className="arec-footer" id="arec-footer">
+            {stats ? (
+              <>
+                <span>
+                  <b>{stats.fields}</b> fields
+                </span>
+                <span>
+                  <b>{stats.albums}</b> albums
+                </span>
+                <span>
+                  <b>{stats.tracks}</b> tracks
+                </span>
+                <span>
+                  <b>{stats.matched}</b> sources matched
+                </span>
+                <span className="arec-id">id {stats.id}</span>
+              </>
+            ) : null}
+          </div>
         </div>
       </div>
-    </div>
+    </BodyPortal>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/artist-db-record.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-db-record.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useState } from 'react';
+
+import type { ArtistInfo } from '../-artist-detail.types';
+
+import {
+  type ArtistRecordPayload,
+  copyRecordText,
+  downloadRecord,
+  jsonHighlightTokens,
+  matchesRecordFilter,
+  recordFooterStats,
+  recordRows,
+  showsDbRecordButton,
+} from '../-artist-detail.db-record';
+
+interface Props {
+  artist: ArtistInfo;
+  isSourceArtist: boolean;
+}
+
+/**
+ * The "DB Record" inspector button and its modal.
+ *
+ * The vanilla appended the button to #artist-hero-section by hand and rebuilt
+ * it on every artist; here it is part of the hero, which is why the
+ * library-only condition is a render guard rather than a display toggle.
+ */
+export function ArtistDbRecord({ artist, isSourceArtist }: Props) {
+  const [open, setOpen] = useState(false);
+  if (!showsDbRecordButton(artist, isSourceArtist)) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="artist-db-record-btn"
+        id="artist-db-record-btn"
+        title="Inspect everything the database knows about this artist"
+        onClick={() => setOpen(true)}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <ellipse cx="12" cy="5" rx="8" ry="3" />
+          <path d="M4 5v6c0 1.66 3.58 3 8 3s8-1.34 8-3V5" />
+          <path d="M4 11v6c0 1.66 3.58 3 8 3s8-1.34 8-3v-6" />
+        </svg>
+        <span>DB Record</span>
+      </button>
+
+      {open ? (
+        <ArtistRecordModal
+          artistId={artist.id}
+          artistName={artist.name || 'Artist'}
+          onClose={() => setOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function ArtistRecordModal({
+  artistId,
+  artistName,
+  onClose,
+}: {
+  artistId: unknown;
+  artistName: string;
+  onClose: () => void;
+}) {
+  const [payload, setPayload] = useState<ArtistRecordPayload | null>(null);
+  const [error, setError] = useState('');
+  const [tab, setTab] = useState<'fields' | 'json'>('fields');
+  const [filter, setFilter] = useState('');
+  // The overlay fades in on the frame AFTER mount; without the two-step the
+  // CSS transition has no starting state to animate from.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const response = await fetch(`/api/artist/${encodeURIComponent(String(artistId))}/record`, {
+          signal: controller.signal,
+        });
+        const data = (await response.json()) as ArtistRecordPayload;
+        if (!data?.success) throw new Error(data?.error || 'Request failed');
+        setPayload(data);
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setError((err as Error).message || String(err));
+      }
+    })();
+    return () => controller.abort();
+  }, [artistId]);
+
+  const record = payload?.record ?? {};
+  const stats = payload ? recordFooterStats(payload) : null;
+
+  return (
+    <div
+      id="artist-record-overlay"
+      className={`arec-overlay${visible ? ' visible' : ''}`}
+      // Only a click on the backdrop itself closes; a click that started inside
+      // the card must not.
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="arec-card" role="dialog" aria-label="Artist database record">
+        <div className="arec-header">
+          <div className="arec-title-wrap">
+            <div className="arec-title">
+              <span className="arec-dot" />
+              Artist DB Record
+            </div>
+            <div className="arec-sub" id="arec-sub">
+              {artistName}
+            </div>
+          </div>
+          <button className="arec-close" id="arec-close" title="Close (Esc)" onClick={onClose}>
+            ×
+          </button>
+        </div>
+
+        <div className="arec-toolbar">
+          <div className="arec-tabs">
+            <button
+              className={`arec-tab${tab === 'fields' ? ' active' : ''}`}
+              data-tab="fields"
+              onClick={() => setTab('fields')}
+            >
+              Fields
+            </button>
+            <button
+              className={`arec-tab${tab === 'json' ? ' active' : ''}`}
+              data-tab="json"
+              onClick={() => setTab('json')}
+            >
+              JSON
+            </button>
+          </div>
+          {/* Hidden with visibility, not display: the toolbar keeps its layout
+              so the action buttons do not shift when you switch tabs. */}
+          <input
+            id="arec-filter"
+            className="arec-filter"
+            type="text"
+            placeholder="filter fields…"
+            autoComplete="off"
+            spellCheck={false}
+            style={{ visibility: tab === 'json' ? 'hidden' : undefined }}
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+          <div className="arec-actions">
+            <button
+              className="arec-btn"
+              id="arec-copy"
+              onClick={() => {
+                void copyRecordText(JSON.stringify(record, null, 2));
+                window.showToast?.('Full record copied as JSON', 'success');
+              }}
+            >
+              Copy JSON
+            </button>
+            <button
+              className="arec-btn"
+              id="arec-download"
+              onClick={() =>
+                window.showToast?.(`Saved ${downloadRecord(record, artistName)}`, 'success')
+              }
+            >
+              Save .json
+            </button>
+          </div>
+        </div>
+
+        <div className="arec-body" id="arec-body">
+          {error ? (
+            <div className="arec-error">Could not load record: {error}</div>
+          ) : !payload ? (
+            <div className="arec-loading">Loading record…</div>
+          ) : tab === 'json' ? (
+            <pre className="arec-code">
+              {jsonHighlightTokens(record).map((token, index) =>
+                token.className ? (
+                  <span className={token.className} key={index}>
+                    {token.text}
+                  </span>
+                ) : (
+                  token.text
+                ),
+              )}
+            </pre>
+          ) : (
+            <div className="arec-fields">
+              {recordRows(record).map((row) => (
+                <div
+                  className={`arec-row${row.isEmpty ? ' is-empty' : ''}`}
+                  key={row.key}
+                  data-field={row.filterKey}
+                  style={{ display: matchesRecordFilter(row, filter) ? undefined : 'none' }}
+                >
+                  <span className="arec-key">{row.key}</span>
+                  <span className="arec-val">
+                    {row.isEmpty ? (
+                      <span className="arec-null">null</span>
+                    ) : row.isJson ? (
+                      <span className="arec-json">{row.text}</span>
+                    ) : (
+                      row.text
+                    )}
+                  </span>
+                  <button
+                    className="arec-rowcopy"
+                    title="Copy value"
+                    data-copy={row.copyValue}
+                    onClick={() => {
+                      void copyRecordText(row.copyValue);
+                      window.showToast?.('Value copied', 'success');
+                    }}
+                  >
+                    ⧉
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="arec-footer" id="arec-footer">
+          {stats ? (
+            <>
+              <span>
+                <b>{stats.fields}</b> fields
+              </span>
+              <span>
+                <b>{stats.albums}</b> albums
+              </span>
+              <span>
+                <b>{stats.tracks}</b> tracks
+              </span>
+              <span>
+                <b>{stats.matched}</b> sources matched
+              </span>
+              <span className="arec-id">id {stats.id}</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-back-button.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-back-button.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from '@tanstack/react-router';
+
+/**
+ * The page-header Back button (index.html #artist-detail-back-btn, wired in
+ * initializeArtistDetailPage).
+ *
+ * That markup lives inside the vanilla #artist-detail-page, which the React
+ * host replaces — so without this the button simply disappeared.
+ *
+ * Browser history first, exactly as the vanilla did, with a Library fallback
+ * for a cold load straight onto an artist URL where going "back" would leave
+ * SoulSync entirely.
+ *
+ * The vanilla also relabelled this "← Back to <artist>" from its own
+ * _artistDetailLabelStack. Nothing pushes to that stack any more — React owns
+ * the navigation now — so it would read "← Back" in every case regardless,
+ * which is the vanilla's own empty-stack label.
+ */
+export function ArtistDetailBackButton() {
+  const router = useRouter();
+
+  return (
+    <div className="page-header">
+      <button
+        type="button"
+        className="back-btn"
+        id="artist-detail-back-btn"
+        onClick={() => {
+          if (window.history.length > 1) {
+            router.history.back();
+            return;
+          }
+          void router.navigate({ to: '/library' });
+        }}
+      >
+        <span>← Back</span>
+      </button>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-back-button.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-back-button.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from '@tanstack/react-router';
 
+import { backButtonLabel, popBackOrigin } from '../-artist-detail.back-label';
+
 /**
  * The page-header Back button (index.html #artist-detail-back-btn, wired in
  * initializeArtistDetailPage).
@@ -7,16 +9,16 @@ import { useRouter } from '@tanstack/react-router';
  * That markup lives inside the vanilla #artist-detail-page, which the React
  * host replaces — so without this the button simply disappeared.
  *
- * Browser history first, exactly as the vanilla did, with a Library fallback
- * for a cold load straight onto an artist URL where going "back" would leave
- * SoulSync entirely.
+ * The label is the smart one, not a bare "Back": arrivals from a still-vanilla
+ * page (search, label detail, enrichment) push their origin onto
+ * artistDetailLabelStack inside navigateToArtistDetail, and artist → artist
+ * hops push the previous artist's name. It reads "Back to Search",
+ * "Back to Aphex Twin", or plain "Back" on a cold load.
  *
- * The vanilla also relabelled this "← Back to <artist>" from its own
- * _artistDetailLabelStack. Nothing pushes to that stack any more — React owns
- * the navigation now — so it would read "← Back" in every case regardless,
- * which is the vanilla's own empty-stack label.
+ * Browser history first, as the vanilla did, with a Library fallback for a cold
+ * load straight onto an artist url where going back would leave SoulSync.
  */
-export function ArtistDetailBackButton() {
+export function ArtistDetailBackButton({ label }: { label?: string }) {
   const router = useRouter();
 
   return (
@@ -27,13 +29,19 @@ export function ArtistDetailBackButton() {
         id="artist-detail-back-btn"
         onClick={() => {
           if (window.history.length > 1) {
+            // The stack follows you back down the chain, so the next label
+            // describes where THAT page came from.
+            popBackOrigin();
             router.history.back();
             return;
           }
-          void router.navigate({ to: '/library' });
+          const origin = popBackOrigin();
+          void router.navigate({
+            to: origin?.type === 'page' && origin.pageId ? `/${origin.pageId}` : '/library',
+          });
         }}
       >
-        <span>← Back</span>
+        <span>{label ?? backButtonLabel()}</span>
       </button>
     </div>
   );

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -457,3 +457,115 @@ describe('the Enhanced view', () => {
     );
   });
 });
+
+describe('the vanilla page-state bridge', () => {
+  /** The shape library.js declares, defaults and all. */
+  type VanillaState = {
+    currentArtistId: unknown;
+    currentArtistName: string | null;
+    currentArtistSource: string | null;
+    enhancedData: unknown;
+    selectedTracks: Set<string>;
+  };
+
+  const install = (): VanillaState => {
+    const state: VanillaState = {
+      currentArtistId: null,
+      currentArtistName: null,
+      currentArtistSource: null,
+      enhancedData: null,
+      selectedTracks: new Set<string>(),
+    };
+    (window as unknown as { artistDetailPageState: VanillaState }).artistDetailPageState = state;
+    return state;
+  };
+
+  afterEach(() => {
+    delete (window as unknown as { artistDetailPageState?: VanillaState }).artistDetailPageState;
+  });
+
+  it('populates the artist BEFORE any hero action can be clicked', async () => {
+    // Artist Radio, the art picker and the discography modal read these two
+    // fields instead of taking arguments; unset, they bail out with
+    // "No artist selected" and the buttons do nothing at all.
+    const state = install();
+    renderPage();
+
+    await screen.findByText('Aphex Twin');
+    expect(state.currentArtistId).toBe(42);
+    expect(state.currentArtistName).toBe('Aphex Twin');
+    expect(state.currentArtistSource).toBe('spotify');
+  });
+
+  it('uses the id the PAYLOAD returned, not the one in the url', async () => {
+    // The library-upgrade case: clicking a Deezer result for an artist already
+    // in the library gets back the library primary key, and the library-only
+    // endpoints behind those buttons need that id.
+    const state = install();
+    stubDetail({
+      success: true,
+      artist: { id: 77, name: 'Aphex Twin', server_source: 'plex' },
+      discography: { albums: [], source: 'spotify' },
+    });
+    renderPage('/artist-detail/deezer/2481');
+
+    await screen.findByText('Aphex Twin');
+    expect(state.currentArtistId).toBe(77);
+  });
+
+  it('clears the artist on unmount, so the next page cannot act on it', async () => {
+    const state = install();
+    const view = renderPage();
+    await screen.findByText('Aphex Twin');
+
+    view.unmount();
+    expect(state.currentArtistId).toBeNull();
+    expect(state.currentArtistName).toBeNull();
+  });
+
+  it('hands the Enhanced payload over once the view is open', async () => {
+    // Every still-vanilla album and track action reads enhancedData for the
+    // artist name and to patch its own copy of the album list.
+    const state = install();
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    renderPage();
+
+    await screen.findByText('SAW');
+    expect((state.enhancedData as { albums: unknown[] })?.albums).toHaveLength(1);
+  });
+
+  it('takes the Enhanced payload back on unmount', async () => {
+    // Otherwise the next artist's page finds the previous artist's albums, and
+    // a delete would patch the wrong list.
+    const state = install();
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    const view = renderPage();
+    await screen.findByText('SAW');
+    expect(state.enhancedData).not.toBeNull();
+
+    view.unmount();
+    expect(state.enhancedData).toBeNull();
+  });
+
+  it('mirrors the track selection into the SAME Set object', async () => {
+    // deleteLibraryTrack deletes from this Set; replacing it would leave those
+    // writes landing somewhere nobody reads.
+    const state = install();
+    const originalSet = state.selectedTracks;
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    renderPage();
+
+    await screen.findByText('SAW');
+    fireEvent.click(document.getElementById('enhanced-album-row-1') as HTMLElement);
+    fireEvent.click(document.querySelector('tbody .enhanced-track-checkbox') as HTMLElement);
+
+    await waitFor(() => expect([...state.selectedTracks]).toEqual(['9']));
+    expect(state.selectedTracks).toBe(originalSet);
+  });
+
+  it('renders fine when library.js is not loaded at all', async () => {
+    // The React page must not depend on the vanilla bundle existing.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -76,7 +76,11 @@ function renderPage(entry = '/artist-detail/library/42') {
   const queryClient = createTestQueryClient();
   const history = createMemoryHistory({ initialEntries: [entry] });
   const router = createAppRouter({ history, queryClient });
-  return { router, ...render(<AppRouterProvider router={router} queryClient={queryClient} />) };
+  return {
+    router,
+    history,
+    ...render(<AppRouterProvider router={router} queryClient={queryClient} />),
+  };
 }
 
 const LIBRARY = {
@@ -567,5 +571,192 @@ describe('the vanilla page-state bridge', () => {
     // The React page must not depend on the vanilla bundle existing.
     renderPage();
     await screen.findByText('Aphex Twin');
+  });
+});
+
+describe('the page header', () => {
+  it('renders the Back button — it lives in markup the React host replaces', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    const back = document.getElementById('artist-detail-back-btn') as HTMLElement;
+    expect(back).not.toBeNull();
+    expect(back.textContent).toBe('← Back');
+    expect(back.closest('.page-header')).not.toBeNull();
+  });
+
+  it('is there while loading and on failure too', async () => {
+    stubDetail({ success: false, error: 'nope' });
+    renderPage();
+    await screen.findByText('Failed to load artist details');
+    expect(document.getElementById('artist-detail-back-btn')).not.toBeNull();
+  });
+
+  it('goes back through history when there is history to go back to', async () => {
+    const length = vi.spyOn(window.history, 'length', 'get').mockReturnValue(3);
+    const { router } = renderPage();
+    await screen.findByText('Aphex Twin');
+    const back = vi.spyOn(router.history, 'back');
+
+    fireEvent.click(document.getElementById('artist-detail-back-btn') as HTMLElement);
+    expect(back).toHaveBeenCalled();
+    back.mockRestore();
+    length.mockRestore();
+  });
+
+  it('falls back to the Library on a COLD load, where back would leave SoulSync', async () => {
+    const length = vi.spyOn(window.history, 'length', 'get').mockReturnValue(1);
+    const { router, history } = renderPage();
+    await screen.findByText('Aphex Twin');
+    const back = vi.spyOn(router.history, 'back');
+
+    fireEvent.click(document.getElementById('artist-detail-back-btn') as HTMLElement);
+    expect(back).not.toHaveBeenCalled();
+    await waitFor(() => expect(history.location.pathname).toBe('/library'));
+    back.mockRestore();
+    length.mockRestore();
+  });
+});
+
+describe('overlays must escape the hero', () => {
+  // .artist-hero-section sets backdrop-filter, which makes it the CONTAINING
+  // BLOCK for any position:fixed descendant. An overlay rendered inside it has
+  // its inset:0 clamped to the hero box — wrong place, cut off at the top, and
+  // a click anywhere else never reaches the backdrop so it cannot be closed.
+  const escapesHero = (el: Element | null) => {
+    expect(el).not.toBeNull();
+    expect(el?.closest('.artist-hero-section')).toBeNull();
+    expect(el?.parentElement).toBe(document.body);
+  };
+
+  it('portals the DB Record modal to the body', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    fireEvent.click(document.getElementById('artist-db-record-btn') as HTMLElement);
+
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).not.toBeNull());
+    escapesHero(document.getElementById('artist-record-overlay'));
+  });
+
+  it('closes the DB Record modal on a backdrop click', async () => {
+    // Only reachable once the overlay actually covers the viewport.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    fireEvent.click(document.getElementById('artist-db-record-btn') as HTMLElement);
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).not.toBeNull());
+
+    fireEvent.click(document.getElementById('artist-record-overlay') as HTMLElement);
+    await waitFor(() => expect(document.getElementById('artist-record-overlay')).toBeNull());
+  });
+
+  it('portals the bulk bar to the body', async () => {
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    renderPage();
+    await screen.findByText('SAW');
+    escapesHero(document.getElementById('enhanced-bulk-bar'));
+  });
+});
+
+describe('the filter bar actually filters the page', () => {
+  const FULL = {
+    success: true,
+    artist: { id: 42, name: 'Aphex Twin', server_source: 'plex' },
+    discography: {
+      albums: [
+        { id: 1, title: 'SAW', owned: true },
+        { id: 2, title: 'Live At Wembley', owned: false },
+      ],
+      eps: [{ id: 3, title: 'Digeridoo', owned: false }],
+      singles: [{ id: 4, title: 'On', owned: true }],
+      source: 'spotify',
+    },
+  };
+
+  const shown = () =>
+    [...document.querySelectorAll('.release-card')]
+      .filter((c) => (c as HTMLElement).style.display !== 'none')
+      .map((c) => c.getAttribute('data-album-name'));
+
+  it('drops a whole category when its chip is switched off', async () => {
+    stubDetail(FULL);
+    renderPage();
+    await screen.findByText('SAW');
+    expect(shown()).toContain('Digeridoo');
+
+    fireEvent.click(
+      document.querySelector('[data-filter="category"][data-value="eps"]') as HTMLElement,
+    );
+    await waitFor(() => expect(shown()).not.toContain('Digeridoo'));
+    // The others are untouched — category chips are independent toggles.
+    expect(shown()).toContain('SAW');
+  });
+
+  it('filters by ownership as a single-select', async () => {
+    stubDetail(FULL);
+    renderPage();
+    await screen.findByText('SAW');
+
+    fireEvent.click(
+      document.querySelector('[data-filter="ownership"][data-value="missing"]') as HTMLElement,
+    );
+    await waitFor(() => expect(shown()).not.toContain('SAW'));
+    expect(shown()).toContain('Digeridoo');
+
+    fireEvent.click(
+      document.querySelector('[data-filter="ownership"][data-value="owned"]') as HTMLElement,
+    );
+    await waitFor(() => expect(shown()).toContain('SAW'));
+    expect(shown()).not.toContain('Digeridoo');
+  });
+
+  it('excludes live releases via the content chip', async () => {
+    stubDetail(FULL);
+    renderPage();
+    await screen.findByText('SAW');
+    expect(shown()).toContain('Live At Wembley');
+
+    fireEvent.click(
+      document.querySelector('[data-filter="content"][data-value="live"]') as HTMLElement,
+    );
+    await waitFor(() => expect(shown()).not.toContain('Live At Wembley'));
+  });
+
+  it('+ Other sources loads gap cards, and switching it off removes them', async () => {
+    stubDetail(FULL);
+    gapFillBody = {
+      success: true,
+      gaps: { albums: [{ id: 'g1', title: 'Only On Deezer', gap_source: 'deezer', year: 2001 }] },
+    };
+    renderPage();
+    await screen.findByText('SAW');
+
+    const chip = document.getElementById('gapfill-toggle-btn') as HTMLElement;
+    expect(chip.className).not.toContain('active');
+
+    fireEvent.click(chip);
+    await screen.findByText('Only On Deezer');
+    expect(chip.className).toContain('active');
+    expect(document.querySelector('.gapfill-source-badge')?.textContent).toBe('Deezer');
+
+    fireEvent.click(chip);
+    await waitFor(() => expect(screen.queryByText('Only On Deezer')).toBeNull());
+    expect(chip.className).not.toContain('active');
+  });
+
+  it('the ownership filter applies to gap cards too', async () => {
+    // They arrive owned:false, so a Missing filter must keep them and an Owned
+    // filter must hide them.
+    stubDetail(FULL);
+    gapFillBody = {
+      success: true,
+      gaps: { albums: [{ id: 'g1', title: 'Only On Deezer', gap_source: 'deezer' }] },
+    };
+    localStorage.setItem('discog_gapfill', '1');
+    renderPage();
+    await screen.findByText('Only On Deezer');
+
+    fireEvent.click(
+      document.querySelector('[data-filter="ownership"][data-value="owned"]') as HTMLElement,
+    );
+    await waitFor(() => expect(shown()).not.toContain('Only On Deezer'));
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -760,3 +760,71 @@ describe('the filter bar actually filters the page', () => {
     await waitFor(() => expect(shown()).not.toContain('Only On Deezer'));
   });
 });
+
+describe('Similar Artists', () => {
+  it('renders the section the vanilla loader fills', async () => {
+    // Its markup lived inside #artist-detail-page, which the React host
+    // replaces — so the whole section disappeared and loadSimilarArtists,
+    // which resolves four elements by id, silently did nothing.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+
+    expect(document.getElementById('ad-similar-artists-section')).not.toBeNull();
+    expect(document.getElementById('ad-similar-artists-loading')).not.toBeNull();
+    expect(document.getElementById('ad-similar-artists-error')).not.toBeNull();
+    expect(document.getElementById('ad-similar-artists-bubbles-container')).not.toBeNull();
+    expect(screen.getByText('Similar Artists')).toBeTruthy();
+  });
+
+  it('has the section in the DOM by the time the loader runs', async () => {
+    // Ordering is the whole difference between a populated section and an
+    // empty one.
+    let sectionAtCallTime: Element | null = null;
+    window.loadSimilarArtists = vi.fn(() => {
+      sectionAtCallTime = document.getElementById('ad-similar-artists-section');
+    });
+
+    renderPage();
+    await waitFor(() => expect(window.loadSimilarArtists).toHaveBeenCalled());
+    expect(sectionAtCallTime).not.toBeNull();
+  });
+
+  it('leaves bubbles the vanilla inserted alone across a re-render', async () => {
+    // React must not reconcile away nodes it did not create.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    const container = document.getElementById(
+      'ad-similar-artists-bubbles-container',
+    ) as HTMLElement;
+    container.innerHTML = '<a class="similar-artist-bubble">Squarepusher</a>';
+
+    fireEvent.click(
+      document.querySelector('[data-filter="category"][data-value="eps"]') as HTMLElement,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(container.querySelector('.similar-artist-bubble')).not.toBeNull();
+  });
+});
+
+describe('the Back button label', () => {
+  type W = { artistDetailLabelStack?: { type: string; pageId?: string; name?: string }[] };
+
+  afterEach(() => {
+    delete (window as W).artistDetailLabelStack;
+  });
+
+  it('names the page you arrived from', async () => {
+    // navigateToArtistDetail pushed this when you came from a vanilla page.
+    (window as W).artistDetailLabelStack = [{ type: 'page', pageId: 'search' }];
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.getElementById('artist-detail-back-btn')?.textContent).toBe('← Back to Search');
+  });
+
+  it('is a plain Back on a cold load', async () => {
+    (window as W).artistDetailLabelStack = [];
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.getElementById('artist-detail-back-btn')?.textContent).toBe('← Back');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
@@ -606,6 +606,9 @@ describe('the page header', () => {
     expect(back).toHaveBeenCalled();
     back.mockRestore();
     length.mockRestore();
+    // Let the remaining in-flight request settle inside act(), so its state
+    // update does not land after the test returns (React's act warning).
+    await act(async () => {});
   });
 
   it('falls back to the Library on a COLD load, where back would leave SoulSync', async () => {
@@ -867,9 +870,15 @@ describe('scroll position', () => {
     await screen.findByText('Aphex Twin');
 
     main.scrollTop = 1200;
-    await router.navigate({
-      to: '/artist-detail/$source/$id',
-      params: { source: 'library', id: '99' },
+    // The navigate itself has to be inside act(): the router commits the new
+    // match -- and the page starts the second artist's fetches -- as it
+    // resolves, and those updates are React state.
+    await act(async () => {
+      await router.navigate({
+        to: '/artist-detail/$source/$id',
+        params: { source: 'library', id: '99' },
+      });
+      await new Promise((r) => setTimeout(r, 30));
     });
     await waitFor(() => expect(main.scrollTop).toBe(0));
     main.remove();

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -535,7 +535,9 @@ describe('the vanilla page-state bridge', () => {
     renderPage();
 
     await screen.findByText('SAW');
-    expect((state.enhancedData as { albums: unknown[] })?.albums).toHaveLength(1);
+    await waitFor(() =>
+      expect((state.enhancedData as { albums: unknown[] })?.albums).toHaveLength(1),
+    );
   });
 
   it('takes the Enhanced payload back on unmount', async () => {
@@ -545,7 +547,10 @@ describe('the vanilla page-state bridge', () => {
     localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
     const view = renderPage();
     await screen.findByText('SAW');
-    expect(state.enhancedData).not.toBeNull();
+    // waitFor, not a bare assertion: findByText resolves on the committed
+    // render, and the sync runs in a passive effect — which can land a tick
+    // later. Asserting synchronously made this flake about once in twenty runs.
+    await waitFor(() => expect(state.enhancedData).not.toBeNull());
 
     view.unmount();
     expect(state.enhancedData).toBeNull();

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -1,0 +1,209 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+/**
+ * Driven through the real router: the page reads route params and search, and
+ * useProfile needs the root route context.
+ */
+vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/platform/shell/route-manifest')>();
+  return {
+    ...actual,
+    getShellRouteByPageId: (pageId: string) =>
+      pageId === 'artist-detail'
+        ? { ...actual.getShellRouteByPageId('artist-detail'), kind: 'react' }
+        : actual.getShellRouteByPageId(pageId as never),
+  };
+});
+
+let requested: string[] = [];
+
+function stubDetail(body: unknown, status = 200) {
+  requested = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      requested.push(url);
+      if (url.includes('/api/album/')) {
+        return new Response(JSON.stringify({ success: true, tracks: [{ id: 1 }] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderPage(entry = '/artist-detail/library/42') {
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: [entry] });
+  const router = createAppRouter({ history, queryClient });
+  return { router, ...render(<AppRouterProvider router={router} queryClient={queryClient} />) };
+}
+
+const LIBRARY = {
+  success: true,
+  artist: { id: 42, name: 'Aphex Twin', server_source: 'plex' },
+  discography: { albums: [{ id: 1, title: 'SAW', owned: true }], source: 'spotify' },
+};
+
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  window.showToast = vi.fn();
+  window.loadSimilarArtists = vi.fn();
+  window.cancelSimilarArtistsLoad = vi.fn();
+  window.checkArtistEnhanceEligibility = vi.fn();
+  window.initializeLibraryWatchlistButton = vi.fn();
+  window.observeLazyBackgrounds = vi.fn();
+  stubDetail(LIBRARY);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.SoulSyncWebShellBridge;
+  delete document.body.dataset.artistSource;
+});
+
+describe('body[data-artist-source]', () => {
+  it('tags the body library for an artist with a server_source', async () => {
+    // CSS keys off this to hide library-only UI.
+    renderPage();
+    await waitFor(() => expect(document.body.dataset.artistSource).toBe('library'));
+  });
+
+  it('tags it source when there is no library record', async () => {
+    stubDetail({ success: true, artist: { id: 'sp1', name: 'X' }, discography: {} });
+    renderPage();
+    await waitFor(() => expect(document.body.dataset.artistSource).toBe('source'));
+  });
+
+  it('clears the flag on unmount so the next page does not inherit it', async () => {
+    const { unmount } = renderPage();
+    await waitFor(() => expect(document.body.dataset.artistSource).toBe('library'));
+    unmount();
+    expect(document.body.dataset.artistSource).toBeUndefined();
+  });
+});
+
+describe('fire-and-forget side effects', () => {
+  it('loads similar artists, cancelling any in flight first', async () => {
+    renderPage();
+    await waitFor(() => expect(window.loadSimilarArtists).toHaveBeenCalledWith('Aphex Twin'));
+    expect(window.cancelSimilarArtistsLoad).toHaveBeenCalled();
+  });
+
+  it('cancels similar artists on unmount', async () => {
+    const { unmount } = renderPage();
+    await waitFor(() => expect(window.loadSimilarArtists).toHaveBeenCalled());
+    (window.cancelSimilarArtistsLoad as ReturnType<typeof vi.fn>).mockClear();
+    unmount();
+    expect(window.cancelSimilarArtistsLoad).toHaveBeenCalled();
+  });
+
+  it('probes enhance eligibility for a LIBRARY artist only', async () => {
+    renderPage();
+    await waitFor(() => expect(window.checkArtistEnhanceEligibility).toHaveBeenCalledWith(42));
+  });
+
+  it('does not probe eligibility for a source artist', async () => {
+    // The endpoint only works on library primary keys.
+    stubDetail({ success: true, artist: { id: 'sp1', name: 'X' }, discography: {} });
+    renderPage();
+    await screen.findByText('X');
+    expect(window.checkArtistEnhanceEligibility).not.toHaveBeenCalled();
+  });
+
+  it('wires the watchlist button to the canonical Spotify identity', async () => {
+    stubDetail({
+      ...LIBRARY,
+      spotify_artist: { spotify_artist_id: 'sp9', spotify_artist_name: 'Aphex Twin' },
+    });
+    renderPage();
+    await waitFor(() =>
+      expect(window.initializeLibraryWatchlistButton).toHaveBeenCalledWith('sp9', 'Aphex Twin'),
+    );
+  });
+
+  it('warns about a provider error but still renders the page', async () => {
+    stubDetail({ ...LIBRARY, provider_error: { error: 'MusicBrainz timed out' } });
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(window.showToast).toHaveBeenCalledWith(
+      'Discography provider warning: MusicBrainz timed out',
+      'error',
+    );
+  });
+});
+
+describe('failure', () => {
+  it('shows the error state with the hero HIDDEN, and toasts', async () => {
+    stubDetail({ success: false, error: 'Artist not found' });
+    renderPage();
+    await screen.findByText('Failed to load artist details');
+    expect(document.getElementById('artist-hero-section')).toBeNull();
+    expect(document.getElementById('artist-detail-error-message')?.textContent).toBe(
+      'Artist not found',
+    );
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith(
+        'Failed to load artist details: Artist not found',
+        'error',
+      ),
+    );
+  });
+});
+
+describe('source artists', () => {
+  it('settles unknown ownership to false so cards do not check forever', async () => {
+    // Nothing will ever stream a result for a source artist.
+    stubDetail({
+      success: true,
+      artist: { id: 'sp1', name: 'X' },
+      discography: { albums: [{ id: 1, title: 'A', owned: null }] },
+    });
+    renderPage();
+    await screen.findByText('A');
+    expect(document.querySelector('.release-card')?.className).toContain('missing');
+    expect(document.querySelector('.completion-overlay')).toBeNull();
+  });
+});
+
+describe('MusicBrainz declutter', () => {
+  it('applies once the discography source is known', async () => {
+    stubDetail({
+      ...LIBRARY,
+      discography: {
+        albums: [{ id: 1, title: 'Studio', secondary_types: [], owned: false }],
+        source: 'musicbrainz',
+      },
+    });
+    renderPage();
+    await screen.findByText('Studio');
+    // The Live toggle is relabelled and starts OFF under the declutter.
+    const live = document.querySelector(
+      '[data-filter="content"][data-value="live"]',
+    ) as HTMLElement;
+    expect(live.textContent).toBe('Non-Studio');
+    expect(live.className).not.toContain('active');
+  });
+
+  it('leaves other sources with the toggle on and labelled Live', async () => {
+    renderPage();
+    await screen.findByText('SAW');
+    const live = document.querySelector(
+      '[data-filter="content"][data-value="live"]',
+    ) as HTMLElement;
+    expect(live.textContent).toBe('Live');
+    expect(live.className).toContain('active');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
@@ -23,6 +23,7 @@ vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
 
 let requested: string[] = [];
 let streamFrames: string[] = [];
+let gapFillBody: unknown = { success: true, gaps: {} };
 
 function stubDetail(body: unknown, status = 200) {
   requested = [];
@@ -31,6 +32,12 @@ function stubDetail(body: unknown, status = 200) {
     vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : String(input);
       requested.push(url);
+      if (url.includes('/discography/gap-fill')) {
+        return new Response(JSON.stringify(gapFillBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/api/library/completion-stream')) {
         const encoder = new TextEncoder();
         let i = 0;
@@ -80,6 +87,8 @@ beforeEach(() => {
   window.initializeLibraryWatchlistButton = vi.fn();
   window.observeLazyBackgrounds = vi.fn();
   streamFrames = [];
+  gapFillBody = { success: true, gaps: {} };
+  localStorage.clear();
   stubDetail(LIBRARY);
 });
 
@@ -274,5 +283,47 @@ describe('ownership completion stream', () => {
     await screen.findByText('X');
     await new Promise((r) => setTimeout(r, 20));
     expect(requested.some((u) => u.includes('completion-stream'))).toBe(false);
+  });
+});
+
+describe('gap-fill (#1067)', () => {
+  it('does not ask for gaps until the chip is on', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(requested.some((u) => u.includes('gap-fill'))).toBe(false);
+  });
+
+  it('merges gap cards into the REAL grids, badged with their source', async () => {
+    // Boulder's live feedback: a separate section felt bolted-on, so gap cards
+    // slot into the Album/EP/Single grids and the badge is what marks them.
+    localStorage.setItem('discog_gapfill', '1');
+    gapFillBody = {
+      success: true,
+      gaps: { albums: [{ id: 'g1', title: 'Only On Deezer', gap_source: 'deezer', year: 2001 }] },
+    };
+    renderPage();
+
+    await screen.findByText('Only On Deezer');
+    const grid = document.getElementById('albums-grid') as HTMLElement;
+    expect(grid.querySelector('.gapfill-card')).not.toBeNull();
+    expect(grid.querySelector('.gapfill-source-badge')?.textContent).toBe('Deezer');
+    // The base release is still there — gap-fill only ever appends.
+    expect(screen.getByText('SAW')).toBeTruthy();
+  });
+
+  it('toggling the chip loads and then removes the gap cards', async () => {
+    gapFillBody = {
+      success: true,
+      gaps: { albums: [{ id: 'g1', title: 'Only On Deezer', gap_source: 'deezer' }] },
+    };
+    renderPage();
+    await screen.findByText('SAW');
+
+    fireEvent.click(document.getElementById('gapfill-toggle-btn') as HTMLElement);
+    await screen.findByText('Only On Deezer');
+
+    fireEvent.click(document.getElementById('gapfill-toggle-btn') as HTMLElement);
+    await waitFor(() => expect(screen.queryByText('Only On Deezer')).toBeNull());
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -828,3 +828,45 @@ describe('the Back button label', () => {
     expect(document.getElementById('artist-detail-back-btn')?.textContent).toBe('← Back');
   });
 });
+
+describe('scroll position', () => {
+  // body is overflow:hidden, so .main-content is the real scroller — the
+  // window never moves and a window.scrollTo would be a silent no-op.
+  const withMainContent = () => {
+    const main = document.createElement('div');
+    main.className = 'main-content';
+    document.body.appendChild(main);
+    Object.defineProperty(main, 'scrollTop', { value: 0, writable: true });
+    main.scrollTop = 900;
+    return main;
+  };
+
+  // Swept centrally, not per test: scrollArtistDetailToTop takes the FIRST
+  // .main-content, so one container left behind by a failing test silently
+  // makes every later test in this block assert against the wrong element.
+  afterEach(() => {
+    document.querySelectorAll('.main-content').forEach((el) => el.remove());
+  });
+
+  it('opens the artist at the top of the scroll container', async () => {
+    const main = withMainContent();
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(main.scrollTop).toBe(0);
+    main.remove();
+  });
+
+  it('resets again when the route moves to another artist', async () => {
+    const main = withMainContent();
+    const { router } = renderPage('/artist-detail/library/42');
+    await screen.findByText('Aphex Twin');
+
+    main.scrollTop = 1200;
+    await router.navigate({
+      to: '/artist-detail/$source/$id',
+      params: { source: 'library', id: '99' },
+    });
+    await waitFor(() => expect(main.scrollTop).toBe(0));
+    main.remove();
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
 });
 
 let requested: string[] = [];
+let streamFrames: string[] = [];
 
 function stubDetail(body: unknown, status = 200) {
   requested = [];
@@ -30,6 +31,19 @@ function stubDetail(body: unknown, status = 200) {
     vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : String(input);
       requested.push(url);
+      if (url.includes('/api/library/completion-stream')) {
+        const encoder = new TextEncoder();
+        let i = 0;
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (i < streamFrames.length) controller.enqueue(encoder.encode(streamFrames[i++]));
+              else controller.close();
+            },
+          }),
+          { status: 200 },
+        );
+      }
       if (url.includes('/api/album/')) {
         return new Response(JSON.stringify({ success: true, tracks: [{ id: 1 }] }), {
           status: 200,
@@ -65,6 +79,7 @@ beforeEach(() => {
   window.checkArtistEnhanceEligibility = vi.fn();
   window.initializeLibraryWatchlistButton = vi.fn();
   window.observeLazyBackgrounds = vi.fn();
+  streamFrames = [];
   stubDetail(LIBRARY);
 });
 
@@ -205,5 +220,59 @@ describe('MusicBrainz declutter', () => {
     ) as HTMLElement;
     expect(live.textContent).toBe('Live');
     expect(live.className).toContain('active');
+  });
+});
+
+describe('ownership completion stream', () => {
+  const UNRESOLVED = {
+    success: true,
+    artist: { id: 42, name: 'Aphex Twin', server_source: 'plex' },
+    discography: {
+      albums: [
+        { id: 1, title: 'SAW', owned: null },
+        { id: 2, title: 'Drukqs', owned: null },
+      ],
+      source: 'spotify',
+    },
+  };
+
+  it('merges streamed ownership into the bars and the section counts', async () => {
+    streamFrames = [
+      'data: {"type":"completion","id":1,"category":"albums","status":"ok","formats":["FLAC"]}\n',
+      'data: {"type":"completion","id":2,"category":"albums","status":"missing"}\n',
+      'data: {"type":"complete","processed_count":2}\n',
+    ];
+    stubDetail(UNRESOLVED);
+    renderPage();
+
+    await waitFor(() => expect(document.getElementById('albums-stats')?.textContent).toBe('1/2'));
+    // The cards move with the bar — the section counts read from the same
+    // merged discography, so this proves the merge reaches the grid too.
+    expect(screen.getByText('1 owned')).toBeTruthy();
+    expect(screen.getByText('1 missing')).toBeTruthy();
+    // Formats are artist-level and only appear on the terminal frame.
+    expect(document.querySelector('.artist-format-tag')?.textContent).toBe('FLAC');
+  });
+
+  it('does not open a stream when every release is already resolved', async () => {
+    stubDetail(LIBRARY);
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(requested.some((u) => u.includes('completion-stream'))).toBe(false);
+  });
+
+  it('does not open a stream for a source artist', async () => {
+    // No library to check against; settleOwnershipForSourceArtist resolves the
+    // cards to "missing" up front instead.
+    stubDetail({
+      success: true,
+      artist: { id: 'sp1', name: 'X' },
+      discography: { albums: [{ id: 1, title: 'A', owned: null }], source: 'deezer' },
+    });
+    renderPage();
+    await screen.findByText('X');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(requested.some((u) => u.includes('completion-stream'))).toBe(false);
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/platform/shell/route-manifest', async (importOriginal) => {
 let requested: string[] = [];
 let streamFrames: string[] = [];
 let gapFillBody: unknown = { success: true, gaps: {} };
+let enhancedBody: unknown = { success: true, artist: { id: 42, name: 'Aphex Twin' }, albums: [] };
 
 function stubDetail(body: unknown, status = 200) {
   requested = [];
@@ -32,6 +33,12 @@ function stubDetail(body: unknown, status = 200) {
     vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : String(input);
       requested.push(url);
+      if (url.includes('/enhanced')) {
+        return new Response(JSON.stringify(enhancedBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.includes('/discography/gap-fill')) {
         return new Response(JSON.stringify(gapFillBody), {
           status: 200,
@@ -88,6 +95,11 @@ beforeEach(() => {
   window.observeLazyBackgrounds = vi.fn();
   streamFrames = [];
   gapFillBody = { success: true, gaps: {} };
+  enhancedBody = {
+    success: true,
+    artist: { id: 42, name: 'Aphex Twin' },
+    albums: [{ id: 1, title: 'SAW', record_type: 'album', tracks: [{ id: 9, title: 'Xtal' }] }],
+  };
   localStorage.clear();
   stubDetail(LIBRARY);
 });
@@ -325,5 +337,123 @@ describe('gap-fill (#1067)', () => {
 
     fireEvent.click(document.getElementById('gapfill-toggle-btn') as HTMLElement);
     await waitFor(() => expect(screen.queryByText('Only On Deezer')).toBeNull());
+  });
+});
+
+describe('the Enhanced view', () => {
+  const toggle = (view: string) =>
+    fireEvent.click(document.querySelector(`[data-view="${view}"]`) as HTMLElement);
+
+  it('offers the toggle to an admin on a library artist', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.querySelector('[data-view="enhanced"]')).not.toBeNull();
+  });
+
+  it('does NOT offer it on a source artist', async () => {
+    // No DB record to edit; the vanilla showed an empty pane with the
+    // discography hidden behind it.
+    stubDetail({ success: true, artist: { id: 'sp1', name: 'X' }, discography: {} });
+    renderPage();
+    await screen.findByText('X');
+    expect(document.querySelector('[data-view="enhanced"]')).toBeNull();
+  });
+
+  it('fetches nothing until the user actually switches', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(requested.some((u) => u.includes('/enhanced'))).toBe(false);
+  });
+
+  it('swaps the discography for the Enhanced container', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    expect(document.querySelector('.discography-sections')).not.toBeNull();
+
+    toggle('enhanced');
+    await waitFor(() => expect(document.getElementById('enhanced-view-container')).not.toBeNull());
+    expect(document.querySelector('.discography-sections')).toBeNull();
+    await screen.findByText('SAW');
+  });
+
+  it('hides Similar Artists, which lives outside React', async () => {
+    const section = document.createElement('div');
+    section.id = 'ad-similar-artists-section';
+    document.body.appendChild(section);
+
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    toggle('enhanced');
+    await waitFor(() => expect(section.style.display).toBe('none'));
+
+    toggle('standard');
+    await waitFor(() => expect(section.style.display).toBe(''));
+    section.remove();
+  });
+
+  it('persists the choice per profile', async () => {
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    toggle('enhanced');
+    await waitFor(() =>
+      expect(localStorage.getItem('soulsync-library-view-mode:2')).toBe('enhanced'),
+    );
+  });
+
+  it('does NOT refetch when toggling back and forth', async () => {
+    // The payload carries every track of every album.
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    toggle('enhanced');
+    await screen.findByText('SAW');
+
+    toggle('standard');
+    toggle('enhanced');
+    await screen.findByText('SAW');
+    expect(requested.filter((u) => u.includes('/enhanced'))).toHaveLength(1);
+  });
+
+  it('opens straight into Enhanced when the profile saved that choice', async () => {
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    renderPage();
+    await waitFor(() => expect(document.getElementById('enhanced-view-container')).not.toBeNull());
+  });
+
+  it('refetches for a DIFFERENT artist', async () => {
+    // One attempt per artist — but a new artist is a new payload.
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+    const first = renderPage('/artist-detail/library/42');
+    await screen.findByText('SAW');
+    first.unmount();
+
+    renderPage('/artist-detail/library/99');
+    await waitFor(() => expect(requested.filter((u) => u.includes('/enhanced'))).toHaveLength(2));
+  });
+
+  it('restores Similar Artists when the page UNMOUNTS', async () => {
+    const section = document.createElement('div');
+    section.id = 'ad-similar-artists-section';
+    document.body.appendChild(section);
+    localStorage.setItem('soulsync-library-view-mode:2', 'enhanced');
+
+    const view = renderPage();
+    await waitFor(() => expect(section.style.display).toBe('none'));
+    view.unmount();
+    // Otherwise the next page inherits a hidden section it never hid.
+    expect(section.style.display).toBe('');
+    section.remove();
+  });
+
+  it('reports a failed load instead of an empty view', async () => {
+    enhancedBody = { success: false, error: 'no library data' };
+    renderPage();
+    await screen.findByText('Aphex Twin');
+    toggle('enhanced');
+    // The message is split across text nodes, so match on the element.
+    await waitFor(() =>
+      expect(document.querySelector('.enhanced-loading')?.textContent).toBe(
+        'Failed to load: no library data',
+      ),
+    );
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 
-import { useReactPageShell } from '@/platform/shell/route-controllers';
+import { useProfile, useReactPageShell } from '@/platform/shell/route-controllers';
 
 import type { Discography, DiscographyBucket, DiscographyRelease } from '../-artist-detail.types';
 
@@ -14,6 +14,11 @@ import {
   settleOwnershipForSourceArtist,
   watchlistIdentity,
 } from '../-artist-detail.api';
+import {
+  readEnhancedViewMode,
+  showsEnhancedToggle,
+  writeEnhancedViewMode,
+} from '../-artist-detail.enhanced';
 import {
   applyMusicBrainzDeclutter,
   defaultFilterState,
@@ -30,10 +35,12 @@ import {
   stillCheckingMessage,
 } from '../-artist-detail.open-release';
 import { useCompletionStream } from '../-artist-detail.use-completion';
+import { useEnhancedData } from '../-artist-detail.use-enhanced';
 import { useGapFill } from '../-artist-detail.use-gap-fill';
 import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
+import { EnhancedView } from './enhanced-view';
 
 const BUCKETS: DiscographyBucket[] = ['albums', 'eps', 'singles'];
 
@@ -100,6 +107,37 @@ export function ArtistDetailPage() {
   );
 
   const isMusicBrainz = isMusicBrainzDiscography(displayed.source);
+
+  /**
+   * Enhanced Management view. Offered to an admin on a library artist only, and
+   * the choice is persisted per profile — a source artist has no DB record to
+   * edit, and forcing the view on one showed an empty pane with the discography
+   * hidden behind it.
+   */
+  const profile = useProfile();
+  const canEnhance = showsEnhancedToggle(Boolean(profile?.isAdmin), sourceOnly);
+  const [enhanced, setEnhanced] = useState(() => readEnhancedViewMode(profile?.profileId));
+  const showEnhanced = canEnhance && enhanced;
+  const enhancedState = useEnhancedData(payload?.artist?.id, showEnhanced);
+
+  const toggleEnhanced = (next: boolean) => {
+    setEnhanced(next);
+    writeEnhancedViewMode(profile?.profileId, next);
+  };
+
+  /**
+   * Similar Artists belongs to the Standard view and is rendered OUTSIDE React,
+   * by loadSimilarArtists into the shell's own section — so hiding it has to be
+   * a DOM effect rather than a branch.
+   */
+  useEffect(() => {
+    const section = document.getElementById('ad-similar-artists-section');
+    if (!section) return;
+    section.style.display = showEnhanced ? 'none' : '';
+    return () => {
+      section.style.display = '';
+    };
+  }, [showEnhanced]);
 
   /**
    * Filters reset on every artist change (resetDiscographyFilters ran BEFORE
@@ -245,18 +283,33 @@ export function ArtistDetailPage() {
             isSourceArtist={sourceOnly}
             gapFillEnabled={gapFill.enabled}
             onToggleGapFill={gapFill.toggle}
+            showViewToggle={canEnhance}
+            enhanced={showEnhanced}
+            onToggleEnhanced={toggleEnhanced}
           />
-          {BUCKETS.map((bucket) => (
-            <DiscographySection
-              key={bucket}
-              bucket={bucket}
-              releases={displayed[bucket] ?? []}
-              filters={filters}
-              isMusicBrainz={isMusicBrainz}
-              isSourceArtist={sourceOnly}
-              onOpen={openRelease}
-            />
-          ))}
+          {showEnhanced ? (
+            <div id="enhanced-view-container">
+              <EnhancedView
+                data={enhancedState.data}
+                status={enhancedState.status}
+                isAdmin={Boolean(profile?.isAdmin)}
+              />
+            </div>
+          ) : (
+            <div className="discography-sections">
+              {BUCKETS.map((bucket) => (
+                <DiscographySection
+                  key={bucket}
+                  bucket={bucket}
+                  releases={displayed[bucket] ?? []}
+                  filters={filters}
+                  isMusicBrainz={isMusicBrainz}
+                  isSourceArtist={sourceOnly}
+                  onOpen={openRelease}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -1,0 +1,219 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+
+import { useReactPageShell } from '@/platform/shell/route-controllers';
+
+import type { Discography, DiscographyBucket, DiscographyRelease } from '../-artist-detail.types';
+
+import { Route } from '../$source/$id';
+import {
+  artistDetailQueryOptions,
+  isSourceOnlyArtist,
+  readArtistDetail,
+  settleOwnershipForSourceArtist,
+  watchlistIdentity,
+} from '../-artist-detail.api';
+import {
+  applyMusicBrainzDeclutter,
+  defaultFilterState,
+  type DiscographyFilterState,
+  isMusicBrainzDiscography,
+} from '../-artist-detail.filters';
+import { heroImage } from '../-artist-detail.hero-stats';
+import {
+  albumTracksParams,
+  isReleaseClickable,
+  openReleaseArtist,
+  releaseToAlbumData,
+  stillCheckingMessage,
+} from '../-artist-detail.open-release';
+import { ArtistHero } from './artist-hero';
+import { DiscographyFilters } from './discography-filters';
+import { DiscographySection } from './discography-section';
+
+const BUCKETS: DiscographyBucket[] = ['albums', 'eps', 'singles'];
+
+export function ArtistDetailPage() {
+  useReactPageShell('artist-detail');
+
+  // Deliberately NOT profile-scoped: /api/artist-detail is not, and the
+  // vanilla never keyed this page on a profile either.
+  const { source, id } = Route.useParams();
+  const { name } = Route.useSearch();
+
+  const query = useQuery(artistDetailQueryOptions(source, id, name));
+
+  const payload = useMemo(() => {
+    try {
+      return readArtistDetail(query.data);
+    } catch {
+      return null;
+    }
+  }, [query.data]);
+
+  const sourceOnly = payload ? isSourceOnlyArtist(payload) : false;
+
+  /**
+   * A source artist has no library to check ownership against, so every
+   * unresolved `owned` is settled to false before render — otherwise those
+   * cards sit in "checking" forever, since nothing will ever stream a result.
+   */
+  const discography: Discography = useMemo(() => {
+    if (!payload?.discography) return {};
+    return sourceOnly ? settleOwnershipForSourceArtist(payload.discography) : payload.discography;
+  }, [payload, sourceOnly]);
+
+  const isMusicBrainz = isMusicBrainzDiscography(discography.source);
+
+  /**
+   * Filters reset on every artist change (resetDiscographyFilters ran BEFORE
+   * the fetch in the vanilla), then the MusicBrainz declutter is applied once
+   * the discography's real source is known.
+   */
+  const [filters, setFilters] = useState<DiscographyFilterState>(defaultFilterState);
+  useEffect(() => {
+    setFilters(applyMusicBrainzDeclutter(defaultFilterState(), discography.source));
+  }, [source, id, discography.source]);
+
+  /**
+   * CSS keys off this to hide library-only UI. Set on the BODY because that is
+   * where the vanilla put it and the stylesheets select on it; cleared on
+   * unmount so a later page does not inherit an artist's flag.
+   */
+  useEffect(() => {
+    if (!payload) return;
+    document.body.dataset.artistSource = sourceOnly ? 'source' : 'library';
+    return () => {
+      delete document.body.dataset.artistSource;
+    };
+  }, [payload, sourceOnly]);
+
+  /** Non-fatal: the page still renders, but the vanilla warned about it. */
+  useEffect(() => {
+    const providerError = payload?.provider_error?.error;
+    if (providerError) {
+      window.showToast?.(`Discography provider warning: ${providerError}`, 'error');
+    }
+  }, [payload]);
+
+  /** Fire-and-forget, exactly as the vanilla did — never awaited. */
+  useEffect(() => {
+    if (!payload?.artist?.name) return;
+    window.cancelSimilarArtistsLoad?.();
+    window.loadSimilarArtists?.(payload.artist.name);
+    return () => window.cancelSimilarArtistsLoad?.();
+  }, [payload?.artist?.name]);
+
+  useEffect(() => {
+    if (!payload || sourceOnly) return;
+    // Library artists only — the endpoint works on library primary keys.
+    window.checkArtistEnhanceEligibility?.(payload.artist?.id);
+  }, [payload, sourceOnly]);
+
+  /** The watchlist is keyed on the CANONICAL Spotify identity where one exists. */
+  useEffect(() => {
+    if (!payload) return;
+    const identity = watchlistIdentity(payload);
+    if (identity) window.initializeLibraryWatchlistButton?.(identity.id, identity.name);
+  }, [payload]);
+
+  const failed = query.isError || query.data?.success === false;
+  const errorMessage =
+    (query.error as Error | undefined)?.message ||
+    query.data?.error ||
+    'Failed to load artist data';
+
+  useEffect(() => {
+    if (failed) window.showToast?.(`Failed to load artist details: ${errorMessage}`, 'error');
+  }, [failed, errorMessage]);
+
+  const openRelease = async (release: DiscographyRelease) => {
+    if (!isReleaseClickable(release)) {
+      window.showToast?.(stillCheckingMessage(release), 'info');
+      return;
+    }
+    if (!payload) return;
+
+    const image = heroImage(payload.artist ?? {}, discography);
+    const artist = openReleaseArtist(payload, payload.artist?.id, image.primary);
+    if (!artist) {
+      window.showToast?.('Error: No artist information available', 'error');
+      return;
+    }
+
+    window.showLoadingOverlay?.('Loading album...');
+    try {
+      const album = releaseToAlbumData(release);
+      const params = new URLSearchParams(albumTracksParams(release, artist));
+      const response = await fetch(`/api/album/${album.id}/tracks?${params}`);
+      if (!response.ok) throw new Error(`Failed to load album tracks: ${response.status}`);
+
+      const data = await response.json();
+      if (!data.success || !data.tracks?.length)
+        throw new Error('No tracks found for this release');
+
+      // The modal opens immediately; ownership backfills behind it.
+      window.hideLoadingOverlay?.();
+      await window.openAddToWishlistModal?.(album, artist, data.tracks, album.album_type);
+      window.lazyLoadTrackOwnership?.(artist.name, data.tracks, null, album.name);
+    } catch (error) {
+      window.hideLoadingOverlay?.();
+      window.showToast?.(`Error opening wishlist modal: ${(error as Error).message}`, 'error');
+    }
+  };
+
+  // The hero stays hidden on failure — the vanilla kept it hidden rather than
+  // showing an empty shell over an error.
+  if (failed) {
+    return (
+      <div className="artist-detail-content">
+        <div className="artist-detail-error" id="artist-detail-error">
+          <div className="error-icon">⚠️</div>
+          <h3>Failed to load artist details</h3>
+          <p id="artist-detail-error-message">{errorMessage}</p>
+          <button type="button" className="retry-btn" onClick={() => void query.refetch()}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (query.isPending || !payload) {
+    return (
+      <div className="artist-detail-content">
+        <div className="artist-detail-loading" id="artist-detail-loading">
+          <div className="loading-spinner" />
+          <p>Loading artist discography...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ArtistHero
+        artist={payload.artist ?? {}}
+        discography={discography}
+        isSourceArtist={sourceOnly}
+      />
+
+      <div className="artist-detail-content">
+        <div className="artist-detail-main" id="artist-detail-main">
+          <DiscographyFilters filters={filters} onChange={setFilters} isSourceArtist={sourceOnly} />
+          {BUCKETS.map((bucket) => (
+            <DiscographySection
+              key={bucket}
+              bucket={bucket}
+              releases={discography[bucket] ?? []}
+              filters={filters}
+              isMusicBrainz={isMusicBrainz}
+              isSourceArtist={sourceOnly}
+              onOpen={openRelease}
+            />
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -9,6 +9,7 @@ import { Route } from '../$source/$id';
 import {
   artistDetailQueryOptions,
   isSourceOnlyArtist,
+  needsCompletionStream,
   readArtistDetail,
   settleOwnershipForSourceArtist,
   watchlistIdentity,
@@ -27,6 +28,7 @@ import {
   releaseToAlbumData,
   stillCheckingMessage,
 } from '../-artist-detail.open-release';
+import { useCompletionStream } from '../-artist-detail.use-completion';
 import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
@@ -63,7 +65,22 @@ export function ArtistDetailPage() {
     return sourceOnly ? settleOwnershipForSourceArtist(payload.discography) : payload.discography;
   }, [payload, sourceOnly]);
 
-  const isMusicBrainz = isMusicBrainzDiscography(discography.source);
+  /**
+   * Ownership streaming. The gate is the vanilla's: library artists only, and
+   * only when something is actually unresolved — a fully-resolved discography
+   * would open a stream that can never report anything.
+   *
+   * Everything below renders from `streamed`, not `discography`, so the section
+   * counts and the release cards move with the bars.
+   */
+  const stream = useCompletionStream(
+    payload?.artist?.name,
+    discography,
+    payload ? needsCompletionStream(payload) : false,
+  );
+  const streamed = stream.discography;
+
+  const isMusicBrainz = isMusicBrainzDiscography(streamed.source);
 
   /**
    * Filters reset on every artist change (resetDiscographyFilters ran BEFORE
@@ -134,7 +151,7 @@ export function ArtistDetailPage() {
     }
     if (!payload) return;
 
-    const image = heroImage(payload.artist ?? {}, discography);
+    const image = heroImage(payload.artist ?? {}, streamed);
     const artist = openReleaseArtist(payload, payload.artist?.id, image.primary);
     if (!artist) {
       window.showToast?.('Error: No artist information available', 'error');
@@ -194,8 +211,10 @@ export function ArtistDetailPage() {
     <>
       <ArtistHero
         artist={payload.artist ?? {}}
-        discography={discography}
+        discography={streamed}
         isSourceArtist={sourceOnly}
+        streamCounts={stream.counts}
+        streamCompleted={stream.completed}
       />
 
       <div className="artist-detail-content">
@@ -205,7 +224,7 @@ export function ArtistDetailPage() {
             <DiscographySection
               key={bucket}
               bucket={bucket}
-              releases={discography[bucket] ?? []}
+              releases={streamed[bucket] ?? []}
               filters={filters}
               isMusicBrainz={isMusicBrainz}
               isSourceArtist={sourceOnly}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useProfile, useReactPageShell } from '@/platform/shell/route-controllers';
 
@@ -14,6 +14,7 @@ import {
   settleOwnershipForSourceArtist,
   watchlistIdentity,
 } from '../-artist-detail.api';
+import { backButtonLabel, pushArtistOrigin } from '../-artist-detail.back-label';
 import {
   readEnhancedViewMode,
   showsEnhancedToggle,
@@ -43,6 +44,7 @@ import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
 import { EnhancedView } from './enhanced-view';
+import { SimilarArtistsSection } from './similar-artists-section';
 
 const BUCKETS: DiscographyBucket[] = ['albums', 'eps', 'singles'];
 
@@ -165,6 +167,23 @@ export function ArtistDetailPage() {
   }, [payload, sourceOnly]);
 
   /**
+   * Record an artist → artist hop for the Back label, the way
+   * navigateToArtistDetail did. Recomputed on every artist change so the label
+   * is read AFTER the push, not before.
+   */
+  const previousArtistName = useRef<string | null>(null);
+  const [backLabel, setBackLabel] = useState('← Back');
+  useEffect(() => {
+    const name = payload?.artist?.name ?? null;
+    if (!name) return;
+    if (previousArtistName.current && previousArtistName.current !== name) {
+      pushArtistOrigin(previousArtistName.current);
+    }
+    previousArtistName.current = name;
+    setBackLabel(backButtonLabel());
+  }, [payload?.artist?.name]);
+
+  /**
    * Hand the artist down to the vanilla page state.
    *
    * Artist Radio, the artist art picker and the Download Discography modal all
@@ -194,7 +213,12 @@ export function ArtistDetailPage() {
     }
   }, [payload]);
 
-  /** Fire-and-forget, exactly as the vanilla did — never awaited. */
+  /**
+   * Fire-and-forget, exactly as the vanilla did — but only once the section
+   * this renders is in the DOM. loadSimilarArtists resolves its four elements
+   * by id and returns silently when they are missing, so ordering here is the
+   * difference between a populated section and an empty one.
+   */
   useEffect(() => {
     if (!payload?.artist?.name) return;
     window.cancelSimilarArtistsLoad?.();
@@ -265,7 +289,7 @@ export function ArtistDetailPage() {
   if (failed) {
     return (
       <>
-        <ArtistDetailBackButton />
+        <ArtistDetailBackButton label={backLabel} />
         <div className="artist-detail-content">
           <div className="artist-detail-error" id="artist-detail-error">
             <div className="error-icon">⚠️</div>
@@ -283,7 +307,7 @@ export function ArtistDetailPage() {
   if (query.isPending || !payload) {
     return (
       <>
-        <ArtistDetailBackButton />
+        <ArtistDetailBackButton label={backLabel} />
         <div className="artist-detail-content">
           <div className="artist-detail-loading" id="artist-detail-loading">
             <div className="loading-spinner" />
@@ -296,7 +320,7 @@ export function ArtistDetailPage() {
 
   return (
     <>
-      <ArtistDetailBackButton />
+      <ArtistDetailBackButton label={backLabel} />
 
       <ArtistHero
         artist={payload.artist ?? {}}
@@ -342,6 +366,11 @@ export function ArtistDetailPage() {
               ))}
             </div>
           )}
+
+          {/* Standard view only — the vanilla hid it in Enhanced. Mounted
+              BEFORE loadSimilarArtists can run, or the loader finds no section
+              and bails. */}
+          <SimilarArtistsSection />
         </div>
       </div>
     </>

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -35,6 +35,7 @@ import {
   releaseToAlbumData,
   stillCheckingMessage,
 } from '../-artist-detail.open-release';
+import { scrollArtistDetailToTop } from '../-artist-detail.scroll';
 import { useCompletionStream } from '../-artist-detail.use-completion';
 import { useEnhancedData } from '../-artist-detail.use-enhanced';
 import { useGapFill } from '../-artist-detail.use-gap-fill';
@@ -165,6 +166,19 @@ export function ArtistDetailPage() {
       delete document.body.dataset.artistSource;
     };
   }, [payload, sourceOnly]);
+
+  /**
+   * Every artist opens at the top — arriving, chaining to a similar artist, or
+   * coming back. The router is told to keep its hands off scroll for this
+   * route, so this is the only thing touching it and there is no race.
+   *
+   * Keyed on the ROUTE params rather than the payload: it has to fire before
+   * the fetch resolves, or you would sit at the previous artist's scroll
+   * position while the new one loads.
+   */
+  useEffect(() => {
+    scrollArtistDetailToTop();
+  }, [source, id]);
 
   /**
    * Record an artist → artist hop for the Back label, the way

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -38,6 +38,7 @@ import { useCompletionStream } from '../-artist-detail.use-completion';
 import { useEnhancedData } from '../-artist-detail.use-enhanced';
 import { useGapFill } from '../-artist-detail.use-gap-fill';
 import { clearVanillaArtist, syncVanillaArtist } from '../-artist-detail.vanilla-state';
+import { ArtistDetailBackButton } from './artist-detail-back-button';
 import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
@@ -263,32 +264,40 @@ export function ArtistDetailPage() {
   // showing an empty shell over an error.
   if (failed) {
     return (
-      <div className="artist-detail-content">
-        <div className="artist-detail-error" id="artist-detail-error">
-          <div className="error-icon">⚠️</div>
-          <h3>Failed to load artist details</h3>
-          <p id="artist-detail-error-message">{errorMessage}</p>
-          <button type="button" className="retry-btn" onClick={() => void query.refetch()}>
-            Retry
-          </button>
+      <>
+        <ArtistDetailBackButton />
+        <div className="artist-detail-content">
+          <div className="artist-detail-error" id="artist-detail-error">
+            <div className="error-icon">⚠️</div>
+            <h3>Failed to load artist details</h3>
+            <p id="artist-detail-error-message">{errorMessage}</p>
+            <button type="button" className="retry-btn" onClick={() => void query.refetch()}>
+              Retry
+            </button>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 
   if (query.isPending || !payload) {
     return (
-      <div className="artist-detail-content">
-        <div className="artist-detail-loading" id="artist-detail-loading">
-          <div className="loading-spinner" />
-          <p>Loading artist discography...</p>
+      <>
+        <ArtistDetailBackButton />
+        <div className="artist-detail-content">
+          <div className="artist-detail-loading" id="artist-detail-loading">
+            <div className="loading-spinner" />
+            <p>Loading artist discography...</p>
+          </div>
         </div>
-      </div>
+      </>
     );
   }
 
   return (
     <>
+      <ArtistDetailBackButton />
+
       <ArtistHero
         artist={payload.artist ?? {}}
         discography={displayed}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -215,6 +215,7 @@ export function ArtistDetailPage() {
         isSourceArtist={sourceOnly}
         streamCounts={stream.counts}
         streamCompleted={stream.completed}
+        enrichment={payload.enrichment_coverage}
       />
 
       <div className="artist-detail-content">

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -20,6 +20,7 @@ import {
   type DiscographyFilterState,
   isMusicBrainzDiscography,
 } from '../-artist-detail.filters';
+import { mergeGapReleases } from '../-artist-detail.gap-fill';
 import { heroImage } from '../-artist-detail.hero-stats';
 import {
   albumTracksParams,
@@ -29,6 +30,7 @@ import {
   stillCheckingMessage,
 } from '../-artist-detail.open-release';
 import { useCompletionStream } from '../-artist-detail.use-completion';
+import { useGapFill } from '../-artist-detail.use-gap-fill';
 import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
@@ -80,7 +82,24 @@ export function ArtistDetailPage() {
   );
   const streamed = stream.discography;
 
-  const isMusicBrainz = isMusicBrainzDiscography(streamed.source);
+  /**
+   * Gap-fill (#1067) merges AFTER the ownership stream, never before: gap
+   * releases belong to other sources and must not ride the base artist's
+   * completion-stream payload, so they come in with their own ownership
+   * already resolved.
+   */
+  const gapFill = useGapFill(
+    payload?.artist?.id,
+    payload?.artist?.name,
+    discography.source ?? undefined,
+    streamed,
+  );
+  const displayed = useMemo(
+    () => mergeGapReleases(streamed, gapFill.releases),
+    [streamed, gapFill.releases],
+  );
+
+  const isMusicBrainz = isMusicBrainzDiscography(displayed.source);
 
   /**
    * Filters reset on every artist change (resetDiscographyFilters ran BEFORE
@@ -151,7 +170,7 @@ export function ArtistDetailPage() {
     }
     if (!payload) return;
 
-    const image = heroImage(payload.artist ?? {}, streamed);
+    const image = heroImage(payload.artist ?? {}, displayed);
     const artist = openReleaseArtist(payload, payload.artist?.id, image.primary);
     if (!artist) {
       window.showToast?.('Error: No artist information available', 'error');
@@ -211,7 +230,7 @@ export function ArtistDetailPage() {
     <>
       <ArtistHero
         artist={payload.artist ?? {}}
-        discography={streamed}
+        discography={displayed}
         isSourceArtist={sourceOnly}
         streamCounts={stream.counts}
         streamCompleted={stream.completed}
@@ -220,12 +239,18 @@ export function ArtistDetailPage() {
 
       <div className="artist-detail-content">
         <div className="artist-detail-main" id="artist-detail-main">
-          <DiscographyFilters filters={filters} onChange={setFilters} isSourceArtist={sourceOnly} />
+          <DiscographyFilters
+            filters={filters}
+            onChange={setFilters}
+            isSourceArtist={sourceOnly}
+            gapFillEnabled={gapFill.enabled}
+            onToggleGapFill={gapFill.toggle}
+          />
           {BUCKETS.map((bucket) => (
             <DiscographySection
               key={bucket}
               bucket={bucket}
-              releases={streamed[bucket] ?? []}
+              releases={displayed[bucket] ?? []}
               filters={filters}
               isMusicBrainz={isMusicBrainz}
               isSourceArtist={sourceOnly}

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -302,7 +302,7 @@ export function ArtistDetailPage() {
   // showing an empty shell over an error.
   if (failed) {
     return (
-      <>
+      <div className="artist-detail-page">
         <ArtistDetailBackButton label={backLabel} />
         <div className="artist-detail-content">
           <div className="artist-detail-error" id="artist-detail-error">
@@ -314,13 +314,13 @@ export function ArtistDetailPage() {
             </button>
           </div>
         </div>
-      </>
+      </div>
     );
   }
 
   if (query.isPending || !payload) {
     return (
-      <>
+      <div className="artist-detail-page">
         <ArtistDetailBackButton label={backLabel} />
         <div className="artist-detail-content">
           <div className="artist-detail-loading" id="artist-detail-loading">
@@ -328,12 +328,19 @@ export function ArtistDetailPage() {
             <p>Loading artist discography...</p>
           </div>
         </div>
-      </>
+      </div>
     );
   }
 
   return (
-    <>
+    /**
+     * The scoping hook the stylesheet needs. 17 rules are written against
+     * #artist-detail-page — the release cards' big-photo treatment, the hero,
+     * and the source-artist hides for Artist Radio / Enhance Quality /
+     * enrichment coverage. React renders inside #webui-react-root, so without
+     * this class every one of them silently stops applying.
+     */
+    <div className="artist-detail-page">
       <ArtistDetailBackButton label={backLabel} />
 
       <ArtistHero
@@ -387,6 +394,6 @@ export function ArtistDetailPage() {
           <SimilarArtistsSection />
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -37,6 +37,7 @@ import {
 import { useCompletionStream } from '../-artist-detail.use-completion';
 import { useEnhancedData } from '../-artist-detail.use-enhanced';
 import { useGapFill } from '../-artist-detail.use-gap-fill';
+import { clearVanillaArtist, syncVanillaArtist } from '../-artist-detail.vanilla-state';
 import { ArtistHero } from './artist-hero';
 import { DiscographyFilters } from './discography-filters';
 import { DiscographySection } from './discography-section';
@@ -161,6 +162,28 @@ export function ArtistDetailPage() {
       delete document.body.dataset.artistSource;
     };
   }, [payload, sourceOnly]);
+
+  /**
+   * Hand the artist down to the vanilla page state.
+   *
+   * Artist Radio, the artist art picker and the Download Discography modal all
+   * read currentArtistId/currentArtistName rather than taking arguments — with
+   * these unset they bail out with "No artist selected" and do nothing.
+   *
+   * The id is the one the PAYLOAD returned, not the one in the URL: when the
+   * backend resolves a source-artist click to an existing library record it
+   * hands back the library primary key, and the library-only endpoints behind
+   * these buttons need that.
+   */
+  useEffect(() => {
+    if (!payload) return;
+    syncVanillaArtist({
+      id: payload.artist?.id ?? null,
+      name: payload.artist?.name ?? null,
+      source: payload.discography?.source ?? payload.artist?.source ?? null,
+    });
+    return clearVanillaArtist;
+  }, [payload]);
 
   /** Non-fatal: the page still renders, but the vanilla warned about it. */
   useEffect(() => {

--- a/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { StreamCounts } from '../-artist-detail.completion';
@@ -43,7 +43,10 @@ const img = () => document.getElementById('artist-detail-image') as HTMLImageEle
 const fallback = () => document.getElementById('artist-detail-image-fallback') as HTMLElement;
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
   delete window.playArtistRadio;
   delete window.openArtistArtPicker;
   delete window.openDiscographyModal;

--- a/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
@@ -1,0 +1,207 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ArtistInfo, Discography } from '../-artist-detail.types';
+
+import { ArtistHero } from './artist-hero';
+
+function renderHero(artist: ArtistInfo, discography: Discography = {}, isSourceArtist = false) {
+  return render(
+    <ArtistHero artist={artist} discography={discography} isSourceArtist={isSourceArtist} />,
+  );
+}
+
+const img = () => document.getElementById('artist-detail-image') as HTMLImageElement;
+const fallback = () => document.getElementById('artist-detail-image-fallback') as HTMLElement;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete window.playArtistRadio;
+  delete window.openArtistArtPicker;
+  delete window.openDiscographyModal;
+});
+
+describe('ArtistHero markup', () => {
+  it('renders the ids the guided tour anchors to', () => {
+    renderHero({ name: 'Aphex Twin' });
+    for (const id of [
+      'artist-hero-section',
+      'artist-detail-name',
+      'artist-hero-badges',
+      'artist-genres',
+    ]) {
+      expect(document.getElementById(id)).not.toBeNull();
+    }
+  });
+
+  it('blurs the primary image behind the hero', () => {
+    renderHero({ name: 'A', image_url: 'a.jpg' });
+    const bg = document.getElementById('artist-detail-hero-bg') as HTMLElement;
+    // jsdom re-serialises the quote style, so match on the url itself.
+    expect(bg.style.backgroundImage).toMatch(/^url\(["']?a\.jpg["']?\)$/);
+  });
+
+  it('falls back to release art for the background when the artist has no photo', () => {
+    renderHero({ name: 'A' }, { albums: [{ image_url: 'rel.jpg' }] });
+    const bg = document.getElementById('artist-detail-hero-bg') as HTMLElement;
+    expect(bg.style.backgroundImage).toMatch(/^url\(["']?rel\.jpg["']?\)$/);
+  });
+});
+
+describe('artist photo fallback chain', () => {
+  it('steps photo -> Deezer -> release -> icon', () => {
+    renderHero(
+      { name: 'A', image_url: 'a.jpg', deezer_id: 7 },
+      { albums: [{ image_url: 'rel.jpg' }] },
+    );
+    expect(img().getAttribute('src')).toBe('a.jpg');
+
+    fireEvent.error(img());
+    expect(img().getAttribute('src')).toBe('https://api.deezer.com/artist/7/image?size=big');
+
+    fireEvent.error(img());
+    expect(img().getAttribute('src')).toBe('rel.jpg');
+
+    fireEvent.error(img());
+    expect(img().style.display).toBe('none');
+    expect(fallback().style.display).toBe('flex');
+  });
+
+  it('shows the icon immediately when there is no image at all', () => {
+    renderHero({ name: 'A' });
+    expect(img().style.display).toBe('none');
+    expect(fallback().style.display).toBe('flex');
+  });
+
+  it('resets the stage when the artist changes', () => {
+    // Navigating from an artist whose image failed to one with a good image
+    // must not start at the fallback.
+    const { rerender } = renderHero({ name: 'A', image_url: 'bad.jpg' });
+    fireEvent.error(img());
+    expect(fallback().style.display).toBe('flex');
+
+    rerender(
+      <ArtistHero
+        artist={{ name: 'B', image_url: 'good.jpg' }}
+        discography={{}}
+        isSourceArtist={false}
+      />,
+    );
+    expect(img().getAttribute('src')).toBe('good.jpg');
+    expect(img().style.display).toBe('block');
+  });
+});
+
+describe('badges', () => {
+  it('links a provider with a url and does not link one without', () => {
+    renderHero({ name: 'A', spotify_artist_id: 'sp', amazon_id: 'az' });
+    const badges = document.querySelectorAll('.artist-hero-badge');
+    expect(badges[0].tagName).toBe('A');
+    expect(badges[0].getAttribute('target')).toBe('_blank');
+    expect(badges[1].tagName).toBe('DIV');
+  });
+
+  it('shows the text fallback when a logo fails to load', () => {
+    renderHero({ name: 'A', spotify_artist_id: 'sp' });
+    fireEvent.error(document.querySelector('.artist-hero-badge img')!);
+    expect(document.querySelector('.artist-hero-badge')?.textContent).toBe('SP');
+  });
+});
+
+describe('genres and bio', () => {
+  it('dims Last.fm tags but not real genres', () => {
+    renderHero({ name: 'A', genres: ['IDM'], lastfm_tags: ['electronic'] });
+    const tags = document.querySelectorAll('.genre-tag');
+    expect((tags[0] as HTMLElement).style.opacity).toBe('');
+    expect((tags[1] as HTMLElement).style.opacity).toBe('0.6');
+  });
+
+  it('toggles the bio between Read more and Show less', () => {
+    renderHero({ name: 'A', lastfm_bio: 'A band. <a href="x">Read more on Last.fm</a>' });
+    const toggle = document.querySelector('.artist-hero-bio-toggle')!;
+    expect(document.querySelector('.bio-text')?.textContent).toBe('A band.');
+    expect(toggle.textContent).toBe('Read more');
+    fireEvent.click(toggle);
+    expect(document.querySelector('.artist-hero-bio')?.className).toContain('expanded');
+    expect(document.querySelector('.artist-hero-bio-toggle')?.textContent).toBe('Show less');
+  });
+
+  it('omits the bio block entirely when only a link remains', () => {
+    renderHero({ name: 'A', lastfm_bio: '<a href="x">Read more on Last.fm</a>' });
+    expect(document.getElementById('artist-hero-bio')).toBeNull();
+  });
+});
+
+describe('stats and actions', () => {
+  it('hides a Last.fm stat that is absent rather than showing 0', () => {
+    renderHero({ name: 'A', lastfm_listeners: 1200000 });
+    expect(document.getElementById('artist-hero-listeners')?.textContent).toContain('1.2M');
+    expect(document.getElementById('artist-hero-playcount')).toBeNull();
+
+    // BOTH branches need an absent case: asserting only on the missing
+    // playcount cannot detect the listeners branch always rendering.
+    document.body.innerHTML = '';
+    renderHero({ name: 'A', lastfm_playcount: 3400 });
+    expect(document.getElementById('artist-hero-listeners')).toBeNull();
+    expect(document.getElementById('artist-hero-playcount')?.textContent).toContain('3.4K');
+
+    document.body.innerHTML = '';
+    renderHero({ name: 'A' });
+    expect(document.querySelectorAll('.artist-hero-stat')).toHaveLength(0);
+  });
+
+  it('hides the completion bars for a source artist', () => {
+    // They own nothing, so every bar would read 0/0.
+    renderHero({ name: 'A' }, { albums: [{ owned: false }] }, true);
+    expect(document.querySelector('.collection-overview')).toBeNull();
+  });
+
+  it('shows a bar per category for a library artist', () => {
+    renderHero({ name: 'A' }, { albums: [{ owned: true }, { owned: false }] });
+    expect(document.getElementById('albums-stats')?.textContent).toBe('1/2');
+    expect((document.getElementById('albums-completion-fill') as HTMLElement).style.width).toBe(
+      '50%',
+    );
+  });
+
+  it('marks the bar as checking while ownership is pending', () => {
+    renderHero({ name: 'A' }, { albums: [{ owned: null }] });
+    const fill = document.getElementById('albums-completion-fill') as HTMLElement;
+    expect(fill.className).toContain('checking');
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('hides Download Discography when there is nothing to download', () => {
+    renderHero({ name: 'A' }, {});
+    expect((document.getElementById('discog-download-wrap') as HTMLElement).style.display).toBe(
+      'none',
+    );
+    document.body.innerHTML = '';
+    renderHero({ name: 'A' }, { albums: [{ id: 1 }] });
+    expect((document.getElementById('discog-download-wrap') as HTMLElement).style.display).toBe('');
+  });
+
+  it('invokes the vanilla globals rather than reimplementing them', () => {
+    const radio = vi.fn();
+    const picker = vi.fn();
+    const discog = vi.fn();
+    window.playArtistRadio = radio;
+    window.openArtistArtPicker = picker;
+    window.openDiscographyModal = discog;
+    renderHero({ name: 'A' }, { albums: [{ id: 1 }] });
+
+    fireEvent.click(document.getElementById('library-artist-radio-btn')!);
+    expect(radio).toHaveBeenCalled();
+    fireEvent.click(document.querySelector('.artist-image-container')!);
+    expect(picker).toHaveBeenCalled();
+    fireEvent.click(document.getElementById('discog-download-btn')!);
+    expect(discog).toHaveBeenCalled();
+  });
+
+  it('does not throw when those globals are absent', () => {
+    expect(() => {
+      renderHero({ name: 'A' }, { albums: [{ id: 1 }] });
+      fireEvent.click(document.getElementById('library-artist-radio-btn')!);
+    }).not.toThrow();
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { StreamCounts } from '../-artist-detail.completion';
 import type { ArtistInfo, Discography } from '../-artist-detail.types';
@@ -42,7 +42,28 @@ function countsWith(
 const img = () => document.getElementById('artist-detail-image') as HTMLImageElement;
 const fallback = () => document.getElementById('artist-detail-image-fallback') as HTMLElement;
 
+/**
+ * The hero mounts the top-tracks sidebar, which fetches on sight — two calls,
+ * per render. Without a stub those hit MSW's `onUnhandledRequest: 'error'` and
+ * surface as unhandled rejections: the tests still pass, but vitest warns that
+ * 34 of them "might cause false positive tests", which is a warning worth
+ * keeping at zero.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        new Response(JSON.stringify({ success: false }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    ),
+  );
+});
+
 afterEach(() => {
+  vi.unstubAllGlobals();
   // NOT document.body.innerHTML = '': anything rendered through BodyPortal
   // lives there, and wiping the body out from under Testing Library's cleanup
   // makes it throw "The node to be removed is not a child of this node".

--- a/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
@@ -1,14 +1,37 @@
 import { fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { StreamCounts } from '../-artist-detail.completion';
 import type { ArtistInfo, Discography } from '../-artist-detail.types';
 
+import { emptyStreamCounts } from '../-artist-detail.completion';
 import { ArtistHero } from './artist-hero';
 
-function renderHero(artist: ArtistInfo, discography: Discography = {}, isSourceArtist = false) {
+function renderHero(
+  artist: ArtistInfo,
+  discography: Discography = {},
+  isSourceArtist = false,
+  stream: { counts?: StreamCounts | null; completed?: boolean } = {},
+) {
   return render(
-    <ArtistHero artist={artist} discography={discography} isSourceArtist={isSourceArtist} />,
+    <ArtistHero
+      artist={artist}
+      discography={discography}
+      isSourceArtist={isSourceArtist}
+      streamCounts={stream.counts}
+      streamCompleted={stream.completed}
+    />,
   );
+}
+
+function countsWith(
+  owned: Partial<Record<'albums' | 'eps' | 'singles', number>>,
+  total: Partial<Record<'albums' | 'eps' | 'singles', number>>,
+): StreamCounts {
+  const counts = emptyStreamCounts();
+  Object.assign(counts.owned, owned);
+  Object.assign(counts.total, total);
+  return counts;
 }
 
 const img = () => document.getElementById('artist-detail-image') as HTMLImageElement;
@@ -203,5 +226,89 @@ describe('stats and actions', () => {
       renderHero({ name: 'A' }, { albums: [{ id: 1 }] });
       fireEvent.click(document.getElementById('library-artist-radio-btn')!);
     }).not.toThrow();
+  });
+});
+
+const barText = (bucket: string) => document.getElementById(`${bucket}-stats`)?.textContent;
+const barFill = (bucket: string) =>
+  document.getElementById(`${bucket}-completion-fill`) as HTMLElement;
+
+describe('completion bars across the three stream states', () => {
+  const DISC: Discography = {
+    albums: [
+      { id: 1, owned: null },
+      { id: 2, owned: null },
+      { id: 3, owned: null },
+    ],
+  };
+
+  it('shows the pending state before the stream reports anything', () => {
+    renderHero({ name: 'A' }, DISC);
+    expect(barText('albums')).toBe('...');
+    expect(barFill('albums').className).toContain('checking');
+  });
+
+  it('shows resolved-so-far while the stream runs, NOT the whole bucket', () => {
+    // One of three albums checked, and it was owned: "1/1", not "1/3".
+    renderHero({ name: 'A' }, DISC, false, { counts: countsWith({ albums: 1 }, { albums: 1 }) });
+    expect(barText('albums')).toBe('1/1');
+    expect(barFill('albums').className).not.toContain('checking');
+    expect(barFill('albums').style.width).toBe('100%');
+  });
+
+  it('recounts from the merged discography once the stream completes', () => {
+    const merged: Discography = {
+      albums: [
+        { id: 1, owned: true },
+        { id: 2, owned: false },
+        { id: 3, owned: null },
+      ],
+    };
+    // The running tallies said 1/1; the recount sees the third album never
+    // resolved and reports 1/2 rather than falling back to "...".
+    renderHero({ name: 'A' }, merged, false, {
+      counts: countsWith({ albums: 1 }, { albums: 1 }),
+      completed: true,
+    });
+    expect(barText('albums')).toBe('1/2');
+    expect(barFill('albums').style.width).toBe('50%');
+  });
+});
+
+describe('artist format tags', () => {
+  const counts = () => {
+    const c = emptyStreamCounts();
+    c.formats.add('MP3');
+    c.formats.add('FLAC');
+    return c;
+  };
+
+  it('renders sorted format tags after the stream completes', () => {
+    renderHero({ name: 'A' }, {}, false, { counts: counts(), completed: true });
+    const tags = [...document.querySelectorAll('.artist-formats .artist-format-tag')];
+    expect(tags.map((n) => n.textContent)).toEqual(['FLAC', 'MP3']);
+  });
+
+  it('stays hidden while the stream is still running', () => {
+    // The set fills up as events arrive, but the vanilla only built the block
+    // on the terminal frame — tags must not appear and grow mid-stream.
+    renderHero({ name: 'A' }, {}, false, { counts: counts(), completed: false });
+    expect(document.querySelector('.artist-formats')).toBeNull();
+  });
+
+  it('renders no empty block when nothing reported a format', () => {
+    renderHero({ name: 'A' }, {}, false, { counts: emptyStreamCounts(), completed: true });
+    expect(document.querySelector('.artist-formats')).toBeNull();
+  });
+
+  it('sits between the genre chips and the bio', () => {
+    renderHero({ name: 'A', genres: ['idm'], lastfm_bio: 'words' }, {}, false, {
+      counts: counts(),
+      completed: true,
+    });
+    const info = document.querySelector('.artist-info') as HTMLElement;
+    const order = [...info.children].map((n) => n.className);
+    expect(order.indexOf('artist-formats')).toBe(order.indexOf('artist-genres-container') + 1);
+    expect(order.indexOf('artist-hero-bio')).toBe(order.indexOf('artist-formats') + 1);
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.test.tsx
@@ -11,7 +11,11 @@ function renderHero(
   artist: ArtistInfo,
   discography: Discography = {},
   isSourceArtist = false,
-  stream: { counts?: StreamCounts | null; completed?: boolean } = {},
+  stream: {
+    counts?: StreamCounts | null;
+    completed?: boolean;
+    enrichment?: Record<string, unknown>;
+  } = {},
 ) {
   return render(
     <ArtistHero
@@ -20,6 +24,7 @@ function renderHero(
       isSourceArtist={isSourceArtist}
       streamCounts={stream.counts}
       streamCompleted={stream.completed}
+      enrichment={stream.enrichment}
     />,
   );
 }
@@ -310,5 +315,56 @@ describe('artist format tags', () => {
     const order = [...info.children].map((n) => n.className);
     expect(order.indexOf('artist-formats')).toBe(order.indexOf('artist-genres-container') + 1);
     expect(order.indexOf('artist-hero-bio')).toBe(order.indexOf('artist-formats') + 1);
+  });
+});
+
+describe('hero elements the vanilla globals reach for by id', () => {
+  it('renders the watchlist button initializeLibraryWatchlistButton wires', () => {
+    // The global installs its own onclick and toggles `watching`; without the
+    // element it silently returns and the button never appears.
+    renderHero({ name: 'A' });
+    const btn = document.getElementById('library-artist-watchlist-btn');
+    expect(btn).not.toBeNull();
+    expect(btn?.querySelector('.watchlist-text')?.textContent).toBe('Add to Watchlist');
+  });
+
+  it('renders the enhance button hidden, for checkArtistEnhanceEligibility to reveal', () => {
+    // It unhides the button and rewrites .enhance-text with a count.
+    renderHero({ name: 'A' });
+    const btn = document.getElementById('library-artist-enhance-btn');
+    expect(btn?.className).toContain('hidden');
+    expect(btn?.querySelector('.enhance-text')).not.toBeNull();
+  });
+
+  it('opens the enhance modal on click', () => {
+    window.openEnhanceQualityModal = vi.fn();
+    renderHero({ name: 'A' });
+    fireEvent.click(document.getElementById('library-artist-enhance-btn') as HTMLElement);
+    expect(window.openEnhanceQualityModal).toHaveBeenCalled();
+    delete window.openEnhanceQualityModal;
+  });
+
+  it('places the actions in the vanilla order', () => {
+    renderHero({ name: 'A' }, { albums: [{ id: 1 }] });
+    const actions = document.querySelector('.artist-hero-actions') as HTMLElement;
+    expect([...actions.children].map((n) => n.id)).toEqual([
+      'library-artist-radio-btn',
+      'library-artist-watchlist-btn',
+      'discog-download-wrap',
+      'library-artist-enhance-btn',
+    ]);
+  });
+
+  it('renders the enrichment rings LAST inside the artist info column', () => {
+    renderHero({ name: 'A' }, {}, false, {
+      enrichment: { total_tracks: 5, spotify: 100 },
+    });
+    const info = document.querySelector('.artist-info') as HTMLElement;
+    expect(info.lastElementChild?.id).toBe('artist-enrichment-coverage');
+  });
+
+  it('leaves the coverage block out when the artist has no enrichment data', () => {
+    renderHero({ name: 'A' });
+    expect(document.getElementById('artist-enrichment-coverage')).toBeNull();
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-hero.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from 'react';
+
+import type { ArtistInfo, Discography, DiscographyBucket } from '../-artist-detail.types';
+
+import { buildHeroBadges } from '../-artist-detail.hero';
+import {
+  buildGenreChips,
+  categoryStats,
+  cleanArtistBio,
+  formatHeroNumber,
+  heroImage,
+  type HeroImageStage,
+  heroImageSrc,
+  nextHeroImageStage,
+  totalReleaseCount,
+} from '../-artist-detail.hero-stats';
+
+interface Props {
+  artist: ArtistInfo;
+  discography: Discography;
+  isSourceArtist: boolean;
+}
+
+const CATEGORY_LABELS: { bucket: DiscographyBucket; label: string }[] = [
+  { bucket: 'albums', label: 'Albums' },
+  { bucket: 'eps', label: 'EPs' },
+  { bucket: 'singles', label: 'Singles' },
+];
+
+/**
+ * Artist photo with the vanilla's three-step fallback.
+ *
+ * `key={stage}` remounts rather than swapping src on the element that just
+ * errored, so each stage gets a clean load cycle. Not test-observable — jsdom
+ * never fetches images, so dropping the key survives mutation. Kept because a
+ * real browser can hold the broken-image state on a reused element.
+ *
+ * The stage reset on artist change IS observable and tested: without it,
+ * navigating from an artist whose image failed to one with a good image would
+ * start at 'fallback' and show the music-note icon over a valid photo.
+ */
+function ArtistPhoto({ artist, discography }: { artist: ArtistInfo; discography: Discography }) {
+  const image = heroImage(artist, discography);
+  const [stage, setStage] = useState<HeroImageStage>(image.primary ? 'primary' : 'fallback');
+
+  useEffect(() => {
+    setStage(image.primary ? 'primary' : 'fallback');
+  }, [image.primary]);
+
+  const showFallback = stage === 'fallback';
+
+  return (
+    <>
+      <img
+        key={stage}
+        className="artist-image"
+        id="artist-detail-image"
+        src={showFallback ? '' : heroImageSrc(stage, artist, image)}
+        alt={artist.name ?? 'Artist Image'}
+        style={{ display: showFallback ? 'none' : 'block' }}
+        onError={() => setStage((s) => nextHeroImageStage(s, artist, image))}
+      />
+      <div
+        className="artist-image-fallback"
+        id="artist-detail-image-fallback"
+        style={{ display: showFallback ? 'flex' : 'none' }}
+      >
+        🎵
+      </div>
+    </>
+  );
+}
+
+/**
+ * The artist hero. Mirrors #artist-hero-section in index.html so the CSS and
+ * the guided-tour anchors apply unchanged.
+ *
+ * Radio and the art picker are vanilla globals invoked through window — they
+ * live in stats-automations.js and library.js respectively and are not
+ * reimplemented here.
+ */
+export function ArtistHero({ artist, discography, isSourceArtist }: Props) {
+  const image = heroImage(artist, discography);
+  const badges = buildHeroBadges(artist);
+  const chips = buildGenreChips(artist);
+  const bio = cleanArtistBio(artist.lastfm_bio);
+  const [bioExpanded, setBioExpanded] = useState(false);
+  const hasReleases = totalReleaseCount(discography) > 0;
+
+  return (
+    <div className="artist-hero-section" id="artist-hero-section">
+      <div
+        className="artist-detail-hero-bg"
+        id="artist-detail-hero-bg"
+        style={{ backgroundImage: image.primary ? `url('${image.primary}')` : undefined }}
+      />
+      <div className="artist-detail-hero-overlay" />
+
+      <div className="artist-hero-content">
+        <div
+          className="artist-image-container"
+          title="Change artist photo"
+          onClick={() => window.openArtistArtPicker?.()}
+        >
+          <ArtistPhoto artist={artist} discography={discography} />
+          <div className="artist-image-edit-overlay">
+            <span>Change photo</span>
+          </div>
+        </div>
+
+        <div className="artist-info">
+          <div className="artist-hero-identity">
+            <h1 className="artist-name" id="artist-detail-name">
+              {artist.name}
+            </h1>
+            <div className="artist-hero-badges" id="artist-hero-badges">
+              {badges.map((badge) =>
+                badge.url ? (
+                  <a
+                    key={badge.key}
+                    className="artist-hero-badge"
+                    title={badge.title}
+                    href={badge.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <BadgeInner logo={badge.logo} fallback={badge.fallback} />
+                  </a>
+                ) : (
+                  // No public artist page — rendered, but not a link.
+                  <div key={badge.key} className="artist-hero-badge" title={badge.title}>
+                    <BadgeInner logo={badge.logo} fallback={badge.fallback} />
+                  </div>
+                ),
+              )}
+            </div>
+          </div>
+
+          <div className="artist-hero-actions">
+            <button
+              type="button"
+              className="library-artist-radio-btn"
+              id="library-artist-radio-btn"
+              onClick={() => window.playArtistRadio?.()}
+            >
+              <span className="radio-icon">📻</span>
+              <span className="radio-text">Artist Radio</span>
+            </button>
+            {/* Only shown when there is something to download. */}
+            <div
+              className="discog-download-wrap"
+              id="discog-download-wrap"
+              style={{ display: hasReleases ? '' : 'none' }}
+            >
+              <button
+                type="button"
+                className="discog-download-btn discog-btn-compact"
+                id="discog-download-btn"
+                onClick={() => window.openDiscographyModal?.()}
+              >
+                <span className="discog-btn-icon">⬇</span>
+                <span className="discog-btn-text">Download Discography</span>
+                <span className="discog-btn-shimmer" />
+              </button>
+            </div>
+          </div>
+
+          <div className="artist-genres-container" id="artist-genres">
+            {chips.map((chip) => (
+              <span
+                key={`${chip.fromLastfm ? 'lfm' : 'genre'}-${chip.label}`}
+                className="genre-tag"
+                // Last.fm tags are dimmed so they read as secondary.
+                style={chip.fromLastfm ? { opacity: 0.6 } : undefined}
+              >
+                {chip.label}
+              </span>
+            ))}
+          </div>
+
+          {bio ? (
+            <div
+              className={`artist-hero-bio${bioExpanded ? ' expanded' : ''}`}
+              id="artist-hero-bio"
+            >
+              <span className="bio-text">{bio}</span>
+              <span className="artist-hero-bio-toggle" onClick={() => setBioExpanded((v) => !v)}>
+                {bioExpanded ? 'Show less' : 'Read more'}
+              </span>
+            </div>
+          ) : null}
+
+          <div className="artist-hero-numbers">
+            {artist.lastfm_listeners ? (
+              <div className="artist-hero-stat" id="artist-hero-listeners">
+                <span className="hero-stat-value">{formatHeroNumber(artist.lastfm_listeners)}</span>
+                <span className="hero-stat-label">listeners</span>
+              </div>
+            ) : null}
+            {artist.lastfm_playcount ? (
+              <div className="artist-hero-stat" id="artist-hero-playcount">
+                <span className="hero-stat-value">{formatHeroNumber(artist.lastfm_playcount)}</span>
+                <span className="hero-stat-label">plays</span>
+              </div>
+            ) : null}
+          </div>
+
+          {/* Completion bars are library-only: a source artist owns nothing, so
+              every bar would read 0/0 and mean nothing. */}
+          {isSourceArtist ? null : (
+            <div className="collection-overview">
+              {CATEGORY_LABELS.map(({ bucket, label }) => {
+                const stats = categoryStats(discography[bucket] ?? []);
+                return (
+                  <div className="collection-category" key={bucket}>
+                    <span className="category-label">{label}</span>
+                    <div className="completion-bar">
+                      <div
+                        className={`completion-fill${stats.checking ? ' checking' : ''}`}
+                        id={`${bucket}-completion-fill`}
+                        style={{ width: stats.width }}
+                      />
+                    </div>
+                    <span className="category-stats" id={`${bucket}-stats`}>
+                      {stats.text}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The vanilla swapped the whole badge for its text on image error. React
+ * cannot replace its own parent, so the image hides and the text underneath
+ * shows — same visual result, without reaching outside this component.
+ */
+function BadgeInner({ logo, fallback }: { logo: string; fallback: string }) {
+  const [broken, setBroken] = useState(false);
+  if (!logo || broken) {
+    return <span style={{ fontSize: 9, fontWeight: 700 }}>{fallback}</span>;
+  }
+  return <img src={logo} alt={fallback} onError={() => setBroken(true)} />;
+}

--- a/webui/src/routes/artist-detail/-ui/artist-hero.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.tsx
@@ -20,6 +20,7 @@ import {
   totalReleaseCount,
 } from '../-artist-detail.hero-stats';
 import { bucketCounts } from '../-artist-detail.use-completion';
+import { ArtistDbRecord } from './artist-db-record';
 import { EnrichmentCoverage } from './enrichment-coverage';
 import { TopTracksSidebar } from './top-tracks-sidebar';
 
@@ -333,6 +334,10 @@ export function ArtistHero({
 
         <TopTracksSidebar artistId={artist.id} artistName={artist.name ?? ''} />
       </div>
+
+      {/* Appended to the hero SECTION, not the content row — the vanilla did
+          the same and the CSS positions it against the section. */}
+      <ArtistDbRecord artist={artist} isSourceArtist={isSourceArtist} />
     </div>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/artist-hero.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.tsx
@@ -1,24 +1,59 @@
 import { useEffect, useState } from 'react';
 
+import type { StreamCounts } from '../-artist-detail.completion';
 import type { ArtistInfo, Discography, DiscographyBucket } from '../-artist-detail.types';
 
 import { buildHeroBadges } from '../-artist-detail.hero';
 import {
+  artistFormatTags,
   buildGenreChips,
   categoryStats,
+  type CategoryStats,
   cleanArtistBio,
   formatHeroNumber,
   heroImage,
   type HeroImageStage,
   heroImageSrc,
   nextHeroImageStage,
+  resolvedCategoryStats,
+  streamCategoryStats,
   totalReleaseCount,
 } from '../-artist-detail.hero-stats';
+import { bucketCounts } from '../-artist-detail.use-completion';
 
 interface Props {
   artist: ArtistInfo;
   discography: Discography;
   isSourceArtist: boolean;
+  /** Running per-bucket tallies while the ownership stream runs. */
+  streamCounts?: StreamCounts | null;
+  /** True once the stream reported `complete`. */
+  streamCompleted?: boolean;
+}
+
+/**
+ * The completion bar for one bucket, in the three states the vanilla had:
+ *
+ *   - no stream yet    -> categoryStats over the whole bucket ("..." if pending)
+ *   - stream running   -> the running tallies, denominator = resolved so far
+ *   - stream complete  -> recounted from the merged discography
+ *
+ * Reproducing all three matters because they disagree: mid-stream the bar reads
+ * "2/3" of a twelve-album discography, and after `complete` anything the
+ * backend never reported drops out of the denominator instead of pinning the
+ * bar back to "...".
+ */
+function bucketStats(
+  bucket: DiscographyBucket,
+  discography: Discography,
+  streamCounts: StreamCounts | null | undefined,
+  streamCompleted: boolean,
+): CategoryStats {
+  const releases = discography[bucket] ?? [];
+  if (streamCompleted) return resolvedCategoryStats(releases);
+  const counts = bucketCounts(streamCounts ?? null, bucket);
+  if (counts) return streamCategoryStats(counts.owned, counts.missing);
+  return categoryStats(releases);
 }
 
 const CATEGORY_LABELS: { bucket: DiscographyBucket; label: string }[] = [
@@ -79,13 +114,22 @@ function ArtistPhoto({ artist, discography }: { artist: ArtistInfo; discography:
  * live in stats-automations.js and library.js respectively and are not
  * reimplemented here.
  */
-export function ArtistHero({ artist, discography, isSourceArtist }: Props) {
+export function ArtistHero({
+  artist,
+  discography,
+  isSourceArtist,
+  streamCounts,
+  streamCompleted = false,
+}: Props) {
   const image = heroImage(artist, discography);
   const badges = buildHeroBadges(artist);
   const chips = buildGenreChips(artist);
   const bio = cleanArtistBio(artist.lastfm_bio);
   const [bioExpanded, setBioExpanded] = useState(false);
   const hasReleases = totalReleaseCount(discography) > 0;
+  // Only after `complete`, matching the vanilla: the set accumulates through
+  // the whole stream but the block was not rendered until it ended.
+  const formats = streamCompleted ? artistFormatTags(streamCounts?.formats) : [];
 
   return (
     <div className="artist-hero-section" id="artist-hero-section">
@@ -178,6 +222,16 @@ export function ArtistHero({ artist, discography, isSourceArtist }: Props) {
             ))}
           </div>
 
+          {formats.length > 0 ? (
+            <div className="artist-formats">
+              {formats.map((format) => (
+                <span className="artist-format-tag" key={format}>
+                  {format}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
           {bio ? (
             <div
               className={`artist-hero-bio${bioExpanded ? ' expanded' : ''}`}
@@ -210,7 +264,7 @@ export function ArtistHero({ artist, discography, isSourceArtist }: Props) {
           {isSourceArtist ? null : (
             <div className="collection-overview">
               {CATEGORY_LABELS.map(({ bucket, label }) => {
-                const stats = categoryStats(discography[bucket] ?? []);
+                const stats = bucketStats(bucket, discography, streamCounts, streamCompleted);
                 return (
                   <div className="collection-category" key={bucket}>
                     <span className="category-label">{label}</span>

--- a/webui/src/routes/artist-detail/-ui/artist-hero.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-hero.tsx
@@ -20,6 +20,8 @@ import {
   totalReleaseCount,
 } from '../-artist-detail.hero-stats';
 import { bucketCounts } from '../-artist-detail.use-completion';
+import { EnrichmentCoverage } from './enrichment-coverage';
+import { TopTracksSidebar } from './top-tracks-sidebar';
 
 interface Props {
   artist: ArtistInfo;
@@ -29,6 +31,8 @@ interface Props {
   streamCounts?: StreamCounts | null;
   /** True once the stream reported `complete`. */
   streamCompleted?: boolean;
+  /** Per-service coverage payload; the panel hides itself when absent. */
+  enrichment?: Record<string, unknown>;
 }
 
 /**
@@ -120,6 +124,7 @@ export function ArtistHero({
   isSourceArtist,
   streamCounts,
   streamCompleted = false,
+  enrichment,
 }: Props) {
   const image = heroImage(artist, discography);
   const badges = buildHeroBadges(artist);
@@ -148,6 +153,20 @@ export function ArtistHero({
         >
           <ArtistPhoto artist={artist} discography={discography} />
           <div className="artist-image-edit-overlay">
+            <svg
+              viewBox="0 0 24 24"
+              width="26"
+              height="26"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <circle cx="8.5" cy="8.5" r="1.5" />
+              <path d="m21 15-5-5L5 21" />
+            </svg>
             <span>Change photo</span>
           </div>
         </div>
@@ -190,6 +209,22 @@ export function ArtistHero({
               <span className="radio-icon">📻</span>
               <span className="radio-text">Artist Radio</span>
             </button>
+            {/*
+              Both of these are driven from outside React: the page calls
+              initializeLibraryWatchlistButton, which installs its own onclick
+              and toggles `watching`, and checkArtistEnhanceEligibility unhides
+              the enhance button and rewrites `.enhance-text` with the count.
+              They are rendered with no React state so a re-render cannot undo
+              what those globals wrote.
+            */}
+            <button
+              type="button"
+              className="library-artist-watchlist-btn"
+              id="library-artist-watchlist-btn"
+            >
+              <span className="watchlist-icon">👁️</span>
+              <span className="watchlist-text">Add to Watchlist</span>
+            </button>
             {/* Only shown when there is something to download. */}
             <div
               className="discog-download-wrap"
@@ -207,6 +242,15 @@ export function ArtistHero({
                 <span className="discog-btn-shimmer" />
               </button>
             </div>
+            <button
+              type="button"
+              className="library-artist-enhance-btn hidden"
+              id="library-artist-enhance-btn"
+              onClick={() => window.openEnhanceQualityModal?.()}
+            >
+              <span className="enhance-icon">⚡</span>
+              <span className="enhance-text">Enhance Quality</span>
+            </button>
           </div>
 
           <div className="artist-genres-container" id="artist-genres">
@@ -283,7 +327,11 @@ export function ArtistHero({
               })}
             </div>
           )}
+
+          <EnrichmentCoverage enrichment={enrichment} />
         </div>
+
+        <TopTracksSidebar artistId={artist.id} artistName={artist.name ?? ''} />
       </div>
     </div>
   );

--- a/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
@@ -4,12 +4,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { applyMusicBrainzDeclutter, defaultFilterState } from '../-artist-detail.filters';
 import { DiscographyFilters } from './discography-filters';
 
-function renderBar(filters = defaultFilterState(), isSourceArtist = false) {
+function renderBar(filters = defaultFilterState(), isSourceArtist = false, gapFill = false) {
   const onChange = vi.fn();
+  const onToggleGapFill = vi.fn();
   render(
-    <DiscographyFilters filters={filters} onChange={onChange} isSourceArtist={isSourceArtist} />,
+    <DiscographyFilters
+      filters={filters}
+      onChange={onChange}
+      isSourceArtist={isSourceArtist}
+      gapFillEnabled={gapFill}
+      onToggleGapFill={onToggleGapFill}
+    />,
   );
-  return { onChange };
+  return { onChange, onToggleGapFill };
 }
 
 const btn = (filter: string, value: string) =>
@@ -133,6 +140,43 @@ describe('source artists', () => {
 
   it('drops the divider along with the group, not leaving a stray one', () => {
     renderBar(defaultFilterState(), true);
-    expect(document.querySelectorAll('.filter-divider')).toHaveLength(1);
+    // Show | Include | Sources — the Status group and its divider are gone.
+    expect(document.querySelectorAll('.filter-divider')).toHaveLength(2);
+    expect(document.querySelectorAll('.filter-group')).toHaveLength(3);
+  });
+});
+
+describe('the gap-fill chip', () => {
+  it('sits in a Sources group after Status', () => {
+    renderBar();
+    const groups = [...document.querySelectorAll('.filter-group .filter-label')].map(
+      (n) => n.textContent,
+    );
+    expect(groups).toEqual(['Show', 'Include', 'Status', 'Sources']);
+  });
+
+  it('shows for a SOURCE artist too', () => {
+    // Unlike Status, this group keeps a button, so the vanilla's
+    // `:has(.filter-label:only-child)` rule never hides it.
+    renderBar(defaultFilterState(), true);
+    expect(document.getElementById('gapfill-toggle-btn')).not.toBeNull();
+  });
+
+  it('reflects the persisted state in its active class', () => {
+    renderBar(defaultFilterState(), false, true);
+    expect(document.getElementById('gapfill-toggle-btn')?.className).toContain('active');
+  });
+
+  it('is inactive when gap-fill is off', () => {
+    renderBar();
+    expect(document.getElementById('gapfill-toggle-btn')?.className).not.toContain('active');
+  });
+
+  it('toggles on click', () => {
+    const { onToggleGapFill, onChange } = renderBar();
+    fireEvent.click(document.getElementById('gapfill-toggle-btn') as HTMLElement);
+    expect(onToggleGapFill).toHaveBeenCalled();
+    // It is a view option, not a discography filter — filter state is untouched.
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { applyMusicBrainzDeclutter, defaultFilterState } from '../-artist-detail.filters';
+import { DiscographyFilters } from './discography-filters';
+
+function renderBar(filters = defaultFilterState(), isSourceArtist = false) {
+  const onChange = vi.fn();
+  render(
+    <DiscographyFilters filters={filters} onChange={onChange} isSourceArtist={isSourceArtist} />,
+  );
+  return { onChange };
+}
+
+const btn = (filter: string, value: string) =>
+  document.querySelector(`[data-filter="${filter}"][data-value="${value}"]`) as HTMLElement;
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('DiscographyFilters markup', () => {
+  it('renders the id the tour anchors to, and the vanilla button classes', () => {
+    renderBar();
+    expect(document.getElementById('discography-filters')).not.toBeNull();
+    expect(btn('category', 'albums').className).toBe('discography-filter-btn active');
+  });
+
+  it('marks inactive buttons without the active class', () => {
+    const filters = defaultFilterState();
+    filters.categories.eps = false;
+    renderBar(filters);
+    expect(btn('category', 'eps').className).toBe('discography-filter-btn');
+  });
+
+  it('defaults ownership to All being the active one', () => {
+    renderBar();
+    expect(btn('ownership', 'all').className).toContain('active');
+    expect(btn('ownership', 'owned').className).not.toContain('active');
+  });
+});
+
+describe('category and content are MULTI-toggles', () => {
+  it('flips one category without touching the others', () => {
+    const { onChange } = renderBar();
+    fireEvent.click(btn('category', 'eps'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ categories: { albums: true, eps: false, singles: true } }),
+    );
+  });
+
+  it('toggles a category back on', () => {
+    const filters = defaultFilterState();
+    filters.categories.albums = false;
+    const { onChange } = renderBar(filters);
+    fireEvent.click(btn('category', 'albums'));
+    expect(onChange.mock.calls[0][0].categories.albums).toBe(true);
+  });
+
+  it('flips one content type without touching the others', () => {
+    const { onChange } = renderBar();
+    fireEvent.click(btn('content', 'compilations'));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ content: { live: true, compilations: false, featured: true } }),
+    );
+  });
+
+  it('preserves ALREADY-OFF siblings when toggling another', () => {
+    // Starting from the default (everything true) cannot detect a sibling
+    // reset, because resetting to true is a no-op there.
+    const filters = defaultFilterState();
+    filters.content.live = false;
+    filters.content.featured = false;
+    const { onChange } = renderBar(filters);
+    fireEvent.click(btn('content', 'compilations'));
+    expect(onChange.mock.calls[0][0].content).toEqual({
+      live: false,
+      compilations: false,
+      featured: false,
+    });
+  });
+
+  it('preserves already-off categories when toggling another', () => {
+    const filters = defaultFilterState();
+    filters.categories.singles = false;
+    const { onChange } = renderBar(filters);
+    fireEvent.click(btn('category', 'eps'));
+    expect(onChange.mock.calls[0][0].categories).toEqual({
+      albums: true,
+      eps: false,
+      singles: false,
+    });
+  });
+});
+
+describe('ownership is SINGLE-select', () => {
+  it('replaces the selection rather than toggling it', () => {
+    const { onChange } = renderBar();
+    fireEvent.click(btn('ownership', 'owned'));
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ ownership: 'owned' }));
+  });
+
+  it('does not turn itself off when the active one is clicked again', () => {
+    // A multi-toggle here would leave ownership undefined and hide everything.
+    const filters = { ...defaultFilterState(), ownership: 'owned' as const };
+    const { onChange } = renderBar(filters);
+    fireEvent.click(btn('ownership', 'owned'));
+    expect(onChange.mock.calls[0][0].ownership).toBe('owned');
+  });
+});
+
+describe('MusicBrainz relabelling', () => {
+  it('calls the Live toggle "Non-Studio" under the MB declutter', () => {
+    // It governs the whole secondary-type set there, not just live albums.
+    renderBar(applyMusicBrainzDeclutter(defaultFilterState(), 'musicbrainz'));
+    expect(btn('content', 'live').textContent).toBe('Non-Studio');
+  });
+
+  it('calls it "Live" everywhere else', () => {
+    renderBar();
+    expect(btn('content', 'live').textContent).toBe('Live');
+  });
+});
+
+describe('source artists', () => {
+  it('hides the Status group entirely — they own nothing', () => {
+    renderBar(defaultFilterState(), true);
+    expect(btn('ownership', 'all')).toBeNull();
+    // ...but the other groups stay.
+    expect(btn('category', 'albums')).not.toBeNull();
+    expect(btn('content', 'live')).not.toBeNull();
+  });
+
+  it('drops the divider along with the group, not leaving a stray one', () => {
+    renderBar(defaultFilterState(), true);
+    expect(document.querySelectorAll('.filter-divider')).toHaveLength(1);
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { applyMusicBrainzDeclutter, defaultFilterState } from '../-artist-detail.filters';
@@ -32,7 +32,10 @@ const btn = (filter: string, value: string) =>
   document.querySelector(`[data-filter="${filter}"][data-value="${value}"]`) as HTMLElement;
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('DiscographyFilters markup', () => {

--- a/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.test.tsx
@@ -4,9 +4,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { applyMusicBrainzDeclutter, defaultFilterState } from '../-artist-detail.filters';
 import { DiscographyFilters } from './discography-filters';
 
-function renderBar(filters = defaultFilterState(), isSourceArtist = false, gapFill = false) {
+function renderBar(
+  filters = defaultFilterState(),
+  isSourceArtist = false,
+  gapFill = false,
+  { showViewToggle = false, enhanced = false } = {},
+) {
   const onChange = vi.fn();
   const onToggleGapFill = vi.fn();
+  const onToggleEnhanced = vi.fn();
   render(
     <DiscographyFilters
       filters={filters}
@@ -14,9 +20,12 @@ function renderBar(filters = defaultFilterState(), isSourceArtist = false, gapFi
       isSourceArtist={isSourceArtist}
       gapFillEnabled={gapFill}
       onToggleGapFill={onToggleGapFill}
+      showViewToggle={showViewToggle}
+      enhanced={enhanced}
+      onToggleEnhanced={onToggleEnhanced}
     />,
   );
-  return { onChange, onToggleGapFill };
+  return { onChange, onToggleGapFill, onToggleEnhanced };
 }
 
 const btn = (filter: string, value: string) =>
@@ -178,5 +187,53 @@ describe('the gap-fill chip', () => {
     expect(onToggleGapFill).toHaveBeenCalled();
     // It is a view option, not a discography filter — filter state is untouched.
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('the View toggle', () => {
+  it('is absent unless the page says the artist can be enhanced', () => {
+    renderBar();
+    expect(document.querySelector('.enhanced-view-toggle-btn')).toBeNull();
+  });
+
+  it('marks Standard active by default', () => {
+    renderBar(defaultFilterState(), false, false, { showViewToggle: true });
+    const [standard, enhanced] = [...document.querySelectorAll('.enhanced-view-toggle-btn')];
+    expect(standard.className).toContain('active');
+    expect(enhanced.className).not.toContain('active');
+  });
+
+  it('marks Enhanced active when it is on', () => {
+    renderBar(defaultFilterState(), false, false, { showViewToggle: true, enhanced: true });
+    const [standard, enhanced] = [...document.querySelectorAll('.enhanced-view-toggle-btn')];
+    expect(standard.className).not.toContain('active');
+    expect(enhanced.className).toContain('active');
+  });
+
+  it('reports which view was picked', () => {
+    const { onToggleEnhanced } = renderBar(defaultFilterState(), false, false, {
+      showViewToggle: true,
+    });
+    fireEvent.click(document.querySelector('[data-view="enhanced"]') as HTMLElement);
+    expect(onToggleEnhanced).toHaveBeenCalledWith(true);
+
+    fireEvent.click(document.querySelector('[data-view="standard"]') as HTMLElement);
+    expect(onToggleEnhanced).toHaveBeenCalledWith(false);
+  });
+
+  it('HIDES the discography filters while Enhanced is on, keeping View', () => {
+    // Enhanced replaces the discography, so filters that only describe it are
+    // meaningless there.
+    renderBar(defaultFilterState(), false, false, { showViewToggle: true, enhanced: true });
+    const groups = [...document.querySelectorAll('.filter-group')] as HTMLElement[];
+    const visible = groups.filter((g) => g.style.display !== 'none');
+    expect(visible).toHaveLength(1);
+    expect(visible[0].querySelector('.filter-label')?.textContent).toBe('View');
+  });
+
+  it('shows them all again in Standard', () => {
+    renderBar(defaultFilterState(), false, false, { showViewToggle: true });
+    const groups = [...document.querySelectorAll('.filter-group')] as HTMLElement[];
+    expect(groups.every((g) => g.style.display !== 'none')).toBe(true);
   });
 });

--- a/webui/src/routes/artist-detail/-ui/discography-filters.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.tsx
@@ -9,6 +9,10 @@ interface Props {
   isSourceArtist: boolean;
   gapFillEnabled: boolean;
   onToggleGapFill: () => void;
+  /** The Enhanced toggle is admin-and-library-only; absent for everyone else. */
+  showViewToggle: boolean;
+  enhanced: boolean;
+  onToggleEnhanced: (enabled: boolean) => void;
 }
 
 const CATEGORIES: { value: DiscographyBucket; label: string }[] = [
@@ -37,6 +41,9 @@ export function DiscographyFilters({
   isSourceArtist,
   gapFillEnabled,
   onToggleGapFill,
+  showViewToggle,
+  enhanced,
+  onToggleEnhanced,
 }: Props) {
   const toggleCategory = (value: DiscographyBucket) =>
     onChange({
@@ -54,7 +61,9 @@ export function DiscographyFilters({
 
   return (
     <div className="discography-filters" id="discography-filters">
-      <div className="filter-group">
+      {/* Enhanced replaces the discography entirely, so the filters that only
+          describe the discography are hidden rather than left inert. */}
+      <div className="filter-group" style={enhanced ? { display: 'none' } : undefined}>
         <span className="filter-label">Show</span>
         {CATEGORIES.map(({ value, label }) => (
           <button
@@ -70,9 +79,9 @@ export function DiscographyFilters({
         ))}
       </div>
 
-      <div className="filter-divider" />
+      <div className="filter-divider" style={enhanced ? { display: 'none' } : undefined} />
 
-      <div className="filter-group">
+      <div className="filter-group" style={enhanced ? { display: 'none' } : undefined}>
         <span className="filter-label">Include</span>
         <button
           type="button"
@@ -110,8 +119,8 @@ export function DiscographyFilters({
           release is "missing" and the filter is meaningless. */}
       {isSourceArtist ? null : (
         <>
-          <div className="filter-divider" />
-          <div className="filter-group">
+          <div className="filter-divider" style={enhanced ? { display: 'none' } : undefined} />
+          <div className="filter-group" style={enhanced ? { display: 'none' } : undefined}>
             <span className="filter-label">Status</span>
             {OWNERSHIP.map(({ value, label }) => (
               <button
@@ -132,8 +141,8 @@ export function DiscographyFilters({
       {/* Rendered for source artists too: unlike Status, this group keeps a
           button so the vanilla's `:has(.filter-label:only-child)` rule never
           hides it, and other sources are exactly what a source artist has. */}
-      <div className="filter-divider" />
-      <div className="filter-group">
+      <div className="filter-divider" style={enhanced ? { display: 'none' } : undefined} />
+      <div className="filter-group" style={enhanced ? { display: 'none' } : undefined}>
         <span className="filter-label">Sources</span>
         <button
           type="button"
@@ -145,6 +154,31 @@ export function DiscographyFilters({
           + Other sources
         </button>
       </div>
+
+      {showViewToggle ? (
+        <>
+          <div className="filter-divider" />
+          <div className="filter-group">
+            <span className="filter-label">View</span>
+            <button
+              type="button"
+              className={`enhanced-view-toggle-btn${enhanced ? '' : ' active'}`}
+              data-view="standard"
+              onClick={() => onToggleEnhanced(false)}
+            >
+              Standard
+            </button>
+            <button
+              type="button"
+              className={`enhanced-view-toggle-btn${enhanced ? ' active' : ''}`}
+              data-view="enhanced"
+              onClick={() => onToggleEnhanced(true)}
+            >
+              Enhanced
+            </button>
+          </div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/discography-filters.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.tsx
@@ -7,6 +7,8 @@ interface Props {
   onChange: (next: DiscographyFilterState) => void;
   /** The Status group is library-only — a source artist owns nothing. */
   isSourceArtist: boolean;
+  gapFillEnabled: boolean;
+  onToggleGapFill: () => void;
 }
 
 const CATEGORIES: { value: DiscographyBucket; label: string }[] = [
@@ -29,7 +31,13 @@ const OWNERSHIP: { value: DiscographyFilterState['ownership']; label: string }[]
  *   - category and content are MULTI-toggles; each button flips independently
  *   - ownership is SINGLE-select; picking one clears its siblings
  */
-export function DiscographyFilters({ filters, onChange, isSourceArtist }: Props) {
+export function DiscographyFilters({
+  filters,
+  onChange,
+  isSourceArtist,
+  gapFillEnabled,
+  onToggleGapFill,
+}: Props) {
   const toggleCategory = (value: DiscographyBucket) =>
     onChange({
       ...filters,
@@ -120,6 +128,23 @@ export function DiscographyFilters({ filters, onChange, isSourceArtist }: Props)
           </div>
         </>
       )}
+
+      {/* Rendered for source artists too: unlike Status, this group keeps a
+          button so the vanilla's `:has(.filter-label:only-child)` rule never
+          hides it, and other sources are exactly what a source artist has. */}
+      <div className="filter-divider" />
+      <div className="filter-group">
+        <span className="filter-label">Sources</span>
+        <button
+          type="button"
+          className={cls(gapFillEnabled)}
+          id="gapfill-toggle-btn"
+          title="Also list releases your other metadata sources know about — shown in the sections below with a source badge (#1067)"
+          onClick={onToggleGapFill}
+        >
+          + Other sources
+        </button>
+      </div>
     </div>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/discography-filters.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-filters.tsx
@@ -1,0 +1,125 @@
+import type { DiscographyBucket } from '../-artist-detail.types';
+
+import { type DiscographyFilterState, liveToggleLabel } from '../-artist-detail.filters';
+
+interface Props {
+  filters: DiscographyFilterState;
+  onChange: (next: DiscographyFilterState) => void;
+  /** The Status group is library-only — a source artist owns nothing. */
+  isSourceArtist: boolean;
+}
+
+const CATEGORIES: { value: DiscographyBucket; label: string }[] = [
+  { value: 'albums', label: 'Albums' },
+  { value: 'eps', label: 'EPs' },
+  { value: 'singles', label: 'Singles' },
+];
+
+const OWNERSHIP: { value: DiscographyFilterState['ownership']; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'owned', label: 'Owned' },
+  { value: 'missing', label: 'Missing' },
+];
+
+/**
+ * The discography filter bar, from #discography-filters in index.html and the
+ * delegated handler in initializeDiscographyFilters (library.js:2174).
+ *
+ * Two different interaction models, and mixing them up is the obvious bug:
+ *   - category and content are MULTI-toggles; each button flips independently
+ *   - ownership is SINGLE-select; picking one clears its siblings
+ */
+export function DiscographyFilters({ filters, onChange, isSourceArtist }: Props) {
+  const toggleCategory = (value: DiscographyBucket) =>
+    onChange({
+      ...filters,
+      categories: { ...filters.categories, [value]: !filters.categories[value] },
+    });
+
+  const toggleContent = (value: keyof DiscographyFilterState['content']) =>
+    onChange({ ...filters, content: { ...filters.content, [value]: !filters.content[value] } });
+
+  const selectOwnership = (value: DiscographyFilterState['ownership']) =>
+    onChange({ ...filters, ownership: value });
+
+  const cls = (active: boolean) => `discography-filter-btn${active ? ' active' : ''}`;
+
+  return (
+    <div className="discography-filters" id="discography-filters">
+      <div className="filter-group">
+        <span className="filter-label">Show</span>
+        {CATEGORIES.map(({ value, label }) => (
+          <button
+            key={value}
+            type="button"
+            className={cls(filters.categories[value])}
+            data-filter="category"
+            data-value={value}
+            onClick={() => toggleCategory(value)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="filter-divider" />
+
+      <div className="filter-group">
+        <span className="filter-label">Include</span>
+        <button
+          type="button"
+          className={cls(filters.content.live)}
+          data-filter="content"
+          data-value="live"
+          onClick={() => toggleContent('live')}
+        >
+          {/* Relabelled to "Non-Studio" on MusicBrainz, where the toggle governs
+              the broader secondary-type set rather than just live albums. */}
+          {liveToggleLabel(filters)}
+        </button>
+        <button
+          type="button"
+          className={cls(filters.content.compilations)}
+          data-filter="content"
+          data-value="compilations"
+          onClick={() => toggleContent('compilations')}
+        >
+          Compilations
+        </button>
+        <button
+          type="button"
+          className={cls(filters.content.featured)}
+          data-filter="content"
+          data-value="featured"
+          onClick={() => toggleContent('featured')}
+        >
+          Featured
+        </button>
+      </div>
+
+      {/* The vanilla hid this group with CSS via body[data-artist-source]; here
+          it is simply not rendered. A source artist has no library, so every
+          release is "missing" and the filter is meaningless. */}
+      {isSourceArtist ? null : (
+        <>
+          <div className="filter-divider" />
+          <div className="filter-group">
+            <span className="filter-label">Status</span>
+            {OWNERSHIP.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                className={cls(filters.ownership === value)}
+                data-filter="ownership"
+                data-value={value}
+                onClick={() => selectOwnership(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
@@ -111,9 +111,8 @@ describe('DiscographySection', () => {
       { id: 1, title: 'A' },
       { id: 1, title: 'B' },
     ]);
-    const warned = spy.mock.calls.some((call) =>
-      call.some((arg) => typeof arg === 'string' && /same key|unique "key"/i.test(arg)),
-    );
+    const calls = spy.mock.calls.map((c) => c.map(String).join(' '));
+    const warned = calls.some((c) => /same key|unique "key"/i.test(c));
     spy.mockRestore();
     expect(warned).toBe(false);
     expect(document.querySelectorAll('.release-card')).toHaveLength(2);

--- a/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { DiscographyRelease } from '../-artist-detail.types';
@@ -24,7 +24,10 @@ function renderSection(
 }
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
   delete window.observeLazyBackgrounds;
 });
 

--- a/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
@@ -1,0 +1,121 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DiscographyRelease } from '../-artist-detail.types';
+
+import { applyMusicBrainzDeclutter, defaultFilterState } from '../-artist-detail.filters';
+import { DiscographySection } from './discography-section';
+
+function renderSection(
+  releases: DiscographyRelease[],
+  filters = defaultFilterState(),
+  opts: Partial<{ mb: boolean; bucket: 'albums' | 'eps' | 'singles' }> = {},
+) {
+  render(
+    <DiscographySection
+      bucket={opts.bucket ?? 'albums'}
+      releases={releases}
+      filters={filters}
+      isMusicBrainz={opts.mb ?? false}
+      isSourceArtist={false}
+      onOpen={vi.fn()}
+    />,
+  );
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('DiscographySection', () => {
+  it('renders the vanilla ids the tour and CSS anchor to', () => {
+    renderSection([{ id: 1, title: 'A', owned: true }]);
+    expect(document.getElementById('albums-section')).not.toBeNull();
+    expect(document.getElementById('albums-grid')).not.toBeNull();
+    expect(document.getElementById('albums-owned-count')).not.toBeNull();
+    expect(document.getElementById('albums-missing-count')).not.toBeNull();
+  });
+
+  it('uses the vanilla headings, including the EPs capitalisation', () => {
+    renderSection([{ id: 1, title: 'A' }], defaultFilterState(), { bucket: 'eps' });
+    expect(document.querySelector('h3')?.textContent).toBe('EPs');
+  });
+
+  it('labels with the FILTERED counts', () => {
+    renderSection([
+      { id: 1, owned: true },
+      { id: 2, owned: false },
+      { id: 3, owned: true },
+    ]);
+    expect(document.getElementById('albums-owned-count')?.textContent).toBe('2 owned');
+    expect(document.getElementById('albums-missing-count')?.textContent).toBe('1 missing');
+  });
+
+  it('shows 0 owned / 0 missing while ownership is still checking', () => {
+    // Not "Checking..." — see sectionStatsLabels.
+    renderSection([
+      { id: 1, owned: null },
+      { id: 2, owned: null },
+    ]);
+    expect(document.getElementById('albums-owned-count')?.textContent).toBe('0 owned');
+    expect(document.querySelectorAll('.release-card')).toHaveLength(2);
+  });
+
+  it('disappears entirely when its category toggle is off', () => {
+    const filters = defaultFilterState();
+    filters.categories.albums = false;
+    renderSection([{ id: 1, owned: true }], filters);
+    expect(document.getElementById('albums-section')).toBeNull();
+  });
+
+  it('disappears when every card is filtered out', () => {
+    const filters = { ...defaultFilterState(), ownership: 'owned' as const };
+    renderSection([{ id: 1, owned: false }], filters);
+    expect(document.getElementById('albums-section')).toBeNull();
+  });
+
+  it('does not RENDER hidden cards, so their artwork is never requested', () => {
+    // The vanilla rendered them and set display:none. Same visible result,
+    // smaller DOM, and no image fetch for a 200-release MB discography.
+    const filters = { ...defaultFilterState(), ownership: 'owned' as const };
+    renderSection(
+      [
+        { id: 1, owned: true },
+        { id: 2, owned: false },
+      ],
+      filters,
+    );
+    expect(document.querySelectorAll('.release-card')).toHaveLength(1);
+  });
+
+  it('exempts owned releases from the MusicBrainz auto-declutter', () => {
+    const filters = applyMusicBrainzDeclutter(defaultFilterState(), 'musicbrainz');
+    renderSection(
+      [
+        { id: 1, title: 'Live at X', secondary_types: ['Live'], owned: true },
+        { id: 2, title: 'Live at Y', secondary_types: ['Live'], owned: false },
+      ],
+      filters,
+      { mb: true },
+    );
+    // The owned live album survives; the missing one is decluttered away.
+    expect(document.querySelectorAll('.release-card')).toHaveLength(1);
+    expect(document.querySelector('.album-card-name')?.textContent).toBe('Live at X');
+  });
+
+  it('keeps keys unique when ids repeat, so React does not mis-reconcile', () => {
+    // Some sources reuse ids across buckets, and MusicBrainz can list the same
+    // release-group id twice. React warns and may reuse the wrong DOM node.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    renderSection([
+      { id: 1, title: 'A' },
+      { id: 1, title: 'B' },
+    ]);
+    const warned = spy.mock.calls.some((call) =>
+      call.some((arg) => typeof arg === 'string' && /same key|unique "key"/i.test(arg)),
+    );
+    spy.mockRestore();
+    expect(warned).toBe(false);
+    expect(document.querySelectorAll('.release-card')).toHaveLength(2);
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
@@ -11,7 +11,7 @@ function renderSection(
   filters = defaultFilterState(),
   opts: Partial<{ mb: boolean; bucket: 'albums' | 'eps' | 'singles' }> = {},
 ) {
-  render(
+  return render(
     <DiscographySection
       bucket={opts.bucket ?? 'albums'}
       releases={releases}
@@ -25,6 +25,7 @@ function renderSection(
 
 afterEach(() => {
   document.body.innerHTML = '';
+  delete window.observeLazyBackgrounds;
 });
 
 describe('DiscographySection', () => {
@@ -116,5 +117,52 @@ describe('DiscographySection', () => {
     spy.mockRestore();
     expect(warned).toBe(false);
     expect(document.querySelectorAll('.release-card')).toHaveLength(2);
+  });
+});
+
+describe('lazy artwork loading', () => {
+  it('hands the grid to core.js so data-bg-src is actually swapped in', () => {
+    // The cards only render the ATTRIBUTE. populateReleaseSection called
+    // observeLazyBackgrounds(grid) after filling it; without the equivalent
+    // here every tile stays blank and nothing errors.
+    const observe = vi.fn();
+    window.observeLazyBackgrounds = observe;
+    renderSection([{ id: 1, title: 'A', image_url: 'a.jpg' }]);
+    expect(observe).toHaveBeenCalledWith(document.getElementById('albums-grid'));
+  });
+
+  it('re-observes when filtering mounts cards that were never seen', () => {
+    // A card revealed by turning a filter back on has never been observed, so
+    // observing only on MOUNT would leave it blank.
+    const observe = vi.fn();
+    window.observeLazyBackgrounds = observe;
+    const releases = [
+      { id: 1, owned: true },
+      { id: 2, owned: false },
+    ];
+    const { rerender } = renderSection(releases, {
+      ...defaultFilterState(),
+      ownership: 'owned' as const,
+    });
+    const first = observe.mock.calls.length;
+
+    rerender(
+      <DiscographySection
+        bucket="albums"
+        releases={releases}
+        filters={defaultFilterState()}
+        isMusicBrainz={false}
+        isSourceArtist={false}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(observe.mock.calls.length).toBeGreaterThan(first);
+    expect(document.querySelectorAll('.release-card')).toHaveLength(2);
+  });
+
+  it('survives core.js being unavailable', () => {
+    // The helper is a vanilla global; a missing one must not throw.
+    expect(() => renderSection([{ id: 1, title: 'A' }])).not.toThrow();
   });
 });

--- a/webui/src/routes/artist-detail/-ui/discography-section.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.tsx
@@ -1,0 +1,77 @@
+import type { DiscographyBucket, DiscographyRelease } from '../-artist-detail.types';
+
+import {
+  type DiscographyFilterState,
+  isReleaseHidden,
+  isSectionHidden,
+  releaseFlags,
+  sectionCounts,
+  sectionStatsLabels,
+} from '../-artist-detail.filters';
+import { ReleaseCard } from './release-card';
+
+const HEADINGS: Record<DiscographyBucket, string> = {
+  albums: 'Albums',
+  eps: 'EPs',
+  singles: 'Singles',
+};
+
+interface Props {
+  bucket: DiscographyBucket;
+  releases: DiscographyRelease[];
+  filters: DiscographyFilterState;
+  isMusicBrainz: boolean;
+  isSourceArtist: boolean;
+  onOpen: (release: DiscographyRelease) => void;
+}
+
+/**
+ * One discography bucket. Mirrors the #<bucket>-section markup in index.html
+ * and the behaviour applyDiscographyFilters gave it.
+ *
+ * Hidden cards are NOT rendered here, where the vanilla rendered them and set
+ * `display: none`. The observable result is the same and the DOM is smaller;
+ * the one thing it changes is that a hidden card's image never gets requested,
+ * which is a strict improvement for a 200-release MusicBrainz discography.
+ */
+export function DiscographySection({
+  bucket,
+  releases,
+  filters,
+  isMusicBrainz,
+  isSourceArtist,
+  onOpen,
+}: Props) {
+  const counts = sectionCounts(releases, isMusicBrainz, filters);
+  if (isSectionHidden(bucket, counts, filters)) return null;
+
+  const labels = sectionStatsLabels(counts);
+  const visible = releases.filter(
+    (release) => !isReleaseHidden(release, releaseFlags(release, isMusicBrainz), filters),
+  );
+
+  return (
+    <div className="discography-section" id={`${bucket}-section`}>
+      <div className="section-header">
+        <h3>{HEADINGS[bucket]}</h3>
+        <div className="section-stats">
+          <span id={`${bucket}-owned-count`}>{labels.owned}</span>
+          <span id={`${bucket}-missing-count`}>{labels.missing}</span>
+        </div>
+      </div>
+      <div className="releases-grid" id={`${bucket}-grid`}>
+        {visible.map((release, index) => (
+          <ReleaseCard
+            // Ids can repeat across buckets on some sources, so the bucket and
+            // index are part of the key; a bare id would collide.
+            key={`${bucket}-${release.id ?? index}`}
+            release={release}
+            isMusicBrainz={isMusicBrainz}
+            isSourceArtist={isSourceArtist}
+            onOpen={onOpen}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/discography-section.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import type { DiscographyBucket, DiscographyRelease } from '../-artist-detail.types';
 
 import {
@@ -50,6 +52,16 @@ export function DiscographySection({
     (release) => !isReleaseHidden(release, releaseFlags(release, isMusicBrainz), filters),
   );
 
+  // The cards render data-bg-src and rely on core.js's shared
+  // IntersectionObserver to swap it in — exactly as populateReleaseSection did
+  // by calling observeLazyBackgrounds(grid) after filling it. Without this the
+  // attribute is inert and NO artwork ever loads. Re-run whenever the visible
+  // set changes, since filtering mounts cards that were never observed.
+  const gridRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    window.observeLazyBackgrounds?.(gridRef.current);
+  });
+
   return (
     <div className="discography-section" id={`${bucket}-section`}>
       <div className="section-header">
@@ -59,7 +71,7 @@ export function DiscographySection({
           <span id={`${bucket}-missing-count`}>{labels.missing}</span>
         </div>
       </div>
-      <div className="releases-grid" id={`${bucket}-grid`}>
+      <div className="releases-grid" id={`${bucket}-grid`} ref={gridRef}>
         {visible.map((release, index) => (
           <ReleaseCard
             // The index is ALWAYS part of the key, not merely a fallback for a

--- a/webui/src/routes/artist-detail/-ui/discography-section.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.tsx
@@ -62,9 +62,12 @@ export function DiscographySection({
       <div className="releases-grid" id={`${bucket}-grid`}>
         {visible.map((release, index) => (
           <ReleaseCard
-            // Ids can repeat across buckets on some sources, so the bucket and
-            // index are part of the key; a bare id would collide.
-            key={`${bucket}-${release.id ?? index}`}
+            // The index is ALWAYS part of the key, not merely a fallback for a
+            // missing id: MusicBrainz can list the same release-group id twice
+            // inside ONE bucket, and `id ?? index` still collides there —
+            // React then warns and may reuse the wrong DOM node. Cards are
+            // stateless, so an index-bearing key costs nothing.
+            key={`${bucket}-${index}-${release.id ?? ''}`}
             release={release}
             isMusicBrainz={isMusicBrainz}
             isSourceArtist={isSourceArtist}

--- a/webui/src/routes/artist-detail/-ui/editable-cell.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/editable-cell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EditableCell } from './editable-cell';
@@ -57,7 +57,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('a non-editable cell', () => {

--- a/webui/src/routes/artist-detail/-ui/editable-cell.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/editable-cell.test.tsx
@@ -1,0 +1,251 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EditableCell } from './editable-cell';
+
+let requests: { url: string; body: unknown }[] = [];
+
+function stubPut(result: unknown = { success: true }) {
+  requests = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderCell(props: Partial<React.ComponentProps<typeof EditableCell>> = {}) {
+  const onSaved = vi.fn();
+  const view = render(
+    <table>
+      <tbody>
+        <tr>
+          <EditableCell
+            className="col-title editable"
+            editable
+            entityType="track"
+            entityId={5}
+            field="title"
+            value="Xtal"
+            onSaved={onSaved}
+            {...props}
+          >
+            Xtal
+          </EditableCell>
+        </tr>
+      </tbody>
+    </table>,
+  );
+  return { onSaved, ...view };
+}
+
+const cell = () => document.querySelector('td') as HTMLElement;
+const input = () => document.querySelector('.enhanced-inline-input') as HTMLInputElement;
+
+beforeEach(() => {
+  window.showToast = vi.fn();
+  stubPut();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.innerHTML = '';
+});
+
+describe('a non-editable cell', () => {
+  it('never turns into an input', () => {
+    renderCell({ editable: false });
+    fireEvent.click(cell());
+    expect(input()).toBeNull();
+    expect(cell().textContent).toBe('Xtal');
+  });
+});
+
+describe('entering the editor', () => {
+  it('opens on click, seeded with the current value and focused', () => {
+    renderCell();
+    fireEvent.click(cell());
+    expect(input().value).toBe('Xtal');
+    expect(document.activeElement).toBe(input());
+  });
+
+  it('starts EMPTY for a null value rather than showing "null"', () => {
+    // A TEXT field on purpose: a number input silently coerces an invalid
+    // "null" to '', so it could not tell the two apart.
+    renderCell({ field: 'title', value: null, children: '-' });
+    fireEvent.click(cell());
+    expect(input().value).toBe('');
+  });
+
+  it('does not let the click reach the album toggle', () => {
+    const onOuter = vi.fn();
+    render(
+      <table onClick={onOuter}>
+        <tbody>
+          <tr>
+            <EditableCell
+              className="c"
+              editable
+              entityType="track"
+              entityId={5}
+              field="title"
+              value="X"
+              onSaved={vi.fn()}
+            >
+              X
+            </EditableCell>
+          </tr>
+        </tbody>
+      </table>,
+    );
+    fireEvent.click(document.querySelector('td') as HTMLElement);
+    expect(onOuter).not.toHaveBeenCalled();
+  });
+
+  it('uses a number input with the right step and floor per field', () => {
+    renderCell({ field: 'track_number', value: 3, children: '3' });
+    fireEvent.click(cell());
+    expect(input().type).toBe('number');
+    expect(input().step).toBe('1');
+    expect(input().min).toBe('1');
+    expect(input().className).toContain('num');
+  });
+
+  it('lets BPM take fractions, with no floor', () => {
+    renderCell({ field: 'bpm', value: 120, children: '120' });
+    fireEvent.click(cell());
+    expect(input().step).toBe('0.1');
+    expect(input().min).toBe('');
+  });
+});
+
+describe('saving', () => {
+  it('PUTs the field to the TRACK endpoint on Enter', async () => {
+    const { onSaved } = renderCell();
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: 'Xtal (Remaster)' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('title', 'Xtal (Remaster)'));
+    expect(requests[0].url).toBe('/api/library/track/5');
+    expect(requests[0].body).toEqual({ title: 'Xtal (Remaster)' });
+    expect(window.showToast).toHaveBeenCalledWith('Updated title', 'success');
+  });
+
+  it('PUTs to the ALBUM endpoint for an album field', async () => {
+    const { onSaved } = renderCell({
+      entityType: 'album',
+      entityId: 9,
+      field: 'label',
+      value: 'x',
+    });
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: 'Warp' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(requests[0].url).toBe('/api/library/album/9');
+  });
+
+  it('saves on blur too', async () => {
+    const { onSaved } = renderCell();
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: 'Changed' } });
+    fireEvent.blur(input());
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('title', 'Changed'));
+  });
+
+  it('does NOT save twice when Enter is followed by the blur', async () => {
+    const { onSaved } = renderCell();
+    fireEvent.click(cell());
+    const el = input();
+    fireEvent.change(el, { target: { value: 'Once' } });
+    fireEvent.keyDown(el, { key: 'Enter' });
+    // Held from before the Enter: the input is unmounted by then, and the real
+    // browser still fires its blur.
+    fireEvent.blur(el);
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(requests).toHaveLength(1);
+  });
+
+  it('sends null for an emptied number, so the field CLEARS', async () => {
+    const { onSaved } = renderCell({ field: 'bpm', value: 120, children: '120' });
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: '' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('bpm', null));
+    expect(requests[0].body).toEqual({ bpm: null });
+  });
+
+  it('parses a fractional BPM but an INTEGER track number', async () => {
+    const { onSaved } = renderCell({ field: 'bpm', value: 1, children: '1' });
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: '128.5' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('bpm', 128.5));
+
+    document.body.innerHTML = '';
+    const second = renderCell({ field: 'track_number', value: 1, children: '1' });
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: '7.9' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+    await waitFor(() => expect(second.onSaved).toHaveBeenCalledWith('track_number', 7));
+  });
+
+  it('leaves the cell showing its old value when the save is REJECTED', async () => {
+    stubPut({ success: false, error: 'locked' });
+    const { onSaved } = renderCell();
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: 'Nope' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Failed to update: locked', 'error'),
+    );
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(cell().textContent).toBe('Xtal');
+  });
+});
+
+describe('escaping', () => {
+  it('reverts without saving', async () => {
+    const { onSaved } = renderCell();
+    fireEvent.click(cell());
+    fireEvent.change(input(), { target: { value: 'Discarded' } });
+    fireEvent.keyDown(input(), { key: 'Escape' });
+
+    expect(input()).toBeNull();
+    expect(cell().textContent).toBe('Xtal');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(requests).toHaveLength(0);
+  });
+
+  it('does not then save on the blur that follows', async () => {
+    renderCell();
+    fireEvent.click(cell());
+    const el = input();
+    fireEvent.keyDown(el, { key: 'Escape' });
+    fireEvent.blur(el);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(requests).toHaveLength(0);
+  });
+
+  it('can be reopened after an escape', () => {
+    renderCell();
+    fireEvent.click(cell());
+    fireEvent.keyDown(input(), { key: 'Escape' });
+    fireEvent.click(cell());
+    expect(input()).not.toBeNull();
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/editable-cell.tsx
+++ b/webui/src/routes/artist-detail/-ui/editable-cell.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  inlineEditDisplay,
+  inlineEditInput,
+  inlineEditUrl,
+  inlineEditValue,
+} from '../-artist-detail.enhanced-album';
+
+interface Props {
+  className: string;
+  /** Falsy for a non-admin or a missing row — the cell is then plain text. */
+  editable: boolean;
+  entityType: 'track' | 'album';
+  entityId: unknown;
+  field: string;
+  /** The raw value the input starts from. */
+  value: string | number | null | undefined;
+  /** Applied locally after a successful PUT, as updateLocalEnhancedData did. */
+  onSaved: (field: string, value: string | number | null) => void;
+  children: React.ReactNode;
+}
+
+/**
+ * A table cell that becomes an input on click (startInlineEdit / saveInlineEdit,
+ * library.js:5963).
+ *
+ * The vanilla replaced the cell's innerHTML and stashed the original so a
+ * failed save could put it back. React owns this DOM, so the edit is state and
+ * the "restore" is simply not committing — but the observable behaviour is the
+ * same: Enter and blur save, Escape reverts, and a rejected save leaves the
+ * cell showing what it showed before.
+ */
+export function EditableCell({
+  className,
+  editable,
+  entityType,
+  entityId,
+  field,
+  value,
+  onSaved,
+  children,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  /**
+   * Guards the blur handler: a save triggered by Enter — or an Escape — must
+   * not fire again when the input loses focus on unmount.
+   *
+   * Not test-observable. React listens for blur at the root, and by the time
+   * the input is unmounted the event no longer reaches the handler under jsdom,
+   * so both guards survive mutation. They are kept because a real browser does
+   * fire blur on a focused element that is removed.
+   */
+  const savingRef = useRef(false);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  if (!editable) {
+    return <td className={className}>{children}</td>;
+  }
+
+  const start = () => {
+    if (editing) return;
+    savingRef.current = false;
+    setDraft(value == null ? '' : String(value));
+    setEditing(true);
+  };
+
+  const save = async () => {
+    if (savingRef.current) return;
+    savingRef.current = true;
+    setEditing(false);
+
+    const parsed = inlineEditValue(field, draft);
+    try {
+      const response = await fetch(inlineEditUrl(entityType, entityId), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [field]: parsed }),
+      });
+      const result = await response.json();
+      if (!result.success) throw new Error(result.error);
+
+      onSaved(field, parsed);
+      window.showToast?.(`Updated ${field}`, 'success');
+    } catch (error) {
+      // Nothing was committed, so the cell already shows its old value.
+      window.showToast?.(`Failed to update: ${(error as Error).message}`, 'error');
+    }
+  };
+
+  const input = inlineEditInput(field);
+
+  return (
+    <td
+      className={className}
+      onClick={(e) => {
+        e.stopPropagation();
+        start();
+      }}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          type={input.type}
+          className={input.className}
+          step={input.step}
+          min={input.min}
+          value={draft}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            // Stopped so a keystroke in the cell cannot reach a page-level
+            // shortcut handler, exactly as the vanilla did.
+            e.stopPropagation();
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void save();
+            } else if (e.key === 'Escape') {
+              savingRef.current = true;
+              setEditing(false);
+            }
+          }}
+          onBlur={() => void save()}
+        />
+      ) : (
+        children
+      )}
+    </td>
+  );
+}
+
+export { inlineEditDisplay };

--- a/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.test.tsx
@@ -1,0 +1,209 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EnhancedBulkBar } from './enhanced-bulk-bar';
+
+let requests: { url: string; body: unknown }[] = [];
+
+function stubApi(result: unknown = { success: true, updated_count: 2 }) {
+  requests = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return new Response(JSON.stringify(result), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }),
+  );
+}
+
+function renderBar(selected = new Set(['1', '2']), isAdmin = true) {
+  const onClear = vi.fn();
+  const onEdited = vi.fn();
+  const view = render(
+    <EnhancedBulkBar selected={selected} isAdmin={isAdmin} onClear={onClear} onEdited={onEdited} />,
+  );
+  return { onClear, onEdited, ...view };
+}
+
+const bar = () => document.getElementById('enhanced-bulk-bar') as HTMLElement;
+const field = (id: string) => document.getElementById(id) as HTMLInputElement;
+
+beforeEach(() => {
+  window.showToast = vi.fn();
+  window.showBatchTagPreview = vi.fn();
+  window._pollBatchRgStatus = vi.fn();
+  stubApi();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.showBatchTagPreview;
+  delete window._pollBatchRgStatus;
+  document.body.innerHTML = '';
+});
+
+describe('visibility', () => {
+  it('stays hidden with nothing selected', () => {
+    renderBar(new Set());
+    expect(bar().className).not.toContain('visible');
+  });
+
+  it('appears once something is ticked, with the count', () => {
+    renderBar();
+    expect(bar().className).toContain('visible');
+    expect(document.getElementById('enhanced-bulk-count')?.textContent).toBe('2');
+  });
+
+  it('stays hidden for a NON-admin even with a selection', () => {
+    // The vanilla hid it outright rather than showing disabled actions.
+    renderBar(new Set(['1']), false);
+    expect(bar().className).not.toContain('visible');
+  });
+});
+
+describe('the simple actions', () => {
+  it('hands the ids straight to the batch tag modal', () => {
+    renderBar();
+    fireEvent.click(document.querySelector('.tag-write') as HTMLElement);
+    expect(window.showBatchTagPreview).toHaveBeenCalledWith(['1', '2'], null);
+  });
+
+  it('starts a batch ReplayGain job and polls it', async () => {
+    renderBar();
+    fireEvent.click(document.querySelector('.rg-analyze') as HTMLElement);
+
+    await waitFor(() => expect(window._pollBatchRgStatus).toHaveBeenCalled());
+    expect(requests[0].url).toBe('/api/library/tracks/analyze-replaygain-batch');
+    expect(requests[0].body).toEqual({ track_ids: ['1', '2'] });
+    expect(window.showToast).toHaveBeenCalledWith(
+      'ReplayGain analysis started for 2 tracks…',
+      'info',
+    );
+  });
+
+  it('does NOT poll when the job was refused', async () => {
+    stubApi({ success: false, error: 'busy' });
+    renderBar();
+    fireEvent.click(document.querySelector('.rg-analyze') as HTMLElement);
+
+    await waitFor(() => expect(window.showToast).toHaveBeenCalledWith('ReplayGain: busy', 'error'));
+    expect(window._pollBatchRgStatus).not.toHaveBeenCalled();
+  });
+
+  it('clears the selection', () => {
+    const { onClear } = renderBar();
+    fireEvent.click(document.querySelector('.btn--danger') as HTMLElement);
+    expect(onClear).toHaveBeenCalled();
+  });
+});
+
+describe('the batch edit modal', () => {
+  const open = () => fireEvent.click(document.querySelectorAll('.enhanced-bulk-btn')[0]);
+
+  it('titles itself with the selection count', () => {
+    renderBar();
+    open();
+    expect(document.getElementById('enhanced-bulk-modal-title')?.textContent).toBe(
+      'Batch Edit 2 Tracks',
+    );
+  });
+
+  it('singularises a single track', () => {
+    renderBar(new Set(['1']));
+    open();
+    expect(document.getElementById('enhanced-bulk-modal-title')?.textContent).toBe(
+      'Batch Edit 1 Track',
+    );
+  });
+
+  it('sends ONLY the fields that were filled in', async () => {
+    // A blank box means "leave this column alone", never "clear it everywhere".
+    const { onEdited, onClear } = renderBar();
+    open();
+    fireEvent.change(field('bulk-edit-style'), { target: { value: 'IDM' } });
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--primary') as HTMLElement,
+    );
+
+    await waitFor(() => expect(onEdited).toHaveBeenCalledWith(['1', '2'], { style: 'IDM' }));
+    expect(requests[0].url).toBe('/api/library/tracks/batch');
+    expect(requests[0].body).toEqual({ track_ids: ['1', '2'], updates: { style: 'IDM' } });
+    expect(window.showToast).toHaveBeenCalledWith('Updated 2 tracks', 'success');
+    // The selection is dropped once applied.
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  it('parses the numeric fields, and explicit as a flag', async () => {
+    const { onEdited } = renderBar();
+    open();
+    fireEvent.change(field('bulk-edit-track-number'), { target: { value: '3' } });
+    fireEvent.change(field('bulk-edit-bpm'), { target: { value: '128.5' } });
+    fireEvent.change(field('bulk-edit-explicit'), { target: { value: '1' } });
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--primary') as HTMLElement,
+    );
+
+    await waitFor(() =>
+      expect(onEdited).toHaveBeenCalledWith(['1', '2'], {
+        track_number: 3,
+        bpm: 128.5,
+        explicit: 1,
+      }),
+    );
+  });
+
+  it('sends explicit:0 — "No" is a real choice, not a blank', async () => {
+    const { onEdited } = renderBar();
+    open();
+    fireEvent.change(field('bulk-edit-explicit'), { target: { value: '0' } });
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--primary') as HTMLElement,
+    );
+    await waitFor(() => expect(onEdited).toHaveBeenCalledWith(['1', '2'], { explicit: 0 }));
+  });
+
+  it('refuses an empty edit without calling the API', () => {
+    renderBar();
+    open();
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--primary') as HTMLElement,
+    );
+    expect(requests).toHaveLength(0);
+    expect(window.showToast).toHaveBeenCalledWith('No changes to apply', 'error');
+  });
+
+  it('keeps the modal open and the selection intact when the API rejects', async () => {
+    stubApi({ success: false, error: 'locked' });
+    const { onEdited, onClear } = renderBar();
+    open();
+    fireEvent.change(field('bulk-edit-style'), { target: { value: 'IDM' } });
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--primary') as HTMLElement,
+    );
+
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Bulk edit failed: locked', 'error'),
+    );
+    expect(onEdited).not.toHaveBeenCalled();
+    expect(onClear).not.toHaveBeenCalled();
+    expect(document.getElementById('enhanced-bulk-edit-overlay')).not.toBeNull();
+  });
+
+  it('closes on Cancel without touching anything', () => {
+    const { onEdited } = renderBar();
+    open();
+    // Scoped to the modal: the bar's own buttons are .btn--secondary too.
+    fireEvent.click(
+      document.querySelector('.enhanced-bulk-modal-footer .btn--secondary') as HTMLElement,
+    );
+    expect(document.getElementById('enhanced-bulk-edit-overlay')).toBeNull();
+    expect(onEdited).not.toHaveBeenCalled();
+    expect(requests).toHaveLength(0);
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EnhancedBulkBar } from './enhanced-bulk-bar';
@@ -45,7 +45,11 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete window.showBatchTagPreview;
   delete window._pollBatchRgStatus;
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': these render through a portal, and
+  // wiping the body out from under Testing Library's own cleanup makes it throw
+  // "The node to be removed is not a child of this node". cleanup() unmounts
+  // the tree, which takes the portal with it.
+  cleanup();
 });
 
 describe('visibility', () => {

--- a/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+
+import {
+  type BulkEditValues,
+  bulkEditTitle,
+  bulkEditUpdates,
+  EMPTY_BULK_EDIT,
+} from '../-artist-detail.enhanced';
+
+interface Props {
+  /** Track ids currently ticked across every open album. */
+  selected: Set<string>;
+  isAdmin: boolean;
+  onClear: () => void;
+  /** Applies a batch edit to the loaded albums, as updateLocalEnhancedData did. */
+  onEdited: (trackIds: string[], updates: Record<string, unknown>) => void;
+}
+
+/**
+ * The bulk action bar (#enhanced-bulk-bar) and its Batch Edit modal.
+ *
+ * Visible only while something is ticked, and only for an admin — the vanilla
+ * hid it outright for everyone else rather than showing disabled actions.
+ */
+export function EnhancedBulkBar({ selected, isAdmin, onClear, onEdited }: Props) {
+  const [editing, setEditing] = useState(false);
+  const trackIds = [...selected];
+  const visible = isAdmin && trackIds.length > 0;
+
+  const analyzeReplayGain = async () => {
+    try {
+      const response = await fetch('/api/library/tracks/analyze-replaygain-batch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ track_ids: trackIds }),
+      });
+      const data = await response.json();
+      if (!data.success) {
+        window.showToast?.(`ReplayGain: ${data.error}`, 'error');
+        return;
+      }
+      window.showToast?.(`ReplayGain analysis started for ${trackIds.length} tracks…`, 'info');
+      window._pollBatchRgStatus?.();
+    } catch {
+      window.showToast?.('Failed to start batch ReplayGain analysis', 'error');
+    }
+  };
+
+  return (
+    <>
+      <div className={`enhanced-bulk-bar${visible ? ' visible' : ''}`} id="enhanced-bulk-bar">
+        <div className="enhanced-bulk-bar-info">
+          <span className="enhanced-bulk-bar-count" id="enhanced-bulk-count">
+            {trackIds.length}
+          </span>
+          <span className="enhanced-bulk-bar-label">tracks selected</span>
+        </div>
+        <div className="enhanced-bulk-bar-actions">
+          <button
+            type="button"
+            className="btn btn--sm btn--secondary enhanced-bulk-btn"
+            onClick={() => setEditing(true)}
+          >
+            Edit Selected
+          </button>
+          <button
+            type="button"
+            className="btn btn--sm btn--secondary enhanced-bulk-btn tag-write"
+            // The vanilla modal takes the ids explicitly, so it works across
+            // the boundary without reading the old selection state.
+            onClick={() => window.showBatchTagPreview?.(trackIds, null)}
+          >
+            Write Tags
+          </button>
+          <button
+            type="button"
+            className="btn btn--sm btn--secondary enhanced-bulk-btn rg-analyze"
+            onClick={() => void analyzeReplayGain()}
+          >
+            ReplayGain
+          </button>
+          <button
+            type="button"
+            className="btn btn--sm btn--danger enhanced-bulk-btn"
+            onClick={onClear}
+          >
+            Clear Selection
+          </button>
+        </div>
+      </div>
+
+      {editing ? (
+        <BulkEditModal
+          trackIds={trackIds}
+          onClose={() => setEditing(false)}
+          onApplied={(updates) => {
+            setEditing(false);
+            onEdited(trackIds, updates);
+            onClear();
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function BulkEditModal({
+  trackIds,
+  onClose,
+  onApplied,
+}: {
+  trackIds: string[];
+  onClose: () => void;
+  onApplied: (updates: Record<string, unknown>) => void;
+}) {
+  const [values, setValues] = useState<BulkEditValues>(EMPTY_BULK_EDIT);
+
+  const set = (field: keyof BulkEditValues) => (e: { target: { value: string } }) =>
+    setValues((current) => ({ ...current, [field]: e.target.value }));
+
+  const apply = async () => {
+    const updates = bulkEditUpdates(values);
+    if (Object.keys(updates).length === 0) {
+      window.showToast?.('No changes to apply', 'error');
+      return;
+    }
+    try {
+      const response = await fetch('/api/library/tracks/batch', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ track_ids: trackIds, updates }),
+      });
+      const result = await response.json();
+      if (!result.success) throw new Error(result.error);
+
+      window.showToast?.(`Updated ${result.updated_count} tracks`, 'success');
+      onApplied(updates);
+    } catch (error) {
+      window.showToast?.(`Bulk edit failed: ${(error as Error).message}`, 'error');
+    }
+  };
+
+  return (
+    <div className="modal-overlay" id="enhanced-bulk-edit-overlay">
+      <div className="enhanced-bulk-modal">
+        <div className="enhanced-bulk-modal-header">
+          <h3 id="enhanced-bulk-modal-title">{bulkEditTitle(trackIds.length)}</h3>
+        </div>
+        <div className="enhanced-bulk-modal-body" id="enhanced-bulk-modal-body">
+          {/* Every field is "leave blank to skip": one value goes to many
+              tracks, so an empty box must never mean "clear it on all". */}
+          <div className="enhanced-bulk-modal-field">
+            <label>Track Number (leave blank to skip)</label>
+            <input
+              type="number"
+              id="bulk-edit-track-number"
+              placeholder="Track number..."
+              min="1"
+              value={values.track_number}
+              onChange={set('track_number')}
+            />
+          </div>
+          <div className="enhanced-bulk-modal-field">
+            <label>BPM (leave blank to skip)</label>
+            <input
+              type="number"
+              id="bulk-edit-bpm"
+              placeholder="BPM..."
+              step="0.1"
+              value={values.bpm}
+              onChange={set('bpm')}
+            />
+          </div>
+          <div className="enhanced-bulk-modal-field">
+            <label>Style (leave blank to skip)</label>
+            <input
+              type="text"
+              id="bulk-edit-style"
+              placeholder="Style..."
+              value={values.style}
+              onChange={set('style')}
+            />
+          </div>
+          <div className="enhanced-bulk-modal-field">
+            <label>Mood (leave blank to skip)</label>
+            <input
+              type="text"
+              id="bulk-edit-mood"
+              placeholder="Mood..."
+              value={values.mood}
+              onChange={set('mood')}
+            />
+          </div>
+          <div className="enhanced-bulk-modal-field">
+            <label>Explicit</label>
+            <select id="bulk-edit-explicit" value={values.explicit} onChange={set('explicit')}>
+              <option value="">-- No change --</option>
+              <option value="0">No</option>
+              <option value="1">Yes</option>
+            </select>
+          </div>
+        </div>
+        <div className="enhanced-bulk-modal-footer">
+          <button type="button" className="btn btn--sm btn--secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn--sm btn--primary" onClick={() => void apply()}>
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-bulk-bar.tsx
@@ -6,6 +6,7 @@ import {
   bulkEditUpdates,
   EMPTY_BULK_EDIT,
 } from '../-artist-detail.enhanced';
+import { BodyPortal } from './portal';
 
 interface Props {
   /** Track ids currently ticked across every open album. */
@@ -46,8 +47,10 @@ export function EnhancedBulkBar({ selected, isAdmin, onClear, onEdited }: Props)
     }
   };
 
+  // Both the bar and the modal are position:fixed, and the vanilla kept them at
+  // body level for that reason.
   return (
-    <>
+    <BodyPortal>
       <div className={`enhanced-bulk-bar${visible ? ' visible' : ''}`} id="enhanced-bulk-bar">
         <div className="enhanced-bulk-bar-info">
           <span className="enhanced-bulk-bar-count" id="enhanced-bulk-count">
@@ -100,7 +103,7 @@ export function EnhancedBulkBar({ selected, isAdmin, onClear, onEdited }: Props)
           }}
         />
       ) : null}
-    </>
+    </BodyPortal>
   );
 }
 

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -1,0 +1,265 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnhancedAlbum } from '../-artist-detail.enhanced';
+
+import { EnhancedTrackTable } from './enhanced-track-table';
+
+const ALBUM: EnhancedAlbum = {
+  id: 7,
+  tracks: [
+    {
+      id: 1,
+      track_number: 1,
+      disc_number: 1,
+      title: 'Xtal',
+      duration: 300_000,
+      bitrate: 1000,
+      bpm: 120,
+      file_path: '/music/Aphex/SAW/01 Xtal.flac',
+      spotify_track_id: 'sp1',
+    },
+    {
+      id: 2,
+      track_number: 2,
+      disc_number: 1,
+      title: 'Tha',
+      duration: 570_000,
+      bitrate: 192,
+      file_path: '/music/Aphex/SAW/02 Tha.mp3',
+    },
+  ],
+  missing_tracks: [
+    { title: 'Ageispolis', track_number: 3, disc_number: 1, source: 'spotify', track_id: 's3' },
+  ],
+};
+
+function renderTable(album: EnhancedAlbum = ALBUM, isAdmin = true, selected = new Set<string>()) {
+  const onSelectedChange = vi.fn();
+  const view = render(
+    <EnhancedTrackTable
+      album={album}
+      isAdmin={isAdmin}
+      selected={selected}
+      onSelectedChange={onSelectedChange}
+    />,
+  );
+  return { onSelectedChange, ...view };
+}
+
+const rows = () => [...document.querySelectorAll('tbody tr')] as HTMLElement[];
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('the empty state', () => {
+  it('says so instead of rendering a headers-only table', () => {
+    renderTable({ id: 7, tracks: [] });
+    expect(document.querySelector('.enhanced-no-tracks')?.textContent).toBe(
+      'No tracks in database',
+    );
+    expect(document.querySelector('table')).toBeNull();
+  });
+});
+
+describe('columns', () => {
+  it('gives an admin a select-all box, write-tag and delete columns', () => {
+    renderTable();
+    const headers = [...document.querySelectorAll('thead th')].map((th) => th.className);
+    expect(headers[0]).toBe('');
+    expect(headers).toContain('col-writetag');
+    expect(headers).toContain('col-delete');
+    expect(headers).not.toContain('col-report');
+  });
+
+  it('gives everyone else a report column and no select-all', () => {
+    renderTable(ALBUM, false);
+    expect(document.querySelector('thead .enhanced-track-checkbox')).toBeNull();
+    const headers = [...document.querySelectorAll('thead th')].map((th) => th.className);
+    expect(headers).toContain('col-report');
+    expect(headers).not.toContain('col-writetag');
+  });
+
+  it('marks the sortable columns and leaves the rest inert', () => {
+    renderTable();
+    const sortable = [...document.querySelectorAll('thead th[data-sort-field]')].map((th) =>
+      th.getAttribute('data-sort-field'),
+    );
+    expect(sortable).toEqual([
+      'track_number',
+      'disc_number',
+      'title',
+      'duration',
+      'format',
+      'bitrate',
+      'bpm',
+    ]);
+  });
+});
+
+describe('the sort arrow', () => {
+  it('appears on the clicked column and flips on a second click', () => {
+    renderTable();
+    const th = document.querySelector('[data-sort-field="title"]') as HTMLElement;
+
+    fireEvent.click(th);
+    expect(th.textContent).toBe('Title ▲');
+    fireEvent.click(th);
+    expect(th.textContent).toBe('Title ▼');
+  });
+
+  it('moves to the newly clicked column', () => {
+    renderTable();
+    fireEvent.click(document.querySelector('[data-sort-field="title"]') as HTMLElement);
+    fireEvent.click(document.querySelector('[data-sort-field="bpm"]') as HTMLElement);
+    expect(document.querySelector('[data-sort-field="title"]')?.textContent).toBe('Title');
+    expect(document.querySelector('[data-sort-field="bpm"]')?.textContent).toBe('BPM ▲');
+  });
+
+  it('does NOT reorder the rows — verbatim vanilla', () => {
+    // sortEnhancedTracks sorted album.tracks and the table then rendered from
+    // _getEnhancedAlbumTrackRows, which re-sorts by disc/track/title. So the
+    // arrow moves and the rows do not.
+    renderTable();
+    const before = rows().map((r) => r.getAttribute('data-track-id'));
+    fireEvent.click(document.querySelector('[data-sort-field="title"]') as HTMLElement);
+    expect(rows().map((r) => r.getAttribute('data-track-id'))).toEqual(before);
+  });
+});
+
+describe('an owned row', () => {
+  it('shows duration, format, bitrate, bpm and the file BASENAME', () => {
+    renderTable();
+    const row = rows()[0];
+    expect(row.querySelector('.col-duration')?.textContent).toBe('5:00');
+    expect(row.querySelector('.enhanced-format-badge')?.textContent).toBe('FLAC');
+    expect(row.querySelector('.enhanced-bitrate')?.textContent).toBe('1000 kbps');
+    expect(row.querySelector('.col-bpm')?.textContent).toBe('120');
+    // The full path is the tooltip; the cell shows the file name.
+    expect(row.querySelector('.col-path')?.textContent).toBe('01 Xtal.flac');
+    expect(row.querySelector('.col-path')?.getAttribute('title')).toBe(
+      '/music/Aphex/SAW/01 Xtal.flac',
+    );
+  });
+
+  it('classes the bitrate by band', () => {
+    renderTable();
+    expect(rows()[0].querySelector('.enhanced-bitrate')?.className).toContain('high');
+    expect(rows()[1].querySelector('.enhanced-bitrate')?.className).toContain('medium');
+  });
+
+  it('chips every match service, matched or not', () => {
+    renderTable();
+    const chips = [...rows()[0].querySelectorAll('.enhanced-track-match-chip')];
+    expect(chips).toHaveLength(8);
+    expect(chips[0].className).toContain('matched');
+    expect(chips[0].getAttribute('title')).toBe('spotify: sp1');
+    expect(chips[1].className).toContain('not-found');
+    // An unmatched chip must not claim an id it does not have.
+    expect(chips[1].getAttribute('title')).toBe('musicbrainz: no match');
+  });
+
+  it('offers play, queue and the admin action buttons', () => {
+    renderTable();
+    const row = rows()[0];
+    expect(row.querySelector('.enhanced-play-btn')?.textContent).toBe('▶');
+    expect(row.querySelector('.enhanced-queue-btn')).not.toBeNull();
+    expect(row.querySelector('.enhanced-write-tag-btn')).not.toBeNull();
+    expect(row.querySelector('.enhanced-delete-btn')).not.toBeNull();
+  });
+
+  it('marks the editable cells for an admin only', () => {
+    renderTable();
+    expect(rows()[0].querySelector('.col-title')?.className).toContain('editable');
+
+    document.body.innerHTML = '';
+    renderTable(ALBUM, false);
+    expect(rows()[0].querySelector('.col-title')?.className).not.toContain('editable');
+    expect(rows()[0].querySelector('.enhanced-track-report-btn')).not.toBeNull();
+  });
+
+  it('DISABLES play for a track with no file', () => {
+    renderTable({ id: 7, tracks: [{ id: 1, track_number: 1, title: 'No file' }] });
+    const play = document.querySelector('.enhanced-play-btn') as HTMLButtonElement;
+    expect(play.disabled).toBe(true);
+    expect(play.title).toBe('No file available');
+    // Nothing to queue either.
+    expect(document.querySelector('.enhanced-queue-btn')).toBeNull();
+  });
+});
+
+describe('a missing row', () => {
+  const missingRow = () => rows()[2];
+
+  it('is badged, dashed and un-selectable', () => {
+    renderTable();
+    const row = missingRow();
+    expect(row.className).toContain('enhanced-missing-track-row');
+    expect(row.querySelector('.enhanced-missing-track-badge')?.textContent).toBe('Missing');
+    expect(row.querySelector('.enhanced-play-btn')?.textContent).toBe('—');
+    expect(row.querySelector('.col-format')?.textContent).toBe('-');
+    expect(row.querySelector('.col-path')?.textContent).toBe('Missing from library');
+    // An empty cell, not a disabled box: there is no file to bulk-act on.
+    expect(row.querySelector('.enhanced-track-checkbox')).toBeNull();
+  });
+
+  it('keeps the track NUMBER editable but not the disc or title (#1051)', () => {
+    // The number is the slot the row claims; disc and title describe a real
+    // file's tags, which a missing row does not have.
+    renderTable();
+    const row = missingRow();
+    expect(row.querySelector('.col-num')?.className).toContain('editable');
+    expect(row.querySelector('.col-disc')?.className).not.toContain('editable');
+    expect(row.querySelector('.col-title')?.className).not.toContain('editable');
+  });
+
+  it('offers Manage instead of the owned-track actions', () => {
+    renderTable();
+    const row = missingRow();
+    expect(row.querySelector('.enhanced-missing-manage-btn')?.textContent).toBe('Manage');
+    expect(row.querySelector('.enhanced-delete-btn')).toBeNull();
+    expect(row.querySelector('.enhanced-write-tag-btn')).toBeNull();
+  });
+
+  it('offers Manage to a non-admin too, in place of Report', () => {
+    renderTable(ALBUM, false);
+    expect(missingRow().querySelector('.enhanced-missing-manage-btn')).not.toBeNull();
+    expect(missingRow().querySelector('.enhanced-track-report-btn')).toBeNull();
+  });
+});
+
+describe('selection', () => {
+  it('ticks one row', () => {
+    const { onSelectedChange } = renderTable();
+    fireEvent.click(rows()[0].querySelector('.enhanced-track-checkbox') as HTMLElement);
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set(['1']));
+  });
+
+  it('unticks a row that was already selected', () => {
+    const { onSelectedChange } = renderTable(ALBUM, true, new Set(['1']));
+    fireEvent.click(rows()[0].querySelector('.enhanced-track-checkbox') as HTMLElement);
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set());
+  });
+
+  it('select-all covers the OWNED rows only', () => {
+    const { onSelectedChange } = renderTable();
+    fireEvent.click(document.querySelector('thead .enhanced-track-checkbox') as HTMLElement);
+    // The missing row has no id in the set.
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set(['1', '2']));
+  });
+
+  it('select-all clears when everything owned is already ticked', () => {
+    const { onSelectedChange } = renderTable(ALBUM, true, new Set(['1', '2']));
+    const all = document.querySelector('thead .enhanced-track-checkbox') as HTMLInputElement;
+    expect(all.checked).toBe(true);
+    fireEvent.click(all);
+    expect(onSelectedChange).toHaveBeenCalledWith(new Set());
+  });
+
+  it('marks the selected row', () => {
+    renderTable(ALBUM, true, new Set(['1']));
+    expect(rows()[0].className).toContain('selected');
+    expect(rows()[1].className).not.toContain('selected');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -38,6 +38,7 @@ const ALBUM: EnhancedAlbum = {
 
 function renderTable(album: EnhancedAlbum = ALBUM, isAdmin = true, selected = new Set<string>()) {
   const onSelectedChange = vi.fn();
+  const onTrackEdited = vi.fn();
   const view = render(
     <EnhancedTrackTable
       album={album}
@@ -45,9 +46,10 @@ function renderTable(album: EnhancedAlbum = ALBUM, isAdmin = true, selected = ne
       artist={ARTIST}
       selected={selected}
       onSelectedChange={onSelectedChange}
+      onTrackEdited={onTrackEdited}
     />,
   );
-  return { onSelectedChange, ...view };
+  return { onSelectedChange, onTrackEdited, ...view };
 }
 
 const ARTIST = { id: 42, name: 'Aphex Twin', thumb_url: 'artist.jpg' };
@@ -412,6 +414,7 @@ describe('row actions', () => {
           artist={ARTIST}
           selected={new Set()}
           onSelectedChange={vi.fn()}
+          onTrackEdited={vi.fn()}
         />
       </div>,
     );

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createShellBridge } from '@/test/shell-bridge';
 
 import type { EnhancedAlbum } from '../-artist-detail.enhanced';
 
@@ -40,6 +42,7 @@ function renderTable(album: EnhancedAlbum = ALBUM, isAdmin = true, selected = ne
     <EnhancedTrackTable
       album={album}
       isAdmin={isAdmin}
+      artist={ARTIST}
       selected={selected}
       onSelectedChange={onSelectedChange}
     />,
@@ -47,9 +50,33 @@ function renderTable(album: EnhancedAlbum = ALBUM, isAdmin = true, selected = ne
   return { onSelectedChange, ...view };
 }
 
+const ARTIST = { id: 42, name: 'Aphex Twin', thumb_url: 'artist.jpg' };
+
 const rows = () => [...document.querySelectorAll('tbody tr')] as HTMLElement[];
 
+const ACTIONS = [
+  'showTagPreview',
+  'analyzeTrackReplayGain',
+  'showTrackSourceInfo',
+  'openReidentifyModal',
+  'showTrackRedownloadModal',
+  'deleteLibraryTrack',
+  'openMissingTrackManageModal',
+  'showReportIssueModal',
+  'openManualMatchModal',
+  '_showMobileTrackActions',
+  'addToQueue',
+  'playNext',
+] as const;
+
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  for (const action of ACTIONS) window[action] = vi.fn() as never;
+});
+
 afterEach(() => {
+  for (const action of ACTIONS) delete window[action];
+  delete window.SoulSyncWebShellBridge;
   document.body.innerHTML = '';
 });
 
@@ -261,5 +288,172 @@ describe('selection', () => {
     renderTable(ALBUM, true, new Set(['1']));
     expect(rows()[0].className).toContain('selected');
     expect(rows()[1].className).not.toContain('selected');
+  });
+});
+
+describe('row actions', () => {
+  const click = (selector: string, row = 0) =>
+    fireEvent.click(rows()[row].querySelector(selector) as HTMLElement);
+
+  it('plays through the library player with the album and artist names', () => {
+    renderTable();
+    click('.enhanced-play-btn');
+    expect(window.SoulSyncWebShellBridge?.playLibraryTrack).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      '',
+      'Aphex Twin',
+    );
+  });
+
+  it('queues with a library payload, art falling back to the ARTIST thumbnail', () => {
+    renderTable();
+    click('.enhanced-queue-btn');
+    expect(window.addToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        is_library: true,
+        file_path: '/music/Aphex/SAW/01 Xtal.flac',
+        album: 'Unknown Album',
+        artist: 'Aphex Twin',
+        image_url: 'artist.jpg',
+        artist_id: 42,
+        album_id: 7,
+      }),
+    );
+  });
+
+  it('play-next uses playNext, not the plain enqueue', () => {
+    renderTable();
+    click('.enhanced-playnext-btn');
+    expect(window.playNext).toHaveBeenCalled();
+    expect(window.addToQueue).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a plain enqueue when the player has no play-next', () => {
+    delete window.playNext;
+    renderTable();
+    click('.enhanced-playnext-btn');
+    expect(window.addToQueue).toHaveBeenCalled();
+  });
+
+  it('wires each admin action to its own handler', () => {
+    renderTable();
+    click('.enhanced-write-tag-btn');
+    expect(window.showTagPreview).toHaveBeenCalledWith(1);
+
+    click('.enhanced-redownload-btn');
+    expect(window.showTrackRedownloadModal).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      ALBUM,
+    );
+
+    click('.enhanced-delete-btn');
+    expect(window.deleteLibraryTrack).toHaveBeenCalledWith(1, 7);
+  });
+
+  it('hands the button element to the two actions that render onto it', () => {
+    renderTable();
+    const rg = rows()[0].querySelector('.enhanced-rg-btn') as HTMLElement;
+    fireEvent.click(rg);
+    expect(window.analyzeTrackReplayGain).toHaveBeenCalledWith(1, rg);
+
+    const info = rows()[0].querySelector('.enhanced-source-info-btn') as HTMLElement;
+    fireEvent.click(info);
+    expect(window.showTrackSourceInfo).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1 }),
+      info,
+    );
+  });
+
+  it('re-identifies with the album art and title for context', () => {
+    renderTable({ ...ALBUM, title: 'SAW 85-92', thumb_url: 'cover.jpg' });
+    click('.enhanced-reidentify-btn');
+    expect(window.openReidentifyModal).toHaveBeenCalledWith(
+      1,
+      'Xtal',
+      'Aphex Twin',
+      'SAW 85-92',
+      'cover.jpg',
+    );
+  });
+
+  it('manages a missing track from either role', () => {
+    renderTable();
+    click('.enhanced-missing-manage-btn', 2);
+    expect(window.openMissingTrackManageModal).toHaveBeenCalledWith(
+      expect.objectContaining({ _missingExpected: true }),
+      ALBUM,
+    );
+
+    document.body.innerHTML = '';
+    renderTable(ALBUM, false);
+    click('.enhanced-missing-manage-btn', 2);
+    expect(window.openMissingTrackManageModal).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a track issue with its ALBUM name too', () => {
+    renderTable(ALBUM, false);
+    click('.enhanced-track-report-btn');
+    expect(window.showReportIssueModal).toHaveBeenCalledWith('track', 1, 'Xtal', 'Aphex Twin', '');
+  });
+
+  it('opens the mobile action popover', () => {
+    renderTable();
+    click('.enhanced-mobile-actions-btn');
+    expect(window._showMobileTrackActions).toHaveBeenCalled();
+  });
+
+  it('does not let an action bubble into the album toggle', () => {
+    const onPanelClick = vi.fn();
+    render(
+      <div onClick={onPanelClick}>
+        <EnhancedTrackTable
+          album={ALBUM}
+          isAdmin
+          artist={ARTIST}
+          selected={new Set()}
+          onSelectedChange={vi.fn()}
+        />
+      </div>,
+    );
+    fireEvent.click(document.querySelector('.enhanced-delete-btn') as HTMLElement);
+    expect(onPanelClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('re-matching a track', () => {
+  it('opens the matcher for the clicked service, with the BARE track title', () => {
+    // The album has a title here on purpose: every service except Bandcamp
+    // searched better on the title alone.
+    renderTable({ ...ALBUM, title: 'SAW 85-92' });
+    fireEvent.click(rows()[0].querySelectorAll('.enhanced-track-match-chip')[1]);
+    expect(window.openManualMatchModal).toHaveBeenCalledWith('track', 1, 'musicbrainz', 'Xtal', 42);
+  });
+
+  it('does not leave a leading space when the album is untitled', () => {
+    renderTable();
+    const chips = rows()[0].querySelectorAll('.enhanced-track-match-chip');
+    fireEvent.click(chips[chips.length - 1]);
+    expect(window.openManualMatchModal).toHaveBeenCalledWith('track', 1, 'bandcamp', 'Xtal', 42);
+  });
+
+  it('sends the ALBUM name alongside the title for Bandcamp only', () => {
+    // Bandcamp searches release pages, where a bare track title is ambiguous
+    // across compilations, remixes and covers.
+    renderTable({ ...ALBUM, title: 'SAW 85-92' });
+    const chips = rows()[0].querySelectorAll('.enhanced-track-match-chip');
+    fireEvent.click(chips[chips.length - 1]);
+    expect(window.openManualMatchModal).toHaveBeenCalledWith(
+      'track',
+      1,
+      'bandcamp',
+      'SAW 85-92 Xtal',
+      42,
+    );
+  });
+
+  it('is inert for a non-admin', () => {
+    renderTable(ALBUM, false);
+    fireEvent.click(rows()[0].querySelectorAll('.enhanced-track-match-chip')[1]);
+    expect(window.openManualMatchModal).not.toHaveBeenCalled();
   });
 });

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -56,6 +56,9 @@ const ARTIST = { id: 42, name: 'Aphex Twin', thumb_url: 'artist.jpg' };
 
 const rows = () => [...document.querySelectorAll('tbody tr')] as HTMLElement[];
 
+const titles = () =>
+  rows().map((r) => r.querySelector('.col-title')?.textContent?.replace('Missing', '') ?? '');
+
 const ACTIONS = [
   'showTagPreview',
   'analyzeTrackReplayGain',
@@ -149,14 +152,84 @@ describe('the sort arrow', () => {
     expect(document.querySelector('[data-sort-field="bpm"]')?.textContent).toBe('BPM ▲');
   });
 
-  it('does NOT reorder the rows — verbatim vanilla', () => {
-    // sortEnhancedTracks sorted album.tracks and the table then rendered from
-    // _getEnhancedAlbumTrackRows, which re-sorts by disc/track/title. So the
-    // arrow moves and the rows do not.
+  it('actually reorders the rows — the vanilla never did', () => {
     renderTable();
-    const before = rows().map((r) => r.getAttribute('data-track-id'));
+    // Default order is track number: Xtal (1), Tha (2), then the missing row.
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
+
     fireEvent.click(document.querySelector('[data-sort-field="title"]') as HTMLElement);
-    expect(rows().map((r) => r.getAttribute('data-track-id'))).toEqual(before);
+    expect(titles()).toEqual(['Tha', 'Xtal', 'Ageispolis']);
+  });
+});
+
+describe('sorting by column', () => {
+  it('sorts by title, and flips on a second click', () => {
+    renderTable();
+    const th = document.querySelector('[data-sort-field="title"]') as HTMLElement;
+
+    fireEvent.click(th);
+    expect(titles()).toEqual(['Tha', 'Xtal', 'Ageispolis']);
+    fireEvent.click(th);
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
+  });
+
+  it('sorts numerically, not as strings', () => {
+    // '1000' vs '192' as text would put 1000 first ascending; as numbers it is
+    // second.
+    renderTable();
+    fireEvent.click(document.querySelector('[data-sort-field="bitrate"]') as HTMLElement);
+    expect(titles()).toEqual(['Tha', 'Xtal', 'Ageispolis']);
+  });
+
+  it('sorts by duration', () => {
+    renderTable();
+    fireEvent.click(document.querySelector('[data-sort-field="duration"]') as HTMLElement);
+    // Xtal is 5:00, Tha is 9:30.
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
+  });
+
+  it('sorts by the derived FORMAT, not by the raw path', () => {
+    renderTable();
+    fireEvent.click(document.querySelector('[data-sort-field="format"]') as HTMLElement);
+    // FLAC before MP3 — from extractFormat, not from '01 Xtal.flac'.
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
+  });
+
+  it('SINKS a track with no value for that column, in both directions', () => {
+    // Only Xtal has a BPM; an unset one must not float to the top ascending.
+    renderTable();
+    const th = document.querySelector('[data-sort-field="bpm"]') as HTMLElement;
+
+    fireEvent.click(th);
+    expect(titles()[0]).toBe('Xtal');
+    fireEvent.click(th);
+    expect(titles()[0]).toBe('Xtal');
+  });
+
+  it('always sinks MISSING rows, whichever way the sort runs', () => {
+    // A row you do not own has no bitrate, no format and no file — sorting it
+    // among real tracks would be sorting on absence.
+    renderTable();
+    const th = document.querySelector('[data-sort-field="title"]') as HTMLElement;
+
+    fireEvent.click(th);
+    expect(titles().at(-1)).toBe('Ageispolis');
+    fireEvent.click(th);
+    expect(titles().at(-1)).toBe('Ageispolis');
+  });
+
+  it('leaves the default order alone until a header is clicked', () => {
+    renderTable();
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
+  });
+
+  it('re-sorts when the column changes', () => {
+    renderTable();
+    fireEvent.click(document.querySelector('[data-sort-field="title"]') as HTMLElement);
+    expect(titles()).toEqual(['Tha', 'Xtal', 'Ageispolis']);
+
+    fireEvent.click(document.querySelector('[data-sort-field="track_number"]') as HTMLElement);
+    expect(titles()).toEqual(['Xtal', 'Tha', 'Ageispolis']);
   });
 });
 

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createShellBridge } from '@/test/shell-bridge';
@@ -79,7 +79,10 @@ beforeEach(() => {
 afterEach(() => {
   for (const action of ACTIONS) delete window[action];
   delete window.SoulSyncWebShellBridge;
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('the empty state', () => {

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -9,6 +9,7 @@ import {
   bitrateClass,
   getAlbumTrackRows,
   queueTrackPayload,
+  sortedTrackRows,
   sortIndicator,
   type TrackSort,
   trackColumns,
@@ -33,13 +34,11 @@ interface Props {
 /**
  * The per-album track table (renderTrackTable / _buildTrackRow, library.js:4776).
  *
- * A note on the column sort, reproduced rather than fixed: the vanilla stored a
+ * The column sort WORKS here, which it never did in the vanilla: that stored a
  * per-album sort, called sortEnhancedTracks on album.tracks, and then rendered
- * from _getEnhancedAlbumTrackRows — which ALWAYS re-sorts by disc, then track,
- * then title. So clicking a header moves the arrow and leaves the rows where
- * they were. Making the columns actually sort would be a behaviour change, not
- * a port, so the arrow behaviour is kept and the row order still comes from
- * getAlbumTrackRows.
+ * from _getEnhancedAlbumTrackRows — which always re-sorts by disc, then track,
+ * then title. The custom sort was applied and immediately thrown away, so a
+ * header click moved the arrow and nothing else. A deliberate fix, not a port.
  */
 export function EnhancedTrackTable({
   album,
@@ -50,7 +49,7 @@ export function EnhancedTrackTable({
   onTrackEdited,
 }: Props) {
   const [sort, setSort] = useState<TrackSort | undefined>(undefined);
-  const rows = getAlbumTrackRows(album);
+  const rows = sortedTrackRows(getAlbumTrackRows(album), sort);
 
   if (rows.length === 0) {
     return <div className="enhanced-no-tracks">No tracks in database</div>;

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -1,0 +1,332 @@
+import { useState } from 'react';
+
+import type { EnhancedAlbum, EnhancedTrack } from '../-artist-detail.enhanced';
+
+import { extractFormat, formatDurationMs } from '../-artist-detail.enhanced';
+import {
+  bitrateClass,
+  getAlbumTrackRows,
+  sortIndicator,
+  type TrackSort,
+  trackColumns,
+  trackFileName,
+  trackMatchChips,
+} from '../-artist-detail.enhanced-album';
+
+interface Props {
+  album: EnhancedAlbum;
+  isAdmin: boolean;
+  /** Track ids currently ticked, owned by the panel so the bulk bar can read them. */
+  selected: Set<string>;
+  onSelectedChange: (next: Set<string>) => void;
+}
+
+/**
+ * The per-album track table (renderTrackTable / _buildTrackRow, library.js:4776).
+ *
+ * A note on the column sort, reproduced rather than fixed: the vanilla stored a
+ * per-album sort, called sortEnhancedTracks on album.tracks, and then rendered
+ * from _getEnhancedAlbumTrackRows — which ALWAYS re-sorts by disc, then track,
+ * then title. So clicking a header moves the arrow and leaves the rows where
+ * they were. Making the columns actually sort would be a behaviour change, not
+ * a port, so the arrow behaviour is kept and the row order still comes from
+ * getAlbumTrackRows.
+ */
+export function EnhancedTrackTable({ album, isAdmin, selected, onSelectedChange }: Props) {
+  const [sort, setSort] = useState<TrackSort | undefined>(undefined);
+  const rows = getAlbumTrackRows(album);
+
+  if (rows.length === 0) {
+    return <div className="enhanced-no-tracks">No tracks in database</div>;
+  }
+
+  const columns = trackColumns(isAdmin);
+  // Only owned rows are selectable; a missing row has no file to act on.
+  const selectableIds = rows
+    .filter((row) => !(row as { _missingExpected?: boolean })._missingExpected)
+    .map((row) => String(row.id));
+  const allSelected = selectableIds.length > 0 && selectableIds.every((id) => selected.has(id));
+
+  const toggleAll = () => {
+    const next = new Set(selected);
+    if (allSelected) for (const id of selectableIds) next.delete(id);
+    else for (const id of selectableIds) next.add(id);
+    onSelectedChange(next);
+  };
+
+  const toggleOne = (id: string) => {
+    const next = new Set(selected);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onSelectedChange(next);
+  };
+
+  const clickHeader = (field: string | undefined) => {
+    if (!field) return;
+    setSort((current) =>
+      current && current.field === field
+        ? { field, ascending: !current.ascending }
+        : { field, ascending: true },
+    );
+  };
+
+  return (
+    <table className="enhanced-track-table" data-album-id={String(album.id)}>
+      <thead>
+        <tr>
+          {isAdmin ? (
+            <th>
+              <input
+                type="checkbox"
+                className="enhanced-track-checkbox"
+                checked={allSelected}
+                onChange={toggleAll}
+              />
+            </th>
+          ) : null}
+          {columns.map((column) => (
+            <th
+              key={column.cls}
+              className={column.cls}
+              style={column.sortField ? { cursor: 'pointer' } : undefined}
+              data-sort-field={column.sortField}
+              data-label={column.sortField ? column.label : undefined}
+              onClick={() => clickHeader(column.sortField)}
+            >
+              {sortIndicator(column, sort)}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((track) => (
+          <TrackRow
+            key={String(track.id)}
+            track={track}
+            album={album}
+            isAdmin={isAdmin}
+            selected={selected.has(String(track.id))}
+            onToggle={() => toggleOne(String(track.id))}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function TrackRow({
+  track,
+  album,
+  isAdmin,
+  selected,
+  onToggle,
+}: {
+  track: EnhancedTrack;
+  album: EnhancedAlbum;
+  isAdmin: boolean;
+  selected: boolean;
+  onToggle: () => void;
+}) {
+  const missing = Boolean((track as { _missingExpected?: boolean })._missingExpected);
+  const editable = isAdmin && !missing ? ' editable' : '';
+  const format = extractFormat(track.file_path);
+
+  return (
+    <tr
+      data-track-id={String(track.id)}
+      data-album-id={String(album.id)}
+      className={`${missing ? 'enhanced-missing-track-row' : ''}${selected ? ' selected' : ''}`.trim()}
+    >
+      {isAdmin ? (
+        <td>
+          {/* A missing row gets an EMPTY cell, not a disabled box: there is no
+              file for a bulk action to touch. */}
+          {missing ? null : (
+            <input
+              type="checkbox"
+              className="enhanced-track-checkbox"
+              checked={selected}
+              onChange={onToggle}
+            />
+          )}
+        </td>
+      ) : null}
+
+      <td className="col-play">
+        <button
+          type="button"
+          className="enhanced-play-btn"
+          title={track.file_path ? 'Play track' : 'No file available'}
+          disabled={!track.file_path}
+        >
+          {missing ? '—' : '▶'}
+        </button>
+      </td>
+
+      {/* The track NUMBER stays editable on a missing row — it is the slot the
+          row claims. The disc and title describe a real file's tags, so those
+          two lose `editable` (#1051). */}
+      <td className={`col-num${isAdmin ? ' editable' : ''}`}>
+        {String(track.track_number || '-')}
+      </td>
+      <td className={`col-disc${editable}`}>{String(track.disc_number || '-')}</td>
+      <td className={`col-title${editable}`}>
+        {String(track.title || 'Unknown')}
+        {missing ? <span className="enhanced-missing-track-badge">Missing</span> : null}
+      </td>
+
+      <td className="col-duration">{formatDurationMs(track.duration)}</td>
+
+      <td className="col-format">
+        {missing ? (
+          '-'
+        ) : (
+          <span
+            className={`enhanced-format-badge ${
+              format === 'FLAC' ? 'flac' : format === 'MP3' ? 'mp3' : 'other'
+            }`}
+          >
+            {format}
+          </span>
+        )}
+      </td>
+
+      <td className="col-bitrate">
+        <span className={`enhanced-bitrate ${bitrateClass(track.bitrate)}`}>
+          {track.bitrate ? `${track.bitrate} kbps` : '-'}
+        </span>
+      </td>
+
+      <td className={`col-bpm${isAdmin ? ' editable' : ''}`}>{String(track.bpm || '-')}</td>
+
+      <td className="col-path" title={String(track.file_path || '-')}>
+        {trackFileName(track)}
+      </td>
+
+      <td className="col-match">
+        <div className="enhanced-track-match-cell">
+          {trackMatchChips(track).map((chip) => (
+            <span
+              key={chip.service}
+              className={chip.className}
+              title={chip.title}
+              data-service={chip.service}
+            >
+              {chip.label}
+            </span>
+          ))}
+        </div>
+      </td>
+
+      {/* `!missing` is redundant — normalizeExpectedMissingTrack never sets a
+          file_path, so a missing row cannot reach the truthy branch. Kept
+          because the vanilla wrote it, and it survives mutation for that
+          reason rather than for want of a test. */}
+      <td className="col-queue">
+        {!missing && track.file_path ? (
+          <>
+            <button type="button" className="enhanced-playnext-btn" title="Play next">
+              ⇥
+            </button>
+            <button type="button" className="enhanced-queue-btn" title="Add to queue">
+              +
+            </button>
+          </>
+        ) : null}
+      </td>
+
+      {isAdmin ? (
+        <>
+          <td className="col-writetag">
+            {track.file_path && !missing ? (
+              <>
+                <button type="button" className="enhanced-write-tag-btn" title="Write tags to file">
+                  ✎
+                </button>
+                <button
+                  type="button"
+                  className="enhanced-rg-btn"
+                  title="Analyze &amp; write ReplayGain (track gain)"
+                >
+                  RG
+                </button>
+              </>
+            ) : null}
+          </td>
+          <td className="col-track-actions">
+            {missing ? (
+              <div className="enhanced-track-actions-group visible">
+                <button
+                  type="button"
+                  className="enhanced-missing-manage-btn"
+                  data-action="manage-missing"
+                  title="Manage this missing album track"
+                >
+                  Manage
+                </button>
+              </div>
+            ) : (
+              <div className="enhanced-track-actions-group">
+                <button
+                  type="button"
+                  className="enhanced-source-info-btn"
+                  title="View download source info"
+                >
+                  ℹ
+                </button>
+                <button
+                  type="button"
+                  className="enhanced-reidentify-btn"
+                  title="Re-identify — file this track under a different release"
+                >
+                  ⇄
+                </button>
+                <button
+                  type="button"
+                  className="enhanced-redownload-btn"
+                  title="Redownload this track"
+                >
+                  ↻
+                </button>
+                <button
+                  type="button"
+                  className="enhanced-delete-btn"
+                  title="Delete track from library"
+                >
+                  ✕
+                </button>
+              </div>
+            )}
+          </td>
+        </>
+      ) : (
+        <td className="col-report">
+          {missing ? (
+            <button
+              type="button"
+              className="enhanced-missing-manage-btn"
+              data-action="manage-missing"
+            >
+              Manage
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="enhanced-track-report-btn"
+              title="Report issue with this track"
+            >
+              ⚑
+            </button>
+          )}
+        </td>
+      )}
+
+      {/* Shown only on mobile, via CSS. */}
+      <td className="col-mobile-actions">
+        <button type="button" className="enhanced-mobile-actions-btn" title="Actions">
+          ⋯
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -16,12 +16,15 @@ import {
   trackMatchChips,
   trackMatchQuery,
 } from '../-artist-detail.enhanced-album';
+import { EditableCell } from './editable-cell';
 
 interface Props {
   album: EnhancedAlbum;
   isAdmin: boolean;
   /** Supplies the artist name and id every track action needs. */
   artist: Record<string, unknown> | undefined;
+  /** Applies a saved inline edit to the album in the panel's state. */
+  onTrackEdited: (trackId: unknown, field: string, value: string | number | null) => void;
   /** Track ids currently ticked, owned by the panel so the bulk bar can read them. */
   selected: Set<string>;
   onSelectedChange: (next: Set<string>) => void;
@@ -38,7 +41,14 @@ interface Props {
  * a port, so the arrow behaviour is kept and the row order still comes from
  * getAlbumTrackRows.
  */
-export function EnhancedTrackTable({ album, isAdmin, artist, selected, onSelectedChange }: Props) {
+export function EnhancedTrackTable({
+  album,
+  isAdmin,
+  artist,
+  selected,
+  onSelectedChange,
+  onTrackEdited,
+}: Props) {
   const [sort, setSort] = useState<TrackSort | undefined>(undefined);
   const rows = getAlbumTrackRows(album);
 
@@ -114,6 +124,7 @@ export function EnhancedTrackTable({ album, isAdmin, artist, selected, onSelecte
             artist={artist}
             selected={selected.has(String(track.id))}
             onToggle={() => toggleOne(String(track.id))}
+            onEdited={(field, value) => onTrackEdited(track.id, field, value)}
           />
         ))}
       </tbody>
@@ -128,6 +139,7 @@ function TrackRow({
   artist,
   selected,
   onToggle,
+  onEdited,
 }: {
   track: EnhancedTrack;
   album: EnhancedAlbum;
@@ -135,6 +147,7 @@ function TrackRow({
   artist: Record<string, unknown> | undefined;
   selected: boolean;
   onToggle: () => void;
+  onEdited: (field: string, value: string | number | null) => void;
 }) {
   const missing = Boolean((track as { _missingExpected?: boolean })._missingExpected);
   const editable = isAdmin && !missing ? ' editable' : '';
@@ -205,14 +218,40 @@ function TrackRow({
       {/* The track NUMBER stays editable on a missing row — it is the slot the
           row claims. The disc and title describe a real file's tags, so those
           two lose `editable` (#1051). */}
-      <td className={`col-num${isAdmin ? ' editable' : ''}`}>
+      <EditableCell
+        className={`col-num${isAdmin ? ' editable' : ''}`}
+        editable={isAdmin}
+        entityType="track"
+        entityId={track.id}
+        field="track_number"
+        value={track.track_number as string | number | null}
+        onSaved={onEdited}
+      >
         {String(track.track_number || '-')}
-      </td>
-      <td className={`col-disc${editable}`}>{String(track.disc_number || '-')}</td>
-      <td className={`col-title${editable}`}>
+      </EditableCell>
+      <EditableCell
+        className={`col-disc${editable}`}
+        editable={Boolean(editable)}
+        entityType="track"
+        entityId={track.id}
+        field="disc_number"
+        value={track.disc_number as string | number | null}
+        onSaved={onEdited}
+      >
+        {String(track.disc_number || '-')}
+      </EditableCell>
+      <EditableCell
+        className={`col-title${editable}`}
+        editable={Boolean(editable)}
+        entityType="track"
+        entityId={track.id}
+        field="title"
+        value={track.title as string | null}
+        onSaved={onEdited}
+      >
         {String(track.title || 'Unknown')}
         {missing ? <span className="enhanced-missing-track-badge">Missing</span> : null}
-      </td>
+      </EditableCell>
 
       <td className="col-duration">{formatDurationMs(track.duration)}</td>
 
@@ -236,7 +275,17 @@ function TrackRow({
         </span>
       </td>
 
-      <td className={`col-bpm${isAdmin ? ' editable' : ''}`}>{String(track.bpm || '-')}</td>
+      <EditableCell
+        className={`col-bpm${isAdmin ? ' editable' : ''}`}
+        editable={isAdmin}
+        entityType="track"
+        entityId={track.id}
+        field="bpm"
+        value={track.bpm as string | number | null}
+        onSaved={onEdited}
+      >
+        {String(track.bpm || '-')}
+      </EditableCell>
 
       <td className="col-path" title={String(track.file_path || '-')}>
         {trackFileName(track)}

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -1,21 +1,27 @@
 import { useState } from 'react';
 
+import { getShellBridge } from '@/platform/shell/bridge';
+
 import type { EnhancedAlbum, EnhancedTrack } from '../-artist-detail.enhanced';
 
 import { extractFormat, formatDurationMs } from '../-artist-detail.enhanced';
 import {
   bitrateClass,
   getAlbumTrackRows,
+  queueTrackPayload,
   sortIndicator,
   type TrackSort,
   trackColumns,
   trackFileName,
   trackMatchChips,
+  trackMatchQuery,
 } from '../-artist-detail.enhanced-album';
 
 interface Props {
   album: EnhancedAlbum;
   isAdmin: boolean;
+  /** Supplies the artist name and id every track action needs. */
+  artist: Record<string, unknown> | undefined;
   /** Track ids currently ticked, owned by the panel so the bulk bar can read them. */
   selected: Set<string>;
   onSelectedChange: (next: Set<string>) => void;
@@ -32,7 +38,7 @@ interface Props {
  * a port, so the arrow behaviour is kept and the row order still comes from
  * getAlbumTrackRows.
  */
-export function EnhancedTrackTable({ album, isAdmin, selected, onSelectedChange }: Props) {
+export function EnhancedTrackTable({ album, isAdmin, artist, selected, onSelectedChange }: Props) {
   const [sort, setSort] = useState<TrackSort | undefined>(undefined);
   const rows = getAlbumTrackRows(album);
 
@@ -105,6 +111,7 @@ export function EnhancedTrackTable({ album, isAdmin, selected, onSelectedChange 
             track={track}
             album={album}
             isAdmin={isAdmin}
+            artist={artist}
             selected={selected.has(String(track.id))}
             onToggle={() => toggleOne(String(track.id))}
           />
@@ -118,18 +125,41 @@ function TrackRow({
   track,
   album,
   isAdmin,
+  artist,
   selected,
   onToggle,
 }: {
   track: EnhancedTrack;
   album: EnhancedAlbum;
   isAdmin: boolean;
+  artist: Record<string, unknown> | undefined;
   selected: boolean;
   onToggle: () => void;
 }) {
   const missing = Boolean((track as { _missingExpected?: boolean })._missingExpected);
   const editable = isAdmin && !missing ? ' editable' : '';
   const format = extractFormat(track.file_path);
+  const artistName = String(artist?.name || '');
+
+  /**
+   * Every action stops propagation, exactly as the delegated handler did: the
+   * row sits inside the album panel, and a bubbling click would toggle the
+   * album shut under the button that was just pressed.
+   */
+  const act =
+    (handler: (e: React.MouseEvent<HTMLElement>) => void) => (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      handler(e);
+    };
+
+  const enqueue = (playNext: boolean) => {
+    if (!track.file_path) return;
+    const payload = queueTrackPayload(track, album, artist);
+    // Play-next falls back to a plain enqueue when the player does not expose
+    // it, which is what the vanilla's typeof check did.
+    if (playNext && typeof window.playNext === 'function') window.playNext(payload);
+    else window.addToQueue?.(payload);
+  };
 
   return (
     <tr
@@ -158,6 +188,15 @@ function TrackRow({
           className="enhanced-play-btn"
           title={track.file_path ? 'Play track' : 'No file available'}
           disabled={!track.file_path}
+          onClick={act(() => {
+            if (track.file_path) {
+              getShellBridge()?.playLibraryTrack(
+                track as never,
+                String(album.title || ''),
+                artistName,
+              );
+            }
+          })}
         >
           {missing ? '—' : '▶'}
         </button>
@@ -211,6 +250,21 @@ function TrackRow({
               className={chip.className}
               title={chip.title}
               data-service={chip.service}
+              onClick={
+                // Re-matching is admin-only; for everyone else the chip is
+                // just a status marker.
+                isAdmin
+                  ? act(() =>
+                      window.openManualMatchModal?.(
+                        'track',
+                        track.id,
+                        chip.service,
+                        trackMatchQuery(chip.service, track, album),
+                        artist?.id ?? null,
+                      ),
+                    )
+                  : undefined
+              }
             >
               {chip.label}
             </span>
@@ -225,10 +279,20 @@ function TrackRow({
       <td className="col-queue">
         {!missing && track.file_path ? (
           <>
-            <button type="button" className="enhanced-playnext-btn" title="Play next">
+            <button
+              type="button"
+              className="enhanced-playnext-btn"
+              title="Play next"
+              onClick={act(() => enqueue(true))}
+            >
               ⇥
             </button>
-            <button type="button" className="enhanced-queue-btn" title="Add to queue">
+            <button
+              type="button"
+              className="enhanced-queue-btn"
+              title="Add to queue"
+              onClick={act(() => enqueue(false))}
+            >
               +
             </button>
           </>
@@ -240,13 +304,19 @@ function TrackRow({
           <td className="col-writetag">
             {track.file_path && !missing ? (
               <>
-                <button type="button" className="enhanced-write-tag-btn" title="Write tags to file">
+                <button
+                  type="button"
+                  className="enhanced-write-tag-btn"
+                  title="Write tags to file"
+                  onClick={act(() => window.showTagPreview?.(track.id))}
+                >
                   ✎
                 </button>
                 <button
                   type="button"
                   className="enhanced-rg-btn"
                   title="Analyze &amp; write ReplayGain (track gain)"
+                  onClick={act((e) => window.analyzeTrackReplayGain?.(track.id, e.currentTarget))}
                 >
                   RG
                 </button>
@@ -261,6 +331,7 @@ function TrackRow({
                   className="enhanced-missing-manage-btn"
                   data-action="manage-missing"
                   title="Manage this missing album track"
+                  onClick={act(() => window.openMissingTrackManageModal?.(track, album))}
                 >
                   Manage
                 </button>
@@ -271,6 +342,7 @@ function TrackRow({
                   type="button"
                   className="enhanced-source-info-btn"
                   title="View download source info"
+                  onClick={act((e) => window.showTrackSourceInfo?.(track, e.currentTarget))}
                 >
                   ℹ
                 </button>
@@ -278,6 +350,15 @@ function TrackRow({
                   type="button"
                   className="enhanced-reidentify-btn"
                   title="Re-identify — file this track under a different release"
+                  onClick={act(() =>
+                    window.openReidentifyModal?.(
+                      track.id,
+                      String(track.title || 'Unknown'),
+                      artistName,
+                      String(album.title || ''),
+                      String(album.thumb_url || ''),
+                    ),
+                  )}
                 >
                   ⇄
                 </button>
@@ -285,6 +366,7 @@ function TrackRow({
                   type="button"
                   className="enhanced-redownload-btn"
                   title="Redownload this track"
+                  onClick={act(() => window.showTrackRedownloadModal?.(track, album))}
                 >
                   ↻
                 </button>
@@ -292,6 +374,7 @@ function TrackRow({
                   type="button"
                   className="enhanced-delete-btn"
                   title="Delete track from library"
+                  onClick={act(() => window.deleteLibraryTrack?.(track.id, album.id))}
                 >
                   ✕
                 </button>
@@ -306,6 +389,7 @@ function TrackRow({
               type="button"
               className="enhanced-missing-manage-btn"
               data-action="manage-missing"
+              onClick={act(() => window.openMissingTrackManageModal?.(track, album))}
             >
               Manage
             </button>
@@ -314,6 +398,15 @@ function TrackRow({
               type="button"
               className="enhanced-track-report-btn"
               title="Report issue with this track"
+              onClick={act(() =>
+                window.showReportIssueModal?.(
+                  'track',
+                  track.id,
+                  String(track.title || 'Unknown'),
+                  artistName,
+                  String(album.title || ''),
+                ),
+              )}
             >
               ⚑
             </button>
@@ -323,7 +416,12 @@ function TrackRow({
 
       {/* Shown only on mobile, via CSS. */}
       <td className="col-mobile-actions">
-        <button type="button" className="enhanced-mobile-actions-btn" title="Actions">
+        <button
+          type="button"
+          className="enhanced-mobile-actions-btn"
+          title="Actions"
+          onClick={act(() => window._showMobileTrackActions?.(track, album))}
+        >
           ⋯
         </button>
       </td>

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
@@ -26,27 +26,27 @@ afterEach(() => {
 
 describe('EnhancedView states', () => {
   it('shows a loading line while the request is in flight', () => {
-    render(<EnhancedView data={null} status={{ loading: true, error: '' }} />);
+    render(<EnhancedView isAdmin={false} data={null} status={{ loading: true, error: '' }} />);
     expect(document.querySelector('.enhanced-loading')?.textContent).toBe(
       'Loading library data...',
     );
   });
 
   it('shows the failure instead of an empty view', () => {
-    render(<EnhancedView data={null} status={{ loading: false, error: 'boom' }} />);
+    render(<EnhancedView isAdmin={false} data={null} status={{ loading: false, error: 'boom' }} />);
     expect(document.querySelector('.enhanced-loading')?.textContent).toBe('Failed to load: boom');
   });
 });
 
 describe('the stats bar', () => {
   it('lists the five stats in order', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const labels = [...document.querySelectorAll('.enhanced-stat-label')].map((n) => n.textContent);
     expect(labels).toEqual(['Albums', 'EPs', 'Singles', 'Tracks', 'Duration']);
   });
 
   it('badges each format with its count, commonest first', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const badges = [...document.querySelectorAll('.enhanced-stats-formats .enhanced-format-badge')];
     expect(badges.map((n) => n.textContent)).toEqual(['FLAC (2)', 'MP3 (1)']);
     expect(badges[0].className).toContain('flac');
@@ -55,7 +55,7 @@ describe('the stats bar', () => {
 
 describe('sections', () => {
   it('renders only the buckets that have albums', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const titles = [...document.querySelectorAll('.enhanced-section-title')].map(
       (n) => n.textContent,
     );
@@ -68,6 +68,7 @@ describe('sections', () => {
     // it, exactly as the vanilla did.
     render(
       <EnhancedView
+        isAdmin={false}
         data={{ albums: [{ id: 9, title: 'Live At', record_type: 'live', tracks: [] }] }}
         status={READY}
       />,
@@ -76,7 +77,7 @@ describe('sections', () => {
   });
 
   it('counts releases and tracks in the section header', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const counts = [...document.querySelectorAll('.enhanced-section-count')].map(
       (n) => n.textContent,
     );
@@ -86,7 +87,7 @@ describe('sections', () => {
 
 describe('album rows', () => {
   it('shows the title, meta line, type badge and format badge', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
     expect(row.querySelector('.enhanced-album-title')?.textContent).toBe('SAW 85-92');
     expect(row.querySelector('.enhanced-album-meta-line')?.textContent).toBe(
@@ -97,14 +98,14 @@ describe('album rows', () => {
   });
 
   it('falls back to the music note when the album has no art', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const row = document.getElementById('enhanced-album-row-2') as HTMLElement;
     expect(row.querySelector('.enhanced-album-thumb')).toBeNull();
     expect(row.querySelector('.enhanced-album-thumb-fallback')).not.toBeNull();
   });
 
   it('swaps a BROKEN thumbnail for the fallback', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const img = document.querySelector('.enhanced-album-thumb') as HTMLImageElement;
     fireEvent.error(img);
     const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
@@ -113,14 +114,20 @@ describe('album rows', () => {
   });
 
   it('titles an untitled album "Unknown"', () => {
-    render(<EnhancedView data={{ albums: [{ id: 3, title: '', tracks: [] }] }} status={READY} />);
+    render(
+      <EnhancedView
+        isAdmin={false}
+        data={{ albums: [{ id: 3, title: '', tracks: [] }] }}
+        status={READY}
+      />,
+    );
     expect(document.querySelector('.enhanced-album-title')?.textContent).toBe('Unknown');
   });
 });
 
 describe('expanding an album', () => {
   it('starts collapsed', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     expect(document.getElementById('enhanced-album-wrapper-1')?.className).not.toContain(
       'expanded',
     );
@@ -128,7 +135,7 @@ describe('expanding an album', () => {
   });
 
   it('marks the row, wrapper and panel on click, and unmarks on a second', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
 
     fireEvent.click(row);
@@ -141,8 +148,18 @@ describe('expanding an album', () => {
     expect(document.getElementById('enhanced-tracks-panel-1')?.className).not.toContain('visible');
   });
 
+  it('does not render the panel body until the album is expanded', () => {
+    // The vanilla's lazy render: a large library can have hundreds of albums,
+    // and each panel is a full header plus track table.
+    render(<EnhancedView isAdmin data={DATA} status={READY} />);
+    expect(document.querySelector('.enhanced-expanded-header')).toBeNull();
+
+    fireEvent.click(document.getElementById('enhanced-album-row-1') as HTMLElement);
+    expect(document.querySelectorAll('.enhanced-expanded-header')).toHaveLength(1);
+  });
+
   it('expands each album independently', () => {
-    render(<EnhancedView data={DATA} status={READY} />);
+    render(<EnhancedView isAdmin={false} data={DATA} status={READY} />);
     fireEvent.click(document.getElementById('enhanced-album-row-1') as HTMLElement);
     expect(document.getElementById('enhanced-tracks-panel-2')?.className).not.toContain('visible');
   });

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { EnhancedView } from './enhanced-view';
+
+const READY = { loading: false, error: '' };
+
+const DATA = {
+  albums: [
+    {
+      id: 1,
+      title: 'SAW 85-92',
+      record_type: 'album',
+      year: 1992,
+      label: 'Apollo',
+      thumb_url: 'a.jpg',
+      tracks: [{ duration: 300_000, file_path: 'a.flac' }, { file_path: 'b.flac' }],
+    },
+    { id: 2, title: 'Digeridoo', record_type: 'ep', tracks: [{ file_path: 'c.mp3' }] },
+  ],
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('EnhancedView states', () => {
+  it('shows a loading line while the request is in flight', () => {
+    render(<EnhancedView data={null} status={{ loading: true, error: '' }} />);
+    expect(document.querySelector('.enhanced-loading')?.textContent).toBe(
+      'Loading library data...',
+    );
+  });
+
+  it('shows the failure instead of an empty view', () => {
+    render(<EnhancedView data={null} status={{ loading: false, error: 'boom' }} />);
+    expect(document.querySelector('.enhanced-loading')?.textContent).toBe('Failed to load: boom');
+  });
+});
+
+describe('the stats bar', () => {
+  it('lists the five stats in order', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const labels = [...document.querySelectorAll('.enhanced-stat-label')].map((n) => n.textContent);
+    expect(labels).toEqual(['Albums', 'EPs', 'Singles', 'Tracks', 'Duration']);
+  });
+
+  it('badges each format with its count, commonest first', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const badges = [...document.querySelectorAll('.enhanced-stats-formats .enhanced-format-badge')];
+    expect(badges.map((n) => n.textContent)).toEqual(['FLAC (2)', 'MP3 (1)']);
+    expect(badges[0].className).toContain('flac');
+  });
+});
+
+describe('sections', () => {
+  it('renders only the buckets that have albums', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const titles = [...document.querySelectorAll('.enhanced-section-title')].map(
+      (n) => n.textContent,
+    );
+    // Singles is omitted rather than shown as an empty header.
+    expect(titles).toEqual(['Albums', 'EPs']);
+  });
+
+  it('never renders a bucket outside album/ep/single', () => {
+    // groupAlbumsByType creates a bucket for any record_type; the view ignores
+    // it, exactly as the vanilla did.
+    render(
+      <EnhancedView
+        data={{ albums: [{ id: 9, title: 'Live At', record_type: 'live', tracks: [] }] }}
+        status={READY}
+      />,
+    );
+    expect(document.querySelector('.enhanced-section')).toBeNull();
+  });
+
+  it('counts releases and tracks in the section header', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const counts = [...document.querySelectorAll('.enhanced-section-count')].map(
+      (n) => n.textContent,
+    );
+    expect(counts[0]).toBe('1 release · 2 tracks');
+  });
+});
+
+describe('album rows', () => {
+  it('shows the title, meta line, type badge and format badge', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
+    expect(row.querySelector('.enhanced-album-title')?.textContent).toBe('SAW 85-92');
+    expect(row.querySelector('.enhanced-album-meta-line')?.textContent).toBe(
+      '1992 · 2 tracks · 5:00 · Apollo',
+    );
+    expect(row.querySelector('.enhanced-album-type-badge')?.textContent).toBe('album');
+    expect(row.querySelector('.enhanced-format-badge')?.textContent).toBe('FLAC');
+  });
+
+  it('falls back to the music note when the album has no art', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const row = document.getElementById('enhanced-album-row-2') as HTMLElement;
+    expect(row.querySelector('.enhanced-album-thumb')).toBeNull();
+    expect(row.querySelector('.enhanced-album-thumb-fallback')).not.toBeNull();
+  });
+
+  it('swaps a BROKEN thumbnail for the fallback', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const img = document.querySelector('.enhanced-album-thumb') as HTMLImageElement;
+    fireEvent.error(img);
+    const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
+    expect(row.querySelector('.enhanced-album-thumb')).toBeNull();
+    expect(row.querySelector('.enhanced-album-thumb-fallback')).not.toBeNull();
+  });
+
+  it('titles an untitled album "Unknown"', () => {
+    render(<EnhancedView data={{ albums: [{ id: 3, title: '', tracks: [] }] }} status={READY} />);
+    expect(document.querySelector('.enhanced-album-title')?.textContent).toBe('Unknown');
+  });
+});
+
+describe('expanding an album', () => {
+  it('starts collapsed', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    expect(document.getElementById('enhanced-album-wrapper-1')?.className).not.toContain(
+      'expanded',
+    );
+    expect(document.getElementById('enhanced-tracks-panel-1')?.className).not.toContain('visible');
+  });
+
+  it('marks the row, wrapper and panel on click, and unmarks on a second', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
+
+    fireEvent.click(row);
+    expect(row.className).toContain('expanded');
+    expect(document.getElementById('enhanced-album-wrapper-1')?.className).toContain('expanded');
+    expect(document.getElementById('enhanced-tracks-panel-1')?.className).toContain('visible');
+
+    fireEvent.click(row);
+    expect(row.className).not.toContain('expanded');
+    expect(document.getElementById('enhanced-tracks-panel-1')?.className).not.toContain('visible');
+  });
+
+  it('expands each album independently', () => {
+    render(<EnhancedView data={DATA} status={READY} />);
+    fireEvent.click(document.getElementById('enhanced-album-row-1') as HTMLElement);
+    expect(document.getElementById('enhanced-tracks-panel-2')?.className).not.toContain('visible');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { EnhancedView } from './enhanced-view';
@@ -21,7 +21,10 @@ const DATA = {
 };
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('EnhancedView states', () => {

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -11,6 +11,7 @@ import {
   sectionTrackTotal,
 } from '../-artist-detail.enhanced';
 import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
+import { AlbumMetaRow } from './album-meta-row';
 import { ExpandedAlbumHeader } from './expanded-album-header';
 
 interface Props {
@@ -137,7 +138,7 @@ function EnhancedSection({
  * full track table.
  */
 function EnhancedAlbumWrapper({
-  album,
+  album: albumProp,
   type,
   artist,
   isAdmin,
@@ -148,8 +149,21 @@ function EnhancedAlbumWrapper({
   isAdmin: boolean;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const meta = albumRowMeta(album);
   const [thumbBroken, setThumbBroken] = useState(false);
+
+  /**
+   * A saved edit is applied here rather than refetching the whole artist. The
+   * vanilla mutated the shared album object in place and hand-patched the row;
+   * holding the record in state does the same thing declaratively, and it
+   * resets whenever a real refetch hands down a new object.
+   */
+  const [seenAlbum, setSeenAlbum] = useState(albumProp);
+  const [album, setAlbum] = useState(albumProp);
+  if (albumProp !== seenAlbum) {
+    setSeenAlbum(albumProp);
+    setAlbum(albumProp);
+  }
+  const meta = albumRowMeta(album);
 
   return (
     <div
@@ -198,17 +212,24 @@ function EnhancedAlbumWrapper({
         className={`enhanced-tracks-panel${expanded ? ' visible' : ''}`}
         id={`enhanced-tracks-panel-${album.id}`}
       >
-        {/* The meta row and track table land in the next slices, with
+        {/* The track table lands in the next slice, with
             _attachTableDelegation. */}
         <div className="enhanced-tracks-panel-inner">
           {expanded ? (
-            <ExpandedAlbumHeader
-              album={album}
-              rows={getAlbumTrackRows(album)}
-              artistId={artist?.id}
-              artistName={String(artist?.name ?? '')}
-              isAdmin={isAdmin}
-            />
+            <>
+              <ExpandedAlbumHeader
+                album={album}
+                rows={getAlbumTrackRows(album)}
+                artistId={artist?.id}
+                artistName={String(artist?.name ?? '')}
+                isAdmin={isAdmin}
+              />
+              <AlbumMetaRow
+                album={album}
+                isAdmin={isAdmin}
+                onSaved={(updates) => setAlbum((current) => ({ ...current, ...updates }))}
+              />
+            </>
           ) : null}
         </div>
       </div>

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { EnhancedAlbum, EnhancedData } from '../-artist-detail.enhanced';
 
@@ -11,6 +11,7 @@ import {
   sectionTrackTotal,
 } from '../-artist-detail.enhanced';
 import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
+import { syncVanillaEnhancedData, syncVanillaSelection } from '../-artist-detail.vanilla-state';
 import { AlbumMetaRow } from './album-meta-row';
 import { EnhancedBulkBar } from './enhanced-bulk-bar';
 import { EnhancedTrackTable } from './enhanced-track-table';
@@ -39,6 +40,23 @@ export function EnhancedView({ data, status, isAdmin }: Props) {
    * ticked, and expanding a second album is a normal way to build that set.
    */
   const [selected, setSelected] = useState<Set<string>>(() => new Set());
+
+  /**
+   * The album and track actions that are still vanilla read this payload for
+   * the artist name and to patch their own copy of the album list, and read
+   * the selection to drop ids they just deleted. Cleared on unmount so a later
+   * page cannot act on a stale artist.
+   */
+  useEffect(() => {
+    syncVanillaEnhancedData(data);
+    return () => syncVanillaEnhancedData(null);
+  }, [data]);
+
+  useEffect(() => {
+    syncVanillaSelection(selected);
+    return () => syncVanillaSelection(new Set());
+  }, [selected]);
+
   if (status.error) {
     return (
       <div className="enhanced-loading" style={{ color: '#ff6b6b' }}>

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -32,6 +32,12 @@ interface Props {
  * an album typed "live" is grouped and then never shown.
  */
 export function EnhancedView({ data, status, isAdmin }: Props) {
+  /**
+   * Selection is page-level and shared across albums, as the vanilla's single
+   * artistDetailPageState.selectedTracks was: the bulk bar acts on everything
+   * ticked, and expanding a second album is a normal way to build that set.
+   */
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
   if (status.error) {
     return (
       <div className="enhanced-loading" style={{ color: '#ff6b6b' }}>
@@ -60,6 +66,8 @@ export function EnhancedView({ data, status, isAdmin }: Props) {
             albums={albums}
             artist={data.artist}
             isAdmin={isAdmin}
+            selected={selected}
+            onSelectedChange={setSelected}
           />
         );
       })}
@@ -96,12 +104,16 @@ function EnhancedSection({
   albums,
   artist,
   isAdmin,
+  selected,
+  onSelectedChange,
 }: {
   type: string;
   label: string;
   albums: EnhancedAlbum[];
   artist: Record<string, unknown> | undefined;
   isAdmin: boolean;
+  selected: Set<string>;
+  onSelectedChange: (next: Set<string>) => void;
 }) {
   return (
     <div className="enhanced-section">
@@ -118,6 +130,8 @@ function EnhancedSection({
             type={type}
             artist={artist}
             isAdmin={isAdmin}
+            selected={selected}
+            onSelectedChange={onSelectedChange}
             key={String(album.id)}
           />
         ))}
@@ -143,17 +157,18 @@ function EnhancedAlbumWrapper({
   type,
   artist,
   isAdmin,
+  selected,
+  onSelectedChange,
 }: {
   album: EnhancedAlbum;
   type: string;
   artist: Record<string, unknown> | undefined;
   isAdmin: boolean;
+  selected: Set<string>;
+  onSelectedChange: (next: Set<string>) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [thumbBroken, setThumbBroken] = useState(false);
-  // Selection is per album, and clears when the panel closes — the vanilla's
-  // shared Set leaked ticks between albums.
-  const [selected, setSelected] = useState<Set<string>>(() => new Set());
 
   /**
    * A saved edit is applied here rather than refetching the whole artist. The
@@ -177,12 +192,7 @@ function EnhancedAlbumWrapper({
       <div
         className={`enhanced-album-row${expanded ? ' expanded' : ''}`}
         id={`enhanced-album-row-${album.id}`}
-        onClick={() =>
-          setExpanded((open) => {
-            if (open) setSelected(new Set());
-            return !open;
-          })
-        }
+        onClick={() => setExpanded((open) => !open)}
       >
         <span className="enhanced-album-expand-icon">▶</span>
 
@@ -243,7 +253,7 @@ function EnhancedAlbumWrapper({
                 isAdmin={isAdmin}
                 artist={artist}
                 selected={selected}
-                onSelectedChange={setSelected}
+                onSelectedChange={onSelectedChange}
                 onTrackEdited={(trackId, field, value) =>
                   setAlbum((current) => ({
                     ...current,

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+
+import type { EnhancedAlbum, EnhancedData } from '../-artist-detail.enhanced';
+
+import {
+  albumRowMeta,
+  ENHANCED_SECTIONS,
+  enhancedStats,
+  groupAlbumsByType,
+  sectionCountLabel,
+  sectionTrackTotal,
+} from '../-artist-detail.enhanced';
+
+interface Props {
+  data: EnhancedData | null;
+  /** Non-null while the request is in flight or after it failed. */
+  status: { loading: boolean; error: string };
+}
+
+/**
+ * The Enhanced Management view: a stats bar over per-type sections of
+ * expandable album rows (renderEnhancedView, library.js:2885).
+ *
+ * Only album/ep/single sections render. groupAlbumsByType will happily create a
+ * bucket for any other record_type, and the vanilla ignored it the same way —
+ * an album typed "live" is grouped and then never shown.
+ */
+export function EnhancedView({ data, status }: Props) {
+  if (status.error) {
+    return (
+      <div className="enhanced-loading" style={{ color: '#ff6b6b' }}>
+        Failed to load: {status.error}
+      </div>
+    );
+  }
+  if (status.loading || !data)
+    return <div className="enhanced-loading">Loading library data...</div>;
+
+  const grouped = groupAlbumsByType(data.albums ?? []);
+
+  return (
+    <>
+      <EnhancedStatsBar data={data} />
+      {ENHANCED_SECTIONS.map(({ type, label }) => {
+        const albums = grouped[type] ?? [];
+        // An empty section is omitted entirely, not rendered as a header with
+        // nothing under it.
+        if (albums.length === 0) return null;
+        return <EnhancedSection key={type} type={type} label={label} albums={albums} />;
+      })}
+    </>
+  );
+}
+
+function EnhancedStatsBar({ data }: { data: EnhancedData }) {
+  const stats = enhancedStats(data);
+  return (
+    <div className="enhanced-stats-bar">
+      <div className="enhanced-stats-items">
+        {stats.items.map((item) => (
+          <div className="enhanced-stat-item" key={item.label}>
+            <span className="enhanced-stat-value">{item.value}</span>
+            <span className="enhanced-stat-label">{item.label}</span>
+          </div>
+        ))}
+      </div>
+      <div className="enhanced-stats-formats">
+        {stats.badges.map((badge) => (
+          <span className={`enhanced-format-badge ${badge.className}`} key={badge.format}>
+            {badge.format} ({badge.count})
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EnhancedSection({
+  type,
+  label,
+  albums,
+}: {
+  type: string;
+  label: string;
+  albums: EnhancedAlbum[];
+}) {
+  return (
+    <div className="enhanced-section">
+      <div className="enhanced-section-header">
+        <span className="enhanced-section-title">{label}</span>
+        <span className="enhanced-section-count">
+          {sectionCountLabel(albums.length, sectionTrackTotal(albums))}
+        </span>
+      </div>
+      <div className="enhanced-album-grid">
+        {albums.map((album) => (
+          <EnhancedAlbumWrapper album={album} type={type} key={String(album.id)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One album: the collapsed row plus its track panel.
+ *
+ * Expansion is local state per album rather than a page-level Set. The vanilla
+ * needed the Set because it re-rendered the whole container from scratch and
+ * had to restore which rows were open; React keeps each row mounted, so the
+ * state can live where it is used.
+ *
+ * The panel body is rendered only once expanded — the vanilla's lazy render,
+ * kept because a large library can have hundreds of albums and each panel is a
+ * full track table.
+ */
+function EnhancedAlbumWrapper({ album, type }: { album: EnhancedAlbum; type: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = albumRowMeta(album);
+  const [thumbBroken, setThumbBroken] = useState(false);
+
+  return (
+    <div
+      className={`enhanced-album-wrapper${expanded ? ' expanded' : ''}`}
+      id={`enhanced-album-wrapper-${album.id}`}
+    >
+      <div
+        className={`enhanced-album-row${expanded ? ' expanded' : ''}`}
+        id={`enhanced-album-row-${album.id}`}
+        onClick={() => setExpanded((open) => !open)}
+      >
+        <span className="enhanced-album-expand-icon">▶</span>
+
+        <div className="enhanced-album-art-wrap">
+          {album.thumb_url && !thumbBroken ? (
+            <img
+              className="enhanced-album-thumb"
+              src={String(album.thumb_url)}
+              alt=""
+              loading="lazy"
+              onError={() => setThumbBroken(true)}
+            />
+          ) : (
+            <div className="enhanced-album-thumb-fallback">🎵</div>
+          )}
+        </div>
+
+        <div className="enhanced-album-info-block">
+          {/* `||`, not `??`: an EMPTY title falls back to "Unknown" too, which
+              is what the vanilla did and what an untitled row needs. */}
+          <span className="enhanced-album-title" title={String(album.title || '')}>
+            {String(album.title || 'Unknown')}
+          </span>
+          <span className="enhanced-album-meta-line">{meta.metaLine}</span>
+        </div>
+
+        <span className={`enhanced-album-type-badge ${(type || 'album').toLowerCase()}`}>
+          {type}
+        </span>
+        {meta.primaryFormat ? (
+          <span className={`enhanced-format-badge ${meta.formatClass}`}>{meta.primaryFormat}</span>
+        ) : null}
+      </div>
+
+      <div
+        className={`enhanced-tracks-panel${expanded ? ' visible' : ''}`}
+        id={`enhanced-tracks-panel-${album.id}`}
+      >
+        {/* The panel body — expanded header, meta row and track table — lands
+            in the next slice with _attachTableDelegation. Rendering nothing
+            here rather than a placeholder: a placeholder is content that can
+            ship by accident. */}
+        <div className="enhanced-tracks-panel-inner" />
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -12,6 +12,7 @@ import {
 } from '../-artist-detail.enhanced';
 import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
 import { AlbumMetaRow } from './album-meta-row';
+import { EnhancedBulkBar } from './enhanced-bulk-bar';
 import { EnhancedTrackTable } from './enhanced-track-table';
 import { ExpandedAlbumHeader } from './expanded-album-header';
 
@@ -50,6 +51,20 @@ export function EnhancedView({ data, status, isAdmin }: Props) {
 
   const grouped = groupAlbumsByType(data.albums ?? []);
 
+  /**
+   * A batch edit is applied to the loaded payload in place, as
+   * updateLocalEnhancedData did — the panels re-render from it rather than
+   * re-fetching every track of every album.
+   */
+  const applyBatch = (trackIds: string[], updates: Record<string, unknown>) => {
+    const ids = new Set(trackIds);
+    for (const album of data.albums ?? []) {
+      album.tracks = (album.tracks ?? []).map((track) =>
+        ids.has(String(track.id)) ? { ...track, ...updates } : track,
+      );
+    }
+  };
+
   return (
     <>
       <EnhancedStatsBar data={data} />
@@ -71,6 +86,13 @@ export function EnhancedView({ data, status, isAdmin }: Props) {
           />
         );
       })}
+
+      <EnhancedBulkBar
+        selected={selected}
+        isAdmin={isAdmin}
+        onClear={() => setSelected(new Set())}
+        onEdited={applyBatch}
+      />
     </>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -241,6 +241,7 @@ function EnhancedAlbumWrapper({
               <EnhancedTrackTable
                 album={album}
                 isAdmin={isAdmin}
+                artist={artist}
                 selected={selected}
                 onSelectedChange={setSelected}
               />

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -10,11 +10,15 @@ import {
   sectionCountLabel,
   sectionTrackTotal,
 } from '../-artist-detail.enhanced';
+import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
+import { ExpandedAlbumHeader } from './expanded-album-header';
 
 interface Props {
   data: EnhancedData | null;
   /** Non-null while the request is in flight or after it failed. */
   status: { loading: boolean; error: string };
+  /** Drives the admin-only action row inside each expanded album. */
+  isAdmin: boolean;
 }
 
 /**
@@ -25,7 +29,7 @@ interface Props {
  * bucket for any other record_type, and the vanilla ignored it the same way —
  * an album typed "live" is grouped and then never shown.
  */
-export function EnhancedView({ data, status }: Props) {
+export function EnhancedView({ data, status, isAdmin }: Props) {
   if (status.error) {
     return (
       <div className="enhanced-loading" style={{ color: '#ff6b6b' }}>
@@ -46,7 +50,16 @@ export function EnhancedView({ data, status }: Props) {
         // An empty section is omitted entirely, not rendered as a header with
         // nothing under it.
         if (albums.length === 0) return null;
-        return <EnhancedSection key={type} type={type} label={label} albums={albums} />;
+        return (
+          <EnhancedSection
+            key={type}
+            type={type}
+            label={label}
+            albums={albums}
+            artist={data.artist}
+            isAdmin={isAdmin}
+          />
+        );
       })}
     </>
   );
@@ -79,10 +92,14 @@ function EnhancedSection({
   type,
   label,
   albums,
+  artist,
+  isAdmin,
 }: {
   type: string;
   label: string;
   albums: EnhancedAlbum[];
+  artist: Record<string, unknown> | undefined;
+  isAdmin: boolean;
 }) {
   return (
     <div className="enhanced-section">
@@ -94,7 +111,13 @@ function EnhancedSection({
       </div>
       <div className="enhanced-album-grid">
         {albums.map((album) => (
-          <EnhancedAlbumWrapper album={album} type={type} key={String(album.id)} />
+          <EnhancedAlbumWrapper
+            album={album}
+            type={type}
+            artist={artist}
+            isAdmin={isAdmin}
+            key={String(album.id)}
+          />
         ))}
       </div>
     </div>
@@ -113,7 +136,17 @@ function EnhancedSection({
  * kept because a large library can have hundreds of albums and each panel is a
  * full track table.
  */
-function EnhancedAlbumWrapper({ album, type }: { album: EnhancedAlbum; type: string }) {
+function EnhancedAlbumWrapper({
+  album,
+  type,
+  artist,
+  isAdmin,
+}: {
+  album: EnhancedAlbum;
+  type: string;
+  artist: Record<string, unknown> | undefined;
+  isAdmin: boolean;
+}) {
   const [expanded, setExpanded] = useState(false);
   const meta = albumRowMeta(album);
   const [thumbBroken, setThumbBroken] = useState(false);
@@ -165,11 +198,19 @@ function EnhancedAlbumWrapper({ album, type }: { album: EnhancedAlbum; type: str
         className={`enhanced-tracks-panel${expanded ? ' visible' : ''}`}
         id={`enhanced-tracks-panel-${album.id}`}
       >
-        {/* The panel body — expanded header, meta row and track table — lands
-            in the next slice with _attachTableDelegation. Rendering nothing
-            here rather than a placeholder: a placeholder is content that can
-            ship by accident. */}
-        <div className="enhanced-tracks-panel-inner" />
+        {/* The meta row and track table land in the next slices, with
+            _attachTableDelegation. */}
+        <div className="enhanced-tracks-panel-inner">
+          {expanded ? (
+            <ExpandedAlbumHeader
+              album={album}
+              rows={getAlbumTrackRows(album)}
+              artistId={artist?.id}
+              artistName={String(artist?.name ?? '')}
+              isAdmin={isAdmin}
+            />
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -12,6 +12,7 @@ import {
 } from '../-artist-detail.enhanced';
 import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
 import { AlbumMetaRow } from './album-meta-row';
+import { EnhancedTrackTable } from './enhanced-track-table';
 import { ExpandedAlbumHeader } from './expanded-album-header';
 
 interface Props {
@@ -150,6 +151,9 @@ function EnhancedAlbumWrapper({
 }) {
   const [expanded, setExpanded] = useState(false);
   const [thumbBroken, setThumbBroken] = useState(false);
+  // Selection is per album, and clears when the panel closes — the vanilla's
+  // shared Set leaked ticks between albums.
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
 
   /**
    * A saved edit is applied here rather than refetching the whole artist. The
@@ -173,7 +177,12 @@ function EnhancedAlbumWrapper({
       <div
         className={`enhanced-album-row${expanded ? ' expanded' : ''}`}
         id={`enhanced-album-row-${album.id}`}
-        onClick={() => setExpanded((open) => !open)}
+        onClick={() =>
+          setExpanded((open) => {
+            if (open) setSelected(new Set());
+            return !open;
+          })
+        }
       >
         <span className="enhanced-album-expand-icon">▶</span>
 
@@ -212,8 +221,8 @@ function EnhancedAlbumWrapper({
         className={`enhanced-tracks-panel${expanded ? ' visible' : ''}`}
         id={`enhanced-tracks-panel-${album.id}`}
       >
-        {/* The track table lands in the next slice, with
-            _attachTableDelegation. */}
+        {/* The row interactions — inline edit, play, queue, per-track actions —
+            land in the next slice with _attachTableDelegation. */}
         <div className="enhanced-tracks-panel-inner">
           {expanded ? (
             <>
@@ -228,6 +237,12 @@ function EnhancedAlbumWrapper({
                 album={album}
                 isAdmin={isAdmin}
                 onSaved={(updates) => setAlbum((current) => ({ ...current, ...updates }))}
+              />
+              <EnhancedTrackTable
+                album={album}
+                isAdmin={isAdmin}
+                selected={selected}
+                onSelectedChange={setSelected}
               />
             </>
           ) : null}

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -244,6 +244,14 @@ function EnhancedAlbumWrapper({
                 artist={artist}
                 selected={selected}
                 onSelectedChange={setSelected}
+                onTrackEdited={(trackId, field, value) =>
+                  setAlbum((current) => ({
+                    ...current,
+                    tracks: (current.tracks ?? []).map((t) =>
+                      String(t.id) === String(trackId) ? { ...t, [field]: value } : t,
+                    ),
+                  }))
+                }
               />
             </>
           ) : null}

--- a/webui/src/routes/artist-detail/-ui/enrichment-coverage.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enrichment-coverage.test.tsx
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { RING_CIRCUMFERENCE, RING_RADIUS } from '../-artist-detail.enrichment';
+import { EnrichmentCoverage } from './enrichment-coverage';
+
+afterEach(() => {
+  delete window.filterJiosaavnServiceEntries;
+});
+
+const COVERAGE = { total_tracks: 120, spotify: 100, musicbrainz: 50, deezer: 0 };
+
+describe('EnrichmentCoverage', () => {
+  it('renders nothing without coverage data', () => {
+    const { container } = render(<EnrichmentCoverage enrichment={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for an artist with no tracks', () => {
+    // A coverage ring over zero tracks is a meaningless 0%.
+    const { container } = render(
+      <EnrichmentCoverage enrichment={{ total_tracks: 0, spotify: 90 }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one ring per visible service, in declaration order', () => {
+    render(<EnrichmentCoverage enrichment={COVERAGE} />);
+    const labels = [...document.querySelectorAll('.artist-enrich-label')].map((n) => n.textContent);
+    // JioSaavn is filtered out by default (experimental, opt-in).
+    expect(labels).toEqual([
+      'Spotify',
+      'MusicBrainz',
+      'Deezer',
+      'Last.fm',
+      'iTunes',
+      'AudioDB',
+      'Discogs',
+      'Genius',
+      'Tidal',
+      'Qobuz',
+      'Bandcamp',
+    ]);
+  });
+
+  it('includes JioSaavn when the shared helper says it is enabled', () => {
+    window.filterJiosaavnServiceEntries = (entries) => entries as never[];
+    render(<EnrichmentCoverage enrichment={COVERAGE} />);
+    const labels = [...document.querySelectorAll('.artist-enrich-label')].map((n) => n.textContent);
+    expect(labels).toContain('JioSaavn');
+  });
+
+  it('empties the ring in proportion to the missing coverage', () => {
+    render(<EnrichmentCoverage enrichment={COVERAGE} />);
+    const fills = [...document.querySelectorAll('.ring-fill')] as SVGElement[];
+
+    // Compared numerically: jsdom normalises the "0.0" the vanilla emitted to
+    // "0", exactly as a real browser does.
+    const offset = (el: SVGElement) => parseFloat(el.style.strokeDashoffset);
+    // 100% coverage leaves nothing empty; 0% leaves the whole circumference.
+    expect(offset(fills[0])).toBe(0);
+    expect(offset(fills[2])).toBeCloseTo(RING_CIRCUMFERENCE, 1);
+    // Half-covered sits halfway, and not at either extreme.
+    expect(offset(fills[1])).toBeCloseTo(RING_CIRCUMFERENCE / 2, 1);
+    expect(fills[0].getAttribute('r')).toBe(String(RING_RADIUS));
+  });
+
+  it('shows a rounded percentage, and 0 for a service with no key', () => {
+    render(<EnrichmentCoverage enrichment={{ total_tracks: 10, spotify: 66.6 }} />);
+    const pcts = [...document.querySelectorAll('.ring-pct')].map((n) => n.textContent);
+    expect(pcts[0]).toBe('67');
+    expect(pcts[1]).toBe('0');
+  });
+
+  it('staggers the ring animations so they sweep in one after another', () => {
+    render(<EnrichmentCoverage enrichment={COVERAGE} />);
+    const fills = [...document.querySelectorAll('.ring-fill')] as SVGElement[];
+    expect(fills[0].style.animation).toContain('0.00s');
+    expect(fills[1].style.animation).toContain('0.08s');
+    expect(fills[2].style.animation).toContain('0.16s');
+
+    // The number fades in 0.3s after its own ring starts.
+    const pcts = [...document.querySelectorAll('.ring-pct')] as HTMLElement[];
+    expect(pcts[1].style.animation).toContain('0.38s');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/enrichment-coverage.tsx
+++ b/webui/src/routes/artist-detail/-ui/enrichment-coverage.tsx
@@ -1,0 +1,72 @@
+import {
+  buildEnrichmentRings,
+  RING_RADIUS,
+  shouldShowEnrichment,
+  visibleEnrichmentServices,
+} from '../-artist-detail.enrichment';
+
+interface Props {
+  enrichment: Record<string, unknown> | undefined;
+}
+
+/**
+ * Per-artist enrichment coverage rings (renderArtistEnrichmentCoverage).
+ *
+ * The vanilla wrote inline `animation:` shorthands rather than CSS classes, and
+ * they are reproduced verbatim: the stagger is what makes the twelve rings
+ * sweep in one after another instead of snapping into place together.
+ *
+ * Hidden entirely when the artist has no tracks — a coverage ring over zero
+ * tracks is a meaningless 0%.
+ */
+export function EnrichmentCoverage({ enrichment }: Props) {
+  if (!shouldShowEnrichment(enrichment)) return null;
+
+  const rings = buildEnrichmentRings(
+    enrichment as Record<string, unknown>,
+    visibleEnrichmentServices(),
+  );
+
+  return (
+    <div className="artist-enrichment-coverage" id="artist-enrichment-coverage">
+      <div className="artist-enrich-title">Enrichment Coverage</div>
+      <div className="artist-enrich-grid">
+        {rings.map((ring) => (
+          <div className="artist-enrich-circle" key={ring.service.key}>
+            <div
+              className="artist-enrich-ring"
+              style={{ '--ring-color': ring.service.color } as React.CSSProperties}
+            >
+              <svg viewBox="0 0 48 48">
+                <circle className="ring-bg" cx="24" cy="24" r={RING_RADIUS} />
+                <circle
+                  className="ring-fill"
+                  cx="24"
+                  cy="24"
+                  r={RING_RADIUS}
+                  stroke={ring.service.color}
+                  strokeDasharray={ring.dashArray}
+                  style={
+                    {
+                      '--ring-circ': ring.dashArray,
+                      '--ring-offset': ring.offset,
+                      strokeDashoffset: ring.offset,
+                      animation: `ringFillIn 1s cubic-bezier(0.4,0,0.2,1) ${ring.delay}s both`,
+                    } as React.CSSProperties
+                  }
+                />
+              </svg>
+              <span
+                className="ring-pct"
+                style={{ animation: `ringPctFade 0.8s ease ${ring.pctDelay}s both` }}
+              >
+                {ring.label}
+              </span>
+            </div>
+            <span className="artist-enrich-label">{ring.service.name}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/expanded-album-header.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/expanded-album-header.test.tsx
@@ -1,0 +1,212 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnhancedAlbum } from '../-artist-detail.enhanced';
+
+import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
+import { ExpandedAlbumHeader } from './expanded-album-header';
+
+const ALBUM: EnhancedAlbum = {
+  id: 7,
+  title: 'SAW 85-92',
+  year: 1992,
+  label: 'Apollo',
+  record_type: 'album',
+  thumb_url: 'cover.jpg',
+  genres: ['ambient', 'idm'],
+  spotify_album_id: 'sp1',
+  spotify_match_status: 'matched',
+  tracks: [{ id: 1, duration: 300_000, track_number: 1 }],
+};
+
+function renderHeader(album: EnhancedAlbum = ALBUM, isAdmin = true) {
+  return render(
+    <ExpandedAlbumHeader
+      album={album}
+      rows={getAlbumTrackRows(album)}
+      artistId={42}
+      artistName="Aphex Twin"
+      isAdmin={isAdmin}
+    />,
+  );
+}
+
+const ACTIONS = [
+  'openAlbumArtPicker',
+  'openManualMatchModal',
+  'runEnrichment',
+  'writeAlbumTags',
+  'analyzeAlbumReplayGain',
+  'showReorganizeModal',
+  'redownloadLibraryAlbum',
+  'deleteLibraryAlbum',
+  'showReportIssueModal',
+] as const;
+
+beforeEach(() => {
+  for (const action of ACTIONS) window[action] = vi.fn() as never;
+});
+
+afterEach(() => {
+  for (const action of ACTIONS) delete window[action];
+  document.body.innerHTML = '';
+});
+
+describe('the header body', () => {
+  it('shows the title, detail line, genres and id badges', () => {
+    renderHeader();
+    expect(document.querySelector('.enhanced-expanded-title')?.textContent).toBe('SAW 85-92');
+    expect(document.querySelector('.enhanced-expanded-meta')?.textContent).toBe(
+      '1992 · 1 track · 5:00 · Apollo · ALBUM',
+    );
+    expect([...document.querySelectorAll('.enhanced-genre-tag')].map((n) => n.textContent)).toEqual(
+      ['ambient', 'idm'],
+    );
+    const badge = document.querySelector('.enhanced-id-badge') as HTMLAnchorElement;
+    expect(badge.getAttribute('href')).toBe('https://open.spotify.com/album/sp1');
+    expect(badge.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  it('omits the genre and id rows entirely when there are none', () => {
+    renderHeader({ id: 7, title: 'X', tracks: [] });
+    expect(document.querySelector('.enhanced-expanded-genres')).toBeNull();
+    expect(document.querySelector('.enhanced-expanded-ids')).toBeNull();
+  });
+
+  it('HIDES a broken cover rather than removing it', () => {
+    // Removing the img would collapse the wrap and lose the click target that
+    // opens the art picker.
+    renderHeader();
+    const img = document.querySelector('.enhanced-expanded-art') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(img.style.visibility).toBe('hidden');
+    expect(document.querySelector('.enhanced-expanded-art')).not.toBeNull();
+  });
+
+  it('opens the art picker from the cover', () => {
+    renderHeader();
+    fireEvent.click(document.querySelector('.enhanced-expanded-art-wrap') as HTMLElement);
+    expect(window.openAlbumArtPicker).toHaveBeenCalledWith(ALBUM);
+  });
+});
+
+describe('match chips', () => {
+  it('renders one per service with its status', () => {
+    renderHeader();
+    const chips = [...document.querySelectorAll('.enhanced-match-chip')];
+    expect(chips).toHaveLength(9);
+    expect(chips[0].textContent).toBe('Spotify: matched');
+    expect(chips[1].textContent).toBe('MB: —');
+  });
+
+  it('opens the manual matcher for its own service', () => {
+    renderHeader();
+    fireEvent.click(document.querySelectorAll('.enhanced-match-chip')[1]);
+    expect(window.openManualMatchModal).toHaveBeenCalledWith(
+      'album',
+      7,
+      'musicbrainz',
+      'SAW 85-92',
+      42,
+    );
+  });
+
+  it('does not let an ID BADGE click bubble into the row toggle', () => {
+    // Following the link would otherwise also collapse the album underneath it.
+    const onRowClick = vi.fn();
+    render(
+      <div onClick={onRowClick}>
+        <ExpandedAlbumHeader
+          album={ALBUM}
+          rows={[]}
+          artistId={42}
+          artistName="Aphex Twin"
+          isAdmin
+        />
+      </div>,
+    );
+    fireEvent.click(document.querySelector('.enhanced-id-badge') as HTMLElement);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('does not let the chip click bubble into the row toggle', () => {
+    const onRowClick = vi.fn();
+    render(
+      <div onClick={onRowClick}>
+        <ExpandedAlbumHeader
+          album={ALBUM}
+          rows={[]}
+          artistId={42}
+          artistName="Aphex Twin"
+          isAdmin
+        />
+      </div>,
+    );
+    fireEvent.click(document.querySelector('.enhanced-match-chip') as HTMLElement);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('admin actions', () => {
+  it('are hidden for a non-admin, but Report Issue stays', () => {
+    renderHeader(ALBUM, false);
+    expect(document.querySelector('.enhanced-enrich-wrap')).toBeNull();
+    expect(document.querySelector('.enhanced-delete-album-btn')).toBeNull();
+    expect(document.querySelector('.enhanced-report-issue-btn')).not.toBeNull();
+  });
+
+  it('reports an issue with the album and its artist', () => {
+    renderHeader(ALBUM, false);
+    fireEvent.click(document.querySelector('.enhanced-report-issue-btn') as HTMLElement);
+    expect(window.showReportIssueModal).toHaveBeenCalledWith('album', 7, 'SAW 85-92', 'Aphex Twin');
+  });
+
+  it('opens the enrich menu on click and closes it after picking a source', () => {
+    renderHeader();
+    const menu = document.querySelector('.enhanced-enrich-menu') as HTMLElement;
+    expect(menu.className).not.toContain('visible');
+
+    fireEvent.click(document.querySelector('.enhanced-enrich-btn') as HTMLElement);
+    expect(menu.className).toContain('visible');
+
+    fireEvent.click(document.querySelectorAll('.enhanced-enrich-menu-item')[0]);
+    expect(window.runEnrichment).toHaveBeenCalledWith(
+      'album',
+      7,
+      'spotify',
+      'SAW 85-92',
+      'Aphex Twin',
+      42,
+    );
+    expect(menu.className).not.toContain('visible');
+  });
+
+  it('wires each album action to its own handler', () => {
+    renderHeader();
+    fireEvent.click(document.querySelector('.enhanced-write-tags-album-btn') as HTMLElement);
+    expect(window.writeAlbumTags).toHaveBeenCalledWith(7);
+
+    fireEvent.click(document.querySelector('.enhanced-reorganize-album-btn') as HTMLElement);
+    expect(window.showReorganizeModal).toHaveBeenCalledWith(7);
+
+    fireEvent.click(document.querySelector('.enhanced-delete-album-btn') as HTMLElement);
+    expect(window.deleteLibraryAlbum).toHaveBeenCalledWith(7);
+  });
+
+  it('hands the BUTTON itself to the two actions that render progress on it', () => {
+    renderHeader();
+    const rg = document.querySelector('.enhanced-rg-album-btn') as HTMLElement;
+    fireEvent.click(rg);
+    expect(window.analyzeAlbumReplayGain).toHaveBeenCalledWith(7, rg);
+
+    const redownload = document.querySelector('.enhanced-redownload-album-btn') as HTMLElement;
+    fireEvent.click(redownload);
+    expect(window.redownloadLibraryAlbum).toHaveBeenCalledWith(ALBUM, 'Aphex Twin', redownload);
+  });
+
+  it('survives a handler that is not loaded rather than throwing', () => {
+    for (const action of ACTIONS) delete window[action];
+    renderHeader();
+    fireEvent.click(document.querySelector('.enhanced-delete-album-btn') as HTMLElement);
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/expanded-album-header.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/expanded-album-header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { EnhancedAlbum } from '../-artist-detail.enhanced';
@@ -49,7 +49,10 @@ beforeEach(() => {
 
 afterEach(() => {
   for (const action of ACTIONS) delete window[action];
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
 });
 
 describe('the header body', () => {

--- a/webui/src/routes/artist-detail/-ui/expanded-album-header.tsx
+++ b/webui/src/routes/artist-detail/-ui/expanded-album-header.tsx
@@ -1,0 +1,270 @@
+import { useState } from 'react';
+
+import type { EnhancedAlbum, EnhancedTrack } from '../-artist-detail.enhanced';
+
+import {
+  albumEnrichServices,
+  albumIdBadges,
+  albumMatchChips,
+  expandedHeaderDetails,
+} from '../-artist-detail.enhanced-album';
+
+interface Props {
+  album: EnhancedAlbum;
+  /** Already merged owned + expected-missing rows. */
+  rows: EnhancedTrack[];
+  artistId: unknown;
+  artistName: string;
+  /** The admin action row is hidden for everyone else. */
+  isAdmin: boolean;
+}
+
+/**
+ * The expanded album panel's header (renderExpandedAlbumHeader, library.js:3783).
+ *
+ * Every action still lives in library.js and is invoked through window; the
+ * modals slice ports them. Two of them are handed the button element itself,
+ * because they render progress onto it.
+ */
+export function ExpandedAlbumHeader({ album, rows, artistId, artistName, isAdmin }: Props) {
+  const [artBroken, setArtBroken] = useState(false);
+  const genres = Array.isArray(album.genres) ? album.genres : [];
+  const badges = albumIdBadges(album);
+  const chips = albumMatchChips(album);
+
+  return (
+    <div className="enhanced-expanded-header">
+      <div
+        className="enhanced-expanded-art-wrap"
+        title="Change cover art"
+        onClick={() => window.openAlbumArtPicker?.(album)}
+      >
+        {/* The vanilla hid a broken cover rather than removing it, so the
+            wrap keeps its size and the click target does not collapse. */}
+        <img
+          className="enhanced-expanded-art"
+          src={album.thumb_url ? String(album.thumb_url) : undefined}
+          alt={String(album.title || '')}
+          style={{ visibility: artBroken ? 'hidden' : undefined }}
+          onError={() => setArtBroken(true)}
+        />
+        <div className="enhanced-art-edit-overlay">
+          <svg
+            viewBox="0 0 24 24"
+            width="26"
+            height="26"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <path d="m21 15-5-5L5 21" />
+          </svg>
+          <span>Change cover</span>
+        </div>
+      </div>
+
+      <div className="enhanced-expanded-info">
+        <div className="enhanced-expanded-title">{String(album.title || 'Unknown')}</div>
+        <div className="enhanced-expanded-meta">{expandedHeaderDetails(album, rows)}</div>
+
+        {genres.length > 0 ? (
+          <div className="enhanced-expanded-genres">
+            {genres.map((genre) => (
+              <span className="enhanced-genre-tag" key={String(genre)}>
+                {String(genre)}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {badges.length > 0 ? (
+          <div className="enhanced-expanded-ids">
+            {badges.map((badge) =>
+              badge.url ? (
+                <a
+                  key={badge.service}
+                  className={badge.className}
+                  href={badge.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={badge.title}
+                  // Without this the row's own click handler collapses the
+                  // album out from under the link.
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {badge.label}
+                </a>
+              ) : (
+                <span key={badge.service} className={badge.className} title={badge.title}>
+                  {badge.label}
+                </span>
+              ),
+            )}
+          </div>
+        ) : null}
+
+        <div className="enhanced-match-status-row compact">
+          {chips.map((chip) => (
+            <span
+              key={chip.service}
+              className={chip.className}
+              title={chip.title}
+              onClick={(e) => {
+                e.stopPropagation();
+                window.openManualMatchModal?.(
+                  'album',
+                  album.id,
+                  chip.service,
+                  String(album.title || ''),
+                  artistId,
+                );
+              }}
+            >
+              {chip.label}: {chip.status}
+            </span>
+          ))}
+        </div>
+
+        <div className="enhanced-expanded-actions">
+          {isAdmin ? (
+            <AdminAlbumActions album={album} artistId={artistId} artistName={artistName} />
+          ) : null}
+
+          {/* Reporting an issue is open to every user, not just admins. */}
+          <button
+            type="button"
+            className="enhanced-report-issue-btn"
+            title="Report a problem with this album"
+            onClick={(e) => {
+              e.stopPropagation();
+              window.showReportIssueModal?.(
+                'album',
+                album.id,
+                String(album.title || ''),
+                artistName,
+              );
+            }}
+          >
+            ⚑ Report Issue
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AdminAlbumActions({
+  album,
+  artistId,
+  artistName,
+}: {
+  album: EnhancedAlbum;
+  artistId: unknown;
+  artistName: string;
+}) {
+  const [enrichOpen, setEnrichOpen] = useState(false);
+
+  return (
+    <>
+      <div className="enhanced-enrich-wrap">
+        <button
+          type="button"
+          className="enhanced-enrich-btn small"
+          onClick={(e) => {
+            e.stopPropagation();
+            setEnrichOpen((open) => !open);
+          }}
+        >
+          Enrich Album ▾
+        </button>
+        <div className={`enhanced-enrich-menu${enrichOpen ? ' visible' : ''}`}>
+          {albumEnrichServices().map((service) => (
+            <div
+              className="enhanced-enrich-menu-item"
+              key={service.id}
+              onClick={(e) => {
+                e.stopPropagation();
+                setEnrichOpen(false);
+                window.runEnrichment?.(
+                  'album',
+                  album.id,
+                  service.id,
+                  String(album.title || ''),
+                  artistName,
+                  artistId,
+                );
+              }}
+            >
+              {service.icon} {service.label}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="enhanced-write-tags-album-btn"
+        title="Write DB metadata to file tags for all tracks in this album"
+        onClick={(e) => {
+          e.stopPropagation();
+          window.writeAlbumTags?.(album.id);
+        }}
+      >
+        ✎ Write All Tags
+      </button>
+
+      <button
+        type="button"
+        className="enhanced-rg-album-btn"
+        title="Analyze ReplayGain for all tracks in this album (writes track + album gain)"
+        data-album-id={String(album.id)}
+        onClick={(e) => {
+          e.stopPropagation();
+          window.analyzeAlbumReplayGain?.(album.id, e.currentTarget);
+        }}
+      >
+        ♫ ReplayGain
+      </button>
+
+      <button
+        type="button"
+        className="enhanced-reorganize-album-btn"
+        title="Reorganize album files using your configured download template"
+        data-album-id={String(album.id)}
+        onClick={(e) => {
+          e.stopPropagation();
+          window.showReorganizeModal?.(album.id);
+        }}
+      >
+        📁 Reorganize
+      </button>
+
+      <button
+        type="button"
+        className="enhanced-redownload-album-btn"
+        title="Redownload this album (opens Download Missing modal with force-download)"
+        onClick={(e) => {
+          e.stopPropagation();
+          window.redownloadLibraryAlbum?.(album, artistName, e.currentTarget);
+        }}
+      >
+        ↻ Redownload
+      </button>
+
+      <button
+        type="button"
+        className="enhanced-delete-album-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          window.deleteLibraryAlbum?.(album.id);
+        }}
+      >
+        Delete Album
+      </button>
+    </>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/portal.tsx
+++ b/webui/src/routes/artist-detail/-ui/portal.tsx
@@ -1,0 +1,18 @@
+import { createPortal } from 'react-dom';
+
+/**
+ * Renders into document.body, where the vanilla appended its overlays.
+ *
+ * This is not tidiness — it is required. `.artist-hero-section` sets
+ * `backdrop-filter`, and a filtered element becomes the CONTAINING BLOCK for
+ * any `position: fixed` descendant. An overlay rendered inside the hero has its
+ * `inset: 0` clamped to the hero box: it lands in the wrong place, gets cut off
+ * at the top, and a click anywhere else on the page never reaches the backdrop,
+ * so it cannot be dismissed.
+ *
+ * Everything the stylesheet positions with `fixed` — .arec-overlay,
+ * .modal-overlay, .enhanced-bulk-bar — has to come through here.
+ */
+export function BodyPortal({ children }: { children: React.ReactNode }) {
+  return createPortal(children, document.body);
+}

--- a/webui/src/routes/artist-detail/-ui/release-card.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DiscographyRelease } from '../-artist-detail.types';
+
+import { ReleaseCard } from './release-card';
+
+function renderCard(
+  release: DiscographyRelease,
+  opts: Partial<{ mb: boolean; source: boolean }> = {},
+) {
+  const onOpen = vi.fn();
+  render(
+    <ReleaseCard
+      release={release}
+      isMusicBrainz={opts.mb ?? false}
+      isSourceArtist={opts.source ?? false}
+      onOpen={onOpen}
+    />,
+  );
+  return { onOpen, card: document.querySelector('.release-card') as HTMLElement };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+describe('ReleaseCard markup', () => {
+  it('keeps both class names and the vanilla data attributes', () => {
+    const { card } = renderCard({ id: 7, title: 'Kid A', album_type: 'album', owned: true });
+    expect(card.className).toBe('release-card album-card');
+    expect(card.dataset.releaseId).toBe('7');
+    expect(card.dataset.albumId).toBe('7');
+    expect(card.dataset.albumName).toBe('Kid A');
+    expect(card.dataset.albumType).toBe('album');
+  });
+
+  it('defaults album_type to album, matching the vanilla', () => {
+    expect(renderCard({ id: 1, title: 'X' }).card.dataset.albumType).toBe('album');
+  });
+
+  it('renders the data-is-* flags the CSS and tour select on', () => {
+    const { card } = renderCard({ id: 1, title: 'Live at Leeds' });
+    expect(card.dataset.isLive).toBe('true');
+    expect(card.dataset.isCompilation).toBe('false');
+    expect(card.dataset.isFeatured).toBe('false');
+  });
+
+  it('recomputes live-ness from secondary_types on MusicBrainz', () => {
+    const { card } = renderCard(
+      { id: 1, title: 'Live Through This', secondary_types: [] },
+      { mb: true },
+    );
+    expect(card.dataset.isLive).toBe('false');
+  });
+
+  it('lazy-loads artwork via data-bg-src, not an inline background', () => {
+    const { card } = renderCard({ id: 1, title: 'X', image_url: 'a.jpg' });
+    const image = card.querySelector('.album-card-image') as HTMLElement;
+    expect(image.dataset.bgSrc).toBe('a.jpg');
+    expect(image.style.backgroundImage).toBe('');
+  });
+
+  it('omits data-bg-src entirely for a blank url', () => {
+    const { card } = renderCard({ id: 1, title: 'X', image_url: '   ' });
+    expect((card.querySelector('.album-card-image') as HTMLElement).dataset.bgSrc).toBeUndefined();
+  });
+
+  it('shows the completion overlay, and drops it for a source artist', () => {
+    expect(
+      renderCard({ id: 1, title: 'X', owned: false }).card.querySelector(
+        '.completion-overlay .completion-status',
+      )?.textContent,
+    ).toBe('Missing');
+    document.body.innerHTML = '';
+    expect(
+      renderCard({ id: 1, title: 'X', owned: false }, { source: true }).card.querySelector(
+        '.completion-overlay',
+      ),
+    ).toBeNull();
+  });
+
+  it('renders the explicit badge only for exactly true', () => {
+    expect(
+      renderCard({ id: 1, title: 'X', explicit: true }).card.querySelector('.explicit-badge'),
+    ).not.toBeNull();
+    document.body.innerHTML = '';
+    expect(renderCard({ id: 1, title: 'X' }).card.querySelector('.explicit-badge')).toBeNull();
+    document.body.innerHTML = '';
+    // Truthy is NOT enough — only `=== true`. Without this case a Boolean()
+    // check would pass every assertion above.
+    expect(
+      renderCard({ id: 1, title: 'X', explicit: 1 as never }).card.querySelector('.explicit-badge'),
+    ).toBeNull();
+  });
+
+  it('omits the year element when there is no usable year', () => {
+    expect(renderCard({ id: 1, title: 'X' }).card.querySelector('.album-card-year')).toBeNull();
+    document.body.innerHTML = '';
+    expect(
+      renderCard({ id: 1, title: 'X', release_date: '1994-01-01' }).card.querySelector(
+        '.album-card-year',
+      )?.textContent,
+    ).toBe('1994');
+  });
+});
+
+describe('ReleaseCard interaction', () => {
+  it('opens the release on click', () => {
+    const { onOpen, card } = renderCard({ id: 1, title: 'Kid A', owned: true });
+    fireEvent.click(card);
+    expect(onOpen).toHaveBeenCalledWith(expect.objectContaining({ title: 'Kid A' }));
+  });
+
+  it('opens MusicBrainz WITHOUT also opening the release', () => {
+    // The icon sits inside the card, so without stopPropagation both fire.
+    const open = vi.fn();
+    vi.stubGlobal('open', open);
+    const { onOpen, card } = renderCard({ id: 1, title: 'X', musicbrainz_release_id: 'mbid' });
+    fireEvent.click(card.querySelector('.mb-card-icon')!);
+    expect(open).toHaveBeenCalledWith('https://musicbrainz.org/release/mbid', '_blank');
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('has no MusicBrainz icon without a release id', () => {
+    expect(renderCard({ id: 1, title: 'X' }).card.querySelector('.mb-card-icon')).toBeNull();
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/release-card.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.test.tsx
@@ -127,3 +127,28 @@ describe('ReleaseCard interaction', () => {
     expect(renderCard({ id: 1, title: 'X' }).card.querySelector('.mb-card-icon')).toBeNull();
   });
 });
+
+describe('gap-fill cards (#1067)', () => {
+  const gap = { id: 'g1', title: 'Gap Album', owned: false, _gap_source: 'itunes' };
+
+  it('names the source it will open from', () => {
+    renderCard(gap);
+    const badge = document.querySelector('.gapfill-source-badge') as HTMLElement;
+    expect(badge.textContent).toBe('Apple Music');
+    expect(badge.title).toBe('Only listed on Apple Music — opens and downloads from there');
+  });
+
+  it('carries the gapfill-card class alongside the normal state classes', () => {
+    renderCard(gap);
+    const card = document.querySelector('.release-card') as HTMLElement;
+    expect(card.className).toContain('gapfill-card');
+    // Still a missing card in every other respect.
+    expect(card.className).toContain('missing');
+  });
+
+  it('leaves ordinary cards unbadged', () => {
+    renderCard({ id: 1, title: 'Normal', owned: true });
+    expect(document.querySelector('.gapfill-source-badge')).toBeNull();
+    expect(document.querySelector('.release-card')?.className).not.toContain('gapfill-card');
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/release-card.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { DiscographyRelease } from '../-artist-detail.types';
@@ -22,7 +22,10 @@ function renderCard(
 }
 
 afterEach(() => {
-  document.body.innerHTML = '';
+  // NOT document.body.innerHTML = '': anything rendered through BodyPortal
+  // lives there, and wiping the body out from under Testing Library's cleanup
+  // makes it throw "The node to be removed is not a child of this node".
+  cleanup();
   vi.unstubAllGlobals();
 });
 

--- a/webui/src/routes/artist-detail/-ui/release-card.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.tsx
@@ -9,6 +9,7 @@ import {
   releaseYearText,
 } from '../-artist-detail.card';
 import { releaseFlags } from '../-artist-detail.filters';
+import { gapSourceLabel } from '../-artist-detail.gap-fill';
 
 interface Props {
   release: DiscographyRelease;
@@ -34,10 +35,13 @@ export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen }: 
   const bg = releaseBackgroundSrc(release);
   const mbUrl = musicbrainzReleaseUrl(release);
   const releaseId = release.id ?? '';
+  // Gap-fill cards (#1067) live in the real grids; the badge is what marks
+  // them, and it names the source the click will resolve from.
+  const gapSource = release._gap_source ? gapSourceLabel(String(release._gap_source)) : '';
 
   return (
     <div
-      className={releaseCardClassName(release)}
+      className={`${releaseCardClassName(release)}${release._gap_source ? ' gapfill-card' : ''}`}
       data-release-id={String(releaseId)}
       data-album-id={String(releaseId)}
       data-album-name={release.title ?? ''}
@@ -64,6 +68,15 @@ export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen }: 
         </div>
         {year ? <div className="album-card-year">{year}</div> : null}
       </div>
+
+      {gapSource ? (
+        <div
+          className="gapfill-source-badge"
+          title={`Only listed on ${gapSource} — opens and downloads from there`}
+        >
+          {gapSource}
+        </div>
+      ) : null}
 
       {/* Rendered LAST so it sits above the gradient overlay. */}
       {mbUrl ? (

--- a/webui/src/routes/artist-detail/-ui/release-card.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.tsx
@@ -1,0 +1,88 @@
+import type { DiscographyRelease } from '../-artist-detail.types';
+
+import {
+  completionOverlay,
+  isExplicit,
+  musicbrainzReleaseUrl,
+  releaseBackgroundSrc,
+  releaseCardClassName,
+  releaseYearText,
+} from '../-artist-detail.card';
+import { releaseFlags } from '../-artist-detail.filters';
+
+interface Props {
+  release: DiscographyRelease;
+  /** Drives the flag recomputation and whether the overlay renders at all. */
+  isMusicBrainz: boolean;
+  isSourceArtist: boolean;
+  onOpen: (release: DiscographyRelease) => void;
+}
+
+/**
+ * One release tile. Markup mirrors createReleaseCard (library.js:1683) so the
+ * existing CSS applies unchanged.
+ *
+ * The `data-is-*` attributes are rendered even though React filters in JS
+ * rather than by reading them back: the discography CSS and the guided tour
+ * both select on them, and dropping them would change the page's appearance
+ * without changing any behaviour a test would notice.
+ */
+export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen }: Props) {
+  const flags = releaseFlags(release, isMusicBrainz);
+  const overlay = completionOverlay(release, isSourceArtist);
+  const year = releaseYearText(release);
+  const bg = releaseBackgroundSrc(release);
+  const mbUrl = musicbrainzReleaseUrl(release);
+  const releaseId = release.id ?? '';
+
+  return (
+    <div
+      className={releaseCardClassName(release)}
+      data-release-id={String(releaseId)}
+      data-album-id={String(releaseId)}
+      data-album-name={release.title ?? ''}
+      data-album-type={release.album_type ?? 'album'}
+      data-is-live={String(flags.isLive)}
+      data-is-compilation={String(flags.isCompilation)}
+      data-is-featured={String(flags.isFeatured)}
+      onClick={() => onOpen(release)}
+    >
+      {/* data-bg-src, not a style: an IntersectionObserver swaps it in, so a
+          75-card grid does not fetch 75 images up front. */}
+      <div className="album-card-image" data-bg-src={bg ?? undefined} />
+
+      {overlay ? (
+        <div className={`completion-overlay ${overlay.className}`}>
+          <span className="completion-status">{overlay.label}</span>
+        </div>
+      ) : null}
+
+      <div className="album-card-content">
+        <div className="album-card-name" title={release.title ?? ''}>
+          {release.title ?? ''}
+          {isExplicit(release) ? <span className="explicit-badge">E</span> : null}
+        </div>
+        {year ? <div className="album-card-year">{year}</div> : null}
+      </div>
+
+      {/* Rendered LAST so it sits above the gradient overlay. */}
+      {mbUrl ? (
+        <div
+          className="mb-card-icon"
+          title="View on MusicBrainz"
+          onClick={(e) => {
+            // Without this the card's own click fires too and opens the album.
+            e.stopPropagation();
+            window.open(mbUrl, '_blank');
+          }}
+        >
+          <img
+            src="/static/img/brands/musicbrainz.png"
+            style={{ width: 20, height: 'auto', display: 'block' }}
+            alt="MusicBrainz"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/similar-artists-section.tsx
+++ b/webui/src/routes/artist-detail/-ui/similar-artists-section.tsx
@@ -1,0 +1,35 @@
+/**
+ * The Similar Artists section at the foot of the page.
+ *
+ * This markup lived inside the vanilla #artist-detail-page, which the React
+ * host replaces — so the section disappeared entirely and loadSimilarArtists
+ * had nothing to render into (it resolves four elements by id and bails when
+ * the section is absent).
+ *
+ * React renders the shell and nothing else: the vanilla loader owns the
+ * loading/error toggles and fills the bubbles container itself. The container
+ * is deliberately left EMPTY here, so React never reconciles away nodes it did
+ * not create.
+ */
+export function SimilarArtistsSection() {
+  return (
+    <div className="similar-artists-section" id="ad-similar-artists-section">
+      <div className="similar-artists-header">
+        <h3 className="similar-artists-title">Similar Artists</h3>
+        <p className="similar-artists-subtitle">Discover artists with a similar sound</p>
+      </div>
+      <div className="similar-artists-loading hidden" id="ad-similar-artists-loading">
+        <div className="loading-spinner-small" />
+        <span>Finding similar artists...</span>
+      </div>
+      <div className="similar-artists-error hidden" id="ad-similar-artists-error">
+        <span className="error-icon">⚠️</span>
+        <span className="error-text">Unable to load similar artists</span>
+      </div>
+      <div
+        className="similar-artists-bubbles-container"
+        id="ad-similar-artists-bubbles-container"
+      />
+    </div>
+  );
+}

--- a/webui/src/routes/artist-detail/-ui/top-tracks-sidebar.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/top-tracks-sidebar.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createShellBridge } from '@/test/shell-bridge';
+
+import { TopTracksSidebar } from './top-tracks-sidebar';
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+let calls: { url: string; body: unknown }[] = [];
+
+function stubRoutes(routes: Record<string, () => Response | Promise<Response>>) {
+  calls = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : null });
+      for (const [fragment, handler] of Object.entries(routes)) {
+        if (url.includes(fragment)) return handler();
+      }
+      return json({ success: false });
+    }),
+  );
+}
+
+const SOURCE_TRACKS = {
+  success: true,
+  source: 'spotify',
+  tracks: [
+    { name: 'Xtal', artists: [{ name: 'AFX' }] },
+    { name: 'Ageispolis', artists: [] },
+  ],
+};
+
+beforeEach(() => {
+  window.SoulSyncWebShellBridge = createShellBridge();
+  window.showToast = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete window.SoulSyncWebShellBridge;
+  delete window.openDownloadMissingModalForArtistAlbum;
+});
+
+describe('TopTracksSidebar', () => {
+  it('stays out of the DOM entirely when nothing loads', async () => {
+    // The vanilla left the panel display:none rather than showing an empty box.
+    stubRoutes({});
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await waitFor(() => expect(calls.length).toBeGreaterThan(0));
+    expect(document.getElementById('artist-hero-sidebar')).toBeNull();
+  });
+
+  it('renders numbered rows with the source heading', async () => {
+    stubRoutes({ '/top-tracks': () => json(SOURCE_TRACKS) });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+
+    await screen.findByText('Xtal');
+    expect(document.getElementById('hero-sidebar-title')?.textContent).toBe('Top Tracks (Spotify)');
+    expect([...document.querySelectorAll('.hero-top-track-num')].map((n) => n.textContent)).toEqual(
+      ['1', '2'],
+    );
+  });
+
+  it('offers a download per row plus Download All for the source pass', async () => {
+    stubRoutes({ '/top-tracks': () => json(SOURCE_TRACKS) });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+
+    await screen.findByText('Xtal');
+    expect(document.querySelectorAll('.hero-top-track-download').length).toBe(2);
+    expect(document.getElementById('hero-top-tracks-download-all')).not.toBeNull();
+    expect(document.querySelector('.hero-top-track-plays')).toBeNull();
+  });
+
+  it('is display-only for the Last.fm pass — playcounts, no downloads', async () => {
+    stubRoutes({
+      'lastfm-top-tracks': () =>
+        json({ success: true, tracks: [{ name: 'A', playcount: 2400000 }] }),
+    });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+
+    await screen.findByText('A');
+    expect(document.querySelector('.hero-top-track-plays')?.textContent).toBe('2.4M');
+    expect(document.querySelector('.hero-top-track-download')).toBeNull();
+    expect(document.getElementById('hero-top-tracks-download-all')).toBeNull();
+  });
+
+  it('wishlists a single row with its own metadata', async () => {
+    stubRoutes({
+      '/top-tracks': () => json(SOURCE_TRACKS),
+      'add-album-to-wishlist': () => json({ success: true }),
+    });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('Xtal');
+
+    fireEvent.click(document.querySelectorAll('.hero-top-track-download')[0]);
+
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Added "Xtal" to wishlist', 'success'),
+    );
+    const posted = calls.find((c) => c.url.includes('add-album-to-wishlist'))?.body as {
+      track: { name: string; artists: { name: string }[] };
+      source_type: string;
+    };
+    expect(posted.track.name).toBe('Xtal');
+    expect(posted.track.artists).toEqual([{ name: 'AFX' }]);
+    expect(posted.source_type).toBe('top_tracks');
+  });
+
+  it('surfaces a wishlist failure instead of claiming success', async () => {
+    stubRoutes({
+      '/top-tracks': () => json(SOURCE_TRACKS),
+      'add-album-to-wishlist': () => json({ success: false, error: 'nope' }),
+    });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('Xtal');
+
+    fireEvent.click(document.querySelectorAll('.hero-top-track-download')[0]);
+    await waitFor(() =>
+      expect(window.showToast).toHaveBeenCalledWith('Failed to wishlist "Xtal": nope', 'error'),
+    );
+  });
+
+  it('opens the bulk download in PLAYLIST context', async () => {
+    // contextType 'playlist' is what renders the playlist hero and keeps each
+    // track routed to its own album folder.
+    window.openDownloadMissingModalForArtistAlbum = vi.fn();
+    stubRoutes({ '/top-tracks': () => json(SOURCE_TRACKS) });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('Xtal');
+
+    fireEvent.click(document.getElementById('hero-top-tracks-download-all') as HTMLElement);
+
+    expect(window.openDownloadMissingModalForArtistAlbum).toHaveBeenCalledWith(
+      'top_tracks_spotify_42',
+      'Aphex Twin — Top Tracks',
+      SOURCE_TRACKS.tracks,
+      expect.objectContaining({ album_type: 'compilation' }),
+      expect.objectContaining({ name: 'Aphex Twin' }),
+      true,
+      'playlist',
+    );
+  });
+
+  it('plays a row through the library-first resolver', async () => {
+    stubRoutes({
+      '/top-tracks': () => json(SOURCE_TRACKS),
+      'resolve-track': () =>
+        json({ success: true, track: { id: 7, title: 'Xtal', file_path: '/x.flac' } }),
+    });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('Xtal');
+
+    fireEvent.click(document.querySelectorAll('.hero-top-track-play')[0]);
+
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge?.playLibraryTrack).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 7 }),
+        '',
+        'AFX',
+      ),
+    );
+  });
+
+  it('plays a Last.fm row under the PAGE artist, not a track artist', async () => {
+    stubRoutes({
+      'lastfm-top-tracks': () =>
+        json({ success: true, tracks: [{ name: 'A', artists: [{ name: 'Wrong' }] }] }),
+      'resolve-track': () => json({ success: true, track: { id: 1, title: 'A', file_path: '/a' } }),
+    });
+    render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('A');
+
+    fireEvent.click(document.querySelector('.hero-top-track-play') as HTMLElement);
+
+    await waitFor(() =>
+      expect(window.SoulSyncWebShellBridge?.playLibraryTrack).toHaveBeenCalledWith(
+        expect.anything(),
+        '',
+        'Aphex Twin',
+      ),
+    );
+  });
+
+  it('clears the previous artist rows BEFORE the next load lands', async () => {
+    stubRoutes({ '/top-tracks': () => json(SOURCE_TRACKS) });
+    const { rerender } = render(<TopTracksSidebar artistId={42} artistName="Aphex Twin" />);
+    await screen.findByText('Xtal');
+
+    // The next artist's request never answers. Without the up-front reset the
+    // previous artist's tracks would sit under the new artist's name for as
+    // long as the request takes — which is exactly why the vanilla hid the
+    // sidebar on entry rather than on response.
+    let release: (r: Response) => void = () => {};
+    stubRoutes({ '/top-tracks': () => new Promise<Response>((r) => (release = r)) });
+    rerender(<TopTracksSidebar artistId={99} artistName="Boards of Canada" />);
+
+    await waitFor(() => expect(screen.queryByText('Xtal')).toBeNull());
+    release(json({ success: false }));
+  });
+});

--- a/webui/src/routes/artist-detail/-ui/top-tracks-sidebar.tsx
+++ b/webui/src/routes/artist-detail/-ui/top-tracks-sidebar.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+
+import { getShellBridge } from '@/platform/shell/bridge';
+
+import type { ArtistDetailTrack } from '../-artist-detail.types';
+
+import {
+  EMPTY_TOP_TRACKS,
+  formatPlaycount,
+  loadTopTracks,
+  playTrackByMetadata,
+  type TopTracksState,
+  topTracksBulkContext,
+  trackArtistLabel,
+  wishlistTrackBody,
+} from '../-artist-detail.top-tracks';
+
+interface Props {
+  artistId: unknown;
+  artistName: string;
+}
+
+/**
+ * The hero top-tracks sidebar (_loadArtistTopTracks).
+ *
+ * Hidden until something loads, exactly as the vanilla was: it starts
+ * display:none and only reveals itself once a pass produced rows, so an artist
+ * with no popularity data shows no empty panel.
+ */
+export function TopTracksSidebar({ artistId, artistName }: Props) {
+  const [state, setState] = useState<TopTracksState>(EMPTY_TOP_TRACKS);
+
+  useEffect(() => {
+    if (!artistName) return;
+    const controller = new AbortController();
+    setState(EMPTY_TOP_TRACKS);
+
+    void loadTopTracks(artistId, artistName, controller.signal).then((next) => {
+      if (!controller.signal.aborted) setState(next);
+    });
+
+    // Aborted on artist change so a slow response for the previous artist
+    // cannot land in the new artist's sidebar.
+    return () => controller.abort();
+  }, [artistId, artistName]);
+
+  if (state.tracks.length === 0) return null;
+
+  const play = (track: ArtistDetailTrack) => {
+    // Read at click time, not render time: the vanilla shell attaches the
+    // bridge asynchronously, and a sidebar that rendered before it landed would
+    // otherwise hold null forever.
+    void playTrackByMetadata(
+      getShellBridge(),
+      track.name ?? '',
+      state.downloadable ? trackArtistLabel(track, artistName) : artistName,
+      '',
+    );
+  };
+
+  const wishlist = async (track: ArtistDetailTrack) => {
+    try {
+      const response = await fetch('/api/add-album-to-wishlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(wishlistTrackBody(track, artistName, artistId)),
+      });
+      const data = await response.json();
+      if (data?.success) {
+        window.showToast?.(`Added "${track.name}" to wishlist`, 'success');
+      } else {
+        window.showToast?.(
+          `Failed to wishlist "${track.name}": ${data?.error || 'unknown'}`,
+          'error',
+        );
+      }
+    } catch {
+      window.showToast?.('Failed to add track to wishlist', 'error');
+    }
+  };
+
+  const downloadAll = () => {
+    const context = topTracksBulkContext(state, artistName, artistId);
+    // Seven arguments on purpose: contextType 'playlist' renders the playlist
+    // hero rather than an album hero, and the shell bridge's convenience
+    // wrapper cannot express it.
+    window.openDownloadMissingModalForArtistAlbum?.(
+      context.virtualPlaylistId,
+      context.playlistName,
+      state.tracks,
+      context.wrapperAlbum,
+      context.artist,
+      true,
+      'playlist',
+    );
+  };
+
+  return (
+    <div className="artist-hero-right" id="artist-hero-sidebar">
+      <div className="hero-sidebar-title" id="hero-sidebar-title">
+        {state.title}
+      </div>
+      <div className="hero-top-tracks" id="hero-top-tracks">
+        {state.tracks.map((track, index) => (
+          <div
+            className="hero-top-track"
+            key={`${index}-${track.name ?? ''}`}
+            data-index={state.downloadable ? index : undefined}
+          >
+            <span className="hero-top-track-num">{index + 1}</span>
+            <button
+              type="button"
+              className="hero-top-track-play"
+              title="Play"
+              onClick={(e) => {
+                e.stopPropagation();
+                play(track);
+              }}
+            >
+              ▶
+            </button>
+            <span className="hero-top-track-name" title={track.name}>
+              {track.name}
+            </span>
+            {state.downloadable ? (
+              <button
+                type="button"
+                className="hero-top-track-download"
+                data-index={index}
+                title="Add to wishlist"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void wishlist(track);
+                }}
+              >
+                ⬇
+              </button>
+            ) : (
+              // Last.fm rows are display-only — a playcount, never a download.
+              <span className="hero-top-track-plays">{formatPlaycount(track.playcount)}</span>
+            )}
+          </div>
+        ))}
+      </div>
+      {state.downloadable ? (
+        <button
+          type="button"
+          className="hero-top-tracks-download-all"
+          id="hero-top-tracks-download-all"
+          onClick={(e) => {
+            e.stopPropagation();
+            downloadAll();
+          }}
+        >
+          Download All
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/webui/src/routes/stats/-route.test.tsx
+++ b/webui/src/routes/stats/-route.test.tsx
@@ -131,16 +131,9 @@ describe('stats route', () => {
     fireEvent.click(bubbleLink);
 
     await waitFor(() => expect(history.location.pathname).toBe('/artist-detail/library/7'));
-    await waitFor(() =>
-      expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).toHaveBeenCalledWith(
-        '7',
-        '',
-        null,
-        {
-          skipRouteChange: true,
-        },
-      ),
-    );
+    // Artist detail is React-owned now, so the click routes there directly
+    // rather than handing the URL back to the legacy shell.
+    expect(window.SoulSyncWebShellBridge?.navigateToArtistDetail).not.toHaveBeenCalled();
   });
 
   it('falls back to streaming when track resolution fails', async () => {

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -244,6 +244,15 @@ const _ARTIST_DETAIL_BACK_LABELS = {
 let _artistDetailLabelStack = [];
 let _artistDetailGoingBack = false;
 
+// Exported for the React artist-detail page, which renders the back button now.
+// Arrivals from a still-vanilla page (search, label detail, enrichment) push
+// onto this stack here, so React has to read the SAME array to label the button
+// "Back to Search" rather than a bare "Back".
+if (typeof window !== 'undefined') {
+    window.artistDetailBackLabels = _ARTIST_DETAIL_BACK_LABELS;
+    window.artistDetailLabelStack = _artistDetailLabelStack;
+}
+
 let artistDetailPageState = {
     isInitialized: false,
     currentArtistId: null,
@@ -388,7 +397,10 @@ function navigateToArtistDetail(artistId, artistName, sourceOverride = null, opt
     } else {
         _artistDetailGoingBack = false; // clear any stale flag
         if (currentPage !== 'artist-detail') {
-            _artistDetailLabelStack = []; // fresh chain from a non-artist page
+            // Cleared IN PLACE, not reassigned: window.artistDetailLabelStack
+            // holds this same array for the React page, and swapping the
+            // binding would leave React reading a detached copy.
+            _artistDetailLabelStack.length = 0; // fresh chain from a non-artist page
         }
         if (currentPage === 'artist-detail' && artistDetailPageState.currentArtistName) {
             _artistDetailLabelStack.push({ type: 'artist', name: artistDetailPageState.currentArtistName });

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -257,6 +257,14 @@ let artistDetailPageState = {
     enhancedTrackSort: {}
 };
 
+// Exported for the React artist-detail page. `let` at the top level of a
+// classic script is a global LEXICAL binding and never lands on window, so a
+// module cannot see it — yet a dozen functions here (playArtistRadio,
+// openArtistArtPicker, openDiscographyModal, deleteLibraryAlbum, runEnrichment,
+// …) read this object when the React page invokes them. Same object, not a
+// copy, so both sides stay in step.
+if (typeof window !== 'undefined') window.artistDetailPageState = artistDetailPageState;
+
 function clearArtistDetailPageState() {
     if (artistDetailPageState.completionController) {
         artistDetailPageState.completionController.abort();

--- a/webui/static/library.js
+++ b/webui/static/library.js
@@ -428,9 +428,31 @@ function navigateToArtistDetail(artistId, artistName, sourceOverride = null, opt
     artistDetailPageState.currentArtistSource = normalizedSource;
     artistDetailPageState.enhancedData = null;
     artistDetailPageState.expandedAlbums = new Set();
-    artistDetailPageState.selectedTracks = new Set();
+    // Cleared IN PLACE: React mirrors its selection into this same Set, and the
+    // vanilla track-delete path deletes from it. Swapping the object out would
+    // leave both writing somewhere nobody reads.
+    artistDetailPageState.selectedTracks.clear();
     artistDetailPageState.enhancedTrackSort = {};
     artistDetailPageState.enhancedView = false;
+
+    // When the React page owns this route, STOP here. Everything below —
+    // resetting the legacy view chrome and loadArtistDetailData — targets DOM
+    // by id and class, and the React page reuses those same ids, so running it
+    // means two pages loading over each other: applyDiscographyFilters hides
+    // React's .release-card elements using the legacy filter state and the
+    // whole discography disappears. React fetches its own data and renders its
+    // own back-button label; the state written above is all it needs from here.
+    const _adRoute = window.SoulSyncWebRouter?.routeManifest?.find(
+        (entry) => entry.pageId === 'artist-detail'
+    );
+    if (_adRoute?.kind === 'react') {
+        navigateToPage('artist-detail', {
+            artistId,
+            artistSource: normalizedSource,
+            skipRouteChange: options.skipRouteChange === true
+        });
+        return;
+    }
 
     // Reset enhanced view toggle to standard
     const toggleBtns = document.querySelectorAll('.enhanced-view-toggle-btn');

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -65308,14 +65308,14 @@ body.max-performance #page-particles-canvas {
 */
 
 /* Library-only: status filter (owned/missing only makes sense when you own things) */
-body[data-artist-source="source"] #artist-detail-page .filter-group:has(.filter-label:only-child),
-body[data-artist-source="source"] #artist-detail-page .discography-filter-btn[data-filter="ownership"] {
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) .filter-group:has(.filter-label:only-child),
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) .discography-filter-btn[data-filter="ownership"] {
     display: none !important;
 }
 
 /* Library-only: Enhanced view toggle + container (per-track editing requires owned tracks) */
-body[data-artist-source="source"] #artist-detail-page .enhanced-view-toggle-btn,
-body[data-artist-source="source"] #artist-detail-page #enhanced-view-container {
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) .enhanced-view-toggle-btn,
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) #enhanced-view-container {
     display: none !important;
 }
 
@@ -65325,23 +65325,33 @@ body[data-artist-source="source"] #artist-detail-page #enhanced-view-container {
    .collection-overview and #artist-hero-sidebar both render usefully for
    source artists (collection shows 0/N missing, Top Tracks pulls from
    Last.fm by name) so they stay visible. */
-body[data-artist-source="source"] #artist-detail-page .artist-enrichment-coverage,
-body[data-artist-source="source"] #artist-detail-page #library-artist-radio-btn,
-body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-btn {
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) .artist-enrichment-coverage,
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) #library-artist-radio-btn,
+body[data-artist-source="source"] :is(#artist-detail-page, .artist-detail-page) #library-artist-enhance-btn {
     display: none !important;
 }
 
+
+/* The artist-detail page is React-rendered now and lives inside
+   #webui-react-root, NOT inside #artist-detail-page. Every rule below is
+   therefore written against BOTH: the legacy container, and the
+   .artist-detail-page wrapper the React page puts around itself. Dropping the
+   second half silently un-styles the whole page — the release cards lose their
+   big-photo treatment and the source-artist hides (Artist Radio, Enhance
+   Quality, enrichment coverage) stop applying, which is how a source artist
+   ended up offering library-only actions.
+   ========================================================================= */
 
 /* =========================================================================
    Standalone /artist-detail page hero — blurred-background treatment
    ========================================================================= */
 
-#artist-detail-page .artist-hero-section {
+:is(#artist-detail-page, .artist-detail-page) .artist-hero-section {
     position: relative;
     overflow: hidden;
 }
 
-#artist-detail-page .artist-detail-hero-bg {
+:is(#artist-detail-page, .artist-detail-page) .artist-detail-hero-bg {
     /* Blurred artist-cover backdrop retired — Boulder didn't want the artist
        image bleeding behind the header. The element stays in the DOM (JS still
        sets its background-image) but is hidden; flip display back on to restore. */
@@ -65357,7 +65367,7 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
     pointer-events: none;
 }
 
-#artist-detail-page .artist-detail-hero-overlay {
+:is(#artist-detail-page, .artist-detail-page) .artist-detail-hero-overlay {
     position: absolute;
     inset: 0;
     background: linear-gradient(180deg,
@@ -65368,7 +65378,7 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
     pointer-events: none;
 }
 
-#artist-detail-page .artist-hero-content {
+:is(#artist-detail-page, .artist-detail-page) .artist-hero-content {
     position: relative;
     z-index: 2;
 }
@@ -65385,7 +65395,7 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
    fixed 300px height, flex column). These overrides switch off the parts
    that fight with the .album-card layout. */
 
-#artist-detail-page .release-card.album-card {
+:is(#artist-detail-page, .artist-detail-page) .release-card.album-card {
     background: rgba(18, 18, 18, 1);
     backdrop-filter: none;
     border: 1px solid rgba(255, 255, 255, 0.06);
@@ -65401,7 +65411,7 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
                 border-color 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-#artist-detail-page .release-card.album-card:hover {
+:is(#artist-detail-page, .artist-detail-page) .release-card.album-card:hover {
     background: rgba(18, 18, 18, 1);
     transform: translateY(-5px) scale(1.02);
     border-color: rgba(var(--accent-rgb), 0.25);
@@ -65409,18 +65419,18 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
                 0 0 24px rgba(var(--accent-rgb), 0.12);
 }
 
-#artist-detail-page .release-card.album-card.missing {
+:is(#artist-detail-page, .artist-detail-page) .release-card.album-card.missing {
     opacity: 1;  /* let the completion-overlay convey state, not the whole card */
 }
 
 /* The fit-content override on the discography page also conflicts with
    aspect-ratio:1 — clear it for album-card variants. */
-#artist-detail-page .discography-sections .release-card.album-card {
+:is(#artist-detail-page, .artist-detail-page) .discography-sections .release-card.album-card {
     height: auto;
 }
 
 /* MusicBrainz icon position (was tied to the old card's padding) */
-#artist-detail-page .release-card.album-card .mb-card-icon {
+:is(#artist-detail-page, .artist-detail-page) .release-card.album-card .mb-card-icon {
     position: absolute;
     top: 8px;
     left: 8px;
@@ -65433,7 +65443,7 @@ body[data-artist-source="source"] #artist-detail-page #library-artist-enhance-bt
     transition: opacity 0.2s ease;
 }
 
-#artist-detail-page .release-card.album-card .mb-card-icon:hover {
+:is(#artist-detail-page, .artist-detail-page) .release-card.album-card .mb-card-icon:hover {
     opacity: 1;
 }
 


### PR DESCRIPTION
# artist detail → react

artist detail is the 5th music page on react. this is the whole page — hero, discography, gap-fill, the ownership stream, the DB record inspector, top tracks, and the entire Enhanced Management view — plus the manifest flip and the round of fixes from live testing.

40 commits. the vanilla page in library.js is untouched apart from four small, deliberate edits (below). flipping back is one line in `route-manifest.ts` — the `isReactOwned()` guard and the legacy handoff are both still in place.

## what's in it

**hero** — badges, genre chips + last.fm tags, bio, listener/play counts, completion bars, artist photo with the deezer → release-art → icon fallback chain, enrichment coverage rings, top tracks sidebar, DB Record inspector, back button, and the watchlist / enhance / radio / download-discography buttons.

**discography** — release cards using the shared #877 content classifier, the filter bar, musicbrainz declutter, gap-fill (#1067) with its own ownership stream (#1071), and the similar-artists section at the foot.

**ownership stream** — merges results into the cards as they arrive, with the bars in all three states the vanilla had (pending "...", running tallies mid-stream, and the recount after the terminal frame).

**Enhanced Management** — stats bar, per-type sections, expandable albums, expanded header with id badges + match chips + admin actions, album metadata row, track table with per-track actions, inline cell editing, bulk action bar.

## what live testing found

worth reading — most of these were invisible to the test suite, and the last four are all the same shape:

- **three buttons were dead.** artist radio, change-photo and download-discography read `artistDetailPageState` rather than taking arguments, and react wasn't writing to it. nine more actions read `enhancedData` and silently failed to sync. the tests asserted "the right global was called with the right args" — true, and useless, because the callee then reads state only the vanilla page ever wrote.
- **the DB record modal was trapped.** `.artist-hero-section` sets `backdrop-filter`, which makes it the containing block for `position: fixed` descendants — so the overlay was clamped to the hero box. wrong position, clipped, and un-closeable because the backdrop covered nothing else. everything fixed-positioned goes through a portal now.
- **the back button and the whole similar-artists section were missing** — that markup lived inside the vanilla page container, which the react host replaces.
- **two pages were loading at once.** search/label-detail/enrichment still call `navigateToArtistDetail`, which fell through into the full legacy load. `applyDiscographyFilters` hides `.release-card` *document-wide* using legacy filter state, so the discography vanished on any artist reached from search.
- **17 stylesheet rules stopped applying** — all scoped to `#artist-detail-page`, which react doesn't render inside. that's why artist radio showed on source artists, and it also silently un-styled the release cards and hero.

## vanilla bugs reproduced, not fixed

- **a non-explicit album always reports `explicit: 0` as a change** on album save, so "no changes to save" is unreachable for those albums. left as-is — fixing it changes what gets written on every save.

## deliberate improvements over the vanilla

- **the Enhanced track-table columns actually sort now.** they never did: `renderTrackTable` sorted `album.tracks` and then built the table from `_getEnhancedAlbumTrackRows`, which always re-sorts by disc/track/title — so the arrow moved and the rows didn't. missing rows sink in both directions, since a row you don't own has no bitrate/format/file. File and Match stay inert; they never carried a sort field.
- **artist detail always opens at the top.** the old page never scrolled, so clicking a similar artist at the bottom left you at the bottom of the next one. every other page keeps its scroll restoration.

## four edits to library.js

all small, all required by the flip: export `artistDetailPageState` and the back-label stack onto `window` (both are top-level `let`s, so they never landed there), clear the label stack and the selection Set **in place** rather than reassigning (react holds references), and stop `navigateToArtistDetail` before the legacy load when react owns the route.

## still vanilla, called through window

the modals: art picker, manual match, enrichment runner, reorganize, redownload, re-identify, tag preview, batch tag preview, missing-track manage, report issue, mobile popover. the react page drives them the same way the vanilla page did. they have to be ported or deliberately kept before the vanilla page can be deleted — which is why cleanup is a separate PR.

## testing

1168 vitest tests / 73 files, tsc clean, production build clean, python contract tests pass. every slice was mutation-tested — ~200 mutants, all killed or documented as equivalent in the code where they live.

three standing audits, one per failure mode jsdom can't see:

| script | catches |
|---|---|
| `artist_detail_parity_audit.py` | logic never ported — fields read, cross-file calls (~50 vanilla functions) |
| `artist_detail_markup_audit.py` | markup never rendered — every id and class in the vanilla page |
| `artist_detail_css_audit.py` | styling that no longer matches — rules scoped to the old container |

each was verified by reverting the thing it guards and confirming it fails.

live-tested by Boulder: source and library artists, filters, + other sources, back button, DB record modal, scroll behaviour. the Enhanced view still wants a proper click-through — expand an album, edit a cell, tick tracks across two albums, run a bulk edit.
