### PR TITLE
React migration search enhanced

### DIFF
--- a/tests/test_react_ids_are_not_duplicated.py
+++ b/tests/test_react_ids_are_not_duplicated.py
@@ -1,0 +1,110 @@
+"""No id may exist in BOTH the vanilla shell and a React page.
+
+When a page is migrated, its React component renders the same ids the vanilla
+markup had — because the rest of the app looks those ids up. `#enhanced-search-
+input` is written by the global download widget; `#enhanced-main-results-area` is
+where showSearchDownloadBubbles draws. If the vanilla markup is left behind after
+the manifest flips, TWO elements answer to each id and `getElementById` resolves
+it by document order.
+
+That is not a contract. It happens to work today only because #webui-react-root
+sits near the top of index.html; moving it, or wrapping it, silently sends every
+one of those lookups to a hidden page instead.
+
+So: an id rendered by a React page must not also appear in index.html.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+WEBUI = Path(__file__).resolve().parent.parent / "webui"
+INDEX = WEBUI / "index.html"
+ROUTES = WEBUI / "src" / "routes"
+
+# `id="..."` in JSX, allowing the value to be a plain string only — a template
+# expression is not a fixed id and cannot collide statically.
+JSX_ID = re.compile(r"""\bid=["']([A-Za-z][\w-]*)["']""")
+HTML_ID = re.compile(r"""\bid=["']([A-Za-z][\w-]*)["']""")
+
+# Ids the React page renders ON PURPOSE into markup the vanilla still owns.
+# There is exactly one: the basic-search panel, which the search page ADOPTS —
+# it is the same element, moved, not a copy.
+ADOPTED = {"basic-search-section"}
+
+# Collisions that predate this guard.
+#
+# The artist-detail port (#1097/#1098) left the vanilla bulk-edit markup in
+# index.html while its React component renders the same ids. It is latent rather
+# than broken: #webui-react-root comes first in the document, so lookups land on
+# the React elements, and the library.js functions that read these ids
+# (updateBulkBar, showBulkEditModal — still present, still reading
+# artistDetailPageState) are no longer reachable from a live page.
+#
+# Not fixed here because it belongs to that port's cleanup, not to search's.
+# Deleting either side without tracing every caller is how a working page goes
+# blank. Listed explicitly so the guard protects everything else in the meantime.
+KNOWN_PRE_EXISTING = {
+    "enhanced-bulk-bar",
+    "enhanced-bulk-count",
+    "enhanced-bulk-edit-overlay",
+    "enhanced-bulk-modal-body",
+    "enhanced-bulk-modal-title",
+}
+
+
+def _react_page_ids() -> dict[str, set[str]]:
+    """Every literal id rendered by a React page component, by file."""
+    found: dict[str, set[str]] = {}
+    for path in ROUTES.rglob("-ui/*.tsx"):
+        if path.name.endswith(".test.tsx"):
+            continue
+        source = path.read_text(encoding="utf-8")
+        # Strip comments so a documented id is not mistaken for a rendered one.
+        source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+        source = re.sub(r"^\s*//.*$", "", source, flags=re.M)
+        ids = set(JSX_ID.findall(source)) - ADOPTED
+        if ids:
+            found[str(path.relative_to(WEBUI))] = ids
+    return found
+
+
+def _index_ids() -> set[str]:
+    source = INDEX.read_text(encoding="utf-8")
+    source = re.sub(r"<!--.*?-->", "", source, flags=re.S)
+    return set(HTML_ID.findall(source))
+
+
+def test_no_react_page_id_is_also_in_index_html():
+    index_ids = _index_ids()
+    collisions: list[str] = []
+    for path, ids in _react_page_ids().items():
+        for shared in sorted(ids & index_ids - KNOWN_PRE_EXISTING):
+            collisions.append(f"{shared} — rendered by {path} and present in index.html")
+
+    assert not collisions, (
+        "These ids exist twice, and getElementById will answer with whichever "
+        "comes first in the document:\n  " + "\n  ".join(collisions)
+    )
+
+
+def test_the_known_collisions_are_still_real():
+    """A stale allowlist hides the next regression behind an id nobody uses.
+
+    When that markup is finally cleaned up, this fails and the entry comes out.
+    """
+    index_ids = _index_ids()
+    react_ids = {i for ids in _react_page_ids().values() for i in ids}
+    stale = sorted(KNOWN_PRE_EXISTING - (index_ids & react_ids))
+    assert not stale, f"No longer duplicated — drop from KNOWN_PRE_EXISTING: {stale}"
+
+
+def test_the_guard_can_see_the_ids_it_is_guarding():
+    """A regex that matched nothing would make the test above pass vacuously."""
+    react_ids = {i for ids in _react_page_ids().values() for i in ids}
+    assert "enhanced-search-input" in react_ids
+    assert "enhanced-main-results-area" in react_ids
+    assert "enh-source-row" in react_ids
+    # And the vanilla side is being read at all.
+    assert "basic-search-section" in _index_ids()

--- a/webui/index.html
+++ b/webui/index.html
@@ -4073,10 +4073,10 @@
                             </div>
                         </div>
 
-                        <!-- Search source picker — icon row populated by search.js.
-                             Each icon triggers a single-source fetch (no fan-out);
-                             results are cached per (query, source) pair. -->
-                        <div id="enh-source-row" class="enh-source-row" role="tablist" aria-label="Search source"></div>
+                        <!-- The source picker is React's (webui/src/routes/search/-ui/
+                             source-row.tsx). The empty div that used to live here shared
+                             its id with the React one, and getElementById answers with
+                             whichever comes first in the document. -->
 
                         <!-- Basic Search Section -->
                         <div id="basic-search-section" class="search-section">
@@ -4146,144 +4146,14 @@
                         </div>
                         <!-- End Basic Search Section -->
 
-                        <!-- Enhanced Search Section (New) -->
-                        <div id="enhanced-search-section" class="search-section active">
-                            <!-- Enhanced Search Bar with Dropdown -->
-                            <div class="enhanced-search-input-wrapper">
-                                <div class="enhanced-search-bar-container">
-                                    <div class="enhanced-search-wrapper">
-                                        <div class="enhanced-search-icon">✨</div>
-                                        <input type="text" id="enhanced-search-input"
-                                            placeholder="Search for artists, albums, or tracks...">
-                                        <button id="enhanced-cancel-btn" class="enhanced-cancel-btn hidden">✕</button>
-                                    </div>
-                                </div>
-
-                                <!-- Link lookup (#775): paste a provider link and resolve
-                                     it directly on the owning source (Spotify / Apple Music
-                                     / MusicBrainz / Deezer) — no fuzzy search. Results render
-                                     in the dropdown below and reuse the normal download/
-                                     import flow. Links only: a bare ID is ambiguous. -->
-                                <div class="enh-id-lookup">
-                                    <span class="enh-id-lookup-icon">🔗</span>
-                                    <input type="text" id="enh-id-input" class="enh-id-input"
-                                        placeholder="…or paste a Spotify / Apple Music / MusicBrainz / Deezer link, or a MusicBrainz ID"
-                                        autocomplete="off" spellcheck="false">
-                                    <button id="enh-id-btn" class="enh-id-btn" type="button">Look up</button>
-                                </div>
-
-                                <!-- Enhanced Search Dropdown (Overlay Panel) -->
-                                <div id="enhanced-dropdown" class="enhanced-dropdown hidden">
-                                    <div class="enhanced-dropdown-content">
-                                        <!-- Mobile close bar -->
-                                        <button id="enhanced-dropdown-close" class="enhanced-dropdown-close">
-                                            <span>✕</span> Close Results
-                                        </button>
-                                        <!-- Loading State -->
-                                        <div id="enhanced-loading" class="enhanced-loading hidden">
-                                            <div class="spinner"></div>
-                                            <p id="enhanced-loading-text">Searching across Spotify and your library...
-                                            </p>
-                                        </div>
-
-                                        <!-- Empty State -->
-                                        <div id="enhanced-empty" class="enhanced-empty hidden">
-                                            <div class="empty-icon">🔍</div>
-                                            <p>No results found</p>
-                                        </div>
-
-                                        <!-- Results Container -->
-                                        <div id="enhanced-results-container" class="enhanced-results-container hidden">
-
-                                            <!-- Fallback banner — shown when user clicked Spotify but backend
-                                                 served Deezer due to rate-limit, etc. Populated by search.js. -->
-                                            <div id="enh-fallback-banner" class="enh-fallback-banner hidden"></div>
-
-                                            <!-- Artists Container (Side by Side) -->
-                                            <div class="enh-artists-wrapper">
-                                                <!-- DB Artists -->
-                                                <div id="enh-db-artists-section"
-                                                    class="enh-dropdown-section enh-artist-section hidden">
-                                                    <div class="enh-section-header">
-                                                        <span class="enh-section-icon">📚</span>
-                                                        <h4 class="enh-section-title">In Your Library</h4>
-                                                        <span class="enh-section-count"
-                                                            id="enh-db-artists-count">0</span>
-                                                    </div>
-                                                    <div class="enh-compact-list" id="enh-db-artists-list"></div>
-                                                </div>
-
-                                                <!-- Spotify Artists -->
-                                                <div id="enh-spotify-artists-section"
-                                                    class="enh-dropdown-section enh-artist-section hidden">
-                                                    <div class="enh-section-header">
-                                                        <span class="enh-section-icon">🎤</span>
-                                                        <h4 class="enh-section-title">Artists</h4>
-                                                        <span class="enh-section-count"
-                                                            id="enh-spotify-artists-count">0</span>
-                                                    </div>
-                                                    <div class="enh-compact-list" id="enh-spotify-artists-list"></div>
-                                                </div>
-                                            </div>
-
-                                            <!-- Albums -->
-                                            <div id="enh-albums-section" class="enh-dropdown-section hidden">
-                                                <div class="enh-section-header">
-                                                    <span class="enh-section-icon">💿</span>
-                                                    <h4 class="enh-section-title">Albums</h4>
-                                                    <span class="enh-section-count" id="enh-albums-count">0</span>
-                                                </div>
-                                                <div class="enh-compact-list" id="enh-albums-list"></div>
-                                            </div>
-
-                                            <!-- Singles & EPs -->
-                                            <div id="enh-singles-section" class="enh-dropdown-section hidden">
-                                                <div class="enh-section-header">
-                                                    <span class="enh-section-icon">🎶</span>
-                                                    <h4 class="enh-section-title">Singles & EPs</h4>
-                                                    <span class="enh-section-count" id="enh-singles-count">0</span>
-                                                </div>
-                                                <div class="enh-compact-list" id="enh-singles-list"></div>
-                                            </div>
-
-                                            <!-- Tracks -->
-                                            <div id="enh-tracks-section" class="enh-dropdown-section hidden">
-                                                <div class="enh-section-header">
-                                                    <span class="enh-section-icon">🎵</span>
-                                                    <h4 class="enh-section-title">Tracks</h4>
-                                                    <span class="enh-section-count" id="enh-tracks-count">0</span>
-                                                </div>
-                                                <div class="enh-compact-list" id="enh-tracks-list"></div>
-                                            </div>
-
-                                            <!-- Labels (record labels — monitored like an artist watchlist) -->
-                                            <div id="enh-labels-section" class="enh-dropdown-section hidden">
-                                                <div class="enh-section-header">
-                                                    <span class="enh-section-icon">🏷️</span>
-                                                    <h4 class="enh-section-title">Labels</h4>
-                                                    <span class="enh-section-count" id="enh-labels-count">0</span>
-                                                </div>
-                                                <div class="enh-compact-list" id="enh-labels-list"></div>
-                                            </div>
-
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Main Search Results Area (for slskd results) -->
-                            <div class="search-results-container">
-                                <div class="search-results-header">
-                                    <h3>Search Results</h3>
-                                </div>
-                                <div class="search-results-scroll-area" id="enhanced-main-results-area">
-                                    <div class="search-results-placeholder">
-                                        <p>Search results will appear here when you select an album or track.</p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- End Enhanced Search Section -->
+                        <!-- Enhanced search is React's: webui/src/routes/search/.
+                             Its markup is deleted rather than left unused, because every id
+                             in it (#enhanced-search-input, #enhanced-main-results-area,
+                             #enh-source-row) is looked up by the global download widget or
+                             by showSearchDownloadBubbles. Two elements answering to one id
+                             is resolved by document order, which is not a contract.
+                             #basic-search-section above STAYS: it is still vanilla, and the
+                             React page moves that very node into its own tree. -->
                     </div>
 
                 </div>

--- a/webui/src/app/router.test.tsx
+++ b/webui/src/app/router.test.tsx
@@ -90,16 +90,17 @@ describe('createAppRouter', () => {
   });
 
   it('routes non-migrated paths through the legacy fallback handler', async () => {
+    // /sync, because /search is React now. Any still-legacy path does.
     window.SoulSyncWebShellBridge = createShellBridge();
 
     const queryClient = createTestQueryClient();
-    const history = createMemoryHistory({ initialEntries: ['/search'] });
+    const history = createMemoryHistory({ initialEntries: ['/sync'] });
     const router = createAppRouter({ history, queryClient });
 
     render(<AppRouterProvider router={router} queryClient={queryClient} />);
 
     await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.activateLegacyPath).toHaveBeenCalledWith('/search');
+      expect(window.SoulSyncWebShellBridge?.activateLegacyPath).toHaveBeenCalledWith('/sync');
     });
   });
 
@@ -142,8 +143,10 @@ describe('createAppRouter', () => {
   });
 
   it('redirects the root route to the profile home page', async () => {
+    // A LEGACY home page, so the assertion is about the redirect reaching the
+    // legacy handler — /search is React now and would render in place instead.
     window.SoulSyncWebShellBridge = createShellBridge({
-      getProfileHomePage: vi.fn<() => ShellPageId>(() => 'search'),
+      getProfileHomePage: vi.fn<() => ShellPageId>(() => 'sync'),
     });
 
     const queryClient = createTestQueryClient();
@@ -153,9 +156,9 @@ describe('createAppRouter', () => {
     render(<AppRouterProvider router={router} queryClient={queryClient} />);
 
     await waitFor(() => {
-      expect(window.SoulSyncWebShellBridge?.activateLegacyPath).toHaveBeenCalledWith('/search');
+      expect(window.SoulSyncWebShellBridge?.activateLegacyPath).toHaveBeenCalledWith('/sync');
     });
 
-    expect(history.location.pathname).toBe('/search');
+    expect(history.location.pathname).toBe('/sync');
   });
 });

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -209,6 +209,33 @@ declare global {
       contextType?: string,
     ) => void | Promise<void>;
     /**
+     * core.js — shows the modal of an already-active download process.
+     *
+     * `activeDownloadProcesses` is a top-level `let` in a classic script, so it
+     * is not a window property and no module can read it. The search page needs
+     * the answer BEFORE fetching album detail: on a re-click while the source is
+     * down, the fetch fails and the modal the user already had would never come
+     * back. Returns true when a modal was shown.
+     */
+    reopenActiveDownloadModal?: (virtualPlaylistId: string) => boolean;
+    /** shared-helpers.js — registers a download in the search bubbles. */
+    registerSearchDownload?: (
+      item: Record<string, unknown>,
+      type: string,
+      virtualPlaylistId: string,
+      artistName?: string,
+    ) => void;
+    /** media-player.js — can this browser decode that file's format? */
+    isAudioFormatSupported?: (filename: string) => boolean;
+    getFileExtension?: (filename: string) => string;
+    /**
+     * shared-helpers.js — samples an image and hands back its palette, which
+     * applyDynamicGlow turns into the card's shadow. Callback-style, not a
+     * promise.
+     */
+    extractImageColors?: (imageUrl: string, callback: (colors: unknown) => void) => void;
+    applyDynamicGlow?: (cardElement: HTMLElement, colors: unknown) => void;
+    /**
      * search.js — the shared enhanced-search call. Label detail uses it to
      * re-resolve a MusicBrainz release onto a source whose images actually
      * load; Cover Art Archive does not.

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -218,6 +218,30 @@ declare global {
      * back. Returns true when a modal was shown.
      */
     reopenActiveDownloadModal?: (virtualPlaylistId: string) => boolean;
+    /**
+     * search.js — binds the BASIC search panel's button, Enter key and Cancel.
+     *
+     * Called by the React search page after it adopts #basic-search-section,
+     * because the `case 'search':` in init.js that used to call it only runs for
+     * legacy pages. It uses addEventListener with no guard, so it must be called
+     * exactly once per page load.
+     */
+    initializeSearch?: () => void;
+    /** wishlist-tools.js — the basic panel's Filters disclosure. */
+    initializeFilters?: () => void;
+    /** downloads.js — runs the basic (Soulseek file) search. */
+    performDownloadsSearch?: () => void;
+    /**
+     * shared-helpers.js — sends the user to the Settings card for a source that
+     * has no credentials, rather than firing a search that cannot succeed.
+     */
+    openSettingsForSource?: (source: string) => void;
+    /**
+     * Set by the React search page so the global download widget can sync the
+     * query BEFORE clicking the Soulseek icon. Without it the icon click hands
+     * off whatever the search page last had, overwriting the widget's query.
+     */
+    _searchPageSetQuery?: (query: string) => void;
     /** shared-helpers.js — registers a download in the search bubbles. */
     registerSearchDownload?: (
       item: Record<string, unknown>,

--- a/webui/src/platform/shell/route-manifest.test.ts
+++ b/webui/src/platform/shell/route-manifest.test.ts
@@ -62,6 +62,7 @@ describe('shellRouteManifest', () => {
     expect(getShellRouteByPageId('artist-detail')?.kind).toBe('react');
     expect(getShellRouteByPageId('label-detail')?.kind).toBe('react');
     expect(reactShellRoutes.map((route) => route.pageId)).toEqual([
+      'search',
       'watchlist',
       'wishlist',
       'automations',
@@ -76,12 +77,15 @@ describe('shellRouteManifest', () => {
   });
 
   it('only resolves legacy page ids for legacy-owned paths', () => {
-    expect(resolveLegacyShellPageFromPath('/search')).toBe('search');
+    expect(resolveLegacyShellPageFromPath('/sync')).toBe('sync');
     expect(resolveLegacyShellPageFromPath('/active-downloads')).toBe('active-downloads');
     expect(resolveLegacyShellPageFromPath('/tools')).toBe('tools');
     expect(resolveLegacyShellPageFromPath('/artist-detail')).toBeNull();
     expect(resolveLegacyShellPageFromPath('/artist-detail/deezer/12345')).toBe('artist-detail');
     expect(resolveLegacyShellPageFromPath('/issues')).toBeNull();
+    // React owns /search now; resolving it as legacy would show the vanilla
+    // page underneath the React one.
+    expect(resolveLegacyShellPageFromPath('/search')).toBeNull();
     expect(resolveLegacyShellPageFromPath('/does-not-exist')).toBeNull();
   });
 

--- a/webui/src/platform/shell/route-manifest.ts
+++ b/webui/src/platform/shell/route-manifest.ts
@@ -33,7 +33,7 @@ export interface ShellRouteDefinition {
 export const shellRouteManifest: readonly ShellRouteDefinition[] = [
   { pageId: 'dashboard', path: '/dashboard', kind: 'legacy' },
   { pageId: 'sync', path: '/sync', kind: 'legacy' },
-  { pageId: 'search', path: '/search', kind: 'legacy' },
+  { pageId: 'search', path: '/search', kind: 'react' },
   { pageId: 'discover', path: '/discover', kind: 'legacy' },
   { pageId: 'playlist-explorer', path: '/playlist-explorer', kind: 'legacy' },
   { pageId: 'watchlist', path: '/watchlist', kind: 'react' },

--- a/webui/src/routeTree.gen.ts
+++ b/webui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SplatRouteImport } from './routes/$'
 import { Route as WishlistRouteRouteImport } from './routes/wishlist/route'
 import { Route as WatchlistRouteRouteImport } from './routes/watchlist/route'
 import { Route as StatsRouteRouteImport } from './routes/stats/route'
+import { Route as SearchRouteRouteImport } from './routes/search/route'
 import { Route as LibraryRouteRouteImport } from './routes/library/route'
 import { Route as IssuesRouteRouteImport } from './routes/issues/route'
 import { Route as ImportRouteRouteImport } from './routes/import/route'
@@ -43,6 +44,11 @@ const WatchlistRouteRoute = WatchlistRouteRouteImport.update({
 const StatsRouteRoute = StatsRouteRouteImport.update({
   id: '/stats',
   path: '/stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SearchRouteRoute = SearchRouteRouteImport.update({
+  id: '/search',
+  path: '/search',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LibraryRouteRoute = LibraryRouteRouteImport.update({
@@ -107,6 +113,7 @@ export interface FileRoutesByFullPath {
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
   '/library': typeof LibraryRouteRoute
+  '/search': typeof SearchRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -123,6 +130,7 @@ export interface FileRoutesByTo {
   '/automations': typeof AutomationsRouteRoute
   '/issues': typeof IssuesRouteRoute
   '/library': typeof LibraryRouteRoute
+  '/search': typeof SearchRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -141,6 +149,7 @@ export interface FileRoutesById {
   '/import': typeof ImportRouteRouteWithChildren
   '/issues': typeof IssuesRouteRoute
   '/library': typeof LibraryRouteRoute
+  '/search': typeof SearchRouteRoute
   '/stats': typeof StatsRouteRoute
   '/watchlist': typeof WatchlistRouteRoute
   '/wishlist': typeof WishlistRouteRoute
@@ -160,6 +169,7 @@ export interface FileRouteTypes {
     | '/import'
     | '/issues'
     | '/library'
+    | '/search'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -176,6 +186,7 @@ export interface FileRouteTypes {
     | '/automations'
     | '/issues'
     | '/library'
+    | '/search'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -193,6 +204,7 @@ export interface FileRouteTypes {
     | '/import'
     | '/issues'
     | '/library'
+    | '/search'
     | '/stats'
     | '/watchlist'
     | '/wishlist'
@@ -211,6 +223,7 @@ export interface RootRouteChildren {
   ImportRouteRoute: typeof ImportRouteRouteWithChildren
   IssuesRouteRoute: typeof IssuesRouteRoute
   LibraryRouteRoute: typeof LibraryRouteRoute
+  SearchRouteRoute: typeof SearchRouteRoute
   StatsRouteRoute: typeof StatsRouteRoute
   WatchlistRouteRoute: typeof WatchlistRouteRoute
   WishlistRouteRoute: typeof WishlistRouteRoute
@@ -247,6 +260,13 @@ declare module '@tanstack/react-router' {
       path: '/stats'
       fullPath: '/stats'
       preLoaderRoute: typeof StatsRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/search': {
+      id: '/search'
+      path: '/search'
+      fullPath: '/search'
+      preLoaderRoute: typeof SearchRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/library': {
@@ -353,6 +373,7 @@ const rootRouteChildren: RootRouteChildren = {
   ImportRouteRoute: ImportRouteRouteWithChildren,
   IssuesRouteRoute: IssuesRouteRoute,
   LibraryRouteRoute: LibraryRouteRoute,
+  SearchRouteRoute: SearchRouteRoute,
   StatsRouteRoute: StatsRouteRoute,
   WatchlistRouteRoute: WatchlistRouteRoute,
   WishlistRouteRoute: WishlistRouteRoute,

--- a/webui/src/routes/search/-route.test.tsx
+++ b/webui/src/routes/search/-route.test.tsx
@@ -344,3 +344,63 @@ describe('the global widget handoff', () => {
     delete window.performDownloadsSearch;
   });
 });
+
+describe('where a result card points', () => {
+  function type(value: string) {
+    const input = document.getElementById('enhanced-search-input') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
+      .set as (v: string) => void;
+    act(() => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  it('links a library artist to /artist-detail/library/<id> and a found one to its source', async () => {
+    // The href IS the feature. The first version guessed `/artist-detail/<id>`,
+    // which matches no route and resolves to nothing — clicking an artist did
+    // nothing at all, and no test noticed.
+    server.use(
+      http.post('/api/enhanced-search', () =>
+        HttpResponse.json({
+          db_artists: [{ id: 7, name: 'Owned Artist' }],
+          spotify_artists: [{ id: 'sp1', name: 'Found Artist', source: 'spotify' }],
+        }),
+      ),
+      http.post('/api/labels/search', () => HttpResponse.json({ labels: [] })),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+      http.get('/api/artist/:id/image', () => HttpResponse.json({ success: false })),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+    type('aphex twin');
+
+    const owned = await screen.findByText('Owned Artist', undefined, { timeout: 3000 });
+    expect(owned.closest('a')?.getAttribute('href')).toBe('/artist-detail/library/7');
+
+    const found = screen.getByText('Found Artist');
+    expect(found.closest('a')?.getAttribute('href')).toBe(
+      '/artist-detail/spotify/sp1?name=Found%20Artist',
+    );
+  });
+
+  it('links a label to /label-detail/<id>', async () => {
+    server.use(
+      http.post('/api/enhanced-search', () =>
+        HttpResponse.json({ spotify_albums: [{ id: 'a1', name: 'Drukqs', artist: 'Aphex Twin' }] }),
+      ),
+      http.post('/api/labels/search', () =>
+        HttpResponse.json({ labels: [{ id: 'l1', name: 'Warp' }] }),
+      ),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+    type('warp');
+
+    const label = await screen.findByText('Warp', undefined, { timeout: 3000 });
+    expect(label.closest('a')?.getAttribute('href')).toBe('/label-detail/l1?name=Warp');
+  });
+});

--- a/webui/src/routes/search/-route.test.tsx
+++ b/webui/src/routes/search/-route.test.tsx
@@ -177,8 +177,9 @@ describe('the dropdown state machine', () => {
   /** Type into the real input the way a keystroke does. */
   function type(value: string) {
     const input = document.getElementById('enhanced-search-input') as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
-      .set as (v: string) => void;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set as (
+      v: string,
+    ) => void;
     act(() => {
       setter.call(input, value);
       input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -348,8 +349,9 @@ describe('the global widget handoff', () => {
 describe('where a result card points', () => {
   function type(value: string) {
     const input = document.getElementById('enhanced-search-input') as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
-      .set as (v: string) => void;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set as (
+      v: string,
+    ) => void;
     act(() => {
       setter.call(input, value);
       input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/webui/src/routes/search/-route.test.tsx
+++ b/webui/src/routes/search/-route.test.tsx
@@ -46,8 +46,15 @@ beforeEach(() => {
   window.SoulSyncWebShellBridge = createShellBridge();
   server.use(
     http.get('/status', () => HttpResponse.json({ metadata_source: { source: 'spotify' } })),
+    // soulseek included on purpose: it needs an slskd URL like any other
+    // credentialed source, so leaving it out makes the picker (correctly) send
+    // its clicks to Settings instead of switching to basic mode.
     http.get('/api/settings/config-status', () =>
-      HttpResponse.json({ spotify: { configured: true }, deezer: { configured: true } }),
+      HttpResponse.json({
+        spotify: { configured: true },
+        deezer: { configured: true },
+        soulseek: { configured: true },
+      }),
     ),
   );
 });
@@ -255,5 +262,60 @@ describe('the dropdown state machine', () => {
     await waitFor(() =>
       expect(document.getElementById('enhanced-dropdown')?.className).toContain('hidden'),
     );
+  });
+});
+
+describe('the global widget handoff', () => {
+  it('runs the basic search ONCE, not once per path into it', async () => {
+    // Three ways to trigger it converge here: this sync, the icon click the
+    // widget makes next, and the debounce catching up. Only the click should
+    // search — the vanilla's equivalent line is a plain state assignment
+    // (downloads.js:5729-5731), and every extra call is another slskd search.
+    mountVanillaBasicSection();
+    const performDownloadsSearch = vi.fn();
+    window.performDownloadsSearch = performDownloadsSearch;
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+
+    act(() => {
+      window._searchPageSetQuery?.('aphex twin');
+    });
+    // The sync alone must not search.
+    expect(performDownloadsSearch).not.toHaveBeenCalled();
+
+    // Now the widget's icon click, which is the part that does.
+    const icon = document.querySelector('#enh-source-row [data-source="soulseek"]');
+    act(() => (icon as HTMLButtonElement).click());
+    expect(performDownloadsSearch).toHaveBeenCalledOnce();
+
+    // And the debounce does not add a third: the sync never touched the
+    // enhanced input, so there is nothing pending.
+    await new Promise((r) => setTimeout(r, SEARCH_DEBOUNCE_MS + 200));
+    expect(performDownloadsSearch).toHaveBeenCalledOnce();
+
+    delete window.performDownloadsSearch;
+  });
+
+  it('hands the widget’s query to basic search, not a remembered one', async () => {
+    mountVanillaBasicSection();
+    const performDownloadsSearch = vi.fn();
+    window.performDownloadsSearch = performDownloadsSearch;
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+
+    // The widget writes the input first, then syncs, then clicks.
+    const basicInput = document.getElementById('downloads-search-input') as HTMLInputElement;
+    basicInput.value = 'from the widget';
+    act(() => {
+      window._searchPageSetQuery?.('from the widget');
+    });
+    const icon = document.querySelector('#enh-source-row [data-source="soulseek"]');
+    act(() => (icon as HTMLButtonElement).click());
+
+    expect(basicInput.value).toBe('from the widget');
+    expect(performDownloadsSearch).toHaveBeenCalledOnce();
+    delete window.performDownloadsSearch;
   });
 });

--- a/webui/src/routes/search/-route.test.tsx
+++ b/webui/src/routes/search/-route.test.tsx
@@ -100,24 +100,49 @@ describe('the search route', () => {
     // MOVED into the React tree — and initializeSearch, which used to run from
     // init.js's legacy `case 'search'`, has to be called or its Search button
     // does nothing.
-    mountVanillaBasicSection();
+    const legacyPage = mountVanillaBasicSection();
     const initializeSearch = vi.fn();
     const initializeFilters = vi.fn();
     window.initializeSearch = initializeSearch;
     window.initializeFilters = initializeFilters;
 
-    const { unmount } = renderRoute('/search');
+    // `container` is the element React renders into. Asserting against
+    // document.body instead would be vacuous — the legacy page is in the body
+    // too, so `contains` is true whether the node moved or not. That exact
+    // mistake let a "removed the appendChild" mutant survive.
+    const { unmount, container } = renderRoute('/search');
     await screen.findByText('Search');
 
-    const section = document.getElementById('basic-search-section');
-    const reactHost = document.getElementById('webui-react-root') ?? document.body;
-    expect(reactHost.contains(section as Node)).toBe(true);
+    const section = document.getElementById('basic-search-section') as HTMLElement;
+    expect(container.contains(section)).toBe(true);
+    expect(legacyPage.contains(section)).toBe(false);
     expect(initializeSearch).toHaveBeenCalledOnce();
     expect(initializeFilters).toHaveBeenCalledOnce();
 
     // And it goes home again, or basic search stays broken until a reload.
     unmount();
-    expect(document.getElementById('search-page')?.contains(section as Node)).toBe(true);
+    expect(legacyPage.contains(section)).toBe(true);
+    expect(container.contains(section)).toBe(false);
+  });
+
+  it('shows the basic panel only when Soulseek is the active source', async () => {
+    // `.search-section` is display:none until `.active`, so this class IS
+    // whether basic search is on screen at all.
+    mountVanillaBasicSection();
+    renderRoute('/search');
+    await screen.findByText('Search');
+
+    const section = document.getElementById('basic-search-section') as HTMLElement;
+    const enhanced = document.getElementById('enhanced-search-section') as HTMLElement;
+    expect(section.classList.contains('active')).toBe(false);
+    expect(enhanced.classList.contains('active')).toBe(true);
+
+    const icon = document.querySelector('#enh-source-row [data-source="soulseek"]');
+    act(() => (icon as HTMLButtonElement).click());
+
+    await waitFor(() => expect(section.classList.contains('active')).toBe(true));
+    // And exactly one of the two is showing.
+    expect(enhanced.classList.contains('active')).toBe(false);
   });
 
   it('does not re-bind the basic listeners on a second visit', async () => {

--- a/webui/src/routes/search/-route.test.tsx
+++ b/webui/src/routes/search/-route.test.tsx
@@ -1,0 +1,259 @@
+import { createMemoryHistory } from '@tanstack/react-router';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppRouterProvider, createAppRouter } from '@/app/router';
+import { server } from '@/test/msw';
+import { createTestQueryClient } from '@/test/query-client';
+import { createShellBridge } from '@/test/shell-bridge';
+
+import { SEARCH_DEBOUNCE_MS } from './-search.helpers';
+import { resetBasicSectionBinding } from './-search.use-basic-section';
+import { resetPersistedSearch } from './-search.use-controller';
+
+function renderRoute(path: string) {
+  const queryClient = createTestQueryClient();
+  const history = createMemoryHistory({ initialEntries: [path] });
+  const router = createAppRouter({ history, queryClient });
+  return render(<AppRouterProvider router={router} queryClient={queryClient} />);
+}
+
+/**
+ * The vanilla basic-search panel, as index.html ships it.
+ *
+ * The React page MOVES this element into its own tree; these tests need a real
+ * one in the document to move.
+ */
+function mountVanillaBasicSection() {
+  const page = document.createElement('div');
+  page.className = 'page';
+  page.id = 'search-page';
+  page.innerHTML = `
+    <div id="basic-search-section" class="search-section">
+      <input id="downloads-search-input" />
+      <button id="downloads-search-btn">Search</button>
+    </div>`;
+  document.body.appendChild(page);
+  return page;
+}
+
+beforeEach(() => {
+  resetPersistedSearch();
+  resetBasicSectionBinding();
+  // Without a bridge the route's beforeLoad cannot ask whether the page is
+  // allowed, and redirects to the profile home before rendering anything.
+  window.SoulSyncWebShellBridge = createShellBridge();
+  server.use(
+    http.get('/status', () => HttpResponse.json({ metadata_source: { source: 'spotify' } })),
+    http.get('/api/settings/config-status', () =>
+      HttpResponse.json({ spotify: { configured: true }, deezer: { configured: true } }),
+    ),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  document.querySelectorAll('#search-page').forEach((node) => node.remove());
+  delete window.initializeSearch;
+  delete window.initializeFilters;
+  delete window._searchPageSetQuery;
+});
+
+describe('the search route', () => {
+  it('renders without the shell’s .page class', async () => {
+    // `.page { display: none }` and the shell only adds `.active` for legacy
+    // pages, so a React page wearing it renders invisibly — with every test
+    // still passing. This is the label-detail trap.
+    await renderRoute('/search');
+    await screen.findByText('Search');
+
+    const host = document.getElementById('webui-react-root') ?? document.body;
+    expect(host.querySelector('.page')).toBeNull();
+  });
+
+  it('shows the header and an idle page with no dropdown', async () => {
+    await renderRoute('/search');
+    await screen.findByText('Find artists, albums, and tracks from any metadata source');
+
+    expect(document.getElementById('enhanced-dropdown')?.className).toContain('hidden');
+    expect(document.getElementById('enhanced-search-input')).not.toBeNull();
+  });
+
+  it('renders #enhanced-main-results-area, where download bubbles land', async () => {
+    // showSearchDownloadBubbles renders into this id and silently returns
+    // without it, so every download started from search would draw nowhere.
+    await renderRoute('/search');
+    await screen.findByText('Search');
+    expect(document.getElementById('enhanced-main-results-area')).not.toBeNull();
+  });
+
+  it('adopts the vanilla basic-search panel and binds its listeners once', async () => {
+    // The shell hides #search-page to show a React page, so the panel has to be
+    // MOVED into the React tree — and initializeSearch, which used to run from
+    // init.js's legacy `case 'search'`, has to be called or its Search button
+    // does nothing.
+    mountVanillaBasicSection();
+    const initializeSearch = vi.fn();
+    const initializeFilters = vi.fn();
+    window.initializeSearch = initializeSearch;
+    window.initializeFilters = initializeFilters;
+
+    const { unmount } = renderRoute('/search');
+    await screen.findByText('Search');
+
+    const section = document.getElementById('basic-search-section');
+    const reactHost = document.getElementById('webui-react-root') ?? document.body;
+    expect(reactHost.contains(section as Node)).toBe(true);
+    expect(initializeSearch).toHaveBeenCalledOnce();
+    expect(initializeFilters).toHaveBeenCalledOnce();
+
+    // And it goes home again, or basic search stays broken until a reload.
+    unmount();
+    expect(document.getElementById('search-page')?.contains(section as Node)).toBe(true);
+  });
+
+  it('does not re-bind the basic listeners on a second visit', async () => {
+    // initializeSearch uses addEventListener with no guard of its own; calling
+    // it twice makes every basic search fire twice.
+    mountVanillaBasicSection();
+    const initializeSearch = vi.fn();
+    window.initializeSearch = initializeSearch;
+
+    const first = renderRoute('/search');
+    await screen.findByText('Search');
+    first.unmount();
+
+    const second = renderRoute('/search');
+    await screen.findByText('Search');
+    expect(initializeSearch).toHaveBeenCalledOnce();
+    second.unmount();
+  });
+
+  it('exposes _searchPageSetQuery for the global widget handoff', async () => {
+    const { unmount } = renderRoute('/search');
+    await screen.findByText('Search');
+    expect(typeof window._searchPageSetQuery).toBe('function');
+
+    unmount();
+    // Cleaned up, so a stale page cannot answer for a live one.
+    await waitFor(() => expect(window._searchPageSetQuery).toBeUndefined());
+  });
+});
+
+describe('the dropdown state machine', () => {
+  /** Type into the real input the way a keystroke does. */
+  function type(value: string) {
+    const input = document.getElementById('enhanced-search-input') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
+      .set as (v: string) => void;
+    act(() => {
+      setter.call(input, value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  it('stays shut for a query shorter than two characters', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      renderRoute('/search');
+      await screen.findByText('Search');
+
+      type('a');
+      act(() => vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS + 50));
+      expect(document.getElementById('enhanced-dropdown')?.className).toContain('hidden');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * Which body is SHOWING.
+   *
+   * All three are always in the DOM and only the `hidden` class differs, so
+   * asserting on text alone proves nothing — "No results found" is present even
+   * while results are on screen.
+   */
+  function visibleBody(): string {
+    const shown = (id: string) => !document.getElementById(id)?.className.includes('hidden');
+    if (shown('enhanced-loading')) return 'loading';
+    if (shown('enhanced-empty')) return 'empty';
+    if (shown('enhanced-results-container')) return 'results';
+    return 'none';
+  }
+
+  it('names the source it is searching while the request is in flight', async () => {
+    let settle: (() => void) | null = null;
+    server.use(
+      http.post('/api/enhanced-search', () => {
+        return new Promise<Response>((resolve) => {
+          settle = () => resolve(HttpResponse.json({ spotify_albums: [] }));
+        });
+      }),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+    type('aphex twin');
+
+    // The text names the ACTIVE source rather than a hardcoded "Spotify", and
+    // the loading body is the one on screen.
+    await screen.findByText('Searching Spotify and your library...', undefined, { timeout: 3000 });
+    await waitFor(() => expect(visibleBody()).toBe('loading'));
+    act(() => settle?.());
+  });
+
+  it('shows the results body once they land', async () => {
+    server.use(
+      http.post('/api/enhanced-search', () =>
+        HttpResponse.json({ spotify_albums: [{ id: 'a1', name: 'Drukqs' }] }),
+      ),
+      http.post('/api/labels/search', () => HttpResponse.json({ labels: [] })),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+    type('aphex twin');
+
+    await waitFor(() => expect(visibleBody()).toBe('results'), { timeout: 3000 });
+    expect(screen.getByText('Drukqs')).toBeInTheDocument();
+    expect(document.getElementById('enhanced-dropdown')?.className).not.toContain('hidden');
+  });
+
+  it('says so when a settled search found nothing', async () => {
+    server.use(
+      http.post('/api/enhanced-search', () => HttpResponse.json({ spotify_albums: [] })),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+
+    type('nothing at all');
+    await waitFor(() => expect(visibleBody()).toBe('empty'), { timeout: 3000 });
+  });
+
+  it('closes on an outside click and reopens on the next search', async () => {
+    server.use(
+      http.post('/api/enhanced-search', () =>
+        HttpResponse.json({ spotify_albums: [{ id: 'a1', name: 'Drukqs' }] }),
+      ),
+      http.post('/api/labels/search', () => HttpResponse.json({ labels: [] })),
+      http.post('/api/enhanced-search/library-check', () => HttpResponse.json({})),
+    );
+
+    renderRoute('/search');
+    await screen.findByText('Search');
+    type('aphex twin');
+    await screen.findByText('Drukqs');
+
+    act(() => {
+      document.body.click();
+    });
+    await waitFor(() =>
+      expect(document.getElementById('enhanced-dropdown')?.className).toContain('hidden'),
+    );
+  });
+});

--- a/webui/src/routes/search/-search.actions.test.ts
+++ b/webui/src/routes/search/-search.actions.test.ts
@@ -1,0 +1,428 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import type { SearchAlbum, SearchTrack } from './-search.types';
+
+import {
+  albumDetailParams,
+  albumVirtualId,
+  buildAlbumObject,
+  buildArtistObject,
+  buildSingleTrackAlbum,
+  enrichAlbumTracks,
+  enrichSingleTrack,
+  openSearchAlbum,
+  openSearchTrack,
+  playOwnedTrack,
+  streamSearchTrack,
+  trackVirtualId,
+  unsupportedStreamFormat,
+} from './-search.actions';
+
+const album = (over: Partial<SearchAlbum> = {}): SearchAlbum => ({
+  id: 'alb1',
+  name: 'Drukqs',
+  artist: 'Aphex Twin',
+  source: 'spotify',
+  ...over,
+});
+
+const track = (over: Partial<SearchTrack> = {}): SearchTrack => ({
+  id: 'trk1',
+  name: 'Xtal',
+  artist: 'Aphex Twin',
+  album: 'SAW 85-92',
+  duration_ms: 293_000,
+  ...over,
+});
+
+const detail = {
+  id: 'alb1',
+  name: 'Drukqs',
+  album_type: 'album',
+  release_date: '2001-10-22',
+  total_tracks: 2,
+  images: [{ url: 'https://cdn/cover.jpg' }],
+  artists: [{ id: 'art1', name: 'Aphex Twin', image_url: 'https://cdn/artist.jpg' }],
+  tracks: [{ id: 'x', name: 'Avril 14th' }],
+};
+
+let modalCalls: unknown[][];
+let bubbleCalls: unknown[][];
+let toasts: unknown[][];
+
+beforeEach(() => {
+  modalCalls = [];
+  bubbleCalls = [];
+  toasts = [];
+  window.openDownloadMissingModalForArtistAlbum = vi.fn((...args: unknown[]) => {
+    modalCalls.push(args);
+  }) as never;
+  window.registerSearchDownload = vi.fn((...args: unknown[]) => {
+    bubbleCalls.push(args);
+  }) as never;
+  window.showToast = vi.fn((...args: unknown[]) => {
+    toasts.push(args);
+  }) as never;
+  window.showLoadingOverlay = vi.fn();
+  window.hideLoadingOverlay = vi.fn();
+  window.reopenActiveDownloadModal = vi.fn(() => false);
+});
+
+afterEach(() => {
+  delete window.openDownloadMissingModalForArtistAlbum;
+  delete window.registerSearchDownload;
+  delete window.showToast;
+  delete window.showLoadingOverlay;
+  delete window.hideLoadingOverlay;
+  delete window.reopenActiveDownloadModal;
+  delete window.isAudioFormatSupported;
+  delete window.getFileExtension;
+  delete window.SoulSyncWebShellBridge;
+});
+
+describe('virtual playlist ids', () => {
+  it('keeps albums and tracks in separate namespaces', () => {
+    // Same id from two sections must not collide into one modal.
+    expect(albumVirtualId(album({ id: '7' }))).toBe('enhanced_search_album_7');
+    expect(trackVirtualId(track({ id: '7' }))).toBe('enhanced_search_track_7');
+  });
+});
+
+describe('albumDetailParams', () => {
+  it('always sends the name and artist the server matches on', () => {
+    const params = albumDetailParams(album(), 'spotify');
+    expect(params.get('name')).toBe('Drukqs');
+    expect(params.get('artist')).toBe('Aphex Twin');
+  });
+
+  it('omits source for spotify and sends it otherwise', () => {
+    expect(albumDetailParams(album(), 'spotify').has('source')).toBe(false);
+    expect(albumDetailParams(album(), 'deezer').get('source')).toBe('deezer');
+  });
+
+  it('carries the hydrabase plugin so the server routes to the right client', () => {
+    const params = albumDetailParams(
+      album({ external_urls: { hydrabase_plugin: 'someplugin' } }),
+      'hydrabase',
+    );
+    expect(params.get('plugin')).toBe('someplugin');
+  });
+
+  it('sends a bandcamp release url, which is the only way to fetch it', () => {
+    // Bandcamp has no id-lookup API; without the url the server re-searches by
+    // name and can land on a different release.
+    const withUrl = album({ external_urls: { bandcamp: 'https://x.bandcamp.com/album/y' } });
+    expect(albumDetailParams(withUrl, 'bandcamp').get('bandcamp_url')).toBe(
+      'https://x.bandcamp.com/album/y',
+    );
+    // Only for bandcamp: another source's fetch has no use for it.
+    expect(albumDetailParams(withUrl, 'deezer').has('bandcamp_url')).toBe(false);
+  });
+});
+
+describe('modal payloads', () => {
+  it('gives every track the whole album object', () => {
+    // The modal reads it per track to build download jobs, and the wishlist
+    // needs it to store a retryable entry.
+    const tracks = enrichAlbumTracks(detail, album());
+    expect(tracks[0].album).toEqual({
+      name: 'Drukqs',
+      id: 'alb1',
+      album_type: 'album',
+      images: [{ url: 'https://cdn/cover.jpg' }],
+      release_date: '2001-10-22',
+      total_tracks: 2,
+    });
+  });
+
+  it('threads the metadata source onto each track', () => {
+    // extract_source_metadata needs it downstream: without it, Deezer collab
+    // tracks import tagged with only the primary artist.
+    expect(enrichAlbumTracks(detail, album({ source: 'deezer' }))[0].source).toBe('deezer');
+    // A track's own source wins over the album's.
+    const withOwn = { ...detail, tracks: [{ id: 'x', source: 'tidal' }] };
+    expect(enrichAlbumTracks(withOwn, album({ source: 'deezer' }))[0].source).toBe('tidal');
+  });
+
+  it('falls back to null rather than an empty source string', () => {
+    expect(enrichAlbumTracks(detail, album({ source: undefined }))[0].source).toBeNull();
+  });
+
+  it('builds the album object from the DETAIL, not the search row', () => {
+    // The search row has no track count and often a coarser title.
+    const built = buildAlbumObject(detail, album({ name: 'drukqs (stale)' }));
+    expect(built.name).toBe('Drukqs');
+    expect(built.total_tracks).toBe(2);
+  });
+
+  it('names the artist from the detail, falling back to the row', () => {
+    expect(buildArtistObject(detail, album(), 'spotify').id).toBe('art1');
+    expect(buildArtistObject({ ...detail, artists: [] }, album(), 'spotify').name).toBe(
+      'Aphex Twin',
+    );
+  });
+
+  it('reads an artist id out of a compound album id when there is nothing else', () => {
+    // Some sources mint `<artistId>_<rest>`. Nonsense elsewhere, which is why it
+    // is the last resort.
+    const built = buildArtistObject({ ...detail, artists: [] }, album({ id: 'art9_alb3' }), 'itunes');
+    expect(built.id).toBe('art9');
+    expect(built.source).toBe('itunes');
+  });
+
+  it('prefers the real artist list over the joined display string', () => {
+    // "A, B" made collab downloads land tagged with one combined artist.
+    const enriched = enrichSingleTrack(track({ artists: ['Aphex Twin', 'Squarepusher'] }));
+    expect(enriched.artists).toEqual(['Aphex Twin', 'Squarepusher']);
+    expect(enrichSingleTrack(track()).artists).toEqual(['Aphex Twin']);
+  });
+
+  it('wraps a single track as a one-track single', () => {
+    const built = buildSingleTrackAlbum(track({ image_url: 'https://cdn/t.jpg' }));
+    expect(built).toMatchObject({
+      name: 'SAW 85-92',
+      album_type: 'single',
+      total_tracks: 1,
+      images: [{ url: 'https://cdn/t.jpg' }],
+      artists: [{ name: 'Aphex Twin' }],
+    });
+  });
+
+  it('sends no images at all when the track has no art', () => {
+    expect(buildSingleTrackAlbum(track({ image_url: undefined })).images).toEqual([]);
+  });
+});
+
+describe('unsupportedStreamFormat', () => {
+  it('skips the check for sources whose filenames are opaque ids', () => {
+    // A youtube "filename" is an encoded id; reading an extension off it rejects
+    // tracks that play fine.
+    window.isAudioFormatSupported = vi.fn(() => false);
+    for (const username of ['youtube', 'tidal', 'qobuz', 'hifi']) {
+      expect(unsupportedStreamFormat({ username, filename: 'abc123' })).toBeNull();
+    }
+    expect(window.isAudioFormatSupported).not.toHaveBeenCalled();
+  });
+
+  it('names the format when the browser cannot play it', () => {
+    window.isAudioFormatSupported = vi.fn(() => false);
+    window.getFileExtension = vi.fn(() => 'wma');
+    expect(unsupportedStreamFormat({ username: 'someuser', filename: 'x.wma' })).toBe('WMA');
+  });
+
+  it('passes a supported format', () => {
+    window.isAudioFormatSupported = vi.fn(() => true);
+    expect(unsupportedStreamFormat({ username: 'someuser', filename: 'x.flac' })).toBeNull();
+  });
+
+  it('lets a result with no filename through, for the player to judge', () => {
+    window.isAudioFormatSupported = vi.fn(() => false);
+    expect(unsupportedStreamFormat({ username: 'someuser' })).toBeNull();
+  });
+});
+
+describe('openSearchAlbum', () => {
+  it('opens the modal and registers the download bubble', async () => {
+    server.use(http.get('/api/spotify/album/alb1', () => HttpResponse.json(detail)));
+    await openSearchAlbum(album(), 'spotify');
+
+    expect(modalCalls).toHaveLength(1);
+    const [id, heading, tracks, albumObject, artistObject, overlay] = modalCalls[0];
+    expect(id).toBe('enhanced_search_album_alb1');
+    expect(heading).toBe('[Aphex Twin] Drukqs');
+    expect(tracks).toHaveLength(1);
+    expect((albumObject as { name: string }).name).toBe('Drukqs');
+    expect((artistObject as { id: string }).id).toBe('art1');
+    // False: this flow already raised its own overlay.
+    expect(overlay).toBe(false);
+
+    expect(bubbleCalls[0][1]).toBe('album');
+    expect(bubbleCalls[0][3]).toBe('Aphex Twin');
+  });
+
+  it('reopens an existing modal WITHOUT fetching album detail', async () => {
+    // The point is not saving a request: on a re-click while the source is down,
+    // fetching first turns the modal the user already had into an error toast.
+    let fetched = false;
+    server.use(
+      http.get('/api/spotify/album/alb1', () => {
+        fetched = true;
+        return HttpResponse.json(detail);
+      }),
+    );
+    window.reopenActiveDownloadModal = vi.fn(() => true);
+
+    await openSearchAlbum(album(), 'spotify');
+    expect(fetched).toBe(false);
+    expect(modalCalls).toHaveLength(0);
+    expect(window.showLoadingOverlay).not.toHaveBeenCalled();
+  });
+
+  it('explains an empty tracklist instead of opening an empty modal', async () => {
+    server.use(
+      http.get('/api/spotify/album/alb1', () => HttpResponse.json({ ...detail, tracks: [] })),
+    );
+    await openSearchAlbum(album(), 'spotify');
+
+    expect(modalCalls).toHaveLength(0);
+    expect(String(toasts[0][0])).toContain('No tracks available for "Drukqs"');
+    expect(toasts[0][1]).toBe('warning');
+  });
+
+  it('says when Spotify is not authenticated rather than "500"', async () => {
+    server.use(http.get('/api/spotify/album/alb1', () => new HttpResponse(null, { status: 401 })));
+    await openSearchAlbum(album(), 'spotify');
+    expect(String(toasts[0][0])).toContain('Spotify not authenticated');
+  });
+
+  it('always takes the overlay back down', async () => {
+    server.use(http.get('/api/spotify/album/alb1', () => new HttpResponse(null, { status: 500 })));
+    await openSearchAlbum(album(), 'spotify');
+    expect(window.hideLoadingOverlay).toHaveBeenCalled();
+    expect(toasts).toHaveLength(1);
+  });
+});
+
+describe('openSearchTrack', () => {
+  it('opens a one-track modal and registers the bubble', async () => {
+    await openSearchTrack(track());
+
+    const [id, heading, tracks, albumObject, artistObject] = modalCalls[0];
+    expect(id).toBe('enhanced_search_track_trk1');
+    expect(heading).toBe('Aphex Twin - Xtal');
+    expect(tracks).toHaveLength(1);
+    expect((albumObject as { album_type: string }).album_type).toBe('single');
+    expect(artistObject).toEqual({ id: null, name: 'Aphex Twin' });
+    expect(bubbleCalls[0][1]).toBe('track');
+  });
+
+  it('reopens an existing modal instead of building a second one', async () => {
+    window.reopenActiveDownloadModal = vi.fn(() => true);
+    await openSearchTrack(track());
+    expect(modalCalls).toHaveLength(0);
+  });
+});
+
+describe('playOwnedTrack', () => {
+  it('plays the LIBRARY row, not the search result', () => {
+    // playLibraryTrack needs the library's own id, title and album thumb; the
+    // search result knows none of them, which is why the whole row travels.
+    const playLibraryTrack = vi.fn();
+    window.SoulSyncWebShellBridge = { playLibraryTrack } as never;
+
+    playOwnedTrack({
+      track_id: 42,
+      title: 'Xtal',
+      file_path: '/music/xtal.flac',
+      album_thumb_url: 'https://cdn/t.jpg',
+      album_title: 'SAW 85-92',
+      artist_name: 'Aphex Twin',
+    });
+
+    expect(playLibraryTrack).toHaveBeenCalledWith(
+      { id: 42, title: 'Xtal', file_path: '/music/xtal.flac', _stats_image: 'https://cdn/t.jpg' },
+      'SAW 85-92',
+      'Aphex Twin',
+    );
+  });
+
+  it('refuses to play a row with no file', () => {
+    // "Owned" can mean a Plex-only entry with nothing on disk. Calling the
+    // player with an empty path opens it on a track that cannot load.
+    const playLibraryTrack = vi.fn();
+    window.SoulSyncWebShellBridge = { playLibraryTrack } as never;
+
+    playOwnedTrack({ track_id: 42, title: 'Xtal' });
+    expect(playLibraryTrack).not.toHaveBeenCalled();
+  });
+
+  it('sends empty strings rather than undefined for the missing bits', () => {
+    // The player writes these straight into the now-playing UI.
+    const playLibraryTrack = vi.fn();
+    window.SoulSyncWebShellBridge = { playLibraryTrack } as never;
+
+    playOwnedTrack({ file_path: '/music/x.flac' });
+    expect(playLibraryTrack).toHaveBeenCalledWith(
+      { id: '', title: '', file_path: '/music/x.flac', _stats_image: null },
+      '',
+      '',
+    );
+  });
+});
+
+describe('streamSearchTrack', () => {
+  it('sends the track metadata and starts the player', async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post('/api/enhanced-search/stream-track', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ success: true, result: { username: 'someuser' } });
+      }),
+    );
+    const startStream = vi.fn();
+    window.SoulSyncWebShellBridge = { startStream } as never;
+    window.isAudioFormatSupported = vi.fn(() => true);
+
+    await streamSearchTrack(track());
+
+    expect(body).toEqual({
+      track_name: 'Xtal',
+      artist_name: 'Aphex Twin',
+      album_name: 'SAW 85-92',
+      duration_ms: 293_000,
+    });
+    expect(startStream).toHaveBeenCalledWith({ username: 'someuser' });
+  });
+
+  it('drops the overlay BEFORE the player opens', async () => {
+    // startStream opens the media player; behind a loading overlay it is hidden.
+    const order: string[] = [];
+    server.use(
+      http.post('/api/enhanced-search/stream-track', () =>
+        HttpResponse.json({ success: true, result: { username: 'youtube', filename: 'abc' } }),
+      ),
+    );
+    window.hideLoadingOverlay = vi.fn(() => order.push('hide')) as never;
+    window.SoulSyncWebShellBridge = { startStream: vi.fn(() => order.push('stream')) } as never;
+
+    await streamSearchTrack(track());
+    expect(order.indexOf('hide')).toBeLessThan(order.indexOf('stream'));
+  });
+
+  it('refuses a format the browser cannot decode, and does not play it', async () => {
+    server.use(
+      http.post('/api/enhanced-search/stream-track', () =>
+        HttpResponse.json({ success: true, result: { username: 'someuser', filename: 'x.wma' } }),
+      ),
+    );
+    const startStream = vi.fn();
+    window.SoulSyncWebShellBridge = { startStream } as never;
+    window.isAudioFormatSupported = vi.fn(() => false);
+    window.getFileExtension = vi.fn(() => 'wma');
+
+    await streamSearchTrack(track());
+    expect(startStream).not.toHaveBeenCalled();
+    expect(String(toasts[0][0])).toContain('WMA format is not supported');
+  });
+
+  it('surfaces the server’s own error message', async () => {
+    server.use(
+      http.post('/api/enhanced-search/stream-track', () =>
+        HttpResponse.json({ error: 'slskd is offline' }, { status: 503 }),
+      ),
+    );
+    await streamSearchTrack(track());
+    expect(String(toasts[0][0])).toContain('slskd is offline');
+  });
+
+  it('says nothing was found when the search succeeds but matches nothing', async () => {
+    server.use(
+      http.post('/api/enhanced-search/stream-track', () => HttpResponse.json({ success: false })),
+    );
+    await streamSearchTrack(track());
+    expect(String(toasts[0][0])).toContain('No suitable track found');
+  });
+});

--- a/webui/src/routes/search/-search.actions.test.ts
+++ b/webui/src/routes/search/-search.actions.test.ts
@@ -168,7 +168,11 @@ describe('modal payloads', () => {
   it('reads an artist id out of a compound album id when there is nothing else', () => {
     // Some sources mint `<artistId>_<rest>`. Nonsense elsewhere, which is why it
     // is the last resort.
-    const built = buildArtistObject({ ...detail, artists: [] }, album({ id: 'art9_alb3' }), 'itunes');
+    const built = buildArtistObject(
+      { ...detail, artists: [] },
+      album({ id: 'art9_alb3' }),
+      'itunes',
+    );
     expect(built.id).toBe('art9');
     expect(built.source).toBe('itunes');
   });

--- a/webui/src/routes/search/-search.actions.ts
+++ b/webui/src/routes/search/-search.actions.ts
@@ -1,0 +1,343 @@
+/**
+ * What a result card does when you click it, ported from search.js:788-1075.
+ *
+ * Three flows: open an album, open a single track, stream a track. Each one ends
+ * in a vanilla global that cannot move (the download modal, the media player),
+ * so the shape handed over matters more than the call — every field below is
+ * read by the modal, the wishlist, or the import pipeline downstream.
+ *
+ * The builders are separated out and pure so those shapes are testable without
+ * standing up a modal.
+ */
+
+import type { SearchAlbum, SearchTrack } from './-search.types';
+
+/** Album detail as /api/spotify/album/<id> returns it. */
+export interface AlbumDetail {
+  id?: string;
+  name?: string;
+  album_type?: string;
+  release_date?: string;
+  total_tracks?: number;
+  images?: { url?: string }[];
+  artists?: { id?: string; name?: string; image_url?: string; images?: { url?: string }[] }[];
+  tracks?: Record<string, unknown>[];
+}
+
+/** The modal's synthetic playlist id. Album and track namespaces are separate. */
+export function albumVirtualId(album: SearchAlbum): string {
+  return `enhanced_search_album_${album.id}`;
+}
+
+export function trackVirtualId(track: SearchTrack): string {
+  return `enhanced_search_track_${track.id}`;
+}
+
+/**
+ * Query params for the album-detail fetch.
+ *
+ * `source` is omitted for spotify — it is the server's default, and sending it
+ * would change nothing. The other two are escape hatches for sources whose ids
+ * are not enough on their own:
+ *   - Hydrabase routes by plugin origin, so the plugin name has to travel.
+ *   - Bandcamp has no id lookup at all, so the release URL is the only way to
+ *     fetch the exact release rather than re-searching by name.
+ */
+export function albumDetailParams(album: SearchAlbum, activeSource: string): URLSearchParams {
+  const params = new URLSearchParams({ name: album.name ?? '', artist: album.artist ?? '' });
+  if (activeSource && activeSource !== 'spotify') params.set('source', activeSource);
+  const hydrabasePlugin = album.external_urls?.hydrabase_plugin;
+  if (hydrabasePlugin) params.set('plugin', String(hydrabasePlugin));
+  if (activeSource === 'bandcamp' && album.external_urls?.bandcamp) {
+    params.set('bandcamp_url', String(album.external_urls.bandcamp));
+  }
+  return params;
+}
+
+/** The album object the modal renders and the wishlist stores. */
+export function buildAlbumObject(detail: AlbumDetail, album: SearchAlbum): Record<string, unknown> {
+  return {
+    name: detail.name,
+    id: detail.id,
+    album_type: detail.album_type || 'album',
+    images: detail.images || [],
+    release_date: detail.release_date,
+    total_tracks: detail.total_tracks,
+    artists: detail.artists || [{ name: album.artist }],
+  };
+}
+
+/**
+ * The artist object, whose id the modal uses to link back to a detail page.
+ *
+ * The fallback is the vanilla's: some sources mint album ids of the form
+ * `<artistId>_<something>`, so the leading segment is the artist. It yields
+ * nonsense for sources that don't, which is why it is last.
+ */
+export function buildArtistObject(
+  detail: AlbumDetail,
+  album: SearchAlbum,
+  activeSource: string,
+): Record<string, unknown> {
+  const first = detail.artists?.[0] ?? {};
+  return {
+    id: first.id || String(album.id ?? '').split('_')[0] || '',
+    name: first.name || album.artist,
+    image_url: first.image_url || first.images?.[0]?.url || '',
+    source: activeSource || '',
+  };
+}
+
+/**
+ * Every track carries the whole album object.
+ *
+ * The modal reads it per track when it builds download jobs, and the wishlist
+ * needs it to store an entry that can be retried later. `source` is threaded
+ * through because the import pipeline runs source-specific logic on the file —
+ * the Deezer contributors upgrade for multi-artist tags depends on it.
+ */
+export function enrichAlbumTracks(
+  detail: AlbumDetail,
+  album: SearchAlbum,
+): Record<string, unknown>[] {
+  const albumForTrack = {
+    name: detail.name,
+    id: detail.id,
+    album_type: detail.album_type || 'album',
+    images: detail.images || [],
+    release_date: detail.release_date,
+    total_tracks: detail.total_tracks,
+  };
+  return (detail.tracks ?? []).map((track) => ({
+    ...track,
+    source: (track as { source?: string }).source || album.source || null,
+    album: albumForTrack,
+  }));
+}
+
+/**
+ * One search track, in the shape the modal expects.
+ *
+ * `artists` prefers the real list over the joined "A, B" display string: that
+ * string is what made collab downloads land tagged with a single combined
+ * artist, because resolve_track_artists saw one value.
+ */
+export function enrichSingleTrack(track: SearchTrack): Record<string, unknown> {
+  const albumObject = {
+    name: track.album,
+    id: null,
+    album_type: 'single',
+    images: track.image_url ? [{ url: track.image_url }] : [],
+    release_date: track.release_date || null,
+    total_tracks: 1,
+  };
+  return {
+    id: track.id,
+    name: track.name,
+    source: track.source || null,
+    artists: track.artists?.length ? track.artists : [track.artist],
+    album: albumObject,
+    duration_ms: track.duration_ms,
+    popularity: track.popularity || 0,
+    preview_url: track.preview_url || null,
+    external_urls: track.external_urls || null,
+    image_url: track.image_url,
+  };
+}
+
+/** The album object for a single track — a one-track "single". */
+export function buildSingleTrackAlbum(track: SearchTrack): Record<string, unknown> {
+  return {
+    name: track.album,
+    id: null,
+    album_type: 'single',
+    images: track.image_url ? [{ url: track.image_url }] : [],
+    release_date: track.release_date || null,
+    total_tracks: 1,
+    artists: [{ name: track.artist }],
+  };
+}
+
+/**
+ * Sources whose "filenames" are opaque ids rather than paths.
+ *
+ * A format check on one of these reads the extension off an encoded string and
+ * rejects a track the browser can play perfectly well.
+ */
+const STREAMING_USERNAMES = new Set(['youtube', 'tidal', 'qobuz', 'hifi']);
+
+export interface StreamResult {
+  username?: string;
+  filename?: string;
+}
+
+/**
+ * Can this stream result actually play here?
+ *
+ * Returns the offending format when it cannot, so the caller can name it. A
+ * missing filename is allowed through: there is nothing to judge, and the
+ * player is the better place to fail.
+ */
+export function unsupportedStreamFormat(result: StreamResult): string | null {
+  if (result.username && STREAMING_USERNAMES.has(result.username)) return null;
+  if (!result.filename) return null;
+  if (window.isAudioFormatSupported?.(result.filename) !== false) return null;
+  return (window.getFileExtension?.(result.filename) ?? '').toUpperCase();
+}
+
+/** Open an album's download modal. */
+export async function openSearchAlbum(album: SearchAlbum, activeSource: string): Promise<void> {
+  // Checked BEFORE the fetch, so a re-click still works when the source is down.
+  if (window.reopenActiveDownloadModal?.(albumVirtualId(album))) return;
+
+  window.showLoadingOverlay?.('Loading album...');
+  try {
+    const params = albumDetailParams(album, activeSource);
+    const response = await fetch(`/api/spotify/album/${album.id}?${params}`);
+    if (!response.ok) {
+      throw new Error(
+        response.status === 401
+          ? 'Spotify not authenticated. Please check your API settings.'
+          : `Failed to load album: ${response.status}`,
+      );
+    }
+    const detail = (await response.json()) as AlbumDetail;
+
+    if (!detail?.tracks?.length) {
+      // Named rather than generic: a delisted or region-locked release is the
+      // usual cause, and "no tracks" alone reads like a bug in SoulSync.
+      window.showToast?.(
+        `No tracks available for "${album.name}". This release may have been delisted or is not available in your region.`,
+        'warning',
+      );
+      return;
+    }
+
+    const virtualId = albumVirtualId(album);
+    await window.openDownloadMissingModalForArtistAlbum?.(
+      virtualId,
+      `[${album.artist}] ${detail.name}`,
+      enrichAlbumTracks(detail, album),
+      buildAlbumObject(detail, album),
+      buildArtistObject(detail, album, activeSource),
+      false,
+    );
+
+    window.registerSearchDownload?.(
+      {
+        id: album.id,
+        name: detail.name,
+        artist: album.artist,
+        image_url: detail.images?.[0]?.url ?? null,
+        images: detail.images || [],
+      },
+      'album',
+      virtualId,
+      album.artist,
+    );
+  } catch (error) {
+    window.showToast?.(`Error opening album: ${(error as Error).message}`, 'error');
+  } finally {
+    window.hideLoadingOverlay?.();
+  }
+}
+
+/** Open a single track's download modal. */
+export async function openSearchTrack(track: SearchTrack): Promise<void> {
+  const virtualId = trackVirtualId(track);
+  if (window.reopenActiveDownloadModal?.(virtualId)) return;
+
+  window.showLoadingOverlay?.('Loading track...');
+  try {
+    await window.openDownloadMissingModalForArtistAlbum?.(
+      virtualId,
+      `${track.artist} - ${track.name}`,
+      [enrichSingleTrack(track)],
+      buildSingleTrackAlbum(track),
+      { id: null, name: track.artist },
+      false,
+    );
+
+    window.registerSearchDownload?.(
+      {
+        id: track.id,
+        name: track.name,
+        artist: track.artist,
+        image_url: track.image_url,
+        images: track.image_url ? [{ url: track.image_url }] : [],
+      },
+      'track',
+      virtualId,
+      track.artist,
+    );
+  } catch (error) {
+    window.showToast?.(`Error opening track: ${(error as Error).message}`, 'error');
+  } finally {
+    window.hideLoadingOverlay?.();
+  }
+}
+
+/** Find this track on Soulseek and play it, without downloading it first. */
+export async function streamSearchTrack(track: SearchTrack): Promise<void> {
+  window.showLoadingOverlay?.(`Searching for ${track.name}...`);
+  try {
+    const response = await fetch('/api/enhanced-search/stream-track', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        track_name: track.name,
+        artist_name: track.artist,
+        album_name: track.album,
+        duration_ms: track.duration_ms,
+      }),
+    });
+
+    if (!response.ok) {
+      const failure = (await response.json().catch(() => ({}))) as { error?: string };
+      throw new Error(failure.error || 'Failed to search for track');
+    }
+
+    const data = (await response.json()) as { success?: boolean; result?: StreamResult };
+    if (!data.success || !data.result) throw new Error('No suitable track found');
+
+    const format = unsupportedStreamFormat(data.result);
+    if (format) {
+      window.showToast?.(
+        `Sorry, ${format} format is not supported in your browser. Try downloading instead.`,
+        'error',
+      );
+      return;
+    }
+
+    // The overlay comes down BEFORE the player starts: startStream opens the
+    // media player, and doing that behind a loading overlay hides it.
+    window.hideLoadingOverlay?.();
+    await window.SoulSyncWebShellBridge?.startStream(data.result as Record<string, unknown>);
+  } catch (error) {
+    window.showToast?.(`Failed to stream track: ${(error as Error).message}`, 'error');
+  } finally {
+    window.hideLoadingOverlay?.();
+  }
+}
+
+/** Play an owned track from disk, with what the library check told us about it. */
+export function playOwnedTrack(row: {
+  track_id?: string | number;
+  title?: string;
+  file_path?: string;
+  album_thumb_url?: string;
+  album_title?: string;
+  artist_name?: string;
+}): void {
+  if (!row.file_path) return;
+  window.SoulSyncWebShellBridge?.playLibraryTrack(
+    {
+      id: row.track_id ?? '',
+      title: row.title ?? '',
+      file_path: row.file_path,
+      _stats_image: row.album_thumb_url || null,
+    },
+    row.album_title || '',
+    row.artist_name || '',
+  );
+}

--- a/webui/src/routes/search/-search.api.test.ts
+++ b/webui/src/routes/search/-search.api.test.ts
@@ -1,0 +1,255 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import {
+  fetchArtistImage,
+  fetchConfigStatus,
+  fetchEnhancedSearch,
+  fetchLabels,
+  fetchLibraryCheck,
+  lookupById,
+  streamVideoSearch,
+} from './-search.api';
+
+/** NDJSON body from a list of chunk payloads, optionally split mid-line. */
+function ndjson(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new Response(
+    new ReadableStream({
+      pull(controller) {
+        if (i < lines.length) controller.enqueue(encoder.encode(lines[i++]));
+        else controller.close();
+      },
+    }),
+    { status: 200 },
+  );
+}
+
+describe('fetchEnhancedSearch', () => {
+  it('sends the query and source', async () => {
+    let body: unknown;
+    server.use(
+      http.post('/api/enhanced-search', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ spotify_albums: [] });
+      }),
+    );
+    await fetchEnhancedSearch('aphex', 'deezer');
+    expect(body).toEqual({ query: 'aphex', source: 'deezer' });
+  });
+
+  it('is abortable', async () => {
+    server.use(http.post('/api/enhanced-search', () => new Promise(() => {})));
+    const controller = new AbortController();
+    const promise = fetchEnhancedSearch('aphex', 'spotify', controller.signal);
+    controller.abort();
+    await expect(promise).rejects.toThrow();
+  });
+});
+
+describe('streamVideoSearch', () => {
+  it('reports each chunk cumulatively as it arrives', async () => {
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () =>
+        ndjson([
+          '{"type":"videos","data":[{"video_id":"a"}]}\n',
+          '{"type":"videos","data":[{"video_id":"b"}]}\n',
+        ]),
+      ),
+    );
+
+    const chunks: number[] = [];
+    const all = await streamVideoSearch('aphex', (videos) => chunks.push(videos.length));
+    // Progressive: the grid fills in rather than appearing all at once.
+    expect(chunks).toEqual([1, 2]);
+    expect(all.map((v) => v.video_id)).toEqual(['a', 'b']);
+  });
+
+  it('holds back a line split across two chunks', async () => {
+    // The obvious way to break NDJSON is to parse a fragment.
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () =>
+        ndjson(['{"type":"videos","data":[{"video_id"', ':"split"}]}\n']),
+      ),
+    );
+    const all = await streamVideoSearch('aphex', () => {});
+    expect(all.map((v) => v.video_id)).toEqual(['split']);
+  });
+
+  it('skips a malformed line without killing the stream', async () => {
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () =>
+        ndjson(['not json\n', '{"type":"videos","data":[{"video_id":"ok"}]}\n']),
+      ),
+    );
+    const all = await streamVideoSearch('aphex', () => {});
+    expect(all.map((v) => v.video_id)).toEqual(['ok']);
+  });
+
+  it('ignores chunks that are not videos', async () => {
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () =>
+        ndjson(['{"type":"progress","data":[{"video_id":"nope"}]}\n']),
+      ),
+    );
+    expect(await streamVideoSearch('aphex', () => {})).toEqual([]);
+  });
+
+  it('returns nothing on a failed response rather than throwing', async () => {
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () =>
+        HttpResponse.json({}, { status: 500 }),
+      ),
+    );
+    await expect(streamVideoSearch('aphex', () => {})).resolves.toEqual([]);
+  });
+});
+
+describe('fetchLibraryCheck', () => {
+  it('sends name/artist per row and keeps request order', async () => {
+    let body: { albums: { name?: string }[] } | undefined;
+    server.use(
+      http.post('/api/enhanced-search/library-check', async ({ request }) => {
+        body = (await request.json()) as { albums: { name?: string }[] };
+        return HttpResponse.json({ albums: [true, false] });
+      }),
+    );
+
+    const result = await fetchLibraryCheck(
+      [
+        { name: 'One', artist: 'A' },
+        { name: 'Two', artist: 'B' },
+      ],
+      [],
+    );
+    expect(body?.albums.map((a) => a.name)).toEqual(['One', 'Two']);
+    expect(result.albums).toEqual([true, false]);
+  });
+
+  it('does not call out for an empty batch', async () => {
+    let called = false;
+    server.use(
+      http.post('/api/enhanced-search/library-check', () => {
+        called = true;
+        return HttpResponse.json({});
+      }),
+    );
+    await fetchLibraryCheck([], []);
+    expect(called).toBe(false);
+  });
+
+  it('leaves everything unbadged when it fails', async () => {
+    // A failure must not be read as "nothing is owned".
+    server.use(http.post('/api/enhanced-search/library-check', () => HttpResponse.error()));
+    await expect(fetchLibraryCheck([{ name: 'x' }], [])).resolves.toEqual({});
+  });
+});
+
+describe('fetchLabels', () => {
+  it('unwraps the labels array', async () => {
+    server.use(
+      http.post('/api/labels/search', () =>
+        HttpResponse.json({ labels: [{ id: 'l1', name: 'Warp' }] }),
+      ),
+    );
+    expect(await fetchLabels('warp')).toHaveLength(1);
+  });
+
+  it('is empty on failure — the section just does not appear', async () => {
+    server.use(http.post('/api/labels/search', () => HttpResponse.error()));
+    expect(await fetchLabels('warp')).toEqual([]);
+  });
+});
+
+describe('fetchArtistImage', () => {
+  it('passes source and name through and returns the url', async () => {
+    let search = '';
+    server.use(
+      http.get('/api/artist/:id/image', ({ request }) => {
+        search = new URL(request.url).search;
+        return HttpResponse.json({ success: true, image_url: 'https://cdn/a.jpg' });
+      }),
+    );
+    expect(await fetchArtistImage(42, 'deezer', 'Aphex Twin')).toBe('https://cdn/a.jpg');
+    expect(search).toContain('source=deezer');
+    expect(search).toContain('name=Aphex+Twin');
+  });
+
+  it('is empty rather than throwing when there is no image', async () => {
+    server.use(http.get('/api/artist/:id/image', () => HttpResponse.json({ success: false })));
+    expect(await fetchArtistImage(42, 'spotify', 'X')).toBe('');
+  });
+});
+
+describe('fetchConfigStatus', () => {
+  it('applies the vanilla per-source rule, not one flattened expression', async () => {
+    // The rule differs BY SOURCE, and my first version flattened it:
+    //   - credential-free sources are always usable
+    //   - spotify is configured OR metadata_available (Spotify Free)
+    //   - everything else is `configured` alone
+    server.use(
+      http.get('/api/settings/config-status', () =>
+        HttpResponse.json({
+          spotify: { configured: false, metadata_available: true },
+          deezer: { configured: false, metadata_available: true },
+          itunes: { configured: true },
+        }),
+      ),
+    );
+    const { configured } = await fetchConfigStatus();
+
+    // Spotify Free: no credentials, still usable.
+    expect(configured.spotify).toBe(true);
+    // Deezer does NOT get that latitude — metadata_available must not light it up.
+    expect(configured.deezer).toBe(false);
+    expect(configured.itunes).toBe(true);
+    // Credential-free sources are usable without appearing in the payload.
+    expect(configured.musicbrainz).toBe(true);
+    expect(configured.amazon).toBe(true);
+  });
+
+  it('reads the experimental flags off the same payload', async () => {
+    // They ride config-status, so fetching them separately would be a second
+    // round-trip for data already in hand.
+    server.use(
+      http.get('/api/settings/config-status', () =>
+        HttpResponse.json({ _experimental: { bandcamp_enabled: true, jiosaavn_enabled: false } }),
+      ),
+    );
+    const { enabledExperimental, configured } = await fetchConfigStatus();
+    expect(enabledExperimental.has('bandcamp')).toBe(true);
+    expect(enabledExperimental.has('jiosaavn')).toBe(false);
+    // And an enabled experimental source is then present in the picker map.
+    expect(configured.bandcamp).toBe(true);
+    expect('jiosaavn' in configured).toBe(false);
+  });
+
+  it('stays optimistic on failure, so the picker does not look broken', async () => {
+    server.use(http.get('/api/settings/config-status', () => HttpResponse.error()));
+    expect(await fetchConfigStatus()).toEqual({
+      configured: {},
+      enabledExperimental: new Set(),
+    });
+  });
+});
+
+describe('lookupById', () => {
+  it('posts the raw string and returns the availability verdict', async () => {
+    let body: unknown;
+    server.use(
+      http.post('/api/enhanced-search/by-id', async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ available: false, message: 'Nothing there' });
+      }),
+    );
+    const data = await lookupById('770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bce');
+    expect(body).toEqual({ query: '770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bce' });
+    expect(data.available).toBe(false);
+    expect(data.message).toBe('Nothing there');
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());

--- a/webui/src/routes/search/-search.api.test.ts
+++ b/webui/src/routes/search/-search.api.test.ts
@@ -41,6 +41,22 @@ describe('fetchEnhancedSearch', () => {
     expect(body).toEqual({ query: 'aphex', source: 'deezer' });
   });
 
+  it('omits the source when there is none to send', async () => {
+    // enhancedSearchFetch's contract (shared-helpers.js:22-23): no source, or
+    // 'auto', means fan out — not "search a source called empty-string".
+    const bodies: unknown[] = [];
+    server.use(
+      http.post('/api/enhanced-search', async ({ request }) => {
+        bodies.push(await request.json());
+        return HttpResponse.json({});
+      }),
+    );
+
+    await fetchEnhancedSearch('aphex', '');
+    await fetchEnhancedSearch('aphex', 'auto');
+    expect(bodies).toEqual([{ query: 'aphex' }, { query: 'aphex' }]);
+  });
+
   it('is abortable', async () => {
     server.use(http.post('/api/enhanced-search', () => new Promise(() => {})));
     const controller = new AbortController();

--- a/webui/src/routes/search/-search.api.ts
+++ b/webui/src/routes/search/-search.api.ts
@@ -1,4 +1,4 @@
-import { apiClient, readJson } from '@/app/api-client';
+import { apiClient, readJson, shellClient } from '@/app/api-client';
 
 import type {
   EnhancedSearchResponse,
@@ -24,12 +24,14 @@ export function fetchEnhancedSearch(
   source: string,
   signal?: AbortSignal,
 ): Promise<EnhancedSearchResponse> {
+  // `source` is omitted rather than sent empty when there is none to send, and
+  // 'auto' means the same thing — that is enhancedSearchFetch's contract
+  // (shared-helpers.js:22-23), and it is what makes the server fan out across
+  // sources instead of searching one called ''.
+  const json: { query: string; source?: string } = { query };
+  if (source && source !== 'auto') json.source = source;
   return readJson<EnhancedSearchResponse>(
-    apiClient.post('enhanced-search', {
-      json: { query, source },
-      timeout: false,
-      signal,
-    }),
+    apiClient.post('enhanced-search', { json, timeout: false, signal }),
   );
 }
 
@@ -150,19 +152,34 @@ export async function fetchLabels(query: string, signal?: AbortSignal): Promise<
   }
 }
 
-/** One artist's image, fetched lazily per card. */
+/**
+ * One artist's image, fetched lazily per card.
+ *
+ * `source` is omitted when it is spotify, which is the vanilla's rule
+ * (search.js:741). Worth being explicit that this is a port, not a judgement:
+ * the endpoint reads a missing `source` as "use the configured primary source"
+ * (web_server.py:10092), so viewing Spotify results while Deezer is primary
+ * resolves Spotify ids against Deezer. That asymmetry is left exactly as it is —
+ * changing it would alter which images resolve, for every user, on a hunch.
+ *
+ * `name` matters for sources that store no artist art at all: MusicBrainz has
+ * MBIDs only, so the resolver searches iTunes/Deezer by name instead.
+ */
 export async function fetchArtistImage(
   artistId: string | number,
   source: string,
   name: string,
 ): Promise<string> {
+  const searchParams: Record<string, string> = {};
+  if (source && source !== 'spotify') searchParams.source = source;
+  if (name) searchParams.name = name;
   try {
     const data = await readJson<{ success?: boolean; image_url?: string }>(
-      apiClient.get(`artist/${encodeURIComponent(String(artistId))}/image`, {
-        searchParams: { source, name },
-      }),
+      apiClient.get(`artist/${encodeURIComponent(String(artistId))}/image`, { searchParams }),
     );
-    return data?.image_url ?? '';
+    // The endpoint answers 200 with success:false on failure, so the flag is the
+    // only signal — a url next to success:false is not one to trust.
+    return data?.success && data.image_url ? data.image_url : '';
   } catch {
     return '';
   }
@@ -183,6 +200,40 @@ export function parseEnabledExperimental(data: unknown): Set<string> {
 export interface ConfigStatus {
   configured: Record<string, boolean>;
   enabledExperimental: Set<string>;
+}
+
+/** What /status says about the configured primary source. */
+export interface MetadataStatus {
+  /** The user's primary metadata source, or '' when /status did not say. */
+  source: string;
+  enabledExperimental: Set<string>;
+}
+
+/**
+ * Read the primary source (and the experimental flags) from /status.
+ *
+ * `/status` rather than `/api/settings`, because settings is admin-only and
+ * answers 403 for a member profile — which used to make every non-admin fall
+ * back to Spotify no matter what the admin had configured
+ * (shared-helpers.js:344-350).
+ *
+ * `metadata_source` is a DICT (`{source, connected, …}`). Reading it as a string
+ * was a real bug: `SOURCE_LABELS[<dict>]` is always undefined, so the picker
+ * silently stayed on Spotify. The legacy string shape is still accepted.
+ */
+export async function fetchMetadataStatus(): Promise<MetadataStatus> {
+  try {
+    // shellClient, not apiClient: /status is a root path, not under /api.
+    const data = await readJson<{ metadata_source?: unknown }>(shellClient.get('status'));
+    const raw = data?.metadata_source;
+    const source =
+      raw && typeof raw === 'object'
+        ? String((raw as { source?: unknown }).source ?? '')
+        : String(raw ?? '');
+    return { source, enabledExperimental: parseEnabledExperimental(data) };
+  } catch {
+    return { source: '', enabledExperimental: new Set() };
+  }
 }
 
 /**

--- a/webui/src/routes/search/-search.api.ts
+++ b/webui/src/routes/search/-search.api.ts
@@ -1,0 +1,227 @@
+import { apiClient, readJson } from '@/app/api-client';
+
+import type {
+  EnhancedSearchResponse,
+  LibraryCheckResponse,
+  SearchAlbum,
+  SearchLabel,
+  SearchTrack,
+  SearchVideo,
+} from './-search.types';
+
+import { visibleSources } from './-search.helpers';
+import { ALWAYS_CONFIGURED_SOURCES } from './-search.types';
+
+/**
+ * The main metadata search.
+ *
+ * No timeout: several providers are slow-and-rate-limited, and the vanilla
+ * fetch had none — ky's default 10s would turn a working search into an error.
+ * The caller owns cancellation through `signal`.
+ */
+export function fetchEnhancedSearch(
+  query: string,
+  source: string,
+  signal?: AbortSignal,
+): Promise<EnhancedSearchResponse> {
+  return readJson<EnhancedSearchResponse>(
+    apiClient.post('enhanced-search', {
+      json: { query, source },
+      timeout: false,
+      signal,
+    }),
+  );
+}
+
+/**
+ * YouTube music videos, which arrive as NDJSON rather than one JSON body.
+ *
+ * The server emits newline-delimited `{type:'videos', data:[...]}` chunks so the
+ * grid can fill in progressively; `onChunk` is called per chunk with the
+ * cumulative list. A partial trailing line is held back until its newline
+ * arrives — splitting mid-object and JSON.parsing the fragment is the obvious
+ * way to break this.
+ */
+export async function streamVideoSearch(
+  query: string,
+  onChunk: (videos: SearchVideo[]) => void,
+  signal?: AbortSignal,
+): Promise<SearchVideo[]> {
+  const response = await fetch('/api/enhanced-search/source/youtube_videos', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+    signal,
+  });
+  if (!response.ok || !response.body) return [];
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const videos: SearchVideo[] = [];
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done || signal?.aborted) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n');
+    // The last element is either '' (clean break) or a partial object.
+    buffer = lines.pop() ?? '';
+
+    let touched = false;
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const parsed = JSON.parse(line) as { type?: string; data?: SearchVideo[] };
+        if (parsed.type === 'videos' && Array.isArray(parsed.data)) {
+          videos.push(...parsed.data);
+          touched = true;
+        }
+      } catch {
+        // A malformed line is skipped rather than killing the whole stream.
+      }
+    }
+    if (touched && !signal?.aborted) onChunk([...videos]);
+  }
+  return videos;
+}
+
+/** Link/ID resolver — a pasted MusicBrainz id or provider URL. */
+export interface IdLookupResponse extends EnhancedSearchResponse {
+  available?: boolean;
+  source?: string;
+  message?: string;
+  artists?: EnhancedSearchResponse['spotify_artists'];
+  albums?: EnhancedSearchResponse['spotify_albums'];
+  tracks?: EnhancedSearchResponse['spotify_tracks'];
+}
+
+export function lookupById(raw: string, signal?: AbortSignal): Promise<IdLookupResponse> {
+  return readJson<IdLookupResponse>(
+    apiClient.post('enhanced-search/by-id', {
+      json: { query: raw },
+      timeout: false,
+      signal,
+    }),
+  );
+}
+
+/**
+ * Which of these albums/tracks are already in the library or on the wishlist.
+ *
+ * The response is POSITIONAL — one entry per row sent, in request order. The
+ * caller must key the answers back by identity, not by where a card ends up on
+ * screen; see albumOwnershipByIdentity for why that distinction matters.
+ *
+ * Best-effort: a failure leaves everything unbadged rather than claiming
+ * nothing is owned.
+ */
+export async function fetchLibraryCheck(
+  albums: SearchAlbum[],
+  tracks: SearchTrack[],
+  signal?: AbortSignal,
+): Promise<LibraryCheckResponse> {
+  if (!albums.length && !tracks.length) return {};
+  try {
+    return await readJson<LibraryCheckResponse>(
+      apiClient.post('enhanced-search/library-check', {
+        json: {
+          albums: albums.map((a) => ({ name: a.name, artist: a.artist })),
+          tracks: tracks.map((t) => ({ name: t.name, artist: t.artist })),
+        },
+        signal,
+      }),
+    );
+  } catch {
+    return {};
+  }
+}
+
+/** Labels for the query. Best-effort — the section simply stays empty. */
+export async function fetchLabels(query: string, signal?: AbortSignal): Promise<SearchLabel[]> {
+  try {
+    const data = await readJson<{ labels?: SearchLabel[] }>(
+      apiClient.post('labels/search', { json: { query }, signal }),
+    );
+    return data?.labels ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** One artist's image, fetched lazily per card. */
+export async function fetchArtistImage(
+  artistId: string | number,
+  source: string,
+  name: string,
+): Promise<string> {
+  try {
+    const data = await readJson<{ success?: boolean; image_url?: string }>(
+      apiClient.get(`artist/${encodeURIComponent(String(artistId))}/image`, {
+        searchParams: { source, name },
+      }),
+    );
+    return data?.image_url ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/** `_experimental` payload → the set of enabled experimental source names. */
+export function parseEnabledExperimental(data: unknown): Set<string> {
+  const enabled = new Set<string>();
+  const flags = (data as { _experimental?: Record<string, unknown> } | null)?._experimental;
+  if (flags && typeof flags === 'object') {
+    for (const [key, value] of Object.entries(flags)) {
+      if (value && key.endsWith('_enabled')) enabled.add(key.slice(0, -'_enabled'.length));
+    }
+  }
+  return enabled;
+}
+
+export interface ConfigStatus {
+  configured: Record<string, boolean>;
+  enabledExperimental: Set<string>;
+}
+
+/**
+ * Which sources are usable — drives the dimmed icons.
+ *
+ * The rule is per-source, not one expression:
+ *   - ALWAYS_CONFIGURED_SOURCES need no credentials, so they are always true.
+ *   - **spotify** is `configured || metadata_available`, because Spotify Free
+ *     works with no credentials when that opt-in source is on.
+ *   - everything else is `configured` alone. An explicit `configured: false`
+ *     means false even if `metadata_available` is true.
+ *
+ * I first wrote this as a single `configured ?? metadata_available` for every
+ * source, which is wrong in both directions — it would light up an
+ * unconfigured Deezer and mis-handle a missing flag. The `_experimental` flags
+ * ride the same payload, so they are parsed from it here rather than fetched
+ * twice.
+ */
+export async function fetchConfigStatus(): Promise<ConfigStatus> {
+  try {
+    const data = await readJson<
+      Record<string, { configured?: boolean; metadata_available?: boolean }>
+    >(apiClient.get('settings/config-status'));
+    const enabledExperimental = parseEnabledExperimental(data);
+    const configured: Record<string, boolean> = {};
+    for (const source of visibleSources(enabledExperimental)) {
+      if (ALWAYS_CONFIGURED_SOURCES.has(source)) {
+        configured[source] = true;
+      } else if (source === 'spotify') {
+        const entry = data?.[source];
+        configured[source] = Boolean(entry && (entry.configured || entry.metadata_available));
+      } else {
+        configured[source] = Boolean(data?.[source]?.configured);
+      }
+    }
+    return { configured, enabledExperimental };
+  } catch {
+    // Optimistic: an unreachable config endpoint must not dim every icon and
+    // make a working picker look broken.
+    return { configured: {}, enabledExperimental: new Set() };
+  }
+}

--- a/webui/src/routes/search/-search.helpers.test.ts
+++ b/webui/src/routes/search/-search.helpers.test.ts
@@ -6,6 +6,7 @@ import type { SearchAlbum } from './-search.types';
 
 import {
   albumIdentity,
+  albumMetaLine,
   albumOwnershipByIdentity,
   artistMetaLine,
   fallbackBannerText,
@@ -22,6 +23,7 @@ import {
   shouldSearch,
   sourceResultsFromResponse,
   splitAlbums,
+  trackMetaLine,
   visibleSources,
 } from './-search.helpers';
 import { emptySourceResults } from './-search.helpers';
@@ -114,9 +116,17 @@ describe('fallbackFor', () => {
     expect(fallbackFor('deezer', { primary_source: 'deezer' })).toBeNull();
   });
 
-  it('does not treat spotify_free as a fallback from spotify', () => {
-    // Same icon, same provider — banner-worthy only if the PROVIDER changed.
-    expect(fallbackFor('spotify', { primary_source: 'spotify_free' })).toBeNull();
+  it('DOES report spotify_free as a fallback from spotify', () => {
+    // A raw comparison, as the vanilla has it (shared-helpers.js:504). On a
+    // no-credentials instance the server answers a 'spotify' request with
+    // 'spotify_free', and the banner naming both is the point — normalising the
+    // two through pickerSource would silently swallow it.
+    expect(fallbackFor('spotify', { primary_source: 'spotify_free' })).toBe('spotify_free');
+  });
+
+  it('reports nothing when the server served exactly what was asked for', () => {
+    expect(fallbackFor('spotify', { primary_source: 'spotify' })).toBeNull();
+    expect(fallbackFor('deezer', { primary_source: 'deezer' })).toBeNull();
   });
 
   it('falls back to metadata_source when primary_source is absent', () => {
@@ -195,7 +205,10 @@ describe('albumOwnershipByIdentity — the badge-misalignment fix', () => {
 });
 
 describe('formatViewCount', () => {
-  it('abbreviates millions and thousands', () => {
+  it('abbreviates billions, millions and thousands', () => {
+    // Billions are ordinary on a music-video grid; without that branch a
+    // 1.2B-view video reads "1200.0M".
+    expect(formatViewCount(1_200_000_000)).toBe('1.2B');
     expect(formatViewCount(1_200_000)).toBe('1.2M');
     expect(formatViewCount(3_400)).toBe('3.4K');
     expect(formatViewCount(742)).toBe('742');
@@ -248,14 +261,26 @@ describe('formatVideoDuration', () => {
 });
 
 describe('meta lines', () => {
-  it('shows a library artist its track count, pluralised', () => {
-    expect(artistMetaLine({ track_count: 1 }, true)).toBe('1 track');
-    expect(artistMetaLine({ track_count: 12 }, true)).toBe('12 tracks');
-    expect(artistMetaLine({}, true)).toBe('0 tracks');
+  it('labels an artist by which section it is in, not by a count', () => {
+    // A count is tempting and wrong: _build_db_artists sends only id, name and
+    // image_url (core/search/orchestrator.py:121-134), so every library artist
+    // would read "0 tracks".
+    expect(artistMetaLine(true)).toBe('In Your Library');
+    expect(artistMetaLine(false)).toBe('Artist');
   });
 
-  it('shows a source artist its source', () => {
-    expect(artistMetaLine({ source: 'deezer' }, false)).toBe('Deezer');
+  it('joins a track artist and album, both being plain strings', () => {
+    // `album` is the album NAME — sources.py copies Track.album, a str.
+    expect(trackMetaLine({ artist: 'Aphex Twin', album: 'Drukqs' })).toBe('Aphex Twin • Drukqs');
+    expect(trackMetaLine({ artist: 'Aphex Twin' })).toBe('Aphex Twin');
+    expect(trackMetaLine({})).toBe('');
+  });
+
+  it('gives an album its year, or the vanilla N/A', () => {
+    expect(albumMetaLine({ artist: 'Aphex Twin', release_date: '2001-10-22' })).toBe(
+      'Aphex Twin • 2001',
+    );
+    expect(albumMetaLine({ artist: 'Aphex Twin' })).toBe('Aphex Twin • N/A');
   });
 
   it('joins a label type and area, or says what it is', () => {

--- a/webui/src/routes/search/-search.helpers.test.ts
+++ b/webui/src/routes/search/-search.helpers.test.ts
@@ -8,6 +8,7 @@ import {
   albumIdentity,
   albumMetaLine,
   albumOwnershipByIdentity,
+  artistDetailPath,
   artistMetaLine,
   fallbackBannerText,
   fallbackFor,
@@ -16,6 +17,7 @@ import {
   formatViewCount,
   hasAnyResults,
   isIdLookupQuery,
+  labelDetailPath,
   labelMetaLine,
   MIN_QUERY_LENGTH,
   pickerSource,
@@ -349,5 +351,53 @@ describe('parity with the vanilla source tables', () => {
 
   it('keeps the experimental set in step', () => {
     expect(vanilla).toContain("const EXPERIMENTAL_SOURCES = new Set(['jiosaavn', 'bandcamp']);");
+  });
+});
+
+describe('detail paths', () => {
+  /**
+   * These mirror buildArtistDetailPath / buildLabelDetailPath (init.js:2964,
+   * 3003) and feed the routes /artist-detail/$source/$id and /label-detail/$id.
+   *
+   * Pinned because the first version of them was GUESSED — `/artist-detail/<id>`
+   * with no source segment, which parseArtistDetailPath rejects outright
+   * (`segs.length < 3`) and which matches no route. Clicking an artist did
+   * nothing at all.
+   */
+  it('puts the SOURCE segment in an artist path', () => {
+    expect(artistDetailPath('sp1', 'spotify')).toBe('/artist-detail/spotify/sp1');
+    // Three segments. Two is not a shorter version of this — it is unroutable.
+    expect(artistDetailPath('sp1', 'spotify').split('/').filter(Boolean)).toHaveLength(3);
+  });
+
+  it('files a library artist under the literal "library"', () => {
+    // A library artist has no metadata source, and the slot cannot be empty.
+    expect(artistDetailPath(42)).toBe('/artist-detail/library/42');
+    expect(artistDetailPath(42, null)).toBe('/artist-detail/library/42');
+    expect(artistDetailPath(42, '')).toBe('/artist-detail/library/42');
+    expect(artistDetailPath(42, '   ')).toBe('/artist-detail/library/42');
+  });
+
+  it('lowercases the source, as _normalizeArtistDetailSource does', () => {
+    expect(artistDetailPath('x', 'Deezer')).toBe('/artist-detail/deezer/x');
+  });
+
+  it('carries the name for sources with no id lookup', () => {
+    // Bandcamp cannot resolve by id at all; on a cold load the name is all
+    // there is to go on.
+    expect(artistDetailPath('abc', 'bandcamp', 'Aphex Twin')).toBe(
+      '/artist-detail/bandcamp/abc?name=Aphex%20Twin',
+    );
+    expect(artistDetailPath('abc', 'bandcamp')).toBe('/artist-detail/bandcamp/abc');
+  });
+
+  it('encodes ids and names that would otherwise break the path', () => {
+    expect(artistDetailPath('a/b', 'spotify')).toBe('/artist-detail/spotify/a%2Fb');
+    expect(artistDetailPath('1', 'spotify', 'AC/DC')).toBe('/artist-detail/spotify/1?name=AC%2FDC');
+  });
+
+  it('builds a label path with its optional name', () => {
+    expect(labelDetailPath('l1')).toBe('/label-detail/l1');
+    expect(labelDetailPath('l1', 'Warp')).toBe('/label-detail/l1?name=Warp');
   });
 });

--- a/webui/src/routes/search/-search.helpers.test.ts
+++ b/webui/src/routes/search/-search.helpers.test.ts
@@ -1,0 +1,301 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import type { SearchAlbum } from './-search.types';
+
+import {
+  albumIdentity,
+  albumOwnershipByIdentity,
+  artistMetaLine,
+  fallbackBannerText,
+  fallbackFor,
+  formatDuration,
+  formatViewCount,
+  hasAnyResults,
+  isIdLookupQuery,
+  labelMetaLine,
+  MIN_QUERY_LENGTH,
+  pickerSource,
+  SEARCH_DEBOUNCE_MS,
+  shouldSearch,
+  sourceResultsFromResponse,
+  splitAlbums,
+  visibleSources,
+} from './-search.helpers';
+import { emptySourceResults } from './-search.helpers';
+import { SOURCE_LABELS, SOURCE_ORDER } from './-search.types';
+
+const album = (over: Partial<SearchAlbum> = {}): SearchAlbum => ({
+  id: 'a1',
+  name: 'Drukqs',
+  artist: 'Aphex Twin',
+  album_type: 'album',
+  ...over,
+});
+
+describe('query gating', () => {
+  it('needs two characters before it fires', () => {
+    expect(shouldSearch('a')).toBe(false);
+    expect(shouldSearch('ap')).toBe(true);
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(shouldSearch('  a  ')).toBe(false);
+    expect(shouldSearch('  ap  ')).toBe(true);
+  });
+
+  it('keeps the vanilla floor and debounce', () => {
+    expect(MIN_QUERY_LENGTH).toBe(2);
+    // Raised from 300ms for #751 — a shorter debounce fires a request per
+    // keystroke against rate-limited providers.
+    expect(SEARCH_DEBOUNCE_MS).toBe(600);
+  });
+});
+
+describe('isIdLookupQuery', () => {
+  it('recognises a bare MusicBrainz uuid', () => {
+    expect(isIdLookupQuery('770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bce')).toBe(true);
+    expect(isIdLookupQuery('  770A1E6B-2D17-4BBE-A0C2-A3C4F77E9BCE  ')).toBe(true);
+  });
+
+  it('leaves a query that merely CONTAINS one as a text search', () => {
+    // Anchored on purpose: "aphex 770a..." is someone searching, not pasting.
+    expect(isIdLookupQuery('aphex 770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bce')).toBe(false);
+  });
+
+  it('is not fooled by a near-miss', () => {
+    expect(isIdLookupQuery('770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bc')).toBe(false);
+    expect(isIdLookupQuery('not-a-uuid')).toBe(false);
+  });
+});
+
+describe('visibleSources', () => {
+  it('hides experimental sources until they are enabled', () => {
+    const none = visibleSources(new Set());
+    expect(none).not.toContain('jiosaavn');
+    expect(none).not.toContain('bandcamp');
+    expect(none).toContain('spotify');
+  });
+
+  it('shows one experimental source without showing the other', () => {
+    const only = visibleSources(new Set(['bandcamp']));
+    expect(only).toContain('bandcamp');
+    expect(only).not.toContain('jiosaavn');
+  });
+
+  it('keeps the canonical order', () => {
+    const all = visibleSources(new Set(['jiosaavn', 'bandcamp']));
+    expect(all).toEqual([...SOURCE_ORDER]);
+  });
+});
+
+describe('pickerSource', () => {
+  it('maps spotify_free onto the spotify icon', () => {
+    // spotify_free has a label but NO icon in the picker; /status can report it
+    // as the primary source, and leaving it unmapped renders nothing active.
+    expect(pickerSource('spotify_free')).toBe('spotify');
+  });
+
+  it('passes everything else through, and defaults to spotify', () => {
+    expect(pickerSource('deezer')).toBe('deezer');
+    expect(pickerSource(undefined)).toBe('spotify');
+    expect(pickerSource('')).toBe('spotify');
+  });
+});
+
+describe('fallbackFor', () => {
+  it('reports the source that actually answered', () => {
+    expect(fallbackFor('spotify', { primary_source: 'deezer' })).toBe('deezer');
+  });
+
+  it('is silent when the requested source answered', () => {
+    expect(fallbackFor('deezer', { primary_source: 'deezer' })).toBeNull();
+  });
+
+  it('does not treat spotify_free as a fallback from spotify', () => {
+    // Same icon, same provider — banner-worthy only if the PROVIDER changed.
+    expect(fallbackFor('spotify', { primary_source: 'spotify_free' })).toBeNull();
+  });
+
+  it('falls back to metadata_source when primary_source is absent', () => {
+    expect(fallbackFor('spotify', { metadata_source: 'itunes' })).toBe('itunes');
+  });
+
+  it('is silent when the server said nothing about the source', () => {
+    expect(fallbackFor('spotify', {})).toBeNull();
+  });
+
+  it('names both sources in the banner', () => {
+    expect(fallbackBannerText('spotify', 'deezer')).toBe('Spotify unavailable — showing Deezer.');
+  });
+});
+
+describe('splitAlbums', () => {
+  it('sends singles and eps one way, everything else the other', () => {
+    const rows = [
+      album({ id: '1', album_type: 'album' }),
+      album({ id: '2', album_type: 'single' }),
+      album({ id: '3', album_type: 'ep' }),
+      album({ id: '4', album_type: 'compilation' }),
+    ];
+    const { albums, singlesAndEps } = splitAlbums(rows);
+    expect(albums.map((a) => a.id)).toEqual(['1', '4']);
+    expect(singlesAndEps.map((a) => a.id)).toEqual(['2', '3']);
+  });
+
+  it('treats a missing type as an album', () => {
+    // "albums" is the catch-all; an unknown type must still be rendered.
+    const { albums } = splitAlbums([album({ album_type: undefined })]);
+    expect(albums).toHaveLength(1);
+  });
+});
+
+describe('albumOwnershipByIdentity — the badge-misalignment fix', () => {
+  it('carries ownership to the right album when the response INTERLEAVES', () => {
+    // The bug this replaces: the vanilla applied library-check answers by
+    // indexing a document-order selector (all albums, then all singles) against
+    // the request order. core/search/orchestrator.py returns the provider's
+    // array unsorted, so the two disagree the moment types interleave.
+    const requested = [
+      album({ id: 'A1', album_type: 'album' }),
+      album({ id: 'S1', album_type: 'single' }),
+      album({ id: 'A2', album_type: 'album' }),
+    ];
+    // Only the LAST row is owned.
+    const owned = albumOwnershipByIdentity(requested, [false, false, true]);
+
+    expect(owned.has(albumIdentity(requested[2]))).toBe(true);
+    // The vanilla would have marked requested[1] here, because A2 is the second
+    // card in document order.
+    expect(owned.has(albumIdentity(requested[1]))).toBe(false);
+    expect(owned.has(albumIdentity(requested[0]))).toBe(false);
+  });
+
+  it('survives a short or missing flags array', () => {
+    const requested = [album({ id: '1' }), album({ id: '2' })];
+    expect(albumOwnershipByIdentity(requested, [true]).size).toBe(1);
+    expect(albumOwnershipByIdentity(requested, undefined).size).toBe(0);
+    expect(albumOwnershipByIdentity(requested, []).size).toBe(0);
+  });
+
+  it('identifies by id when there is one, and by name+artist when there is not', () => {
+    expect(albumIdentity(album({ id: 'x' }))).toBe('id:x');
+    expect(albumIdentity(album({ id: undefined }))).toBe('na:drukqs|aphex twin');
+    // Case-insensitive, so a source that title-cases differently still matches.
+    expect(albumIdentity(album({ id: undefined, name: 'DRUKQS' }))).toBe('na:drukqs|aphex twin');
+  });
+
+  it('does not collide two same-named albums by different artists', () => {
+    const a = album({ id: undefined, name: 'Untitled', artist: 'A' });
+    const b = album({ id: undefined, name: 'Untitled', artist: 'B' });
+    expect(albumIdentity(a)).not.toBe(albumIdentity(b));
+  });
+});
+
+describe('formatViewCount', () => {
+  it('abbreviates millions and thousands', () => {
+    expect(formatViewCount(1_200_000)).toBe('1.2M');
+    expect(formatViewCount(3_400)).toBe('3.4K');
+    expect(formatViewCount(742)).toBe('742');
+  });
+
+  it('is empty for nothing and for nonsense', () => {
+    expect(formatViewCount(0)).toBe('');
+    expect(formatViewCount(undefined)).toBe('');
+    expect(formatViewCount(-5)).toBe('');
+  });
+});
+
+describe('formatDuration', () => {
+  it('is m:ss with a zero-padded seconds field', () => {
+    expect(formatDuration(215_000)).toBe('3:35');
+    expect(formatDuration(65_000)).toBe('1:05');
+    expect(formatDuration(600_000)).toBe('10:00');
+  });
+
+  it('is empty when there is no duration', () => {
+    expect(formatDuration(0)).toBe('');
+    expect(formatDuration(undefined)).toBe('');
+  });
+});
+
+describe('meta lines', () => {
+  it('shows a library artist its track count, pluralised', () => {
+    expect(artistMetaLine({ track_count: 1 }, true)).toBe('1 track');
+    expect(artistMetaLine({ track_count: 12 }, true)).toBe('12 tracks');
+    expect(artistMetaLine({}, true)).toBe('0 tracks');
+  });
+
+  it('shows a source artist its source', () => {
+    expect(artistMetaLine({ source: 'deezer' }, false)).toBe('Deezer');
+  });
+
+  it('joins a label type and area, or says what it is', () => {
+    expect(labelMetaLine({ type: 'Original Production', area: 'US' })).toBe(
+      'Original Production • US',
+    );
+    expect(labelMetaLine({ type: 'Original Production' })).toBe('Original Production');
+    expect(labelMetaLine({})).toBe('Record label');
+  });
+});
+
+describe('response unpacking', () => {
+  it('reads the historical spotify_* field names for every source', () => {
+    // These names carry Deezer/iTunes/MusicBrainz results too — renaming them
+    // would mean changing the API contract.
+    const results = sourceResultsFromResponse({
+      db_artists: [{ name: 'in library' }],
+      spotify_artists: [{ name: 'from source' }],
+      spotify_albums: [album()],
+      spotify_tracks: [{ name: 'track' }],
+    });
+    expect(results.db_artists).toHaveLength(1);
+    expect(results.artists).toHaveLength(1);
+    expect(results.albums).toHaveLength(1);
+    expect(results.tracks).toHaveLength(1);
+    expect(results.videos).toEqual([]);
+  });
+
+  it('gives every list a value, so no consumer reads undefined', () => {
+    expect(sourceResultsFromResponse({})).toEqual(emptySourceResults());
+  });
+});
+
+describe('hasAnyResults', () => {
+  it('counts videos, so a video-only search is not empty', () => {
+    const results = emptySourceResults();
+    results.videos = [{ video_id: 'v1' }];
+    expect(hasAnyResults(results)).toBe(true);
+  });
+
+  it('is false only when every list is empty', () => {
+    expect(hasAnyResults(emptySourceResults())).toBe(false);
+  });
+});
+
+describe('parity with the vanilla source tables', () => {
+  const vanilla = readFileSync(resolve(process.cwd(), 'static/shared-helpers.js'), 'utf8');
+
+  it('keeps the picker order identical', () => {
+    // The row the user sees. Reading the vanilla's own array rather than
+    // restating it, because a reorder here is invisible in review.
+    const match = /const SOURCE_ORDER = \[([\s\S]*?)\];/.exec(vanilla);
+    expect(match).toBeTruthy();
+    const order = Array.from(match![1].matchAll(/'([a-z_]+)'/g)).map((m) => m[1]);
+    expect(order).toEqual([...SOURCE_ORDER]);
+  });
+
+  it('keeps every source label and badge class', () => {
+    // The badge classes are CSS hooks; a typo silently unstyles a source.
+    for (const [source, label] of Object.entries(SOURCE_LABELS)) {
+      expect(vanilla).toContain(`text: '${label.text}'`);
+      expect(vanilla).toContain(`badgeClass: '${label.badgeClass}'`);
+      expect(vanilla).toContain(`${source}: {`);
+    }
+  });
+
+  it('keeps the experimental set in step', () => {
+    expect(vanilla).toContain("const EXPERIMENTAL_SOURCES = new Set(['jiosaavn', 'bandcamp']);");
+  });
+});

--- a/webui/src/routes/search/-search.helpers.test.ts
+++ b/webui/src/routes/search/-search.helpers.test.ts
@@ -11,6 +11,7 @@ import {
   fallbackBannerText,
   fallbackFor,
   formatDuration,
+  formatVideoDuration,
   formatViewCount,
   hasAnyResults,
   isIdLookupQuery,
@@ -217,6 +218,32 @@ describe('formatDuration', () => {
   it('is empty when there is no duration', () => {
     expect(formatDuration(0)).toBe('');
     expect(formatDuration(undefined)).toBe('');
+  });
+});
+
+describe('formatVideoDuration', () => {
+  it('reads its input as SECONDS', () => {
+    // The same 3:35 as formatDuration(215_000) — the units are the only
+    // difference between the two functions, and the reason there are two.
+    expect(formatVideoDuration(215)).toBe('3:35');
+    expect(formatVideoDuration(65)).toBe('1:05');
+    expect(formatVideoDuration(600)).toBe('10:00');
+  });
+
+  it('does not roll over into hours', () => {
+    // The vanilla printed 90:00 for a 90-minute upload rather than 1:30:00;
+    // kept, because a music-video grid effectively never sees one.
+    expect(formatVideoDuration(5400)).toBe('90:00');
+  });
+
+  it('floors a fractional duration instead of printing a decimal', () => {
+    expect(formatVideoDuration(59.7)).toBe('0:59');
+  });
+
+  it('is empty when there is no duration', () => {
+    expect(formatVideoDuration(0)).toBe('');
+    expect(formatVideoDuration(undefined)).toBe('');
+    expect(formatVideoDuration(-5)).toBe('');
   });
 });
 

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -172,6 +172,20 @@ export function formatDuration(durationMs: number | undefined | null): string {
   return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
+/**
+ * Video durations are SECONDS, unlike track durations which are milliseconds.
+ *
+ * Two fields both called `duration`, in different units, on shapes that sit
+ * side by side in the same results — kept as separate functions so no caller
+ * has to remember which is which.
+ */
+export function formatVideoDuration(seconds: number | undefined | null): string {
+  const total = Number(seconds);
+  if (!Number.isFinite(total) || total <= 0) return '';
+  const minutes = Math.floor(total / 60);
+  return `${minutes}:${String(Math.floor(total % 60)).padStart(2, '0')}`;
+}
+
 /** An artist's display line: the vanilla showed a library track count or the source. */
 export function artistMetaLine(artist: SearchArtist, inLibrary: boolean): string {
   if (inLibrary) {

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -264,6 +264,34 @@ export function albumMetaLine(album: SearchAlbum): string {
   return `${album.artist ?? ''} • ${year}`;
 }
 
+/**
+ * Where an artist card points, mirroring buildArtistDetailPath (init.js:2964).
+ *
+ * The SOURCE SEGMENT is not optional. `/artist-detail/<source>/<id>` is what
+ * parseArtistDetailPath splits on, and it rejects anything with fewer than three
+ * segments outright — so a path without it resolves to nothing at all. An artist
+ * from the library has no metadata source, and the literal 'library' is what
+ * fills the slot (_normalizeArtistDetailSource, init.js:2959).
+ *
+ * `name` rides along because some sources have no id lookup at all (Bandcamp):
+ * on a cold page load the name is the only thing left to resolve against.
+ */
+export function artistDetailPath(
+  artistId: string | number,
+  source?: string | null,
+  name?: string | null,
+): string {
+  const normalized = String(source ?? '').trim().toLowerCase() || 'library';
+  const path = `/artist-detail/${encodeURIComponent(normalized)}/${encodeURIComponent(String(artistId))}`;
+  return name ? `${path}?name=${encodeURIComponent(name)}` : path;
+}
+
+/** Where a label card points — buildLabelDetailPath (init.js:3003). */
+export function labelDetailPath(labelId: string | number, name?: string | null): string {
+  const path = `/label-detail/${encodeURIComponent(String(labelId))}`;
+  return name ? `${path}?name=${encodeURIComponent(name)}` : path;
+}
+
 /** A label's display line — `type • area`, or a plain fallback. */
 export function labelMetaLine(label: { type?: string; area?: string }): string {
   const parts = [label.type, label.area].filter(Boolean);

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -97,10 +97,7 @@ export function resolveInitialSource({
 }
 
 /** May the picker switch to this source at all? */
-export function canSelectSource(
-  source: string,
-  enabledExperimental: ReadonlySet<string>,
-): boolean {
+export function canSelectSource(source: string, enabledExperimental: ReadonlySet<string>): boolean {
   if (!SOURCE_LABELS[source]) return false;
   // A hidden experimental source has no icon; selecting it programmatically
   // would strand the row with nothing active.
@@ -281,7 +278,10 @@ export function artistDetailPath(
   source?: string | null,
   name?: string | null,
 ): string {
-  const normalized = String(source ?? '').trim().toLowerCase() || 'library';
+  const normalized =
+    String(source ?? '')
+      .trim()
+      .toLowerCase() || 'library';
   const path = `/artist-detail/${encodeURIComponent(normalized)}/${encodeURIComponent(String(artistId))}`;
   return name ? `${path}?name=${encodeURIComponent(name)}` : path;
 }

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -64,6 +64,49 @@ export function sourceLabel(source: string): string {
   return SOURCE_LABELS[source]?.text ?? source;
 }
 
+/**
+ * Which source the picker should start on.
+ *
+ * Four rules, in the order shared-helpers.js:361-395 applies them, and each one
+ * exists because of a way the picker can otherwise open unusable:
+ *
+ *   1. take /status's primary source, mapped through pickerSource;
+ *   2. anything unrecognised falls back to spotify;
+ *   3. an experimental source that is not enabled is not in the row at all, so
+ *      starting on it would leave nothing selected;
+ *   4. a source with no credentials would show an empty result set and blame the
+ *      provider — fall forward to the first source that IS configured.
+ */
+export function resolveInitialSource({
+  statusSource,
+  enabledExperimental,
+  configured,
+}: {
+  statusSource: string;
+  enabledExperimental: ReadonlySet<string>;
+  configured: Record<string, boolean>;
+}): string {
+  let source = pickerSource(statusSource);
+  if (!SOURCE_LABELS[source]) source = 'spotify';
+  if (EXPERIMENTAL_SOURCES.has(source) && !enabledExperimental.has(source)) source = 'spotify';
+  if (configured[source] === false) {
+    const usable = visibleSources(enabledExperimental).find((s) => configured[s] !== false);
+    if (usable) source = usable;
+  }
+  return source;
+}
+
+/** May the picker switch to this source at all? */
+export function canSelectSource(
+  source: string,
+  enabledExperimental: ReadonlySet<string>,
+): boolean {
+  if (!SOURCE_LABELS[source]) return false;
+  // A hidden experimental source has no icon; selecting it programmatically
+  // would strand the row with nothing active.
+  return !EXPERIMENTAL_SOURCES.has(source) || enabledExperimental.has(source);
+}
+
 /** Empty slice — every consumer reads five arrays, so none of them may be absent. */
 export function emptySourceResults(): SourceResults {
   return { db_artists: [], artists: [], albums: [], tracks: [], videos: [] };
@@ -89,7 +132,12 @@ export function sourceResultsFromResponse(data: EnhancedSearchResponse): SourceR
 export function fallbackFor(requested: string, data: EnhancedSearchResponse): string | null {
   const served = data.primary_source || data.metadata_source;
   if (!served) return null;
-  return pickerSource(served) === pickerSource(requested) ? null : served;
+  // A RAW comparison, as shared-helpers.js:504 has it — deliberately not
+  // normalised through pickerSource. On a no-credentials instance the server
+  // answers a 'spotify' request with 'spotify_free', and that IS worth saying:
+  // normalising would collapse the two and silently drop the banner telling the
+  // user which Spotify actually served their results.
+  return served === requested ? null : served;
 }
 
 export function fallbackBannerText(requested: string, served: string): string {
@@ -153,10 +201,17 @@ export function albumOwnershipByIdentity(
   return owned;
 }
 
-/** `_formatViewCount` — 1.2M / 3.4K / raw. */
+/**
+ * `_formatViewCount` — 1.2B / 1.2M / 3.4K / raw.
+ *
+ * The billions branch is not hypothetical on a music-video grid: plenty of the
+ * things people search for here have passed a billion plays, and without it they
+ * render as "1200.0M".
+ */
 export function formatViewCount(count: number | undefined | null): string {
   const n = Number(count);
   if (!Number.isFinite(n) || n <= 0) return '';
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
@@ -186,13 +241,27 @@ export function formatVideoDuration(seconds: number | undefined | null): string 
   return `${minutes}:${String(Math.floor(total % 60)).padStart(2, '0')}`;
 }
 
-/** An artist's display line: the vanilla showed a library track count or the source. */
-export function artistMetaLine(artist: SearchArtist, inLibrary: boolean): string {
-  if (inLibrary) {
-    const count = artist.track_count ?? 0;
-    return `${count} track${count === 1 ? '' : 's'}`;
-  }
-  return sourceLabel(artist.source ?? '');
+/**
+ * An artist's display line — two fixed strings, as search.js:480/494 has them.
+ *
+ * Deliberately NOT a track count: `_build_db_artists`
+ * (core/search/orchestrator.py:121-134) sends only id, name and image_url, so a
+ * count would read "0 tracks" on every library artist. The badge beside it
+ * already says Library or names the source.
+ */
+export function artistMetaLine(inLibrary: boolean): string {
+  return inLibrary ? 'In Your Library' : 'Artist';
+}
+
+/** A track's display line — `artist • album`, skipping whichever is missing. */
+export function trackMetaLine(track: SearchTrack): string {
+  return [track.artist, track.album].filter(Boolean).join(' • ');
+}
+
+/** An album's display line — `artist • year`, with the vanilla's N/A year. */
+export function albumMetaLine(album: SearchAlbum): string {
+  const year = album.release_date ? album.release_date.slice(0, 4) : 'N/A';
+  return `${album.artist ?? ''} • ${year}`;
 }
 
 /** A label's display line — `type • area`, or a plain fallback. */

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -1,0 +1,210 @@
+/**
+ * Enhanced search's pure logic, ported from search.js + shared-helpers.js.
+ *
+ * The one deliberate behaviour CHANGE lives here: `albumOwnershipByIdentity`.
+ * See its comment — the vanilla matched the library-check response to cards by
+ * list position, and that is demonstrably wrong.
+ */
+
+import type {
+  EnhancedSearchResponse,
+  SearchAlbum,
+  SearchArtist,
+  SearchTrack,
+  SourceResults,
+} from './-search.types';
+
+import { EXPERIMENTAL_SOURCES, SOURCE_LABELS, SOURCE_ORDER } from './-search.types';
+
+/** The shortest query that is allowed to fire. Below this the dropdown hides. */
+export const MIN_QUERY_LENGTH = 2;
+
+/**
+ * Input debounce, raised from 300ms to 600ms for #751.
+ *
+ * Enter bypasses it entirely — see the page component.
+ */
+export const SEARCH_DEBOUNCE_MS = 600;
+
+/**
+ * A bare MusicBrainz UUID is treated as an ID LOOKUP, not a fuzzy search.
+ *
+ * Anchored on purpose: a query that merely CONTAINS a uuid is still a text
+ * search.
+ */
+export const MBID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isIdLookupQuery(query: string): boolean {
+  return MBID_RE.test(query.trim());
+}
+
+export function shouldSearch(query: string): boolean {
+  return query.trim().length >= MIN_QUERY_LENGTH;
+}
+
+/** The source label row, minus experimental sources the user has not enabled. */
+export function visibleSources(enabledExperimental: ReadonlySet<string>): string[] {
+  return SOURCE_ORDER.filter(
+    (source) => !EXPERIMENTAL_SOURCES.has(source) || enabledExperimental.has(source),
+  );
+}
+
+/**
+ * `spotify_free` has a label but NO icon in the picker order.
+ *
+ * /status can report it as the user's primary source, and leaving it unmapped
+ * renders a picker with nothing active at all.
+ */
+export function pickerSource(source: string | undefined | null): string {
+  if (!source) return 'spotify';
+  return source === 'spotify_free' ? 'spotify' : source;
+}
+
+export function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source]?.text ?? source;
+}
+
+/** Empty slice — every consumer reads five arrays, so none of them may be absent. */
+export function emptySourceResults(): SourceResults {
+  return { db_artists: [], artists: [], albums: [], tracks: [], videos: [] };
+}
+
+/** Unpack /api/enhanced-search into the per-source cache shape. */
+export function sourceResultsFromResponse(data: EnhancedSearchResponse): SourceResults {
+  return {
+    db_artists: data.db_artists ?? [],
+    artists: data.spotify_artists ?? [],
+    albums: data.spotify_albums ?? [],
+    tracks: data.spotify_tracks ?? [],
+    videos: [],
+  };
+}
+
+/**
+ * Did the server serve something other than what was asked for?
+ *
+ * `primary_source` is what actually answered. When it differs, the banner names
+ * both so the user is not silently reading Deezer results under a Spotify icon.
+ */
+export function fallbackFor(requested: string, data: EnhancedSearchResponse): string | null {
+  const served = data.primary_source || data.metadata_source;
+  if (!served) return null;
+  return pickerSource(served) === pickerSource(requested) ? null : served;
+}
+
+export function fallbackBannerText(requested: string, served: string): string {
+  return `${sourceLabel(requested)} unavailable — showing ${sourceLabel(served)}.`;
+}
+
+/**
+ * Albums vs singles/EPs.
+ *
+ * "albums" is the catch-all: anything whose album_type is not explicitly single
+ * or ep lands there, including an unknown or missing type.
+ */
+export function splitAlbums(all: SearchAlbum[]): {
+  albums: SearchAlbum[];
+  singlesAndEps: SearchAlbum[];
+} {
+  const singlesAndEps = all.filter((a) => a.album_type === 'single' || a.album_type === 'ep');
+  const albums = all.filter((a) => a.album_type !== 'single' && a.album_type !== 'ep');
+  return { albums, singlesAndEps };
+}
+
+/**
+ * Stable identity for one album row.
+ *
+ * Used to carry ownership from the library-check response back to the right
+ * card. Falls back to name+artist because not every source returns an id.
+ */
+export function albumIdentity(album: SearchAlbum): string {
+  if (album.id != null && album.id !== '') return `id:${String(album.id)}`;
+  return `na:${(album.name ?? '').toLowerCase()}|${(album.artist ?? '').toLowerCase()}`;
+}
+
+/**
+ * Ownership per album, keyed by IDENTITY rather than list position.
+ *
+ * **This fixes a real bug rather than porting it.** The vanilla sent the
+ * unsplit `spotify_albums` array to /api/enhanced-search/library-check, which
+ * answers one boolean per row IN REQUEST ORDER — then applied the answers by
+ * indexing `document.querySelectorAll('#enh-albums-list .enh-compact-item,
+ * #enh-singles-list .enh-compact-item')`, which returns DOCUMENT order: every
+ * album, then every single.
+ *
+ * Those two orders only agree when the response happens to be pre-grouped, and
+ * it is not: core/search/orchestrator.py passes the provider's array straight
+ * through with no sort, so albums and singles interleave freely. Given
+ * [album, single, album], the DOM is [album, album, single] and the third
+ * answer lands on the second album — an "In Library" badge on a release you do
+ * not own.
+ *
+ * Keying by identity makes the split irrelevant.
+ */
+export function albumOwnershipByIdentity(
+  requested: SearchAlbum[],
+  flags: boolean[] | undefined,
+): Set<string> {
+  const owned = new Set<string>();
+  if (!flags?.length) return owned;
+  requested.forEach((album, index) => {
+    if (flags[index]) owned.add(albumIdentity(album));
+  });
+  return owned;
+}
+
+/** `_formatViewCount` — 1.2M / 3.4K / raw. */
+export function formatViewCount(count: number | undefined | null): string {
+  const n = Number(count);
+  if (!Number.isFinite(n) || n <= 0) return '';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+/** `formatDuration` — m:ss from milliseconds. */
+export function formatDuration(durationMs: number | undefined | null): string {
+  const ms = Number(durationMs);
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+/** An artist's display line: the vanilla showed a library track count or the source. */
+export function artistMetaLine(artist: SearchArtist, inLibrary: boolean): string {
+  if (inLibrary) {
+    const count = artist.track_count ?? 0;
+    return `${count} track${count === 1 ? '' : 's'}`;
+  }
+  return sourceLabel(artist.source ?? '');
+}
+
+/** A label's display line — `type • area`, or a plain fallback. */
+export function labelMetaLine(label: { type?: string; area?: string }): string {
+  const parts = [label.type, label.area].filter(Boolean);
+  return parts.length ? parts.join(' • ') : 'Record label';
+}
+
+/**
+ * Does this source's result set have anything at all in it?
+ *
+ * Drives the empty state. Videos count: a youtube_videos search with videos and
+ * nothing else is NOT empty.
+ */
+export function hasAnyResults(results: SourceResults): boolean {
+  return (
+    results.db_artists.length > 0 ||
+    results.artists.length > 0 ||
+    results.albums.length > 0 ||
+    results.tracks.length > 0 ||
+    results.videos.length > 0
+  );
+}
+
+/** Track identity, for carrying library-check answers back to track rows. */
+export function trackIdentity(track: SearchTrack): string {
+  if (track.id != null && track.id !== '') return `id:${String(track.id)}`;
+  return `na:${(track.name ?? '').toLowerCase()}|${(track.artist ?? '').toLowerCase()}`;
+}

--- a/webui/src/routes/search/-search.types.ts
+++ b/webui/src/routes/search/-search.types.ts
@@ -1,0 +1,230 @@
+/**
+ * Enhanced (metadata) search shapes.
+ *
+ * Field names are the vanilla's — `spotify_artists` / `spotify_albums` /
+ * `spotify_tracks` are historical and carry results from EVERY source, not just
+ * Spotify. Renaming them would mean renaming the API contract, so they stay.
+ */
+
+/** Metadata source ids, in the picker's canonical display order. */
+export const SOURCE_ORDER = [
+  'spotify',
+  'itunes',
+  'deezer',
+  'discogs',
+  'hydrabase',
+  'amazon',
+  'musicbrainz',
+  'jiosaavn',
+  'bandcamp',
+  'youtube_videos',
+  'soulseek',
+] as const;
+
+export type SearchSource = (typeof SOURCE_ORDER)[number];
+
+/**
+ * Opt-in sources, hidden from the picker unless enabled in
+ * Settings → Advanced → Experimental. The backend reports their state in the
+ * `_experimental` payload.
+ */
+export const EXPERIMENTAL_SOURCES: ReadonlySet<string> = new Set(['jiosaavn', 'bandcamp']);
+
+/**
+ * Sources config-status does not cover because they need no credentials — they
+ * always render as configured.
+ *
+ * Soulseek is deliberately NOT here: it needs an slskd URL, so the picker dims
+ * it when none is set up and sends clicks to Settings instead.
+ */
+export const ALWAYS_CONFIGURED_SOURCES: ReadonlySet<string> = new Set([
+  'amazon',
+  'musicbrainz',
+  'jiosaavn',
+  'bandcamp',
+  'youtube_videos',
+]);
+
+export interface SourceLabel {
+  text: string;
+  icon: string;
+  logo?: string;
+  tabClass: string;
+  badgeClass: string;
+}
+
+/** Mirrors SOURCE_LABELS in shared-helpers.js; pinned by a differential test. */
+export const SOURCE_LABELS: Record<string, SourceLabel> = {
+  spotify: {
+    text: 'Spotify',
+    icon: '🎵',
+    logo: '/static/img/brands/spotify.png',
+    tabClass: 'enh-tab-spotify',
+    badgeClass: 'enh-badge-spotify',
+  },
+  spotify_free: {
+    text: 'Spotify (no auth)',
+    icon: '🎵',
+    logo: '/static/img/brands/spotify.png',
+    tabClass: 'enh-tab-spotify',
+    badgeClass: 'enh-badge-spotify',
+  },
+  itunes: {
+    text: 'Apple Music',
+    icon: '🍎',
+    logo: '/static/img/brands/itunes.png',
+    tabClass: 'enh-tab-itunes',
+    badgeClass: 'enh-badge-itunes',
+  },
+  deezer: {
+    text: 'Deezer',
+    icon: '🎶',
+    logo: '/static/img/brands/deezer.png',
+    tabClass: 'enh-tab-deezer',
+    badgeClass: 'enh-badge-deezer',
+  },
+  discogs: {
+    text: 'Discogs',
+    icon: '📀',
+    logo: '/static/img/brands/discogs-icon.png',
+    tabClass: 'enh-tab-discogs',
+    badgeClass: 'enh-badge-discogs',
+  },
+  hydrabase: {
+    text: 'Hydrabase',
+    icon: '💎',
+    logo: '/static/hydrabase.png',
+    tabClass: 'enh-tab-hydrabase',
+    badgeClass: 'enh-badge-hydrabase',
+  },
+  amazon: {
+    text: 'Amazon Music',
+    icon: '🛒',
+    tabClass: 'enh-tab-amazon',
+    badgeClass: 'enh-badge-amazon',
+  },
+  musicbrainz: {
+    text: 'MusicBrainz',
+    icon: '🧠',
+    logo: '/static/img/brands/musicbrainz.png',
+    tabClass: 'enh-tab-musicbrainz',
+    badgeClass: 'enh-badge-musicbrainz',
+  },
+  jiosaavn: {
+    text: 'JioSaavn',
+    icon: '🎵',
+    tabClass: 'enh-tab-jiosaavn',
+    badgeClass: 'enh-badge-jiosaavn',
+  },
+  bandcamp: {
+    text: 'Bandcamp',
+    icon: '🎵',
+    logo: '/static/img/brands/bandcamp.svg',
+    tabClass: 'enh-tab-bandcamp',
+    badgeClass: 'enh-badge-bandcamp',
+  },
+  youtube_videos: {
+    text: 'Music Videos',
+    icon: '🎬',
+    tabClass: 'enh-tab-youtube',
+    badgeClass: 'enh-badge-youtube',
+  },
+  soulseek: {
+    // Routes through /api/search (raw slskd file results) — called "Basic
+    // Search" in the UI since before the source picker existed.
+    text: 'Basic Search',
+    icon: '🎼',
+    tabClass: 'enh-tab-soulseek',
+    badgeClass: 'enh-badge-soulseek',
+  },
+};
+
+export interface SearchArtist {
+  id?: string | number;
+  name?: string;
+  image_url?: string;
+  images?: { url?: string }[];
+  source?: string;
+  followers?: number;
+  /** DB artists only — drives the "In Your Library" section. */
+  track_count?: number;
+}
+
+export interface SearchAlbum {
+  id?: string | number;
+  name?: string;
+  artist?: string;
+  artists?: { id?: string | number; name?: string }[];
+  album_type?: string;
+  image_url?: string;
+  images?: { url?: string }[];
+  release_date?: string;
+  total_tracks?: number;
+  source?: string;
+  plugin?: string;
+  bandcamp_url?: string;
+}
+
+export interface SearchTrack {
+  id?: string | number;
+  name?: string;
+  artist?: string;
+  artists?: { id?: string | number; name?: string }[];
+  album?: SearchAlbum;
+  duration_ms?: number;
+  image_url?: string;
+  source?: string;
+}
+
+export interface SearchLabel {
+  id?: string;
+  name?: string;
+  type?: string;
+  area?: string;
+}
+
+export interface SearchVideo {
+  video_id?: string;
+  title?: string;
+  channel?: string;
+  thumbnail?: string;
+  duration?: string;
+  view_count?: number;
+}
+
+/** One source's slice of results, as cached per (query, source). */
+export interface SourceResults {
+  db_artists: SearchArtist[];
+  artists: SearchArtist[];
+  albums: SearchAlbum[];
+  tracks: SearchTrack[];
+  videos: SearchVideo[];
+}
+
+export interface EnhancedSearchResponse {
+  db_artists?: SearchArtist[];
+  spotify_artists?: SearchArtist[];
+  spotify_albums?: SearchAlbum[];
+  spotify_tracks?: SearchTrack[];
+  /** What the server ACTUALLY served — differs from the request on fallback. */
+  primary_source?: string;
+  metadata_source?: string;
+  source_available?: boolean;
+}
+
+/** The per-row answer from /api/enhanced-search/library-check. */
+export interface LibraryCheckTrack {
+  in_library?: boolean;
+  in_wishlist?: boolean;
+  track_id?: string | number;
+  title?: string;
+  file_path?: string;
+  album_title?: string;
+  artist_name?: string;
+  album_thumb_url?: string;
+}
+
+export interface LibraryCheckResponse {
+  albums?: boolean[];
+  tracks?: LibraryCheckTrack[];
+}

--- a/webui/src/routes/search/-search.types.ts
+++ b/webui/src/routes/search/-search.types.ts
@@ -146,8 +146,6 @@ export interface SearchArtist {
   images?: { url?: string }[];
   source?: string;
   followers?: number;
-  /** DB artists only — drives the "In Your Library" section. */
-  track_count?: number;
 }
 
 export interface SearchAlbum {
@@ -161,19 +159,38 @@ export interface SearchAlbum {
   release_date?: string;
   total_tracks?: number;
   source?: string;
-  plugin?: string;
-  bandcamp_url?: string;
+  release_group_id?: string;
+  /**
+   * Per-source escape hatches, not just links:
+   *   - `hydrabase_plugin` names the plugin an album came from, and the server
+   *     needs it to route the detail fetch to the right client.
+   *   - `bandcamp` is the release URL; Bandcamp has no id-lookup API, so it is
+   *     the only way to fetch that exact release instead of re-searching.
+   */
+  external_urls?: Record<string, string | undefined>;
 }
 
 export interface SearchTrack {
   id?: string | number;
   name?: string;
+  /** The joined display string ("A, B"); `artists` carries the real list. */
   artist?: string;
-  artists?: { id?: string | number; name?: string }[];
-  album?: SearchAlbum;
+  artists?: string[];
+  /**
+   * The album NAME, not an album object.
+   *
+   * core/search/sources.py:105 copies `track.album` straight from the Track
+   * dataclass, where it is a plain string (core/spotify_client.py:438). Typing
+   * it as an object silently loses the album from every track's meta line.
+   */
+  album?: string;
   duration_ms?: number;
   image_url?: string;
+  release_date?: string;
   source?: string;
+  popularity?: number;
+  preview_url?: string | null;
+  external_urls?: Record<string, string | undefined> | null;
 }
 
 export interface SearchLabel {
@@ -191,6 +208,13 @@ export interface SearchVideo {
   /** SECONDS, not milliseconds — see formatVideoDuration. */
   duration?: number;
   view_count?: number;
+  /**
+   * The watch URL. Not decoration: the download POST sends
+   * {video_id, url, title, channel} (downloads.js:5463), so dropping this field
+   * from the type means the request goes out with `url: undefined`.
+   */
+  url?: string;
+  upload_date?: string;
 }
 
 /** One source's slice of results, as cached per (query, source). */

--- a/webui/src/routes/search/-search.types.ts
+++ b/webui/src/routes/search/-search.types.ts
@@ -188,7 +188,8 @@ export interface SearchVideo {
   title?: string;
   channel?: string;
   thumbnail?: string;
-  duration?: string;
+  /** SECONDS, not milliseconds — see formatVideoDuration. */
+  duration?: number;
   view_count?: number;
 }
 

--- a/webui/src/routes/search/-search.use-artist-images.test.tsx
+++ b/webui/src/routes/search/-search.use-artist-images.test.tsx
@@ -1,0 +1,220 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import type { SearchArtist } from './-search.types';
+
+import { artistsNeedingImages, useArtistImages } from './-search.use-artist-images';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete window.extractImageColors;
+  delete window.applyDynamicGlow;
+});
+
+describe('artistsNeedingImages', () => {
+  it('takes library artists first, then source ones', () => {
+    // Document order, so the images fill in from the top of the list the user is
+    // actually reading.
+    const pending = artistsNeedingImages([{ id: 'db1' }], [{ id: 'sp1' }], {});
+    expect(pending.map((a) => a.id)).toEqual(['db1', 'sp1']);
+  });
+
+  it('skips an artist that already has art, from either field', () => {
+    const pending = artistsNeedingImages(
+      [],
+      [
+        { id: 'has-url', image_url: 'https://cdn/a.jpg' },
+        { id: 'has-images', images: [{ url: 'https://cdn/b.jpg' }] },
+        { id: 'needs' },
+      ],
+      {},
+    );
+    expect(pending.map((a) => a.id)).toEqual(['needs']);
+  });
+
+  it('skips one already resolved, so a re-render does not re-fetch it', () => {
+    expect(artistsNeedingImages([], [{ id: 'sp1' }], { sp1: 'https://cdn/a.jpg' })).toEqual([]);
+  });
+
+  it('skips an artist with no id, which nothing could be looked up by', () => {
+    expect(artistsNeedingImages([], [{ name: 'Nameless only' }], {})).toEqual([]);
+  });
+});
+
+describe('useArtistImages', () => {
+  it('resolves one image at a time, in order', async () => {
+    // Sequential on purpose: the resolver falls back to third-party lookups
+    // server-side, so ten parallel requests are ten parallel iTunes hits.
+    const started: string[] = [];
+    let inFlight = 0;
+    let peak = 0;
+    server.use(
+      http.get('/api/artist/:id/image', async ({ params }) => {
+        started.push(String(params.id));
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        return HttpResponse.json({ success: true, image_url: `https://cdn/${params.id}.jpg` });
+      }),
+    );
+
+    const artists: SearchArtist[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const { result } = renderHook(() => useArtistImages([], artists, 'spotify'));
+
+    await waitFor(() => expect(Object.keys(result.current)).toHaveLength(3));
+    expect(started).toEqual(['a', 'b', 'c']);
+    expect(peak).toBe(1);
+    expect(result.current.a).toBe('https://cdn/a.jpg');
+  });
+
+  it('passes the artist name, for sources that store no art at all', async () => {
+    // MusicBrainz has MBIDs and nothing else; the name is what the resolver
+    // searches iTunes/Deezer with.
+    let url = '';
+    server.use(
+      http.get('/api/artist/:id/image', ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ success: true, image_url: 'https://cdn/x.jpg' });
+      }),
+    );
+
+    const artists: SearchArtist[] = [{ id: 'mb1', name: 'Aphex Twin' }];
+    const { result } = renderHook(() => useArtistImages([], artists, 'musicbrainz'));
+    await waitFor(() => expect(result.current.mb1).toBeTruthy());
+
+    expect(new URL(url).searchParams.get('name')).toBe('Aphex Twin');
+    expect(new URL(url).searchParams.get('source')).toBe('musicbrainz');
+  });
+
+  it('omits the source param for spotify, as the vanilla did', async () => {
+    let url = '';
+    server.use(
+      http.get('/api/artist/:id/image', ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ success: true, image_url: 'https://cdn/x.jpg' });
+      }),
+    );
+
+    const artists: SearchArtist[] = [{ id: 'sp1', name: 'A' }];
+    const { result } = renderHook(() => useArtistImages([], artists, 'spotify'));
+    await waitFor(() => expect(result.current.sp1).toBeTruthy());
+    expect(new URL(url).searchParams.has('source')).toBe(false);
+  });
+
+  it('keeps going after one artist has no image', async () => {
+    server.use(
+      http.get('/api/artist/:id/image', ({ params }) =>
+        params.id === 'a'
+          ? HttpResponse.json({ success: false, image_url: null })
+          : HttpResponse.json({ success: true, image_url: 'https://cdn/b.jpg' }),
+      ),
+    );
+
+    const artists: SearchArtist[] = [{ id: 'a' }, { id: 'b' }];
+    const { result } = renderHook(() => useArtistImages([], artists, 'spotify'));
+    await waitFor(() => expect(result.current.b).toBe('https://cdn/b.jpg'));
+    expect(result.current.a).toBeUndefined();
+  });
+
+  it('does not trust a url that came back alongside success:false', async () => {
+    server.use(
+      http.get('/api/artist/:id/image', () =>
+        HttpResponse.json({ success: false, image_url: 'https://cdn/stale.jpg' }),
+      ),
+    );
+    const { result } = renderHook(() => useArtistImages([], [{ id: 'a' }], 'spotify'));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(result.current.a).toBeUndefined();
+  });
+
+  it('leaves the glow to the card, which glows ANY artwork', async () => {
+    // Not this hook's job: renderCompactSection glowed every card with an image,
+    // so CompactItem owns it and fires on the resolved url like any other.
+    server.use(
+      http.get('/api/artist/:id/image', () =>
+        HttpResponse.json({ success: true, image_url: 'https://cdn/x.jpg' }),
+      ),
+    );
+    window.extractImageColors = vi.fn() as never;
+
+    const { result } = renderHook(() => useArtistImages([], [{ id: 'sp1' }], 'spotify'));
+    await waitFor(() => expect(result.current.sp1).toBe('https://cdn/x.jpg'));
+    expect(window.extractImageColors).not.toHaveBeenCalled();
+  });
+
+  it('abandons the run when the results are replaced mid-loop', async () => {
+    // The old query's first request is held open, so the loop is provably parked
+    // on it when the results change — timing-free, unlike waiting a few ms and
+    // hoping.
+    const seen: string[] = [];
+    const release: (() => void)[] = [];
+    server.use(
+      http.get('/api/artist/:id/image', ({ params }) => {
+        const id = String(params.id);
+        seen.push(id);
+        if (!id.startsWith('old')) {
+          return HttpResponse.json({ success: true, image_url: `https://cdn/${id}.jpg` });
+        }
+        return new Promise<Response>((resolve) => {
+          release.push(() => resolve(HttpResponse.json({ success: true, image_url: 'https://x' })));
+        });
+      }),
+    );
+
+    const { result, rerender, unmount } = renderHook(
+      ({ artists }: { artists: SearchArtist[] }) => useArtistImages([], artists, 'spotify'),
+      { initialProps: { artists: [{ id: 'old1' }, { id: 'old2' }, { id: 'old3' }] } },
+    );
+    await waitFor(() => expect(seen).toEqual(['old1']));
+
+    rerender({ artists: [{ id: 'new1' }] });
+    await waitFor(() => expect(result.current.new1).toBe('https://cdn/new1.jpg'));
+
+    // Let the abandoned request land: it must not resume the old queue, and must
+    // not write an image for a card nobody is looking at.
+    release[0]();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(seen).toEqual(['old1', 'new1']);
+    expect(result.current.old1).toBeUndefined();
+    unmount();
+  });
+
+  it('requests each artist ONCE, however often the caller re-renders', async () => {
+    // The loop writes state as it goes, so a dep on the arrays (or on the
+    // resolved map) restarts it after every image and re-requests the rest of
+    // the queue. The empty `[]` below is the trap in miniature: a fresh literal
+    // on every render.
+    const seen: string[] = [];
+    server.use(
+      http.get('/api/artist/:id/image', async ({ params }) => {
+        seen.push(String(params.id));
+        await new Promise((r) => setTimeout(r, 5));
+        return HttpResponse.json({ success: true, image_url: `https://cdn/${params.id}.jpg` });
+      }),
+    );
+
+    const artists: SearchArtist[] = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const { result } = renderHook(() => useArtistImages([], artists, 'spotify'));
+
+    await waitFor(() => expect(Object.keys(result.current)).toHaveLength(3));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(seen).toEqual(['a', 'b', 'c']);
+  });
+
+  it('asks for nothing when every artist already has art', async () => {
+    let asked = false;
+    server.use(
+      http.get('/api/artist/:id/image', () => {
+        asked = true;
+        return HttpResponse.json({ success: true, image_url: 'https://cdn/x.jpg' });
+      }),
+    );
+    renderHook(() => useArtistImages([], [{ id: 'a', image_url: 'https://cdn/a.jpg' }], 'spotify'));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(asked).toBe(false);
+  });
+});

--- a/webui/src/routes/search/-search.use-artist-images.ts
+++ b/webui/src/routes/search/-search.use-artist-images.ts
@@ -1,0 +1,93 @@
+/**
+ * Resolving artist photos the source did not send.
+ *
+ * Ported from lazyLoadEnhancedSearchArtistImages (search.js:715-771). Two
+ * properties of that loop are deliberate and preserved:
+ *
+ * 1. **Sequential, one request at a time.** The resolver falls back to hitting
+ *    iTunes/Deezer server-side for sources that store no artist art (MusicBrainz
+ *    has MBIDs and nothing else), so ten parallel requests means ten parallel
+ *    third-party lookups. Slow and polite beats fast and rate-limited.
+ * 2. **In document order**, library artists first, so the images fill in from the
+ *    top of the list the way the user is reading it.
+ *
+ * The one thing that had to change: the vanilla replaced the placeholder node
+ * in-place and glowed the card from here. In React the resolved url goes into
+ * state, the card re-renders with it, and CompactItem's own glow effect fires on
+ * the new url — so the glow is not this file's business. That is also the more
+ * faithful arrangement: renderCompactSection glowed EVERY card with artwork, not
+ * only the ones whose photo had to be resolved.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { SearchArtist } from './-search.types';
+
+import { fetchArtistImage } from './-search.api';
+
+/** Which artists still need a photo, in the order they are rendered. */
+export function artistsNeedingImages(
+  dbArtists: SearchArtist[],
+  artists: SearchArtist[],
+  resolved: Record<string, string>,
+): SearchArtist[] {
+  return [...dbArtists, ...artists].filter((artist) => {
+    const id = String(artist.id ?? '');
+    if (!id) return false;
+    if (resolved[id]) return false;
+    return !artist.image_url && !artist.images?.[0]?.url;
+  });
+}
+
+/**
+ * Resolved artist images, keyed by artist id.
+ *
+ * Restarts whenever the artist lists change — a new query means a new set of
+ * cards, and the run in flight is resolving photos nobody is looking at.
+ */
+export function useArtistImages(
+  dbArtists: SearchArtist[],
+  artists: SearchArtist[],
+  activeSource: string,
+): Record<string, string> {
+  const [resolved, setResolved] = useState<Record<string, string>>({});
+
+  /**
+   * Everything the loop reads goes through a ref, and the effect keys on the
+   * artist IDS instead.
+   *
+   * Neither half is incidental. Depending on the arrays themselves re-runs the
+   * loop whenever a caller passes a fresh literal — which is every render, since
+   * an absent source's results are rebuilt by emptySourceResults() — and each
+   * re-run re-requests whatever was in flight. Depending on `resolved` is worse:
+   * the loop writes to it, so it would restart after every single image and
+   * duplicate the rest of the queue.
+   */
+  const listKey = [...dbArtists, ...artists].map((artist) => String(artist.id ?? '')).join('|');
+  const inputsRef = useRef({ dbArtists, artists, resolved });
+  inputsRef.current = { dbArtists, artists, resolved };
+
+  useEffect(() => {
+    const { dbArtists: db, artists: source, resolved: done } = inputsRef.current;
+    const pending = artistsNeedingImages(db, source, done);
+    if (!pending.length) return;
+
+    let live = true;
+    void (async () => {
+      for (const artist of pending) {
+        if (!live) return;
+        const id = String(artist.id ?? '');
+        const url = await fetchArtistImage(id, activeSource, artist.name ?? '');
+        if (!live) return;
+        if (!url) continue;
+        setResolved((prev) => ({ ...prev, [id]: url }));
+      }
+    })();
+
+    return () => {
+      live = false;
+    };
+  }, [listKey, activeSource]);
+
+  return resolved;
+}

--- a/webui/src/routes/search/-search.use-basic-section.ts
+++ b/webui/src/routes/search/-search.use-basic-section.ts
@@ -1,0 +1,80 @@
+/**
+ * Keeping basic (Soulseek) search working while React owns the page.
+ *
+ * Basic search is not part of this port: its markup is `#basic-search-section`
+ * in index.html and its logic is `performDownloadsSearch` in downloads.js. But
+ * the shell shows a React page by removing `.active` from every `.page`
+ * (shell-bridge.js:66-69), which hides `#search-page` and the basic section
+ * inside it. So the panel is adopted: the real element is MOVED into the React
+ * tree, keeping its ids, its children and any listeners already bound to it.
+ * Precedent: the automations page mounts what `_buildAutomationHub()` returns
+ * rather than restating it.
+ *
+ * Moving the markup is only half of it. `initializeSearch()` (search.js:12-36)
+ * is what binds the Search button, the Enter key and Cancel, and it runs from
+ * `case 'search':` in init.js — which loadPageData only reaches for LEGACY
+ * pages. After the manifest flip that call never happens again, so the adopted
+ * panel would render perfectly and do nothing at all. It is invoked here, once.
+ *
+ * `initializeSearchModeToggle` is deliberately NOT invoked: that is the vanilla
+ * enhanced-search controller this page replaces, and running it would build a
+ * second source row and a second set of listeners over the same DOM.
+ */
+
+import { useEffect, useRef } from 'react';
+
+export const BASIC_SECTION_ID = 'basic-search-section';
+
+/**
+ * Bound once per page load, not once per mount.
+ *
+ * initializeSearch uses addEventListener with no guard of its own, so calling it
+ * twice makes every basic search fire twice. The listeners live on the adopted
+ * node, which outlives this component, so the flag has to as well.
+ */
+let basicListenersBound = false;
+
+/** Test seam — the module-level flag would otherwise leak between tests. */
+export function resetBasicSectionBinding() {
+  basicListenersBound = false;
+}
+
+/**
+ * Move `#basic-search-section` into `host`, and put it back on the way out.
+ *
+ * Returning it matters: leaving it inside a React container that unmounts would
+ * destroy the node, and basic search would stay broken until a full page reload.
+ */
+export function useAdoptedBasicSection(host: HTMLElement | null, active: boolean) {
+  const originRef = useRef<{ parent: Node; next: Node | null } | null>(null);
+
+  useEffect(() => {
+    if (!host) return;
+    const section = document.getElementById(BASIC_SECTION_ID);
+    if (!section) return;
+
+    if (!originRef.current && section.parentNode) {
+      originRef.current = { parent: section.parentNode, next: section.nextSibling };
+    }
+    host.appendChild(section);
+
+    if (!basicListenersBound) {
+      basicListenersBound = true;
+      window.initializeSearch?.();
+      window.initializeFilters?.();
+    }
+
+    return () => {
+      const origin = originRef.current;
+      if (origin?.parent) origin.parent.insertBefore(section, origin.next);
+    };
+  }, [host]);
+
+  // `.active` is what the stylesheet keys the two panels on, and the vanilla
+  // toggles exactly this class when the source picker switches modes.
+  useEffect(() => {
+    const section = document.getElementById(BASIC_SECTION_ID);
+    if (!section) return;
+    section.classList.toggle('active', active);
+  }, [active]);
+}

--- a/webui/src/routes/search/-search.use-basic-section.ts
+++ b/webui/src/routes/search/-search.use-basic-section.ts
@@ -66,7 +66,13 @@ export function useAdoptedBasicSection(host: HTMLElement | null, active: boolean
 
     return () => {
       const origin = originRef.current;
-      if (origin?.parent) origin.parent.insertBefore(section, origin.next);
+      if (!origin?.parent) return;
+      // insertBefore throws if the sibling it was recorded next to has since
+      // been removed, so fall back to appending. Losing the ORDER inside a
+      // hidden legacy page is nothing; throwing during unmount would take the
+      // navigation with it.
+      const next = origin.next && origin.next.parentNode === origin.parent ? origin.next : null;
+      origin.parent.insertBefore(section, next);
     };
   }, [host]);
 

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { server } from '@/test/msw';
 
-import { activeResults, useSearchController } from './-search.use-controller';
+import { activeResults, resetPersistedSearch, useSearchController } from './-search.use-controller';
 
 /** A search handler you can settle per source, so races are observable. */
 function deferredSearch() {
@@ -58,6 +58,9 @@ describe('useSearchController', () => {
    * handlers after these.
    */
   beforeEach(() => {
+    // The navigate-back cache is module-level by design; without this it would
+    // carry one test's query into the next.
+    resetPersistedSearch();
     server.use(
       http.get('/status', () => HttpResponse.json({ metadata_source: { source: 'spotify' } })),
       http.get('/api/settings/config-status', () =>
@@ -293,5 +296,63 @@ describe('useSearchController', () => {
     const { result } = renderHook(() => useSearchController());
     act(() => result.current.seedFromIdLookup('x', { source: 'spotify_free', albums: [] }));
     expect(result.current.state.activeSource).toBe('spotify');
+  });
+});
+
+describe('surviving navigation', () => {
+  it('still has its results when the page comes back', async () => {
+    // A React route unmounts on navigation, so without the module-level cache
+    // the user returns to an empty page — the exact "results vanish on
+    // navigate-back" problem _searchPageRestoreOnEnter exists to solve.
+    resetPersistedSearch();
+    const seen = stubSearch({ spotify: { spotify_albums: [{ id: 'a1', name: 'Drukqs' }] } });
+
+    const first = renderHook(() => useSearchController());
+    act(() => first.result.current.submitQuery('aphex'));
+    await waitFor(() => expect(activeResults(first.result.current.state).albums).toHaveLength(1));
+    first.unmount();
+
+    // Remount, as the router does on the way back.
+    const second = renderHook(() => useSearchController());
+    expect(second.result.current.state.query).toBe('aphex');
+    expect(activeResults(second.result.current.state).albums).toHaveLength(1);
+    // And it did NOT re-fetch to get them back.
+    expect(seen).toEqual(['spotify']);
+    await flush();
+    second.unmount();
+  });
+
+  it('comes back on the source the user had picked', async () => {
+    resetPersistedSearch();
+    stubSearch({ deezer: { spotify_albums: [] } });
+
+    const first = renderHook(() => useSearchController());
+    act(() => first.result.current.setActiveSource('deezer'));
+    await waitFor(() => expect(first.result.current.state.activeSource).toBe('deezer'));
+    await flush();
+    first.unmount();
+
+    const second = renderHook(() => useSearchController());
+    expect(second.result.current.state.activeSource).toBe('deezer');
+    // userPickedSource travels too, so init does not overwrite the choice.
+    await flush();
+    expect(second.result.current.state.activeSource).toBe('deezer');
+    second.unmount();
+  });
+
+  it('does not carry a spinner across the remount', async () => {
+    // loadingSources describes a request that died with the old page; restoring
+    // it would leave an icon spinning forever.
+    resetPersistedSearch();
+    deferredSearch();
+
+    const first = renderHook(() => useSearchController());
+    act(() => first.result.current.submitQuery('aphex'));
+    await waitFor(() => expect(first.result.current.state.loadingSources.size).toBe(1));
+    first.unmount();
+
+    const second = renderHook(() => useSearchController());
+    expect(second.result.current.state.loadingSources.size).toBe(0);
+    second.unmount();
   });
 });

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -1,0 +1,254 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import { activeResults, useSearchController } from './-search.use-controller';
+
+/** A search handler you can settle per source, so races are observable. */
+function deferredSearch() {
+  const pending: { source: string; settle: (body: Record<string, unknown>) => void }[] = [];
+  server.use(
+    http.post('/api/enhanced-search', async ({ request }) => {
+      const body = (await request.json()) as { source: string };
+      return new Promise((resolve) => {
+        pending.push({
+          source: body.source,
+          settle: (payload) => resolve(HttpResponse.json(payload)),
+        });
+      });
+    }),
+  );
+  return pending;
+}
+
+function stubSearch(bySource: Record<string, unknown>) {
+  const seen: string[] = [];
+  server.use(
+    http.post('/api/enhanced-search', async ({ request }) => {
+      const body = (await request.json()) as { source: string };
+      seen.push(body.source);
+      return HttpResponse.json(bySource[body.source] ?? {});
+    }),
+  );
+  return seen;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+describe('useSearchController', () => {
+  it('starts with every source usable, so no flash of dimmed icons', () => {
+    const { result } = renderHook(() => useSearchController());
+    expect(result.current.state.configuredSources.spotify).toBe(true);
+    expect(result.current.state.configuredSources.deezer).toBe(true);
+  });
+
+  it('replaces the optimistic map with the real config status', async () => {
+    server.use(
+      http.get('/api/settings/config-status', () =>
+        HttpResponse.json({ spotify: { configured: true }, deezer: { configured: false } }),
+      ),
+    );
+    const { result } = renderHook(() => useSearchController());
+    await waitFor(() => expect(result.current.state.configuredSources.deezer).toBe(false));
+    expect(result.current.state.configuredSources.spotify).toBe(true);
+  });
+
+  it('fetches the active source and exposes its results', async () => {
+    stubSearch({ spotify: { spotify_albums: [{ id: 'a1', name: 'Drukqs' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(activeResults(result.current.state).albums).toHaveLength(1));
+  });
+
+  it('serves a repeat query for the same source from cache, with no request', async () => {
+    const seen = stubSearch({ spotify: { spotify_albums: [{ id: 'a1' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(activeResults(result.current.state).albums).toHaveLength(1));
+    act(() => result.current.submitQuery('aphex'));
+    await flush();
+
+    expect(seen).toEqual(['spotify']);
+  });
+
+  it('empties the cache when the query changes', async () => {
+    stubSearch({ spotify: { spotify_albums: [{ id: 'a1' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(activeResults(result.current.state).albums).toHaveLength(1));
+
+    act(() => result.current.submitQuery('squarepusher'));
+    // Synchronous: the previous query's results must not sit under the new one.
+    expect(result.current.state.sources).toEqual({});
+    expect(result.current.state.fallbacks).toEqual({});
+  });
+
+  it('FETCHES again for a new query, rather than reading the emptied cache', async () => {
+    // Caught by mutation testing: `previous.sources` is the pre-change state, so
+    // a cache check that ignores whether the query changed returns early and
+    // the second search never fires at all.
+    const seen = stubSearch({ spotify: { spotify_albums: [{ id: 'a1' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(seen).toEqual(['spotify']));
+
+    act(() => result.current.submitQuery('squarepusher'));
+    await waitFor(() => expect(seen).toEqual(['spotify', 'spotify']));
+    await waitFor(() => expect(activeResults(result.current.state).albums).toHaveLength(1));
+  });
+
+  it('does not write a settle that lands after the query changed', async () => {
+    // The tokens are DELETED on a query change, not just re-stamped, precisely
+    // so this cannot repopulate the cache we just emptied.
+    const pending = deferredSearch();
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    act(() => result.current.submitQuery('squarepusher'));
+    await act(async () => {
+      pending[0].settle({ spotify_albums: [{ id: 'stale' }] });
+      await flush();
+    });
+
+    expect(result.current.state.sources.spotify).toBeUndefined();
+  });
+
+  it('clears the spinner of a source that a DIFFERENT source superseded', async () => {
+    // The reason the tokens are per-source: switching aborts spotify's fetch,
+    // and spotify's own catch still has to clear its loadingSources entry.
+    const pending = deferredSearch();
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(result.current.state.loadingSources.has('spotify')).toBe(true));
+
+    act(() => result.current.setActiveSource('deezer'));
+    await waitFor(() => expect(result.current.state.loadingSources.has('deezer')).toBe(true));
+
+    await act(async () => {
+      pending[0].settle({ spotify_albums: [] });
+      await flush();
+    });
+    // Spotify is no longer spinning, even though Deezer took over.
+    expect(result.current.state.loadingSources.has('spotify')).toBe(false);
+  });
+
+  it('records a fallback when the server serves a different source', async () => {
+    stubSearch({ spotify: { primary_source: 'deezer', spotify_albums: [] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(result.current.state.fallbacks.spotify).toBe('deezer'));
+  });
+
+  it('hands a soulseek query off instead of fetching', async () => {
+    const onSoulseekSelected = vi.fn();
+    const seen = stubSearch({});
+    const { result } = renderHook(() => useSearchController({ onSoulseekSelected }));
+
+    act(() => result.current.setActiveSource('soulseek'));
+    act(() => result.current.submitQuery('aphex'));
+    await flush();
+
+    expect(onSoulseekSelected).toHaveBeenCalledWith('aphex');
+    expect(seen).toEqual([]);
+  });
+
+  it('re-fires the handoff when soulseek is clicked while ALREADY active', async () => {
+    // Deliberately not a no-op — clicking it again is how a basic search is
+    // re-run.
+    const onSoulseekSelected = vi.fn();
+    const { result } = renderHook(() => useSearchController({ onSoulseekSelected }));
+
+    act(() => result.current.submitQuery('aphex'));
+    act(() => result.current.setActiveSource('soulseek'));
+    act(() => result.current.setActiveSource('soulseek'));
+
+    expect(onSoulseekSelected).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetches a newly-selected source but not one already cached', async () => {
+    const seen = stubSearch({ spotify: { spotify_albums: [] }, deezer: { spotify_albums: [] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(seen).toEqual(['spotify']));
+
+    act(() => result.current.setActiveSource('deezer'));
+    await waitFor(() => expect(seen).toEqual(['spotify', 'deezer']));
+
+    // Back to spotify — already cached, so nothing new goes out.
+    act(() => result.current.setActiveSource('spotify'));
+    await flush();
+    expect(seen).toEqual(['spotify', 'deezer']);
+  });
+
+  it('does not fetch on source change when there is no query yet', async () => {
+    const seen = stubSearch({ deezer: {} });
+    const { result } = renderHook(() => useSearchController());
+    act(() => result.current.setActiveSource('deezer'));
+    await flush();
+    expect(seen).toEqual([]);
+  });
+
+  it('fills the video grid progressively from the NDJSON stream', async () => {
+    const encoder = new TextEncoder();
+    const lines = [
+      '{"type":"videos","data":[{"video_id":"v1"}]}\n',
+      '{"type":"videos","data":[{"video_id":"v2"}]}\n',
+    ];
+    let i = 0;
+    server.use(
+      http.post('/api/enhanced-search/source/youtube_videos', () => {
+        i = 0;
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              if (i < lines.length) controller.enqueue(encoder.encode(lines[i++]));
+              else controller.close();
+            },
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    const { result } = renderHook(() => useSearchController());
+    act(() => result.current.setActiveSource('youtube_videos'));
+    act(() => result.current.submitQuery('aphex'));
+
+    await waitFor(() => expect(activeResults(result.current.state).videos).toHaveLength(2));
+  });
+
+  it('adopts the resolved source when an id lookup seeds it', () => {
+    // Replaces the vanilla's reach-in state mutation with an explicit seam.
+    const { result } = renderHook(() => useSearchController());
+    act(() =>
+      result.current.seedFromIdLookup('770a1e6b-2d17-4bbe-a0c2-a3c4f77e9bce', {
+        available: true,
+        source: 'musicbrainz',
+        albums: [{ id: 'mb1', name: 'Found' }],
+      }),
+    );
+
+    expect(result.current.state.activeSource).toBe('musicbrainz');
+    expect(activeResults(result.current.state).albums).toHaveLength(1);
+    expect(result.current.state.loadingSources.size).toBe(0);
+  });
+
+  it('maps a spotify_free lookup onto the spotify icon', () => {
+    // spotify_free has no icon of its own; leaving it unmapped shows a picker
+    // with nothing active.
+    const { result } = renderHook(() => useSearchController());
+    act(() => result.current.seedFromIdLookup('x', { source: 'spotify_free', albums: [] }));
+    expect(result.current.state.activeSource).toBe('spotify');
+  });
+});

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { server } from '@/test/msw';
 
@@ -35,9 +35,26 @@ function stubSearch(bySource: Record<string, unknown>) {
   return seen;
 }
 
-const flush = () => new Promise((r) => setTimeout(r, 10));
+/**
+ * Let pending promises and timers land.
+ *
+ * Wrapped in act() because a settling fetch writes state, and this hook has one
+ * request in flight from the moment it mounts (config status) that no individual
+ * test asked for.
+ */
+const flush = () =>
+  act(async () => {
+    await new Promise((r) => setTimeout(r, 10));
+  });
 
 describe('useSearchController', () => {
+  // Every mount fetches config status. Left unhandled it is not a failure — the
+  // catch swallows it — but MSW logs an error for each one and the real noise
+  // hides a real miss. Tests that care register their own handler after this.
+  beforeEach(() => {
+    server.use(http.get('/api/settings/config-status', () => HttpResponse.json({})));
+  });
+
   it('starts with every source usable, so no flash of dimmed icons', () => {
     const { result } = renderHook(() => useSearchController());
     expect(result.current.state.configuredSources.spotify).toBe(true);
@@ -166,6 +183,11 @@ describe('useSearchController', () => {
     // Deliberately not a no-op — clicking it again is how a basic search is
     // re-run.
     const onSoulseekSelected = vi.fn();
+    // submitQuery runs while SPOTIFY is still active, so it really does fetch.
+    // Stubbed and drained here rather than left in flight: an unstubbed request
+    // settling after the test ends lands inside the NEXT one, as an unhandled
+    // MSW request and an act() warning nowhere near its cause.
+    stubSearch({ spotify: { spotify_albums: [] } });
     const { result } = renderHook(() => useSearchController({ onSoulseekSelected }));
 
     act(() => result.current.submitQuery('aphex'));
@@ -173,6 +195,9 @@ describe('useSearchController', () => {
     act(() => result.current.setActiveSource('soulseek'));
 
     expect(onSoulseekSelected).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await flush();
+    });
   });
 
   it('fetches a newly-selected source but not one already cached', async () => {

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -366,9 +366,15 @@ describe('syncQuery', () => {
     const { result } = renderHook(() => useSearchController());
 
     act(() => result.current.syncQuery('from the widget'));
-    await flush();
 
+    // Checked SYNCHRONOUSLY, because a fetch marks its source loading before it
+    // awaits anything. Waiting for the request to show up in `seen` instead is
+    // a race the mutant wins: 10ms is not always enough for MSW to record it,
+    // which is exactly how a "syncQuery also searches" mutant survived once.
+    expect(result.current.state.loadingSources.size).toBe(0);
     expect(result.current.state.query).toBe('from the widget');
+
+    await new Promise((r) => setTimeout(r, 100));
     expect(seen).toEqual([]);
   });
 

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -48,11 +48,29 @@ const flush = () =>
   });
 
 describe('useSearchController', () => {
-  // Every mount fetches config status. Left unhandled it is not a failure — the
-  // catch swallows it — but MSW logs an error for each one and the real noise
-  // hides a real miss. Tests that care register their own handler after this.
+  /**
+   * Every mount runs the init sequence: /status then config-status.
+   *
+   * The config payload has to be REALISTIC. An empty `{}` says Spotify has no
+   * credentials, and the picker then correctly falls forward to the first
+   * source that needs none — Amazon — which is right behaviour and a useless
+   * baseline for testing everything else. Tests that care register their own
+   * handlers after these.
+   */
   beforeEach(() => {
-    server.use(http.get('/api/settings/config-status', () => HttpResponse.json({})));
+    server.use(
+      http.get('/status', () => HttpResponse.json({ metadata_source: { source: 'spotify' } })),
+      http.get('/api/settings/config-status', () =>
+        HttpResponse.json({
+          spotify: { configured: true },
+          itunes: { configured: true },
+          deezer: { configured: true },
+          discogs: { configured: true },
+          hydrabase: { configured: true },
+          soulseek: { configured: true },
+        }),
+      ),
+    );
   });
 
   it('starts with every source usable, so no flash of dimmed icons', () => {

--- a/webui/src/routes/search/-search.use-controller.test.tsx
+++ b/webui/src/routes/search/-search.use-controller.test.tsx
@@ -356,3 +356,54 @@ describe('surviving navigation', () => {
     second.unmount();
   });
 });
+
+describe('syncQuery', () => {
+  it('adopts the query without searching for it', async () => {
+    // The widget's handoff. It clicks the Soulseek icon straight after, and
+    // that click is what searches — doing it here too runs the basic search
+    // twice for one handoff.
+    const seen = stubSearch({ spotify: {} });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.syncQuery('from the widget'));
+    await flush();
+
+    expect(result.current.state.query).toBe('from the widget');
+    expect(seen).toEqual([]);
+  });
+
+  it('does not hand a soulseek query off by itself', async () => {
+    const onSoulseekSelected = vi.fn();
+    const { result } = renderHook(() => useSearchController({ onSoulseekSelected }));
+    await flush();
+
+    act(() => result.current.syncQuery('aphex'));
+    expect(onSoulseekSelected).not.toHaveBeenCalled();
+  });
+
+  it('empties the cache when the query actually changed', async () => {
+    // The vanilla assigned state.query raw, which would leave the previous
+    // query's results in place to be served for this one.
+    stubSearch({ spotify: { spotify_albums: [{ id: 'a1' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(result.current.state.sources.spotify).toBeDefined());
+
+    act(() => result.current.syncQuery('squarepusher'));
+    expect(result.current.state.sources).toEqual({});
+    expect(result.current.state.query).toBe('squarepusher');
+  });
+
+  it('leaves a matching query completely alone', async () => {
+    stubSearch({ spotify: { spotify_albums: [{ id: 'a1' }] } });
+    const { result } = renderHook(() => useSearchController());
+
+    act(() => result.current.submitQuery('aphex'));
+    await waitFor(() => expect(result.current.state.sources.spotify).toBeDefined());
+
+    // Same query: the cache is still good and must not be thrown away.
+    act(() => result.current.syncQuery('aphex'));
+    expect(result.current.state.sources.spotify).toBeDefined();
+  });
+});

--- a/webui/src/routes/search/-search.use-controller.ts
+++ b/webui/src/routes/search/-search.use-controller.ts
@@ -43,6 +43,8 @@ export interface SearchController {
   state: SearchControllerState;
   submitQuery: (query: string) => void;
   setActiveSource: (source: string) => void;
+  /** Adopt a query without searching for it — the widget handoff. */
+  syncQuery: (query: string) => void;
   /**
    * The ID-lookup seam.
    *
@@ -264,6 +266,38 @@ export function useSearchController({
     }
   }, []);
 
+  /**
+   * Adopt a query WITHOUT searching for it.
+   *
+   * This is the global download widget's handoff. It writes the basic-search
+   * input itself and then clicks the Soulseek icon; all it needs from here is
+   * for the controller to agree what the query is, so that the click hands off
+   * the right one. The vanilla did it by assigning `state.query` directly
+   * (downloads.js:5729-5731) — a plain assignment, no fetch and no callback.
+   *
+   * Searching here instead would run the basic search THREE times for one
+   * handoff: once from this call, once from the icon click, and once more when
+   * the debounce caught up.
+   *
+   * The cache is cleared when the query actually differs, which the vanilla's
+   * raw assignment did not do — leaving it would let a later search for this
+   * query serve results that belong to the previous one.
+   */
+  const syncQuery = useCallback((query: string) => {
+    const previous = stateRef.current;
+    if (query === previous.query) return;
+    for (const key of Object.keys(tokensRef.current)) delete tokensRef.current[key];
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setState((prev) => ({
+      ...prev,
+      query,
+      sources: {},
+      fallbacks: {},
+      loadingSources: new Set<string>(),
+    }));
+  }, []);
+
   const submitQuery = useCallback(
     (query: string) => {
       const previous = stateRef.current;
@@ -362,7 +396,7 @@ export function useSearchController({
     }));
   }, []);
 
-  return { state, submitQuery, setActiveSource, seedFromIdLookup };
+  return { state, submitQuery, setActiveSource, syncQuery, seedFromIdLookup };
 }
 
 /** The slice the page renders — the active source's results, or an empty one. */

--- a/webui/src/routes/search/-search.use-controller.ts
+++ b/webui/src/routes/search/-search.use-controller.ts
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { IdLookupResponse } from './-search.api';
+import type { SearchSource, SourceResults } from './-search.types';
+
+import { fetchConfigStatus, fetchEnhancedSearch, streamVideoSearch } from './-search.api';
+import {
+  emptySourceResults,
+  fallbackFor,
+  pickerSource,
+  sourceResultsFromResponse,
+} from './-search.helpers';
+import { SOURCE_ORDER } from './-search.types';
+
+export interface SearchControllerState {
+  query: string;
+  activeSource: string;
+  /** Per-(query, source) cache. Wiped wholesale when the query changes. */
+  sources: Record<string, SourceResults>;
+  /** requested source → what the server actually served. */
+  fallbacks: Record<string, string>;
+  loadingSources: ReadonlySet<string>;
+  configuredSources: Record<string, boolean>;
+  enabledExperimental: ReadonlySet<string>;
+}
+
+export interface SearchController {
+  state: SearchControllerState;
+  submitQuery: (query: string) => void;
+  setActiveSource: (source: string) => void;
+  /**
+   * The ID-lookup seam.
+   *
+   * The vanilla's submitIdLookup reached in and mutated controller state
+   * directly — adopting the resolved source and seeding its cache. Immutable
+   * state needs that as an explicit entry point rather than a reach-in.
+   */
+  seedFromIdLookup: (raw: string, data: IdLookupResponse) => void;
+}
+
+/** Every source starts optimistically usable, so no flash of dimmed icons. */
+function optimisticConfigured(): Record<string, boolean> {
+  const configured: Record<string, boolean> = {};
+  for (const source of SOURCE_ORDER) configured[source] = true;
+  return configured;
+}
+
+/**
+ * The source picker's brain, ported from createSearchController.
+ *
+ * Two pieces of machinery matter more than they look:
+ *
+ * **Per-source request tokens, not one global sequence.** Each fetch stamps a
+ * monotonic id into `tokens[source]`, and a settle bails if the id for THAT
+ * source has moved on. The vanilla's comment spells out why a single token is
+ * wrong: switching Spotify → Deezer aborts Spotify's fetch, and Spotify's catch
+ * still needs to clear 'spotify' from loadingSources — which Deezer's request
+ * never touched. Per-source ownership is what keeps a spinner from sticking.
+ *
+ * **Tokens are deleted, not just re-stamped, on a query change.** A settle that
+ * lands after the query was cleared would otherwise still match its token and
+ * write stale results into the freshly-emptied cache.
+ */
+export function useSearchController({
+  onSoulseekSelected,
+  initialSource = 'spotify',
+}: {
+  onSoulseekSelected?: (query: string) => void;
+  initialSource?: string;
+} = {}): SearchController {
+  const [state, setState] = useState<SearchControllerState>(() => ({
+    query: '',
+    activeSource: pickerSource(initialSource),
+    sources: {},
+    fallbacks: {},
+    loadingSources: new Set<string>(),
+    configuredSources: optimisticConfigured(),
+    enabledExperimental: new Set<string>(),
+  }));
+
+  const tokensRef = useRef<Record<string, number>>(Object.create(null));
+  const seqRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const soulseekRef = useRef(onSoulseekSelected);
+  soulseekRef.current = onSoulseekSelected;
+
+  /** Real config status replaces the optimistic map once it lands. */
+  useEffect(() => {
+    let live = true;
+    void fetchConfigStatus().then(({ configured, enabledExperimental }) => {
+      if (!live || !Object.keys(configured).length) return;
+      setState((prev) => ({
+        ...prev,
+        configuredSources: { ...prev.configuredSources, ...configured },
+        enabledExperimental,
+      }));
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const fetchSource = useCallback(async (source: string, query: string) => {
+    if (!query) return;
+
+    const requestId = ++seqRef.current;
+    tokensRef.current[source] = requestId;
+
+    setState((prev) => {
+      const loading = new Set(prev.loadingSources);
+      loading.add(source);
+      return { ...prev, loadingSources: loading };
+    });
+
+    // One controller across sources: switching source abandons the previous
+    // fetch, which is the point — its results are for an icon you left.
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const stillCurrent = () => tokensRef.current[source] === requestId;
+
+    try {
+      if (source === 'youtube_videos') {
+        await streamVideoSearch(
+          query,
+          (videos) => {
+            // Re-checked per chunk: a long stream can outlive its query.
+            if (!stillCurrent()) return;
+            setState((prev) => ({
+              ...prev,
+              sources: {
+                ...prev.sources,
+                [source]: { ...emptySourceResults(), videos },
+              },
+            }));
+          },
+          controller.signal,
+        );
+      } else {
+        const data = await fetchEnhancedSearch(query, source, controller.signal);
+        if (!stillCurrent()) return;
+        const served = fallbackFor(source, data);
+        setState((prev) => ({
+          ...prev,
+          sources: { ...prev.sources, [source]: sourceResultsFromResponse(data) },
+          fallbacks: served ? { ...prev.fallbacks, [source]: served } : prev.fallbacks,
+        }));
+      }
+    } catch {
+      // Swallowed: an abort is the normal case here, and a genuine failure
+      // shows as an empty result rather than an error page — the vanilla's
+      // behaviour.
+    } finally {
+      // This source's own spinner, cleared even when a DIFFERENT source
+      // superseded it. That is the whole reason the tokens are per-source.
+      if (stillCurrent()) {
+        setState((prev) => {
+          const loading = new Set(prev.loadingSources);
+          loading.delete(source);
+          return { ...prev, loadingSources: loading };
+        });
+      }
+    }
+  }, []);
+
+  const submitQuery = useCallback(
+    (query: string) => {
+      const previous = stateRef.current;
+      const changed = query !== previous.query;
+
+      if (changed) {
+        // Every in-flight token is invalidated, not merely re-stamped, so a
+        // settle arriving after this point cannot write into the cache we are
+        // about to empty.
+        //
+        // Honest about its weight: the abort below already covers the common
+        // case, and a mutant that removes this deletion SURVIVES the suite
+        // because of that. It stays as defence in depth — a response that
+        // resolved just before the abort landed would otherwise still pass the
+        // per-source token check — but no test proves it, and pretending
+        // otherwise would be worse than saying so.
+        for (const key of Object.keys(tokensRef.current)) delete tokensRef.current[key];
+        abortRef.current?.abort();
+        abortRef.current = null;
+        setState((prev) => ({
+          ...prev,
+          query,
+          sources: {},
+          fallbacks: {},
+          loadingSources: new Set<string>(),
+        }));
+      }
+
+      const source = previous.activeSource;
+
+      // Soulseek is not a metadata source — the page hands the query to basic
+      // search instead of fetching anything here.
+      if (source === 'soulseek') {
+        soulseekRef.current?.(query);
+        return;
+      }
+
+      // Cache hit: instant, no request. Only valid when the query is unchanged,
+      // because a change just emptied the cache.
+      if (!changed && previous.sources[source]) return;
+
+      void fetchSource(source, query);
+    },
+    [fetchSource],
+  );
+
+  const setActiveSource = useCallback(
+    (source: string) => {
+      const previous = stateRef.current;
+      setState((prev) => ({ ...prev, activeSource: source }));
+
+      if (source === 'soulseek') {
+        // Deliberately fires even when soulseek is ALREADY active: clicking it
+        // again is how the user re-runs a basic search.
+        soulseekRef.current?.(previous.query);
+        return;
+      }
+      if (!previous.query) return;
+      if (previous.sources[source]) return;
+      void fetchSource(source, previous.query);
+    },
+    [fetchSource],
+  );
+
+  const seedFromIdLookup = useCallback((raw: string, data: IdLookupResponse) => {
+    const source = pickerSource(data.source);
+    setState((prev) => ({
+      ...prev,
+      query: raw,
+      activeSource: source,
+      sources: {
+        ...prev.sources,
+        [source]: {
+          ...emptySourceResults(),
+          artists: data.artists ?? data.spotify_artists ?? [],
+          albums: data.albums ?? data.spotify_albums ?? [],
+          tracks: data.tracks ?? data.spotify_tracks ?? [],
+          db_artists: data.db_artists ?? [],
+        },
+      },
+      loadingSources: new Set<string>(),
+    }));
+  }, []);
+
+  return { state, submitQuery, setActiveSource, seedFromIdLookup };
+}
+
+/** The slice the page renders — the active source's results, or an empty one. */
+export function activeResults(state: SearchControllerState): SourceResults {
+  return state.sources[state.activeSource] ?? emptySourceResults();
+}
+
+/** Has the active source answered yet for the current query? */
+export function activeSourceSettled(state: SearchControllerState): boolean {
+  return Boolean(state.sources[state.activeSource]);
+}
+
+export type { SearchSource };

--- a/webui/src/routes/search/-search.use-controller.ts
+++ b/webui/src/routes/search/-search.use-controller.ts
@@ -3,11 +3,18 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { IdLookupResponse } from './-search.api';
 import type { SearchSource, SourceResults } from './-search.types';
 
-import { fetchConfigStatus, fetchEnhancedSearch, streamVideoSearch } from './-search.api';
 import {
+  fetchConfigStatus,
+  fetchEnhancedSearch,
+  fetchMetadataStatus,
+  streamVideoSearch,
+} from './-search.api';
+import {
+  canSelectSource,
   emptySourceResults,
   fallbackFor,
   pickerSource,
+  resolveInitialSource,
   sourceResultsFromResponse,
 } from './-search.helpers';
 import { SOURCE_ORDER } from './-search.types';
@@ -22,6 +29,14 @@ export interface SearchControllerState {
   loadingSources: ReadonlySet<string>;
   configuredSources: Record<string, boolean>;
   enabledExperimental: ReadonlySet<string>;
+  /**
+   * Has the user clicked a source themselves?
+   *
+   * The init sequence resolves a default from /status and config-status, and
+   * both land asynchronously. Without this flag a click made while they were in
+   * flight would be overwritten a moment later.
+   */
+  userPickedSource: boolean;
 }
 
 export interface SearchController {
@@ -63,9 +78,12 @@ function optimisticConfigured(): Record<string, boolean> {
  */
 export function useSearchController({
   onSoulseekSelected,
+  onUnconfiguredSource,
   initialSource = 'spotify',
 }: {
   onSoulseekSelected?: (query: string) => void;
+  /** Called instead of switching when a source has no credentials. */
+  onUnconfiguredSource?: (source: string) => void;
   initialSource?: string;
 } = {}): SearchController {
   const [state, setState] = useState<SearchControllerState>(() => ({
@@ -76,6 +94,7 @@ export function useSearchController({
     loadingSources: new Set<string>(),
     configuredSources: optimisticConfigured(),
     enabledExperimental: new Set<string>(),
+    userPickedSource: false,
   }));
 
   const tokensRef = useRef<Record<string, number>>(Object.create(null));
@@ -85,22 +104,52 @@ export function useSearchController({
   stateRef.current = state;
   const soulseekRef = useRef(onSoulseekSelected);
   soulseekRef.current = onSoulseekSelected;
+  const unconfiguredRef = useRef(onUnconfiguredSource);
+  unconfiguredRef.current = onUnconfiguredSource;
 
-  /** Real config status replaces the optimistic map once it lands. */
+  /**
+   * The init sequence, in the vanilla's order (shared-helpers.js:355-397).
+   *
+   * /status first — it names the user's primary source AND carries the
+   * experimental flags, so a config-status failure still leaves opted-in
+   * experimental sources visible. Then config-status, which is the fresher read
+   * of both. Only then is the active source resolvable: it depends on which
+   * sources are visible and which have credentials.
+   */
   useEffect(() => {
     let live = true;
-    void fetchConfigStatus().then(({ configured, enabledExperimental }) => {
-      if (!live || !Object.keys(configured).length) return;
+    void (async () => {
+      const status = await fetchMetadataStatus();
+      if (!live) return;
+      const config = await fetchConfigStatus();
+      if (!live) return;
+
+      const enabledExperimental = config.enabledExperimental.size
+        ? config.enabledExperimental
+        : status.enabledExperimental;
+      const configured = Object.keys(config.configured).length
+        ? config.configured
+        : optimisticConfigured();
+
       setState((prev) => ({
         ...prev,
         configuredSources: { ...prev.configuredSources, ...configured },
         enabledExperimental,
+        // Only adopted while the user has not picked anything themselves; their
+        // click always outranks the configured default.
+        activeSource: prev.userPickedSource
+          ? prev.activeSource
+          : resolveInitialSource({
+              statusSource: status.source || initialSource,
+              enabledExperimental,
+              configured,
+            }),
       }));
-    });
+    })();
     return () => {
       live = false;
     };
-  }, []);
+  }, [initialSource]);
 
   useEffect(() => () => abortRef.current?.abort(), []);
 
@@ -217,7 +266,21 @@ export function useSearchController({
   const setActiveSource = useCallback(
     (source: string) => {
       const previous = stateRef.current;
-      setState((prev) => ({ ...prev, activeSource: source }));
+
+      // Unknown, or an experimental source the user has not enabled — there is
+      // no icon for it, so activating it would leave the row with nothing lit.
+      if (!canSelectSource(source, previous.enabledExperimental)) return;
+
+      // No credentials: hand off to Settings and DO NOT swap the active source,
+      // so the user's working pick is still current when they come back
+      // (shared-helpers.js:466-472). The row gates this too, but the rule
+      // belongs here — a caller that is not the row must not slip past it.
+      if (previous.configuredSources[source] === false) {
+        unconfiguredRef.current?.(source);
+        return;
+      }
+
+      setState((prev) => ({ ...prev, activeSource: source, userPickedSource: true }));
 
       if (source === 'soulseek') {
         // Deliberately fires even when soulseek is ALREADY active: clicking it

--- a/webui/src/routes/search/-search.use-controller.ts
+++ b/webui/src/routes/search/-search.use-controller.ts
@@ -76,6 +76,43 @@ function optimisticConfigured(): Record<string, boolean> {
  * lands after the query was cleared would otherwise still match its token and
  * write stale results into the freshly-emptied cache.
  */
+/**
+ * What survives leaving the page.
+ *
+ * The vanilla page is never torn down, so its controller keeps the last query
+ * and its per-source cache; `_searchPageRestoreOnEnter` (search.js:226-234)
+ * exists purely to re-render them on the way back, and its comment names the
+ * problem it solves: "results vanish on navigate-back". A React route unmounts,
+ * which would take the cache with it — so the cache lives out here instead.
+ *
+ * Deliberately NOT the whole state: loadingSources and configuredSources are
+ * about a live page and would be lies by the time anyone came back.
+ */
+interface PersistedSearch {
+  query: string;
+  activeSource: string;
+  sources: Record<string, SourceResults>;
+  fallbacks: Record<string, string>;
+  userPickedSource: boolean;
+}
+
+let persisted: PersistedSearch | null = null;
+
+/** Test seam — a module-level cache would otherwise leak between tests. */
+export function resetPersistedSearch() {
+  persisted = null;
+}
+
+/**
+ * The query the page came back to, for seeding the input.
+ *
+ * Restoring the cache without this leaves the results on screen above an EMPTY
+ * search box — which reads as a bug even though the results are correct.
+ */
+export function getPersistedQuery(): string {
+  return persisted?.query ?? '';
+}
+
 export function useSearchController({
   onSoulseekSelected,
   onUnconfiguredSource,
@@ -87,15 +124,25 @@ export function useSearchController({
   initialSource?: string;
 } = {}): SearchController {
   const [state, setState] = useState<SearchControllerState>(() => ({
-    query: '',
-    activeSource: pickerSource(initialSource),
-    sources: {},
-    fallbacks: {},
+    query: persisted?.query ?? '',
+    activeSource: persisted?.activeSource ?? pickerSource(initialSource),
+    sources: persisted?.sources ?? {},
+    fallbacks: persisted?.fallbacks ?? {},
     loadingSources: new Set<string>(),
     configuredSources: optimisticConfigured(),
     enabledExperimental: new Set<string>(),
-    userPickedSource: false,
+    userPickedSource: persisted?.userPickedSource ?? false,
   }));
+
+  // Mirrored on every change rather than on unmount: an unmount hook would not
+  // run if the tab were closed mid-search, and this costs nothing.
+  persisted = {
+    query: state.query,
+    activeSource: state.activeSource,
+    sources: state.sources,
+    fallbacks: state.fallbacks,
+    userPickedSource: state.userPickedSource,
+  };
 
   const tokensRef = useRef<Record<string, number>>(Object.create(null));
   const seqRef = useRef(0);

--- a/webui/src/routes/search/-search.use-dismiss.test.tsx
+++ b/webui/src/routes/search/-search.use-dismiss.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { shouldDismiss, useDismissOnOutsideClick } from './-search.use-dismiss';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+/** Build a click target inside the given markup and return it. */
+function targetInside(html: string, selector: string): Element {
+  document.body.innerHTML = html;
+  return document.querySelector(selector)!;
+}
+
+describe('shouldDismiss', () => {
+  it('dismisses on a click somewhere unrelated', () => {
+    expect(shouldDismiss(targetInside('<main><p id="t">hi</p></main>', '#t'))).toBe(true);
+  });
+
+  it('keeps the dropdown open while you are using the input', () => {
+    const target = targetInside(
+      '<div class="enhanced-search-input-wrapper"><input id="t"></div>',
+      '#t',
+    );
+    expect(shouldDismiss(target)).toBe(false);
+  });
+
+  it('keeps it open for the source row, which sits OUTSIDE the dropdown', () => {
+    // The icons live above the input and switch which cached source is shown —
+    // dismissing on them would close the results they just asked for.
+    const target = targetInside('<div id="enh-source-row"><button id="t"></button></div>', '#t');
+    expect(shouldDismiss(target)).toBe(false);
+  });
+
+  it('keeps it open for the download modal that opens on top of it', () => {
+    const target = targetInside(
+      '<div class="download-missing-modal"><button id="t">×</button></div>',
+      '#t',
+    );
+    expect(shouldDismiss(target)).toBe(false);
+  });
+
+  it('keeps it open for the media player and the now-playing modal (#732)', () => {
+    // Clicking the mini bar to expand it used to dismiss the search results.
+    expect(shouldDismiss(targetInside('<div id="media-player"><b id="t"></b></div>', '#t'))).toBe(
+      false,
+    );
+    expect(
+      shouldDismiss(targetInside('<div id="np-modal-overlay"><b id="t"></b></div>', '#t')),
+    ).toBe(false);
+  });
+
+  it('dismisses when the target is not an element at all', () => {
+    // A click reported against the document itself is still a click outside.
+    expect(shouldDismiss(document)).toBe(true);
+    expect(shouldDismiss(null)).toBe(true);
+  });
+});
+
+describe('useDismissOnOutsideClick', () => {
+  it('fires once for an outside click while open', () => {
+    document.body.innerHTML = '<p id="outside">x</p>';
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsideClick(true, onDismiss));
+
+    fireEvent.click(document.getElementById('outside')!);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('listens for nothing while closed', () => {
+    document.body.innerHTML = '<p id="outside">x</p>';
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsideClick(false, onDismiss));
+
+    fireEvent.click(document.getElementById('outside')!);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('ignores a click on an exempt element', () => {
+    document.body.innerHTML = '<div id="enh-source-row"><button id="icon"></button></div>';
+    const onDismiss = vi.fn();
+    renderHook(() => useDismissOnOutsideClick(true, onDismiss));
+
+    fireEvent.click(document.getElementById('icon')!);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once unmounted', () => {
+    document.body.innerHTML = '<p id="outside">x</p>';
+    const onDismiss = vi.fn();
+    const { unmount } = renderHook(() => useDismissOnOutsideClick(true, onDismiss));
+    unmount();
+
+    fireEvent.click(document.getElementById('outside')!);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/webui/src/routes/search/-search.use-dismiss.ts
+++ b/webui/src/routes/search/-search.use-dismiss.ts
@@ -1,0 +1,44 @@
+/**
+ * Closing the results dropdown when the user clicks away.
+ *
+ * Ported from the document listener at search.js:371-390. The value is entirely
+ * in the exemptions — four things sit visually over or beside the dropdown and
+ * must NOT dismiss it:
+ *
+ *   - the input wrapper itself (you are typing in it)
+ *   - the source row, which lives ABOVE the input and outside the dropdown, and
+ *     whose whole job is switching which results are shown
+ *   - the download-missing modal, which opens on top; closing it must not also
+ *     throw away the results you opened it from
+ *   - the media player, mini bar and expanded now-playing modal both (#732 —
+ *     clicking the mini player to expand it dismissed the search)
+ */
+
+import { useEffect } from 'react';
+
+/** Selectors a click may land in without closing the dropdown. */
+export const DISMISS_EXEMPT_SELECTORS = [
+  '.enhanced-search-input-wrapper',
+  '#enh-source-row',
+  '.download-missing-modal',
+  '#media-player',
+  '#np-modal-overlay',
+] as const;
+
+/** Should a click on this element dismiss the dropdown? */
+export function shouldDismiss(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return true;
+  return !DISMISS_EXEMPT_SELECTORS.some((selector) => target.closest(selector));
+}
+
+/** Dismiss the dropdown on an outside click, while it is open. */
+export function useDismissOnOutsideClick(open: boolean, onDismiss: () => void) {
+  useEffect(() => {
+    if (!open) return;
+    const onDocumentClick = (event: MouseEvent) => {
+      if (shouldDismiss(event.target)) onDismiss();
+    };
+    document.addEventListener('click', onDocumentClick);
+    return () => document.removeEventListener('click', onDocumentClick);
+  }, [open, onDismiss]);
+}

--- a/webui/src/routes/search/-search.use-library-check.test.tsx
+++ b/webui/src/routes/search/-search.use-library-check.test.tsx
@@ -134,7 +134,10 @@ describe('useLibraryCheck', () => {
     // Best effort by design: an unbadged owned album is a small loss, an error
     // state over the whole result list is not.
     server.use(
-      http.post('/api/enhanced-search/library-check', () => new HttpResponse(null, { status: 500 })),
+      http.post(
+        '/api/enhanced-search/library-check',
+        () => new HttpResponse(null, { status: 500 }),
+      ),
     );
     const { result } = renderHook(() => useLibraryCheck([album()], [track()]));
     await new Promise((r) => setTimeout(r, 20));
@@ -180,8 +183,8 @@ describe('useLibraryCheck', () => {
       }),
     );
 
-    const { rerender } = renderHook(({ albums }: { albums: SearchAlbum[] }) =>
-      useLibraryCheck(albums, []),
+    const { rerender } = renderHook(
+      ({ albums }: { albums: SearchAlbum[] }) => useLibraryCheck(albums, []),
       { initialProps: { albums: [album()] } },
     );
     await waitFor(() => expect(asks).toBe(1));

--- a/webui/src/routes/search/-search.use-library-check.test.tsx
+++ b/webui/src/routes/search/-search.use-library-check.test.tsx
@@ -1,0 +1,195 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import type { SearchAlbum, SearchTrack } from './-search.types';
+
+import { albumIdentity, trackIdentity } from './-search.helpers';
+import { ownershipFromResponse, useLibraryCheck } from './-search.use-library-check';
+import { EMPTY_OWNERSHIP } from './-ui/search-results';
+
+const album = (over: Partial<SearchAlbum> = {}): SearchAlbum => ({
+  id: 'a1',
+  name: 'Drukqs',
+  artist: 'Aphex Twin',
+  ...over,
+});
+
+const track = (over: Partial<SearchTrack> = {}): SearchTrack => ({
+  id: 't1',
+  name: 'Xtal',
+  artist: 'Aphex Twin',
+  ...over,
+});
+
+describe('ownershipFromResponse', () => {
+  it('keys album answers by identity, not by document position', () => {
+    // The response is in REQUEST order and interleaves albums with singles; the
+    // rendered list is grouped. Indexing the DOM badges an album you do not own.
+    const rows = [
+      album({ id: 'A1', album_type: 'album' }),
+      album({ id: 'S1', album_type: 'single' }),
+      album({ id: 'A2', album_type: 'album' }),
+    ];
+    const state = ownershipFromResponse(rows, [], { albums: [false, true, false] });
+    expect([...state.ownedAlbums]).toEqual([albumIdentity(rows[1])]);
+  });
+
+  it('splits tracks into owned and wished, never both', () => {
+    const rows = [track({ id: 't1' }), track({ id: 't2' }), track({ id: 't3' })];
+    const state = ownershipFromResponse([], rows, {
+      tracks: [
+        { in_library: true, file_path: '/m/a.flac' },
+        { in_wishlist: true },
+        // in_library wins outright — the vanilla's else-if.
+        { in_library: true, in_wishlist: true, file_path: '/m/c.flac' },
+      ],
+    });
+
+    expect(state.ownedTracks.has(trackIdentity(rows[0]))).toBe(true);
+    expect(state.wishlistTracks.has(trackIdentity(rows[1]))).toBe(true);
+    expect(state.ownedTracks.has(trackIdentity(rows[2]))).toBe(true);
+    expect(state.wishlistTracks.has(trackIdentity(rows[2]))).toBe(false);
+  });
+
+  it('keeps the whole library row, for what playLibraryTrack needs', () => {
+    const rows = [track()];
+    const row = {
+      in_library: true,
+      track_id: 42,
+      title: 'Xtal',
+      file_path: '/m/xtal.flac',
+      album_title: 'SAW 85-92',
+      artist_name: 'Aphex Twin',
+      album_thumb_url: 'https://cdn/t.jpg',
+    };
+    const state = ownershipFromResponse([], rows, { tracks: [row] });
+    expect(state.libraryTracks.get(trackIdentity(rows[0]))).toEqual(row);
+  });
+
+  it('does not offer to play an owned track with no local file', () => {
+    // Owned on a Plex-only entry: badge it, but there is nothing to play.
+    const rows = [track()];
+    const state = ownershipFromResponse([], rows, { tracks: [{ in_library: true }] });
+    expect(state.ownedTracks.size).toBe(1);
+    expect(state.libraryTracks.size).toBe(0);
+  });
+
+  it('ignores answers past the end of the list it asked about', () => {
+    const state = ownershipFromResponse([album()], [], { albums: [true, true, true] });
+    expect(state.ownedAlbums.size).toBe(1);
+  });
+
+  it('owns nothing when the check answered nothing', () => {
+    const state = ownershipFromResponse([album()], [track()], null);
+    expect(state.ownedAlbums.size).toBe(0);
+    expect(state.ownedTracks.size).toBe(0);
+  });
+});
+
+describe('useLibraryCheck', () => {
+  it('asks with names and artists only, and badges what came back', async () => {
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post('/api/enhanced-search/library-check', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ albums: [true], tracks: [{ in_wishlist: true }] });
+      }),
+    );
+
+    const albums = [album()];
+    const tracks = [track()];
+    const { result } = renderHook(() => useLibraryCheck(albums, tracks));
+
+    await waitFor(() => expect(result.current.ownedAlbums.size).toBe(1));
+    expect(result.current.wishlistTracks.size).toBe(1);
+    // Ids are useless here: the check matches the local database by name.
+    expect(body).toEqual({
+      albums: [{ name: 'Drukqs', artist: 'Aphex Twin' }],
+      tracks: [{ name: 'Xtal', artist: 'Aphex Twin' }],
+    });
+  });
+
+  it('asks nothing, and re-renders nothing, when there is nothing on screen', async () => {
+    let asked = false;
+    server.use(
+      http.post('/api/enhanced-search/library-check', () => {
+        asked = true;
+        return HttpResponse.json({});
+      }),
+    );
+
+    const { result } = renderHook(() => useLibraryCheck([], []));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(asked).toBe(false);
+    // The SAME object, not an equal one. Handing back a fresh empty state on
+    // every empty query re-renders the whole result surface for nothing —
+    // React bails out only when the identity is unchanged.
+    expect(result.current).toBe(EMPTY_OWNERSHIP);
+  });
+
+  it('leaves every card unbadged when the check fails', async () => {
+    // Best effort by design: an unbadged owned album is a small loss, an error
+    // state over the whole result list is not.
+    server.use(
+      http.post('/api/enhanced-search/library-check', () => new HttpResponse(null, { status: 500 })),
+    );
+    const { result } = renderHook(() => useLibraryCheck([album()], [track()]));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.ownedAlbums.size).toBe(0);
+  });
+
+  it('does not apply an answer to a result set that has been replaced', async () => {
+    // The classic stale-response bug: badges from the previous query landing on
+    // the new one's cards.
+    const pending: (() => void)[] = [];
+    server.use(
+      http.post('/api/enhanced-search/library-check', () => {
+        return new Promise<Response>((resolve) => {
+          pending.push(() => resolve(HttpResponse.json({ albums: [true] })));
+        });
+      }),
+    );
+
+    const first = [album({ id: 'first' })];
+    const { result, rerender, unmount } = renderHook(
+      ({ albums }: { albums: SearchAlbum[] }) => useLibraryCheck(albums, []),
+      { initialProps: { albums: first } },
+    );
+    await waitFor(() => expect(pending).toHaveLength(1));
+
+    rerender({ albums: [album({ id: 'second' })] });
+    pending[0]();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(result.current.ownedAlbums.has(albumIdentity(first[0]))).toBe(false);
+    unmount();
+  });
+
+  it('does not re-ask when a render passes the same rows in a new array', async () => {
+    // The page rebuilds its result arrays freely — emptySourceResults() mints new
+    // ones on every read. Keying the effect on array identity turns each render
+    // into another round trip.
+    let asks = 0;
+    server.use(
+      http.post('/api/enhanced-search/library-check', () => {
+        asks += 1;
+        return HttpResponse.json({ albums: [false] });
+      }),
+    );
+
+    const { rerender } = renderHook(({ albums }: { albums: SearchAlbum[] }) =>
+      useLibraryCheck(albums, []),
+      { initialProps: { albums: [album()] } },
+    );
+    await waitFor(() => expect(asks).toBe(1));
+
+    // Same album, brand new array and object.
+    rerender({ albums: [album()] });
+    rerender({ albums: [album()] });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(asks).toBe(1);
+  });
+});

--- a/webui/src/routes/search/-search.use-library-check.ts
+++ b/webui/src/routes/search/-search.use-library-check.ts
@@ -1,0 +1,110 @@
+/**
+ * "Do I already own this?" for the albums and tracks on screen.
+ *
+ * Ported from _checkSearchResultsLibraryOwnership (search.js:568-648), with one
+ * behaviour deliberately corrected: the answers are carried back to cards by
+ * IDENTITY rather than by list position. See albumOwnershipByIdentity for why the
+ * positional version was wrong.
+ *
+ * The check is best-effort. A failure leaves every card unbadged, which is what
+ * the vanilla's swallowed catch did — an unbadged owned album is a small loss,
+ * an error state over the whole result list is not.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { LibraryCheckTrack, SearchAlbum, SearchTrack } from './-search.types';
+import type { OwnershipState } from './-ui/search-results';
+
+import { fetchLibraryCheck } from './-search.api';
+import { albumIdentity, trackIdentity } from './-search.helpers';
+import { EMPTY_OWNERSHIP } from './-ui/search-results';
+
+/**
+ * Fold the response into ownership sets.
+ *
+ * A track gets EITHER the library badge or the wishlist one, never both — the
+ * vanilla's else-if, and not an accident: on an album card both badges are
+ * positioned at top-left (style.css:40405/40436), so two would sit exactly on
+ * top of each other.
+ */
+export function ownershipFromResponse(
+  albums: SearchAlbum[],
+  tracks: SearchTrack[],
+  response: { albums?: boolean[]; tracks?: LibraryCheckTrack[] } | null,
+): OwnershipState {
+  if (!response) return EMPTY_OWNERSHIP;
+
+  const ownedAlbums = new Set<string>();
+  (response.albums ?? []).forEach((owned, index) => {
+    const album = albums[index];
+    if (owned && album) ownedAlbums.add(albumIdentity(album));
+  });
+
+  const ownedTracks = new Set<string>();
+  const wishlistTracks = new Set<string>();
+  const libraryTracks = new Map<string, LibraryCheckTrack>();
+  (response.tracks ?? []).forEach((row, index) => {
+    const track = tracks[index];
+    if (!row || !track) return;
+    const identity = trackIdentity(track);
+    if (row.in_library) {
+      ownedTracks.add(identity);
+      // Only rows with a path are playable; the rest are owned but unreachable
+      // (a Plex-only entry with no local file).
+      if (row.file_path) libraryTracks.set(identity, row);
+    } else if (row.in_wishlist) {
+      wishlistTracks.add(identity);
+    }
+  });
+
+  return { ownedAlbums, ownedTracks, wishlistTracks, libraryTracks };
+}
+
+/**
+ * Ownership for the current result set, refreshed whenever it changes.
+ *
+ * Keyed on the row identities rather than on the arrays: a caller handing over a
+ * fresh array of the same rows on every render — which is what
+ * emptySourceResults() does for a source with no results — would otherwise re-ask
+ * the server on every render.
+ */
+export function useLibraryCheck(albums: SearchAlbum[], tracks: SearchTrack[]): OwnershipState {
+  const [ownership, setOwnership] = useState<OwnershipState>(EMPTY_OWNERSHIP);
+
+  const key = [
+    ...albums.map((album) => albumIdentity(album)),
+    ...tracks.map((track) => trackIdentity(track)),
+  ].join('|');
+  const rowsRef = useRef({ albums, tracks });
+  rowsRef.current = { albums, tracks };
+
+  useEffect(() => {
+    const { albums: askAlbums, tracks: askTracks } = rowsRef.current;
+    if (!askAlbums.length && !askTracks.length) {
+      setOwnership(EMPTY_OWNERSHIP);
+      return;
+    }
+
+    const controller = new AbortController();
+    let live = true;
+    // fetchLibraryCheck swallows its own failures and answers {}, so the only
+    // job here is to ignore an answer for a result set that is already gone.
+    //
+    // Honest about `live`: the abort below already handles the ordinary case,
+    // and a mutant that drops this flag SURVIVES the suite because of that. It
+    // stays for the ordering the abort cannot catch — a response already parsed
+    // when the results changed, whose `.then` is queued behind the re-render —
+    // but no test pins that, and saying otherwise would be worse than admitting
+    // it.
+    void fetchLibraryCheck(askAlbums, askTracks, controller.signal).then((response) => {
+      if (live) setOwnership(ownershipFromResponse(askAlbums, askTracks, response));
+    });
+    return () => {
+      live = false;
+      controller.abort();
+    };
+  }, [key]);
+
+  return ownership;
+}

--- a/webui/src/routes/search/-search.use-video-downloads.test.tsx
+++ b/webui/src/routes/search/-search.use-video-downloads.test.tsx
@@ -60,9 +60,7 @@ describe('useVideoDownloads', () => {
   });
 
   it('marks the card downloading straight away, before any answer', () => {
-    server.use(
-      http.post('/api/music-video/download', () => new Promise(() => {})),
-    );
+    server.use(http.post('/api/music-video/download', () => new Promise(() => {})));
     const { result } = renderHook(() => useVideoDownloads());
     act(() => result.current.download(video()));
 

--- a/webui/src/routes/search/-search.use-video-downloads.test.tsx
+++ b/webui/src/routes/search/-search.use-video-downloads.test.tsx
@@ -1,0 +1,226 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import type { SearchVideo } from './-search.types';
+
+import { useVideoDownloads } from './-search.use-video-downloads';
+
+const video = (over: Partial<SearchVideo> = {}): SearchVideo => ({
+  video_id: 'v1',
+  title: 'Windowlicker',
+  channel: 'Warp',
+  url: 'https://youtu.be/v1',
+  ...over,
+});
+
+/** Queue of statuses the poller will see, one per call. */
+function stubStatus(sequence: { status?: string; progress?: number }[]) {
+  let index = 0;
+  const asked: string[] = [];
+  server.use(
+    http.post('/api/music-video/download', () => HttpResponse.json({ ok: true })),
+    http.get('/api/music-video/status/:id', ({ params }) => {
+      asked.push(String(params.id));
+      const next = sequence[Math.min(index, sequence.length - 1)];
+      index += 1;
+      return HttpResponse.json(next);
+    }),
+  );
+  return asked;
+}
+
+describe('useVideoDownloads', () => {
+  it('sends what the download endpoint needs, url included', async () => {
+    // The vanilla posts {video_id, url, title, channel} (downloads.js:5463).
+    // `url` is the one that is easy to lose: it is not shown anywhere on the
+    // card, so a missing field is invisible until the download fails.
+    let body: Record<string, unknown> = {};
+    server.use(
+      http.post('/api/music-video/download', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ ok: true });
+      }),
+      http.get('/api/music-video/status/:id', () => HttpResponse.json({ progress: 10 })),
+    );
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+
+    await waitFor(() =>
+      expect(body).toEqual({
+        video_id: 'v1',
+        url: 'https://youtu.be/v1',
+        title: 'Windowlicker',
+        channel: 'Warp',
+      }),
+    );
+  });
+
+  it('marks the card downloading straight away, before any answer', () => {
+    server.use(
+      http.post('/api/music-video/download', () => new Promise(() => {})),
+    );
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+
+    // Not after the round trip: the ring has to appear on the click.
+    expect(result.current.progress.v1).toEqual({ state: 'downloading', percent: 0 });
+  });
+
+  it('follows progress and settles on completed', async () => {
+    stubStatus([{ progress: 40 }, { progress: 80 }, { status: 'completed', progress: 100 }]);
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+
+    await waitFor(() => expect(result.current.progress.v1?.percent).toBe(40), { timeout: 3000 });
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('completed'), {
+      timeout: 5000,
+    });
+    expect(result.current.progress.v1?.percent).toBe(100);
+  });
+
+  it('ignores a progress field that is missing or zero', async () => {
+    // The vanilla guarded on `progress > 0` so an absent field could not snap
+    // the ring back to empty mid-download.
+    stubStatus([{ progress: 55 }, {}, { progress: 0 }]);
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+
+    await waitFor(() => expect(result.current.progress.v1?.percent).toBe(55), { timeout: 3000 });
+    await new Promise((r) => setTimeout(r, 2500));
+    expect(result.current.progress.v1?.percent).toBe(55);
+  });
+
+  it('marks an errored download, and lets it be retried', async () => {
+    // The vanilla re-armed cardEl.onclick on failure. Here that is simply the
+    // absence of the downloading/completed guard.
+    stubStatus([{ status: 'error' }]);
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('errored'), {
+      timeout: 3000,
+    });
+
+    stubStatus([{ status: 'completed', progress: 100 }]);
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('completed'), {
+      timeout: 3000,
+    });
+  });
+
+  it('refuses a second click while one is in flight, and after it finished', async () => {
+    let posts = 0;
+    server.use(
+      http.post('/api/music-video/download', () => {
+        posts += 1;
+        return HttpResponse.json({ ok: true });
+      }),
+      http.get('/api/music-video/status/:id', () => HttpResponse.json({ progress: 50 })),
+    );
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(posts).toBe(1));
+
+    act(() => result.current.download(video()));
+    expect(posts).toBe(1);
+
+    // And once it has completed, clicking must not download it a second time.
+    server.use(
+      http.get('/api/music-video/status/:id', () =>
+        HttpResponse.json({ status: 'completed', progress: 100 }),
+      ),
+    );
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('completed'), {
+      timeout: 3000,
+    });
+    act(() => result.current.download(video()));
+    expect(posts).toBe(1);
+  });
+
+  it('errors the card when the download request itself is refused', async () => {
+    server.use(
+      http.post('/api/music-video/download', () => new HttpResponse(null, { status: 500 })),
+    );
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('errored'));
+  });
+
+  it('keeps polling through a single failed status check', async () => {
+    // One dropped request is not a failed download; the next tick may answer.
+    let calls = 0;
+    server.use(
+      http.post('/api/music-video/download', () => HttpResponse.json({ ok: true })),
+      http.get('/api/music-video/status/:id', () => {
+        calls += 1;
+        if (calls === 1) return new HttpResponse(null, { status: 503 });
+        return HttpResponse.json({ status: 'completed', progress: 100 });
+      }),
+    );
+
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(result.current.progress.v1?.state).toBe('completed'), {
+      timeout: 5000,
+    });
+  });
+
+  it('tracks each video separately', async () => {
+    stubStatus([{ progress: 30 }]);
+    const { result } = renderHook(() => useVideoDownloads());
+
+    act(() => result.current.download(video({ video_id: 'v1' })));
+    act(() => result.current.download(video({ video_id: 'v2' })));
+
+    await waitFor(() => expect(result.current.progress.v1?.percent).toBe(30), { timeout: 3000 });
+    await waitFor(() => expect(result.current.progress.v2?.percent).toBe(30), { timeout: 3000 });
+  });
+
+  it('ignores a video with no id, which nothing could be polled by', async () => {
+    let posts = 0;
+    server.use(
+      http.post('/api/music-video/download', () => {
+        posts += 1;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const { result } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video({ video_id: undefined })));
+
+    // Awaited, not asserted on the spot: the request would be in flight, and a
+    // synchronous check passes whether or not it was ever sent.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(posts).toBe(0);
+    expect(result.current.progress).toEqual({});
+  });
+
+  it('stops polling when the page goes away', async () => {
+    let calls = 0;
+    server.use(
+      http.post('/api/music-video/download', () => HttpResponse.json({ ok: true })),
+      http.get('/api/music-video/status/:id', () => {
+        calls += 1;
+        return HttpResponse.json({ progress: 10 });
+      }),
+    );
+
+    const { result, unmount } = renderHook(() => useVideoDownloads());
+    act(() => result.current.download(video()));
+    await waitFor(() => expect(calls).toBeGreaterThan(0), { timeout: 3000 });
+
+    unmount();
+    const afterUnmount = calls;
+    await new Promise((r) => setTimeout(r, 2500));
+    // A live interval would have added several more requests for a page that
+    // no longer exists.
+    expect(calls).toBe(afterUnmount);
+  });
+});

--- a/webui/src/routes/search/-search.use-video-downloads.ts
+++ b/webui/src/routes/search/-search.use-video-downloads.ts
@@ -1,0 +1,101 @@
+/**
+ * Downloading a music video from the grid, ported from _downloadMusicVideo
+ * (downloads.js:5446-5495).
+ *
+ * The vanilla drove the card's DOM directly — adding classes, unhiding the ring,
+ * writing strokeDashoffset — and re-armed `cardEl.onclick` to retry after a
+ * failure. Here the card is a pure function of state, so this hook owns the
+ * state and VideoGrid renders it.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { SearchVideo } from './-search.types';
+import type { VideoProgress } from './-ui/video-grid';
+
+/** How often the vanilla asked for progress. */
+const POLL_MS = 1000;
+
+interface StatusResponse {
+  status?: string;
+  progress?: number;
+}
+
+export function useVideoDownloads(): {
+  progress: Record<string, VideoProgress>;
+  download: (video: SearchVideo) => void;
+} {
+  const [progress, setProgress] = useState<Record<string, VideoProgress>>({});
+  const timersRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+  const progressRef = useRef(progress);
+  progressRef.current = progress;
+
+  // Every poller has to be stopped, or a navigation away leaves intervals
+  // hitting the server for a page nobody is looking at.
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const id of Object.keys(timers)) clearInterval(timers[id]);
+    };
+  }, []);
+
+  const download = useCallback((video: SearchVideo) => {
+    const id = String(video.video_id ?? '');
+    if (!id) return;
+
+    // A card mid-download or already finished ignores clicks; a FAILED one is
+    // clickable again, which is how the vanilla offered a retry.
+    const current = progressRef.current[id]?.state;
+    if (current === 'downloading' || current === 'completed') return;
+
+    setProgress((prev) => ({ ...prev, [id]: { state: 'downloading', percent: 0 } }));
+
+    void fetch('/api/music-video/download', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        video_id: video.video_id,
+        url: video.url,
+        title: video.title,
+        channel: video.channel,
+      }),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error('Download request failed');
+
+        timersRef.current[id] = setInterval(() => {
+          void fetch(`/api/music-video/status/${encodeURIComponent(id)}`)
+            .then((r) => r.json() as Promise<StatusResponse>)
+            .then((status) => {
+              if (status.status === 'completed') {
+                clearInterval(timersRef.current[id]);
+                delete timersRef.current[id];
+                setProgress((prev) => ({ ...prev, [id]: { state: 'completed', percent: 100 } }));
+                return;
+              }
+              if (status.status === 'error') {
+                clearInterval(timersRef.current[id]);
+                delete timersRef.current[id];
+                setProgress((prev) => ({ ...prev, [id]: { state: 'errored', percent: 0 } }));
+                return;
+              }
+              // Only a real number moves the ring: the vanilla guarded on
+              // `progress > 0` so an absent field could not snap it back to 0.
+              const percent = Number(status.progress);
+              if (Number.isFinite(percent) && percent > 0) {
+                setProgress((prev) => ({ ...prev, [id]: { state: 'downloading', percent } }));
+              }
+            })
+            .catch(() => {
+              // A single failed poll is not a failed download — the next tick
+              // may well answer. The interval keeps running.
+            });
+        }, POLL_MS);
+      })
+      .catch(() => {
+        setProgress((prev) => ({ ...prev, [id]: { state: 'errored', percent: 0 } }));
+      });
+  }, []);
+
+  return { progress, download };
+}

--- a/webui/src/routes/search/-ui/compact-item.test.tsx
+++ b/webui/src/routes/search/-ui/compact-item.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { CompactItemProps } from './compact-item';
+
+import { CompactItem, ResultSection } from './compact-item';
+
+function renderItem(over: Partial<CompactItemProps> = {}) {
+  render(
+    <CompactItem kind="album" name="Drukqs" meta="Aphex Twin" placeholder="💿" {...over} />,
+  );
+  return document.querySelector('.enh-compact-item') as HTMLElement;
+}
+
+afterEach(cleanup);
+
+describe('CompactItem', () => {
+  it('wears the compound class its kind needs, never the bare one', () => {
+    // `.album-card` and `.artist-card` alone belong to the discography grids on
+    // other pages; only the compound `.enh-compact-item.album-card` selector is
+    // styled for search. A bare class here inherits a 300px stacked card.
+    expect(renderItem({ kind: 'album' }).className).toBe('enh-compact-item album-card');
+    cleanup();
+    expect(renderItem({ kind: 'track' }).className).toBe('enh-compact-item track-item');
+    cleanup();
+    expect(renderItem({ kind: 'artist' }).className).toBe('enh-compact-item artist-card');
+    cleanup();
+    expect(renderItem({ kind: 'label' }).className).toBe('enh-compact-item label-card artist-card');
+  });
+
+  it('uses its kind for the image and placeholder classes too', () => {
+    renderItem({ kind: 'track', image: 'https://cdn/a.jpg' });
+    expect(document.querySelector('img')?.className).toBe('enh-item-image track-cover');
+    cleanup();
+    renderItem({ kind: 'track' });
+    expect(document.querySelector('div[data-lazy-image]')?.className).toBe(
+      'enh-item-image-placeholder track-placeholder',
+    );
+  });
+
+  it('is keyboard-operable when it is clickable', () => {
+    const onClick = vi.fn();
+    const card = renderItem({ onClick });
+    expect(card.getAttribute('role')).toBe('button');
+    expect(card.getAttribute('tabindex')).toBe('0');
+
+    fireEvent.keyDown(card, { key: 'Enter' });
+    fireEvent.keyDown(card, { key: ' ' });
+    fireEvent.keyDown(card, { key: 'x' });
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('is not announced as a button when it does nothing', () => {
+    const card = renderItem();
+    expect(card.getAttribute('role')).toBeNull();
+    expect(card.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('renders artists and labels as anchors, but not albums or tracks', () => {
+    // A middle-clickable link is the whole reason these two are anchors; an
+    // album opens a modal, so it stays a div.
+    renderItem({ kind: 'artist', href: '/artist-detail/spotify/1' });
+    expect(document.querySelector('a')?.getAttribute('href')).toBe('/artist-detail/spotify/1');
+    cleanup();
+    renderItem({ kind: 'album', href: '/nope' });
+    expect(document.querySelector('a')).toBeNull();
+  });
+
+  it('shows a duration only on a track', () => {
+    renderItem({ kind: 'track', duration: '3:35' });
+    expect(document.querySelector('.enh-item-duration')?.textContent).toContain('3:35');
+    cleanup();
+    // An album's total runtime would land in the track row's slot; the vanilla
+    // never rendered one there.
+    renderItem({ kind: 'album', duration: '3:35' });
+    expect(document.querySelector('.enh-item-duration')).toBeNull();
+  });
+
+  it('marks a resolved artist image as not needing one', () => {
+    renderItem({ kind: 'artist', artistId: 'sp1', artistName: 'Aphex', image: 'https://cdn/a.jpg' });
+    const card = document.querySelector('[data-artist-id="sp1"]') as HTMLElement;
+    expect(card.getAttribute('data-needs-image')).toBe('false');
+    expect(card.getAttribute('data-artist-name')).toBe('Aphex');
+  });
+
+  it('carries no artist data attributes when there is no artist id', () => {
+    // The lazy loader queries `[data-needs-image="true"]` app-wide; an album card
+    // answering that query would be asked to resolve an artist photo.
+    expect(renderItem().hasAttribute('data-needs-image')).toBe(false);
+  });
+
+  it('stacks extra badges alongside the source badge', () => {
+    renderItem({
+      badge: { text: 'Spotify', className: 'enh-badge-spotify' },
+      extraBadges: [
+        { text: 'In Library', className: 'enh-item-lib-badge' },
+        { text: 'Wishlisted', className: 'enh-item-wishlist-badge' },
+      ],
+    });
+    expect(document.querySelector('.enh-item-badge.enh-badge-spotify')).not.toBeNull();
+    expect(document.querySelector('.enh-item-lib-badge')).not.toBeNull();
+    expect(document.querySelector('.enh-item-wishlist-badge')).not.toBeNull();
+  });
+});
+
+describe('ResultSection', () => {
+  it('renders nothing at all when the count is zero', () => {
+    render(
+      <ResultSection
+        id="s"
+        listId="l"
+        countId="c"
+        icon="💿"
+        title="Albums"
+        kind="album"
+        count={0}
+      >
+        <div>child</div>
+      </ResultSection>,
+    );
+    // Not merely hidden — absent, children included.
+    expect(document.getElementById('s')).toBeNull();
+    expect(document.body.textContent).toBe('');
+  });
+
+  it('gives each kind its own grid class', () => {
+    const section = (kind: 'album' | 'track' | 'artist') =>
+      render(
+        <ResultSection
+          id="s"
+          listId="l"
+          countId="c"
+          icon="x"
+          title="T"
+          kind={kind}
+          count={1}
+        >
+          <div>child</div>
+        </ResultSection>,
+      );
+
+    section('album');
+    expect(document.getElementById('l')?.className).toBe('enh-compact-list enh-albums-grid');
+    cleanup();
+    section('track');
+    expect(document.getElementById('l')?.className).toBe('enh-compact-list enh-tracks-list');
+    cleanup();
+    section('artist');
+    expect(document.getElementById('l')?.className).toBe('enh-compact-list enh-artists-grid');
+  });
+
+  it('titles itself with a heading, as the vanilla did', () => {
+    // The stylesheet keys on the class alone, so this is purely the document
+    // outline; a page of six unheaded lists is worse to navigate by screen
+    // reader for no styling gain.
+    render(
+      <ResultSection id="s" listId="l" countId="c" icon="💿" title="Albums" kind="album" count={1}>
+        <div>child</div>
+      </ResultSection>,
+    );
+    expect(document.querySelector('.enh-section-title')?.tagName).toBe('H4');
+  });
+
+  it('shows the count the header advertises', () => {
+    render(
+      <ResultSection id="s" listId="l" countId="c" icon="💿" title="Albums" kind="album" count={7}>
+        <div>child</div>
+      </ResultSection>,
+    );
+    expect(document.getElementById('c')?.textContent).toBe('7');
+    expect(document.querySelector('.enh-section-title')?.textContent).toBe('Albums');
+  });
+});

--- a/webui/src/routes/search/-ui/compact-item.test.tsx
+++ b/webui/src/routes/search/-ui/compact-item.test.tsx
@@ -6,9 +6,7 @@ import type { CompactItemProps } from './compact-item';
 import { CompactItem, ResultSection } from './compact-item';
 
 function renderItem(over: Partial<CompactItemProps> = {}) {
-  render(
-    <CompactItem kind="album" name="Drukqs" meta="Aphex Twin" placeholder="💿" {...over} />,
-  );
+  render(<CompactItem kind="album" name="Drukqs" meta="Aphex Twin" placeholder="💿" {...over} />);
   return document.querySelector('.enh-compact-item') as HTMLElement;
 }
 
@@ -81,7 +79,12 @@ describe('CompactItem', () => {
   });
 
   it('marks a resolved artist image as not needing one', () => {
-    renderItem({ kind: 'artist', artistId: 'sp1', artistName: 'Aphex', image: 'https://cdn/a.jpg' });
+    renderItem({
+      kind: 'artist',
+      artistId: 'sp1',
+      artistName: 'Aphex',
+      image: 'https://cdn/a.jpg',
+    });
     const card = document.querySelector('[data-artist-id="sp1"]') as HTMLElement;
     expect(card.getAttribute('data-needs-image')).toBe('false');
     expect(card.getAttribute('data-artist-name')).toBe('Aphex');
@@ -154,15 +157,7 @@ describe('CompactItem', () => {
 describe('ResultSection', () => {
   it('renders nothing at all when the count is zero', () => {
     render(
-      <ResultSection
-        id="s"
-        listId="l"
-        countId="c"
-        icon="💿"
-        title="Albums"
-        kind="album"
-        count={0}
-      >
+      <ResultSection id="s" listId="l" countId="c" icon="💿" title="Albums" kind="album" count={0}>
         <div>child</div>
       </ResultSection>,
     );
@@ -174,15 +169,7 @@ describe('ResultSection', () => {
   it('gives each kind its own grid class', () => {
     const section = (kind: 'album' | 'track' | 'artist') =>
       render(
-        <ResultSection
-          id="s"
-          listId="l"
-          countId="c"
-          icon="x"
-          title="T"
-          kind={kind}
-          count={1}
-        >
+        <ResultSection id="s" listId="l" countId="c" icon="x" title="T" kind={kind} count={1}>
           <div>child</div>
         </ResultSection>,
       );

--- a/webui/src/routes/search/-ui/compact-item.test.tsx
+++ b/webui/src/routes/search/-ui/compact-item.test.tsx
@@ -12,7 +12,11 @@ function renderItem(over: Partial<CompactItemProps> = {}) {
   return document.querySelector('.enh-compact-item') as HTMLElement;
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  delete window.extractImageColors;
+  delete window.applyDynamicGlow;
+});
 
 describe('CompactItem', () => {
   it('wears the compound class its kind needs, never the bare one', () => {
@@ -87,6 +91,50 @@ describe('CompactItem', () => {
     // The lazy loader queries `[data-needs-image="true"]` app-wide; an album card
     // answering that query would be asked to resolve an artist photo.
     expect(renderItem().hasAttribute('data-needs-image')).toBe(false);
+  });
+
+  it('glows from its artwork — on an ALBUM, not just an artist', () => {
+    // renderCompactSection ran this for every card with an image
+    // (shared-helpers.js:748-753), and the stylesheet turns the sampled palette
+    // into the hover border and shadow of album, track and artist cards alike.
+    const applyDynamicGlow = vi.fn();
+    window.extractImageColors = vi.fn((_url: string, cb: (colors: unknown) => void) => {
+      cb(['#111', '#222']);
+    }) as never;
+    window.applyDynamicGlow = applyDynamicGlow as never;
+
+    const card = renderItem({ kind: 'album', image: 'https://cdn/cover.jpg' });
+
+    expect(window.extractImageColors).toHaveBeenCalledWith(
+      'https://cdn/cover.jpg',
+      expect.any(Function),
+    );
+    expect(applyDynamicGlow.mock.calls[0][0]).toBe(card);
+  });
+
+  it('does not glow a card that has no artwork', () => {
+    window.extractImageColors = vi.fn() as never;
+    renderItem({ kind: 'album' });
+    expect(window.extractImageColors).not.toHaveBeenCalled();
+  });
+
+  it('stops glowing when the image turns out to be broken', () => {
+    // A 404 falls back to the placeholder; sampling the dead url would paint the
+    // card from nothing.
+    window.extractImageColors = vi.fn() as never;
+    renderItem({ kind: 'album', image: 'https://cdn/missing.jpg' });
+    (window.extractImageColors as unknown as { mockClear: () => void }).mockClear();
+
+    fireEvent.error(document.querySelector('img') as HTMLImageElement);
+    expect(window.extractImageColors).not.toHaveBeenCalled();
+  });
+
+  it('still renders when sampling the palette throws', () => {
+    // Reading pixels off a CORS-opaque image throws; the card must survive it.
+    window.extractImageColors = vi.fn(() => {
+      throw new Error('canvas is tainted');
+    }) as never;
+    expect(renderItem({ kind: 'album', image: 'https://cdn/cover.jpg' })).not.toBeNull();
   });
 
   it('stacks extra badges alongside the source badge', () => {

--- a/webui/src/routes/search/-ui/compact-item.tsx
+++ b/webui/src/routes/search/-ui/compact-item.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 /**
  * One result card, ported from renderCompactSection's per-item DOM.
@@ -47,12 +47,23 @@ export interface CompactItemProps {
   href?: string;
   duration?: string;
   badge?: { text: string; className: string };
-  /** Extra badges the library check adds — in-library / on-wishlist. */
-  extraBadges?: { text: string; className: string }[];
+  /**
+   * Extra badges the library check adds — in-library / on-wishlist.
+   *
+   * `delay` staggers the arrival animation, which is how the vanilla's
+   * setTimeout cascade reads without any timers.
+   */
+  extraBadges?: { text: string; className: string; delay?: string }[];
   artistId?: string | number;
   artistName?: string;
-  onClick?: () => void;
+  /**
+   * Receives the event: a link card has to be able to preventDefault so the
+   * click routes in-app instead of reloading the page.
+   */
+  onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
   onPlay?: () => void;
+  /** The play button's tooltip — it streams, or plays a local file. */
+  playTitle?: string;
 }
 
 export function CompactItem({
@@ -69,6 +80,7 @@ export function CompactItem({
   artistName,
   onClick,
   onPlay,
+  playTitle = 'Stream this track',
 }: CompactItemProps) {
   /**
    * A deterministic image URL that 404s is common — MusicBrainz Cover Art
@@ -77,6 +89,32 @@ export function CompactItem({
    */
   const [imageFailed, setImageFailed] = useState(false);
   const showImage = Boolean(image) && !imageFailed;
+
+  /**
+   * Every card with artwork gets a glow sampled from that artwork.
+   *
+   * Not an artist-only flourish: renderCompactSection ran this for ANY card with
+   * an image (shared-helpers.js:748-753), and the stylesheet turns the sampled
+   * palette into the hover border and box-shadow of album, track and artist
+   * cards alike (style.css:40314/40538). Skipping it leaves every result card
+   * with the plain grey hover it has when art fails to load.
+   *
+   * Keyed on the url, so a lazily-resolved artist photo arriving later glows
+   * too — the same path, one effect.
+   */
+  const cardRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    const card = cardRef.current;
+    if (!card || !image || imageFailed) return;
+    try {
+      window.extractImageColors?.(image, (colors) => {
+        window.applyDynamicGlow?.(card, colors);
+      });
+    } catch {
+      // Reading pixels can throw on a CORS-opaque image. A card without a glow
+      // is fine; a card that failed to render is not.
+    }
+  }, [image, imageFailed]);
 
   const content = (
     <>
@@ -104,7 +142,7 @@ export function CompactItem({
           {duration}
           <button
             className="enh-item-play-btn"
-            title="Stream this track"
+            title={playTitle}
             type="button"
             onClick={(event) => {
               // Without this the card's own click fires too and the download
@@ -119,7 +157,11 @@ export function CompactItem({
       ) : null}
       {badge ? <div className={`enh-item-badge ${badge.className}`}>{badge.text}</div> : null}
       {extraBadges?.map((extra) => (
-        <div key={extra.className} className={extra.className}>
+        <div
+          key={extra.className}
+          className={extra.className}
+          style={extra.delay ? { animationDelay: extra.delay } : undefined}
+        >
           {extra.text}
         </div>
       ))}
@@ -140,10 +182,13 @@ export function CompactItem({
   if (href && (kind === 'artist' || kind === 'label')) {
     return (
       <a
+        ref={cardRef as React.Ref<HTMLAnchorElement>}
         className={CARD_CLASS[kind]}
         href={href}
         aria-label={name || 'Artist'}
         style={{ color: 'inherit', textDecoration: 'none' }}
+        // The handler receives the event so the page can preventDefault and
+        // route in-app; the href stays real for middle-click and copy-link.
         onClick={onClick}
         {...dataAttrs}
       >
@@ -154,6 +199,7 @@ export function CompactItem({
 
   return (
     <div
+      ref={cardRef as React.Ref<HTMLDivElement>}
       className={CARD_CLASS[kind]}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
@@ -162,7 +208,7 @@ export function CompactItem({
         if (!onClick) return;
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();
-          onClick();
+          onClick(event);
         }
       }}
       {...dataAttrs}

--- a/webui/src/routes/search/-ui/compact-item.tsx
+++ b/webui/src/routes/search/-ui/compact-item.tsx
@@ -1,0 +1,228 @@
+import { useState } from 'react';
+
+/**
+ * One result card, ported from renderCompactSection's per-item DOM.
+ *
+ * The class names are the vanilla's and are load-bearing: the stylesheet keys on
+ * the COMPOUND selectors (`.enh-compact-item.album-card`), which is the only
+ * thing keeping these cards clear of the global `.album-card` used by the
+ * artist-detail and library discographies. Rendering `.album-card` alone here
+ * would inherit the 300px stacked treatment from a different page.
+ *
+ * The vanilla inferred the card type from the section id string
+ * (`sectionId.includes('albums')`). That is passed explicitly instead — a
+ * renamed section silently changing card type is a trap, not a feature.
+ */
+export type CompactItemKind = 'artist' | 'label' | 'album' | 'track';
+
+const IMAGE_CLASS: Record<CompactItemKind, string> = {
+  artist: 'artist-image',
+  label: 'artist-image',
+  album: 'album-cover',
+  track: 'track-cover',
+};
+
+const PLACEHOLDER_CLASS: Record<CompactItemKind, string> = {
+  artist: 'artist-placeholder',
+  label: 'artist-placeholder',
+  album: 'album-placeholder',
+  track: 'track-placeholder',
+};
+
+/** Labels piggyback the artist card's styling, hence both classes. */
+const CARD_CLASS: Record<CompactItemKind, string> = {
+  artist: 'enh-compact-item artist-card',
+  label: 'enh-compact-item label-card artist-card',
+  album: 'enh-compact-item album-card',
+  track: 'enh-compact-item track-item',
+};
+
+export interface CompactItemProps {
+  kind: CompactItemKind;
+  name: string;
+  meta: string;
+  placeholder: string;
+  image?: string;
+  /** Artists and labels render as links so middle-click and copy-link work. */
+  href?: string;
+  duration?: string;
+  badge?: { text: string; className: string };
+  /** Extra badges the library check adds — in-library / on-wishlist. */
+  extraBadges?: { text: string; className: string }[];
+  artistId?: string | number;
+  artistName?: string;
+  onClick?: () => void;
+  onPlay?: () => void;
+}
+
+export function CompactItem({
+  kind,
+  name,
+  meta,
+  placeholder,
+  image,
+  href,
+  duration,
+  badge,
+  extraBadges,
+  artistId,
+  artistName,
+  onClick,
+  onPlay,
+}: CompactItemProps) {
+  /**
+   * A deterministic image URL that 404s is common — MusicBrainz Cover Art
+   * Archive urls are constructed without probing first. Falling back to the
+   * placeholder on error is what stops the browser's broken-image glyph.
+   */
+  const [imageFailed, setImageFailed] = useState(false);
+  const showImage = Boolean(image) && !imageFailed;
+
+  const content = (
+    <>
+      {showImage ? (
+        <img
+          src={image}
+          className={`enh-item-image ${IMAGE_CLASS[kind]}`}
+          alt={name}
+          onError={() => setImageFailed(true)}
+        />
+      ) : (
+        <div
+          className={`enh-item-image-placeholder ${PLACEHOLDER_CLASS[kind]}`}
+          data-lazy-image="true"
+        >
+          {placeholder}
+        </div>
+      )}
+      <div className="enh-item-info">
+        <div className="enh-item-name">{name}</div>
+        <div className="enh-item-meta">{meta}</div>
+      </div>
+      {duration && kind === 'track' ? (
+        <div className="enh-item-duration">
+          {duration}
+          <button
+            className="enh-item-play-btn"
+            title="Stream this track"
+            type="button"
+            onClick={(event) => {
+              // Without this the card's own click fires too and the download
+              // modal opens behind the player.
+              event.stopPropagation();
+              onPlay?.();
+            }}
+          >
+            ▶
+          </button>
+        </div>
+      ) : null}
+      {badge ? <div className={`enh-item-badge ${badge.className}`}>{badge.text}</div> : null}
+      {extraBadges?.map((extra) => (
+        <div key={extra.className} className={extra.className}>
+          {extra.text}
+        </div>
+      ))}
+    </>
+  );
+
+  // `data-needs-image` is what the lazy image loader looks for; it must be
+  // 'true' only when there is genuinely nothing to show yet.
+  const dataAttrs =
+    artistId != null
+      ? {
+          'data-artist-id': String(artistId),
+          'data-needs-image': image ? 'false' : 'true',
+          ...(artistName ? { 'data-artist-name': artistName } : {}),
+        }
+      : {};
+
+  if (href && (kind === 'artist' || kind === 'label')) {
+    return (
+      <a
+        className={CARD_CLASS[kind]}
+        href={href}
+        aria-label={name || 'Artist'}
+        style={{ color: 'inherit', textDecoration: 'none' }}
+        onClick={onClick}
+        {...dataAttrs}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <div
+      className={CARD_CLASS[kind]}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={(event) => {
+        if (!onClick) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onClick();
+        }
+      }}
+      {...dataAttrs}
+    >
+      {content}
+    </div>
+  );
+}
+
+/** The grid class each kind's list wears. */
+export const LIST_CLASS: Record<CompactItemKind, string> = {
+  artist: 'enh-artists-grid',
+  label: 'enh-artists-grid',
+  album: 'enh-albums-grid',
+  track: 'enh-tracks-list',
+};
+
+/**
+ * One titled section. Renders nothing at all when empty — the vanilla added
+ * `.hidden`, and an empty section with a "0" count is noise.
+ */
+export function ResultSection({
+  id,
+  listId,
+  countId,
+  icon,
+  title,
+  kind,
+  count,
+  sectionClass,
+  children,
+}: {
+  id: string;
+  listId: string;
+  countId: string;
+  icon: string;
+  title: string;
+  kind: CompactItemKind;
+  count: number;
+  /** Extra section class — `enh-artist-section` strips the card chrome. */
+  sectionClass?: string;
+  children: React.ReactNode;
+}) {
+  if (!count) return null;
+  return (
+    <div className={`enh-dropdown-section${sectionClass ? ` ${sectionClass}` : ''}`} id={id}>
+      <div className="enh-section-header">
+        {/* The icon is display:none in the stylesheet; kept so the markup still
+            matches the vanilla's, and re-showing it stays a CSS-only change. */}
+        <span className="enh-section-icon">{icon}</span>
+        {/* A heading, as the vanilla's was — the styling is class-only, so this
+            is purely the document outline a screen reader reads. */}
+        <h4 className="enh-section-title">{title}</h4>
+        <span className="enh-section-count" id={countId}>
+          {count}
+        </span>
+      </div>
+      <div className={`enh-compact-list ${LIST_CLASS[kind]}`} id={listId}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/search/-ui/search-bar.test.tsx
+++ b/webui/src/routes/search/-ui/search-bar.test.tsx
@@ -7,14 +7,12 @@ import { SearchBar } from './search-bar';
 /** A host that actually re-renders, so the controlled input behaves like the page. */
 function Host({
   onQueryChange,
-  loading = false,
-  onCancel = () => {},
+  onClear,
   onSubmit = () => {},
   onIdSubmit = () => {},
 }: {
   onQueryChange?: (value: string) => void;
-  loading?: boolean;
-  onCancel?: () => void;
+  onClear?: () => void;
   onSubmit?: () => void;
   onIdSubmit?: () => void;
 }) {
@@ -23,13 +21,15 @@ function Host({
   return (
     <SearchBar
       query={query}
-      loading={loading}
       onQueryChange={(value) => {
         setQuery(value);
         onQueryChange?.(value);
       }}
       onSubmit={onSubmit}
-      onCancel={onCancel}
+      onClear={() => {
+        setQuery('');
+        onClear?.();
+      }}
       idValue={idValue}
       onIdChange={setIdValue}
       onIdSubmit={onIdSubmit}
@@ -131,15 +131,28 @@ describe('SearchBar', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it('offers cancel only while a search is in flight', () => {
-    render(<Host />);
+  it('shows the ✕ whenever there is text, not while a search runs', () => {
+    // search.js:241-243 toggles it on `query.length === 0` — nothing to do with
+    // a request being in flight. Tying it to loading hides it while you type.
+    const onClear = vi.fn();
+    render(<Host onClear={onClear} />);
     expect(document.getElementById('enhanced-cancel-btn')).toBeNull();
 
-    cleanup();
-    const onCancel = vi.fn();
-    render(<Host loading onCancel={onCancel} />);
+    typeInto(input(), 'aphex');
+    expect(document.getElementById('enhanced-cancel-btn')).not.toBeNull();
+  });
+
+  it('empties the box when the ✕ is clicked', () => {
+    // It CLEARS; it does not cancel (search.js:278-283).
+    const onClear = vi.fn();
+    render(<Host onClear={onClear} />);
+    typeInto(input(), 'aphex');
+
     fireEvent.click(document.getElementById('enhanced-cancel-btn') as HTMLElement);
-    expect(onCancel).toHaveBeenCalledOnce();
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(input().value).toBe('');
+    // And the button goes away with the text.
+    expect(document.getElementById('enhanced-cancel-btn')).toBeNull();
   });
 
   it('runs an ID lookup from the button and from Enter', () => {
@@ -151,8 +164,27 @@ describe('SearchBar', () => {
     expect(idInput.value).toBe('https://open.spotify.com/album/x');
 
     fireEvent.keyDown(idInput, { key: 'Enter' });
-    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Look up' }));
     expect(onIdSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the ID box’s own affordances', () => {
+    // The placeholder is the only place this feature explains itself (#775),
+    // and autocomplete/spellcheck are wrong for pasted URLs and UUIDs.
+    render(<Host />);
+    const idInput = document.getElementById('enh-id-input') as HTMLInputElement;
+    expect(idInput.placeholder).toBe(
+      '…or paste a Spotify / Apple Music / MusicBrainz / Deezer link, or a MusicBrainz ID',
+    );
+    expect(idInput.getAttribute('autocomplete')).toBe('off');
+    expect(idInput.getAttribute('spellcheck')).toBe('false');
+  });
+
+  it('wears the vanilla’s search glyph', () => {
+    render(<Host />);
+    const glyph = document.querySelector('.enhanced-search-icon');
+    expect(glyph?.tagName).toBe('DIV');
+    expect(glyph?.textContent).toBe('✨');
   });
 
   it('keeps the ids the rest of the app reaches for', () => {

--- a/webui/src/routes/search/-ui/search-bar.test.tsx
+++ b/webui/src/routes/search/-ui/search-bar.test.tsx
@@ -1,0 +1,166 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SearchBar } from './search-bar';
+
+/** A host that actually re-renders, so the controlled input behaves like the page. */
+function Host({
+  onQueryChange,
+  loading = false,
+  onCancel = () => {},
+  onSubmit = () => {},
+  onIdSubmit = () => {},
+}: {
+  onQueryChange?: (value: string) => void;
+  loading?: boolean;
+  onCancel?: () => void;
+  onSubmit?: () => void;
+  onIdSubmit?: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [idValue, setIdValue] = useState('');
+  return (
+    <SearchBar
+      query={query}
+      loading={loading}
+      onQueryChange={(value) => {
+        setQuery(value);
+        onQueryChange?.(value);
+      }}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      idValue={idValue}
+      onIdChange={setIdValue}
+      onIdSubmit={onIdSubmit}
+    />
+  );
+}
+
+const input = () => document.getElementById('enhanced-search-input') as HTMLInputElement;
+
+/**
+ * The prototype setter, which is how you simulate an actual keystroke.
+ *
+ * React patches the INSTANCE `value` descriptor to remember the last value it
+ * knows about. Going through the prototype leaves that tracker stale, so React
+ * treats the following event as a genuine edit — exactly like typing. Writing
+ * `input.value = x` instead hits React's patched setter, updating the tracker,
+ * and React then ignores the event: that is the downloads.js widget's path.
+ */
+const nativeValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!
+  .set as (this: HTMLInputElement, value: string) => void;
+
+function typeInto(element: HTMLInputElement, value: string) {
+  act(() => {
+    nativeValueSetter.call(element, value);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+afterEach(cleanup);
+
+describe('SearchBar', () => {
+  it('reports a keystroke EXACTLY once, and keeps the input in sync', () => {
+    // Both listeners see the one `input` event a keystroke produces. Without the
+    // claim, each edit is reported twice — which this test is the only thing
+    // that catches, since fireEvent.change dispatches no `input` event at all
+    // and so never reaches the native listener.
+    const onQueryChange = vi.fn();
+    render(<Host onQueryChange={onQueryChange} />);
+
+    typeInto(input(), 'a');
+    typeInto(input(), 'ap');
+
+    expect(onQueryChange.mock.calls).toEqual([['a'], ['ap']]);
+    expect(input().value).toBe('ap');
+  });
+
+  it('accepts a programmatic write from the global download widget', () => {
+    // downloads.js:5753 sets `.value` and dispatches a bubbling native `input`
+    // event to hand a query over. React does not fire onChange for it — its value
+    // tracker was updated by the very assignment — so the native listener is the
+    // ONLY thing making the handoff work.
+    const onQueryChange = vi.fn();
+    render(<Host onQueryChange={onQueryChange} />);
+
+    act(() => {
+      input().value = 'from the widget';
+      input().dispatchEvent(new Event('input', { bubbles: true }));
+    });
+
+    expect(onQueryChange).toHaveBeenCalledExactlyOnceWith('from the widget');
+    expect(input().value).toBe('from the widget');
+  });
+
+  it('ignores a programmatic write of the text already on screen', () => {
+    const onQueryChange = vi.fn();
+    render(<Host onQueryChange={onQueryChange} />);
+    typeInto(input(), 'aphex');
+    onQueryChange.mockClear();
+
+    act(() => {
+      input().value = 'aphex';
+      input().dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onQueryChange).not.toHaveBeenCalled();
+  });
+
+  it('still reports a change event that arrives on its own', () => {
+    // Autofill and undo can produce one without a preceding `input`; that lands
+    // on React's onChange and nowhere else, so the React path has to stay live.
+    const onQueryChange = vi.fn();
+    render(<Host onQueryChange={onQueryChange} />);
+    fireEvent.change(input(), { target: { value: 'autofilled' } });
+    expect(onQueryChange).toHaveBeenCalledExactlyOnceWith('autofilled');
+  });
+
+  it('submits on Enter, bypassing the debounce', () => {
+    const onSubmit = vi.fn();
+    render(<Host onSubmit={onSubmit} />);
+    fireEvent.change(input(), { target: { value: 'aphex' } });
+    fireEvent.keyDown(input(), { key: 'Enter' });
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
+  it('ignores other keys', () => {
+    const onSubmit = vi.fn();
+    render(<Host onSubmit={onSubmit} />);
+    fireEvent.keyDown(input(), { key: 'a' });
+    fireEvent.keyDown(input(), { key: 'Escape' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('offers cancel only while a search is in flight', () => {
+    render(<Host />);
+    expect(document.getElementById('enhanced-cancel-btn')).toBeNull();
+
+    cleanup();
+    const onCancel = vi.fn();
+    render(<Host loading onCancel={onCancel} />);
+    fireEvent.click(document.getElementById('enhanced-cancel-btn') as HTMLElement);
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('runs an ID lookup from the button and from Enter', () => {
+    const onIdSubmit = vi.fn();
+    render(<Host onIdSubmit={onIdSubmit} />);
+    const idInput = document.getElementById('enh-id-input') as HTMLInputElement;
+
+    fireEvent.change(idInput, { target: { value: 'https://open.spotify.com/album/x' } });
+    expect(idInput.value).toBe('https://open.spotify.com/album/x');
+
+    fireEvent.keyDown(idInput, { key: 'Enter' });
+    fireEvent.click(screen.getByRole('button', { name: 'Go' }));
+    expect(onIdSubmit).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the ids the rest of the app reaches for', () => {
+    // downloads.js targets #enhanced-search-input by id; renaming it silently
+    // breaks the handoff.
+    render(<Host />);
+    expect(input()).not.toBeNull();
+    expect(document.getElementById('enh-id-input')).not.toBeNull();
+    expect(document.getElementById('enh-id-btn')).not.toBeNull();
+  });
+});

--- a/webui/src/routes/search/-ui/search-bar.tsx
+++ b/webui/src/routes/search/-ui/search-bar.tsx
@@ -26,20 +26,28 @@ type ClaimedEvent = { _nativeHandled?: boolean };
  */
 export function SearchBar({
   query,
-  loading,
   onQueryChange,
   onSubmit,
-  onCancel,
+  onClear,
   idValue,
   onIdChange,
   onIdSubmit,
 }: {
   query: string;
-  loading: boolean;
   onQueryChange: (value: string) => void;
   /** Enter — bypasses the debounce entirely. */
   onSubmit: () => void;
-  onCancel: () => void;
+  /**
+   * The ✕ CLEARS the box; it does not cancel a search.
+   *
+   * Worth being blunt about because the first version of this got it backwards:
+   * search.js:241-243 shows the button whenever the input has ANY text and
+   * hides it when empty — nothing to do with a request being in flight — and
+   * search.js:278-283 empties the input and closes the dropdown when it is
+   * clicked. Tying it to a loading flag hides it while you type and turns it
+   * into a different feature.
+   */
+  onClear: () => void;
   idValue: string;
   onIdChange: (value: string) => void;
   onIdSubmit: () => void;
@@ -67,7 +75,9 @@ export function SearchBar({
     <div className="enhanced-search-input-wrapper">
       <div className="enhanced-search-bar-container">
         <div className="enhanced-search-wrapper">
-          <span className="enhanced-search-icon">🔍</span>
+          {/* ✨ in a div, both as in index.html:4155 — the stylesheet sizes and
+              positions this by class, and the glyph is part of the page's look. */}
+          <div className="enhanced-search-icon">✨</div>
           <input
             ref={inputRef}
             id="enhanced-search-input"
@@ -85,27 +95,31 @@ export function SearchBar({
               }
             }}
           />
-          {loading ? (
+          {query ? (
             <button
               className="enhanced-cancel-btn"
               id="enhanced-cancel-btn"
               type="button"
-              title="Cancel search"
-              onClick={onCancel}
+              title="Clear search"
+              onClick={onClear}
             >
               ✕
             </button>
           ) : null}
         </div>
 
-        {/* Paste a provider URL or a MusicBrainz id to resolve one exact release. */}
+        {/* Paste a provider URL or a MusicBrainz id to resolve one exact release.
+            The placeholder names the four providers on purpose — it is the only
+            place the feature explains itself (#775). */}
         <div className="enh-id-lookup">
           <span className="enh-id-lookup-icon">🔗</span>
           <input
             id="enh-id-input"
             className="enh-id-input"
             type="text"
-            placeholder="Paste a link or ID"
+            placeholder="…or paste a Spotify / Apple Music / MusicBrainz / Deezer link, or a MusicBrainz ID"
+            autoComplete="off"
+            spellCheck={false}
             value={idValue}
             onChange={(event) => onIdChange(event.currentTarget.value)}
             onKeyDown={(event) => {
@@ -116,7 +130,7 @@ export function SearchBar({
             }}
           />
           <button className="enh-id-btn" id="enh-id-btn" type="button" onClick={onIdSubmit}>
-            Go
+            Look up
           </button>
         </div>
       </div>

--- a/webui/src/routes/search/-ui/search-bar.tsx
+++ b/webui/src/routes/search/-ui/search-bar.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useRef } from 'react';
+
+/** Marker the native listener stamps on an event it has already reported. */
+type ClaimedEvent = { _nativeHandled?: boolean };
+
+/**
+ * The query input and the ID-lookup box.
+ *
+ * The input is CONTROLLED but must also honour a programmatic write. The global
+ * download widget (downloads.js:5753) sets `#enhanced-search-input.value`
+ * directly and dispatches `new Event('input', {bubbles:true})` to hand a query
+ * over from elsewhere in the app. React does NOT fire onChange for that: it
+ * patches the input's own `value` descriptor to track the last value it knows
+ * about, and a direct assignment goes through that patched setter, so by the
+ * time the event arrives React sees no change at all. The native listener is the
+ * only thing making the handoff work, and dropping it would break the widget
+ * silently.
+ *
+ * Both listeners see a real keystroke though, so one of them has to yield. The
+ * NATIVE one claims the event and the React one stands down — that order is
+ * forced, not chosen: React delegates at the root container, so the element's
+ * own listener always runs first and a flag set inside onChange would be set too
+ * late to suppress anything. (The React path still earns its keep: a `change`
+ * event with no preceding `input` — as fireEvent.change produces — reaches
+ * onChange and nothing else.)
+ */
+export function SearchBar({
+  query,
+  loading,
+  onQueryChange,
+  onSubmit,
+  onCancel,
+  idValue,
+  onIdChange,
+  onIdSubmit,
+}: {
+  query: string;
+  loading: boolean;
+  onQueryChange: (value: string) => void;
+  /** Enter — bypasses the debounce entirely. */
+  onSubmit: () => void;
+  onCancel: () => void;
+  idValue: string;
+  onIdChange: (value: string) => void;
+  onIdSubmit: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const changeRef = useRef(onQueryChange);
+  changeRef.current = onQueryChange;
+
+  useEffect(() => {
+    const element = inputRef.current;
+    if (!element) return;
+    const onNativeInput = (event: Event) => {
+      // Claimed before anything else, so onChange knows to stand down when this
+      // same event reaches the root.
+      (event as ClaimedEvent)._nativeHandled = true;
+      const value = (event.target as HTMLInputElement).value;
+      // A programmatic write of the text already on screen is not an edit.
+      if (value !== query) changeRef.current(value);
+    };
+    element.addEventListener('input', onNativeInput);
+    return () => element.removeEventListener('input', onNativeInput);
+  }, [query]);
+
+  return (
+    <div className="enhanced-search-input-wrapper">
+      <div className="enhanced-search-bar-container">
+        <div className="enhanced-search-wrapper">
+          <span className="enhanced-search-icon">🔍</span>
+          <input
+            ref={inputRef}
+            id="enhanced-search-input"
+            type="text"
+            placeholder="Search for artists, albums, or tracks..."
+            value={query}
+            onChange={(event) => {
+              if ((event.nativeEvent as ClaimedEvent)._nativeHandled) return;
+              onQueryChange(event.currentTarget.value);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                onSubmit();
+              }
+            }}
+          />
+          {loading ? (
+            <button
+              className="enhanced-cancel-btn"
+              id="enhanced-cancel-btn"
+              type="button"
+              title="Cancel search"
+              onClick={onCancel}
+            >
+              ✕
+            </button>
+          ) : null}
+        </div>
+
+        {/* Paste a provider URL or a MusicBrainz id to resolve one exact release. */}
+        <div className="enh-id-lookup">
+          <span className="enh-id-lookup-icon">🔗</span>
+          <input
+            id="enh-id-input"
+            className="enh-id-input"
+            type="text"
+            placeholder="Paste a link or ID"
+            value={idValue}
+            onChange={(event) => onIdChange(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                onIdSubmit();
+              }
+            }}
+          />
+          <button className="enh-id-btn" id="enh-id-btn" type="button" onClick={onIdSubmit}>
+            Go
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/search/-ui/search-page.tsx
+++ b/webui/src/routes/search/-ui/search-page.tsx
@@ -63,7 +63,7 @@ export function SearchPage() {
     },
     onUnconfiguredSource: (source) => window.openSettingsForSource?.(source),
   });
-  const { state, submitQuery, setActiveSource, seedFromIdLookup } = controller;
+  const { state, submitQuery, setActiveSource, syncQuery, seedFromIdLookup } = controller;
 
   const results = activeResults(state);
   const soulseekActive = state.activeSource === 'soulseek';
@@ -179,17 +179,19 @@ export function SearchPage() {
 
   /**
    * The global download widget syncs its query here before clicking the
-   * Soulseek icon (downloads.js:5710-5735). Without it the click hands off THIS
+   * Soulseek icon (downloads.js:5710-5740). Without it the click hands off THIS
    * page's last query — which, now that results survive navigation, can be a
    * stale one — and overwrites what the widget just typed.
+   *
+   * It SYNCS and does not search. The widget writes the basic input and then
+   * clicks the icon, which is what runs the search; searching here as well
+   * would run it twice, and updating the enhanced input would start the
+   * debounce and run it a third time.
    */
-  const submitRef = useRef(submitQuery);
-  submitRef.current = submitQuery;
+  const syncRef = useRef(syncQuery);
+  syncRef.current = syncQuery;
   useEffect(() => {
-    window._searchPageSetQuery = (next: string) => {
-      setQuery(next);
-      submitRef.current(next.trim());
-    };
+    window._searchPageSetQuery = (next: string) => syncRef.current(next.trim());
     return () => {
       delete window._searchPageSetQuery;
     };

--- a/webui/src/routes/search/-ui/search-page.tsx
+++ b/webui/src/routes/search/-ui/search-page.tsx
@@ -3,13 +3,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SearchAlbum, SearchArtist, SearchLabel, SearchTrack } from '../-search.types';
 import type { LibraryCheckTrack } from '../-search.types';
 
-import { fetchLabels, lookupById } from '../-search.api';
 import {
   openSearchAlbum,
   openSearchTrack,
   playOwnedTrack,
   streamSearchTrack,
 } from '../-search.actions';
+import { fetchLabels, lookupById } from '../-search.api';
 import {
   artistDetailPath,
   fallbackBannerText,
@@ -19,8 +19,8 @@ import {
   shouldSearch,
   sourceLabel,
 } from '../-search.helpers';
-import { useAdoptedBasicSection } from '../-search.use-basic-section';
 import { useArtistImages } from '../-search.use-artist-images';
+import { useAdoptedBasicSection } from '../-search.use-basic-section';
 import { activeResults, getPersistedQuery, useSearchController } from '../-search.use-controller';
 import { useDismissOnOutsideClick } from '../-search.use-dismiss';
 import { useLibraryCheck } from '../-search.use-library-check';
@@ -146,8 +146,11 @@ export function SearchPage() {
    * appears on its own.
    */
   const hasSourceResults =
-    results.db_artists.length + results.artists.length + results.albums.length +
-      results.tracks.length + results.videos.length >
+    results.db_artists.length +
+      results.artists.length +
+      results.albums.length +
+      results.tracks.length +
+      results.videos.length >
     0;
   useEffect(() => {
     const trimmed = state.query.trim();
@@ -239,7 +242,10 @@ export function SearchPage() {
         */}
         <div ref={setBasicHost} style={{ display: 'contents' }} />
 
-        <div className={`search-section${soulseekActive ? '' : ' active'}`} id="enhanced-search-section">
+        <div
+          className={`search-section${soulseekActive ? '' : ' active'}`}
+          id="enhanced-search-section"
+        >
           <SearchBar
             query={query}
             onQueryChange={setQuery}
@@ -268,7 +274,10 @@ export function SearchPage() {
                 <span>✕</span> Close Results
               </button>
 
-              <div className={`enhanced-loading${view === 'loading' ? '' : ' hidden'}`} id="enhanced-loading">
+              <div
+                className={`enhanced-loading${view === 'loading' ? '' : ' hidden'}`}
+                id="enhanced-loading"
+              >
                 <div className="spinner" />
                 <p id="enhanced-loading-text">
                   {idLookupPending
@@ -277,7 +286,10 @@ export function SearchPage() {
                 </p>
               </div>
 
-              <div className={`enhanced-empty${view === 'empty' ? '' : ' hidden'}`} id="enhanced-empty">
+              <div
+                className={`enhanced-empty${view === 'empty' ? '' : ' hidden'}`}
+                id="enhanced-empty"
+              >
                 <div className="empty-icon">🔍</div>
                 <p>No results found</p>
               </div>
@@ -306,7 +318,9 @@ export function SearchPage() {
                   artistImages={artistImages}
                   onArtistHref={onArtistHref}
                   onLabelHref={onLabelHref}
-                  onAlbumClick={(album: SearchAlbum) => void openSearchAlbum(album, state.activeSource)}
+                  onAlbumClick={(album: SearchAlbum) =>
+                    void openSearchAlbum(album, state.activeSource)
+                  }
                   onTrackClick={(track: SearchTrack) => void openSearchTrack(track)}
                   onTrackPlay={(track: SearchTrack, row: LibraryCheckTrack | undefined) => {
                     if (row) playOwnedTrack(row);

--- a/webui/src/routes/search/-ui/search-page.tsx
+++ b/webui/src/routes/search/-ui/search-page.tsx
@@ -11,8 +11,10 @@ import {
   streamSearchTrack,
 } from '../-search.actions';
 import {
+  artistDetailPath,
   fallbackBannerText,
   isIdLookupQuery,
+  labelDetailPath,
   SEARCH_DEBOUNCE_MS,
   shouldSearch,
   sourceLabel,
@@ -199,10 +201,17 @@ export function SearchPage() {
 
   const served = state.fallbacks[state.activeSource];
 
-  const onArtistHref = (artist: SearchArtist) =>
-    `/artist-detail/${encodeURIComponent(String(artist.id ?? ''))}`;
-  const onLabelHref = (label: SearchLabel) =>
-    `/label-detail/${encodeURIComponent(String(label.id ?? ''))}`;
+  /**
+   * A library artist resolves under 'library'; a found one under the source it
+   * came from, with its name in tow. Both need the source SEGMENT — the route is
+   * /artist-detail/$source/$id and a two-segment path resolves to nothing.
+   */
+  const onArtistHref = (artist: SearchArtist, inLibrary: boolean) =>
+    inLibrary
+      ? artistDetailPath(artist.id ?? '')
+      : artistDetailPath(artist.id ?? '', state.activeSource, artist.name);
+
+  const onLabelHref = (label: SearchLabel) => labelDetailPath(label.id ?? '', label.name);
 
   return (
     <div className="downloads-content">

--- a/webui/src/routes/search/-ui/search-page.tsx
+++ b/webui/src/routes/search/-ui/search-page.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import type { SearchAlbum, SearchArtist, SearchLabel, SearchTrack } from '../-search.types';
+import type { LibraryCheckTrack } from '../-search.types';
+
+import { fetchLabels, lookupById } from '../-search.api';
+import {
+  openSearchAlbum,
+  openSearchTrack,
+  playOwnedTrack,
+  streamSearchTrack,
+} from '../-search.actions';
+import {
+  fallbackBannerText,
+  isIdLookupQuery,
+  SEARCH_DEBOUNCE_MS,
+  shouldSearch,
+  sourceLabel,
+} from '../-search.helpers';
+import { useAdoptedBasicSection } from '../-search.use-basic-section';
+import { useArtistImages } from '../-search.use-artist-images';
+import { activeResults, getPersistedQuery, useSearchController } from '../-search.use-controller';
+import { useDismissOnOutsideClick } from '../-search.use-dismiss';
+import { useLibraryCheck } from '../-search.use-library-check';
+import { useVideoDownloads } from '../-search.use-video-downloads';
+import { SearchBar } from './search-bar';
+import { SearchResults } from './search-results';
+import { SourceRow } from './source-row';
+
+/** Which of the dropdown's three bodies is showing. */
+type DropdownView = 'hidden' | 'loading' | 'empty' | 'results';
+
+/**
+ * The enhanced search page.
+ *
+ * The state machine is the vanilla's `_renderFromState` (search.js:109-200),
+ * and its order matters: mid-fetch with no cache is LOADING even though a
+ * previous source's results may still be in the cache; a settled fetch with
+ * nothing in it is EMPTY; and an empty query hides the dropdown outright rather
+ * than showing "no results" for a question nobody asked.
+ *
+ * Labels are counted out of that total on purpose. They come from a separate
+ * endpoint and are purely additive, so a query that matched ONLY labels shows
+ * the empty state — exactly as it does today.
+ */
+export function SearchPage() {
+  const [basicHost, setBasicHost] = useState<HTMLElement | null>(null);
+  // Seeded from the restored cache: coming back to results sitting above an
+  // empty search box reads as a bug even when the results are right.
+  const [query, setQuery] = useState(getPersistedQuery);
+  const [idValue, setIdValue] = useState('');
+  const [dismissed, setDismissed] = useState(false);
+  const [labels, setLabels] = useState<SearchLabel[]>([]);
+  const [idLookupPending, setIdLookupPending] = useState(false);
+
+  const controller = useSearchController({
+    onSoulseekSelected: (handoffQuery) => {
+      // Basic search owns this one: fill its input and run the vanilla's search.
+      const input = document.getElementById('downloads-search-input') as HTMLInputElement | null;
+      if (input && handoffQuery) input.value = handoffQuery;
+      setDismissed(true);
+      if (input?.value) window.performDownloadsSearch?.();
+    },
+    onUnconfiguredSource: (source) => window.openSettingsForSource?.(source),
+  });
+  const { state, submitQuery, setActiveSource, seedFromIdLookup } = controller;
+
+  const results = activeResults(state);
+  const soulseekActive = state.activeSource === 'soulseek';
+
+  useAdoptedBasicSection(basicHost, soulseekActive);
+
+  const ownership = useLibraryCheck(results.albums, results.tracks);
+  const artistImages = useArtistImages(results.db_artists, results.artists, state.activeSource);
+  const { progress: videoProgress, download: downloadVideo } = useVideoDownloads();
+
+  /**
+   * Resolve a pasted link or id on its owning source (#775).
+   *
+   * The backend answers with the single hit plus the source that served it, and
+   * that source is adopted so the album re-fetch and download flow route the
+   * same way a normal search would.
+   */
+  const runIdLookup = useCallback(
+    async (raw: string) => {
+      const value = raw.trim();
+      if (!value) return;
+      setDismissed(false);
+      setIdLookupPending(true);
+      try {
+        const data = await lookupById(value);
+        if (data?.available && data.source) {
+          seedFromIdLookup(value, data);
+        } else {
+          // The backend's own hint, surfaced without destroying what is on
+          // screen — the vanilla toasts and shows the empty state.
+          window.showToast?.(data?.message || 'No match for that link.', 'warning');
+        }
+      } catch {
+        window.showToast?.('Link/ID lookup failed.', 'error');
+      } finally {
+        setIdLookupPending(false);
+      }
+    },
+    [seedFromIdLookup],
+  );
+
+  /**
+   * Enter and the debounce share this.
+   *
+   * A bare MusicBrainz UUID is an exact identifier, not a name, so it goes to
+   * the id resolver from BOTH paths rather than being fuzzy-searched.
+   */
+  const runSearch = useCallback(
+    (raw: string) => {
+      const trimmed = raw.trim();
+      if (!shouldSearch(trimmed)) return;
+      if (isIdLookupQuery(trimmed)) {
+        void runIdLookup(trimmed);
+        return;
+      }
+      setDismissed(false);
+      submitQuery(trimmed);
+    },
+    [submitQuery, runIdLookup],
+  );
+
+  /** The debounce. Raised to 600ms for #751 so a name coalesces into ONE search. */
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!shouldSearch(trimmed)) {
+      setDismissed(true);
+      return;
+    }
+    const timer = setTimeout(() => runSearch(trimmed), SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [query, runSearch]);
+
+  /**
+   * Labels, fetched once per query and rendered alongside the source results.
+   *
+   * Only when there is something else to show: the vanilla reaches
+   * _maybeFetchLabels AFTER the empty-state return, so a labels-only match never
+   * appears on its own.
+   */
+  const hasSourceResults =
+    results.db_artists.length + results.artists.length + results.albums.length +
+      results.tracks.length + results.videos.length >
+    0;
+  useEffect(() => {
+    const trimmed = state.query.trim();
+    if (!trimmed || !hasSourceResults) {
+      setLabels([]);
+      return;
+    }
+    let live = true;
+    void fetchLabels(trimmed).then((found) => {
+      if (live) setLabels(found);
+    });
+    return () => {
+      live = false;
+    };
+  }, [state.query, hasSourceResults]);
+
+  const loading = state.loadingSources.has(state.activeSource) || idLookupPending;
+  const cached = Boolean(state.sources[state.activeSource]);
+
+  const view: DropdownView = useMemo(() => {
+    if (dismissed || soulseekActive) return 'hidden';
+    if (idLookupPending) return 'loading';
+    if (loading && !cached) return 'loading';
+    if (!cached) return state.query ? 'empty' : 'hidden';
+    return hasSourceResults ? 'results' : 'empty';
+  }, [dismissed, soulseekActive, idLookupPending, loading, cached, state.query, hasSourceResults]);
+
+  const open = view !== 'hidden';
+  const onDismiss = useCallback(() => setDismissed(true), []);
+  useDismissOnOutsideClick(open, onDismiss);
+
+  /**
+   * The global download widget syncs its query here before clicking the
+   * Soulseek icon (downloads.js:5710-5735). Without it the click hands off THIS
+   * page's last query — which, now that results survive navigation, can be a
+   * stale one — and overwrites what the widget just typed.
+   */
+  const submitRef = useRef(submitQuery);
+  submitRef.current = submitQuery;
+  useEffect(() => {
+    window._searchPageSetQuery = (next: string) => {
+      setQuery(next);
+      submitRef.current(next.trim());
+    };
+    return () => {
+      delete window._searchPageSetQuery;
+    };
+  }, []);
+
+  const served = state.fallbacks[state.activeSource];
+
+  const onArtistHref = (artist: SearchArtist) =>
+    `/artist-detail/${encodeURIComponent(String(artist.id ?? ''))}`;
+  const onLabelHref = (label: SearchLabel) =>
+    `/label-detail/${encodeURIComponent(String(label.id ?? ''))}`;
+
+  return (
+    <div className="downloads-content">
+      <div className="downloads-main-panel">
+        <div className={`downloads-header${open ? ' enh-results-active-hide' : ''}`}>
+          <div className="downloads-header-content">
+            <div className="downloads-header-text">
+              <h2 className="downloads-title">
+                <img src="/static/search.png" className="page-header-icon" alt="" />
+                <span>Search</span>
+              </h2>
+              <p className="downloads-subtitle">
+                Find artists, albums, and tracks from any metadata source
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <SourceRow state={state} onSelect={setActiveSource} onOpenSettings={openSettings} />
+
+        {/*
+          The vanilla basic-search panel is MOVED in here; see the hook.
+          display:contents so this wrapper adds nothing to the layout — the
+          panel keeps the box it has as a direct child of the main panel.
+        */}
+        <div ref={setBasicHost} style={{ display: 'contents' }} />
+
+        <div className={`search-section${soulseekActive ? '' : ' active'}`} id="enhanced-search-section">
+          <SearchBar
+            query={query}
+            onQueryChange={setQuery}
+            onSubmit={() => runSearch(query)}
+            onClear={() => {
+              setQuery('');
+              setDismissed(true);
+            }}
+            idValue={idValue}
+            onIdChange={setIdValue}
+            onIdSubmit={() => void runIdLookup(idValue)}
+          />
+
+          <div id="enhanced-dropdown" className={`enhanced-dropdown${open ? '' : ' hidden'}`}>
+            <div className="enhanced-dropdown-content">
+              <button
+                id="enhanced-dropdown-close"
+                className="enhanced-dropdown-close"
+                type="button"
+                onClick={(event) => {
+                  // The document-level dismiss would fire on this same click.
+                  event.stopPropagation();
+                  setDismissed(true);
+                }}
+              >
+                <span>✕</span> Close Results
+              </button>
+
+              <div className={`enhanced-loading${view === 'loading' ? '' : ' hidden'}`} id="enhanced-loading">
+                <div className="spinner" />
+                <p id="enhanced-loading-text">
+                  {idLookupPending
+                    ? 'Resolving link…'
+                    : `Searching ${sourceLabel(state.activeSource)} and your library...`}
+                </p>
+              </div>
+
+              <div className={`enhanced-empty${view === 'empty' ? '' : ' hidden'}`} id="enhanced-empty">
+                <div className="empty-icon">🔍</div>
+                <p>No results found</p>
+              </div>
+
+              <div
+                id="enhanced-results-container"
+                className={`enhanced-results-container${view === 'results' ? '' : ' hidden'}`}
+              >
+                <div
+                  id="enh-fallback-banner"
+                  className={`enh-fallback-banner${served ? '' : ' hidden'}`}
+                >
+                  {served ? fallbackBannerText(state.activeSource, served) : null}
+                </div>
+
+                <SearchResults
+                  activeSource={state.activeSource}
+                  dbArtists={results.db_artists}
+                  artists={results.artists}
+                  albums={results.albums}
+                  tracks={results.tracks}
+                  labels={labels}
+                  videos={results.videos}
+                  videoProgress={videoProgress}
+                  ownership={ownership}
+                  artistImages={artistImages}
+                  onArtistHref={onArtistHref}
+                  onLabelHref={onLabelHref}
+                  onAlbumClick={(album: SearchAlbum) => void openSearchAlbum(album, state.activeSource)}
+                  onTrackClick={(track: SearchTrack) => void openSearchTrack(track)}
+                  onTrackPlay={(track: SearchTrack, row: LibraryCheckTrack | undefined) => {
+                    if (row) playOwnedTrack(row);
+                    else void streamSearchTrack(track);
+                  }}
+                  onVideoDownload={downloadVideo}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/*
+            NOT decoration. showSearchDownloadBubbles (shared-helpers.js:2385)
+            renders the download-progress bubbles into #enhanced-main-results-area,
+            fed by the registerSearchDownload call every album and track download
+            makes. Without this container those downloads have nowhere to draw and
+            the function silently returns. Its children are static so React never
+            re-renders over what the vanilla writes there.
+          */}
+          <div className={`search-results-container${open ? ' enh-results-active-hide' : ''}`}>
+            <div className="search-results-header">
+              <h3>Search Results</h3>
+            </div>
+            <div className="search-results-scroll-area" id="enhanced-main-results-area">
+              <div className="search-results-placeholder">
+                <p>Search results will appear here when you select an album or track.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Jump to the Settings card for a source that has no credentials. */
+function openSettings(source: string) {
+  window.openSettingsForSource?.(source);
+}

--- a/webui/src/routes/search/-ui/search-results.test.tsx
+++ b/webui/src/routes/search/-ui/search-results.test.tsx
@@ -1,0 +1,277 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SearchAlbum, SearchTrack } from '../-search.types';
+
+import { albumIdentity, trackIdentity } from '../-search.helpers';
+import { EMPTY_OWNERSHIP, SearchResults } from './search-results';
+
+const album = (over: Partial<SearchAlbum> = {}): SearchAlbum => ({
+  id: 'a1',
+  name: 'Drukqs',
+  artist: 'Aphex Twin',
+  album_type: 'album',
+  source: 'spotify',
+  ...over,
+});
+
+function renderResults(props: Partial<Parameters<typeof SearchResults>[0]> = {}) {
+  return render(
+    <SearchResults
+      activeSource="spotify"
+      dbArtists={[]}
+      artists={[]}
+      albums={[]}
+      tracks={[]}
+      labels={[]}
+      videos={[]}
+      videoProgress={{}}
+      ownership={EMPTY_OWNERSHIP}
+      artistImages={{}}
+      onArtistHref={(a) => `/artist-detail/spotify/${a.id}`}
+      onLabelHref={(l) => `/label-detail/${l.id}`}
+      onAlbumClick={vi.fn()}
+      onTrackClick={vi.fn()}
+      onTrackPlay={vi.fn()}
+      onVideoDownload={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+describe('SearchResults', () => {
+  it('renders nothing for a section with no results', () => {
+    // An empty section with a "0" count is noise; the vanilla hid it.
+    renderResults();
+    expect(document.getElementById('enh-albums-section')).toBeNull();
+    expect(document.getElementById('enh-tracks-section')).toBeNull();
+  });
+
+  it('splits albums from singles and EPs into their own sections', () => {
+    renderResults({
+      albums: [
+        album({ id: '1', name: 'LP', album_type: 'album' }),
+        album({ id: '2', name: 'A Single', album_type: 'single' }),
+        album({ id: '3', name: 'An EP', album_type: 'ep' }),
+      ],
+    });
+
+    const albumsList = document.getElementById('enh-albums-list');
+    const singlesList = document.getElementById('enh-singles-list');
+    expect(albumsList?.textContent).toContain('LP');
+    expect(singlesList?.textContent).toContain('A Single');
+    expect(singlesList?.textContent).toContain('An EP');
+    expect(document.getElementById('enh-albums-count')?.textContent).toBe('1');
+    expect(document.getElementById('enh-singles-count')?.textContent).toBe('2');
+  });
+
+  it('badges the RIGHT album when albums and singles interleave', () => {
+    // The whole point of keying ownership by identity. In document order this
+    // owned single is the LAST card; in request order it is the middle row.
+    const rows = [
+      album({ id: 'A1', name: 'First LP', album_type: 'album' }),
+      album({ id: 'S1', name: 'Owned Single', album_type: 'single' }),
+      album({ id: 'A2', name: 'Second LP', album_type: 'album' }),
+    ];
+    renderResults({
+      albums: rows,
+      ownership: { ...EMPTY_OWNERSHIP, ownedAlbums: new Set([albumIdentity(rows[1])]) },
+    });
+
+    const badges = document.querySelectorAll('.enh-item-lib-badge');
+    expect(badges).toHaveLength(1);
+    // The badge sits on the single, not on whichever card shares its index.
+    expect(badges[0].closest('.enh-compact-item')?.textContent).toContain('Owned Single');
+  });
+
+  it('keeps the compound card classes the stylesheet targets', () => {
+    // `.album-card` alone collides with the global one used by the
+    // artist-detail and library discographies; the compound is the guard.
+    renderResults({ albums: [album()], tracks: [{ id: 't1', name: 'Xtal' }] });
+    expect(document.querySelector('.enh-compact-item.album-card')).not.toBeNull();
+    expect(document.querySelector('.enh-compact-item.track-item')).not.toBeNull();
+  });
+
+  it('renders artists and labels as real links', () => {
+    // Links, not click handlers — middle-click and copy-link have to work.
+    renderResults({
+      artists: [{ id: 'sp1', name: 'Aphex Twin', source: 'spotify' }],
+      labels: [{ id: 'l1', name: 'Warp' }],
+    });
+    expect(screen.getByText('Aphex Twin').closest('a')?.getAttribute('href')).toBe(
+      '/artist-detail/spotify/sp1',
+    );
+    expect(screen.getByText('Warp').closest('a')?.getAttribute('href')).toBe('/label-detail/l1');
+  });
+
+  it('gives a label card the artist styling it piggybacks on', () => {
+    renderResults({ labels: [{ id: 'l1', name: 'Warp' }] });
+    const card = screen.getByText('Warp').closest('.enh-compact-item');
+    expect(card?.className).toContain('label-card');
+    expect(card?.className).toContain('artist-card');
+  });
+
+  it('shows a library artist its track count and a source artist its source', () => {
+    renderResults({
+      dbArtists: [{ id: 1, name: 'Owned', track_count: 12 }],
+      artists: [{ id: 'sp1', name: 'Found', source: 'deezer' }],
+    });
+    const metas = [...document.querySelectorAll('.enh-item-meta')].map((el) => el.textContent);
+    expect(metas).toEqual(['12 tracks', 'Deezer']);
+  });
+
+  it('marks a needs-image artist for the lazy loader, and a resolved one not', () => {
+    renderResults({
+      artists: [
+        { id: 'no-img', name: 'Needs', source: 'spotify' },
+        { id: 'has-img', name: 'Has', source: 'spotify', image_url: 'https://cdn/a.jpg' },
+      ],
+    });
+    expect(
+      document.querySelector('[data-artist-id="no-img"]')?.getAttribute('data-needs-image'),
+    ).toBe('true');
+    expect(
+      document.querySelector('[data-artist-id="has-img"]')?.getAttribute('data-needs-image'),
+    ).toBe('false');
+  });
+
+  it('prefers a lazily-resolved image over the source one', () => {
+    renderResults({
+      artists: [{ id: 'sp1', name: 'A', source: 'spotify', image_url: 'https://cdn/old.jpg' }],
+      artistImages: { sp1: 'https://cdn/resolved.jpg' },
+    });
+    expect(document.querySelector('img')?.getAttribute('src')).toBe('https://cdn/resolved.jpg');
+  });
+
+  it('falls back to the placeholder when an image 404s', () => {
+    // MusicBrainz cover-art urls are built without probing, so misses are
+    // routine; the browser's broken-image glyph is not acceptable.
+    renderResults({ albums: [album({ image_url: 'https://cdn/missing.jpg' })] });
+    const img = document.querySelector('img') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(document.querySelector('.album-placeholder')?.textContent).toBe('💿');
+  });
+
+  it('opens an album, and a track, through their own handlers', () => {
+    const onAlbumClick = vi.fn();
+    const onTrackClick = vi.fn();
+    renderResults({ albums: [album()], tracks: [{ id: 't1', name: 'Xtal' }], onAlbumClick, onTrackClick });
+
+    fireEvent.click(screen.getByText('Drukqs'));
+    fireEvent.click(screen.getByText('Xtal'));
+    expect(onAlbumClick).toHaveBeenCalledOnce();
+    expect(onTrackClick).toHaveBeenCalledOnce();
+  });
+
+  it('plays a track without also opening its download modal', () => {
+    const onTrackClick = vi.fn();
+    const onTrackPlay = vi.fn();
+    const track: SearchTrack = { id: 't1', name: 'Xtal', duration_ms: 60_000 };
+    renderResults({ tracks: [track], onTrackClick, onTrackPlay });
+
+    fireEvent.click(document.querySelector('.enh-item-play-btn') as HTMLElement);
+    expect(onTrackPlay).toHaveBeenCalledOnce();
+    // The card's own click must not fire underneath the button.
+    expect(onTrackClick).not.toHaveBeenCalled();
+  });
+
+  it('hands a local file path to the play handler for an owned track', () => {
+    // An owned track plays from disk; the vanilla swapped the button's listener
+    // by cloning it, which is the same decision made messily.
+    const onTrackPlay = vi.fn();
+    const track: SearchTrack = { id: 't1', name: 'Xtal', duration_ms: 60_000 };
+    renderResults({
+      tracks: [track],
+      onTrackPlay,
+      ownership: {
+        ...EMPTY_OWNERSHIP,
+        ownedTracks: new Set([trackIdentity(track)]),
+        playableTracks: new Map([[trackIdentity(track), '/music/xtal.flac']]),
+      },
+    });
+
+    fireEvent.click(document.querySelector('.enh-item-play-btn') as HTMLElement);
+    expect(onTrackPlay).toHaveBeenCalledWith(track, '/music/xtal.flac');
+  });
+
+  it('shows both library and wishlist badges on a track', () => {
+    const track: SearchTrack = { id: 't1', name: 'Xtal' };
+    renderResults({
+      tracks: [track],
+      ownership: {
+        ...EMPTY_OWNERSHIP,
+        ownedTracks: new Set([trackIdentity(track)]),
+        wishlistTracks: new Set([trackIdentity(track)]),
+      },
+    });
+    expect(document.querySelector('.enh-item-lib-badge')).not.toBeNull();
+    expect(document.querySelector('.enh-item-wishlist-badge')).not.toBeNull();
+  });
+
+  it('pairs the two artist sections inside the wrapper that lays them out', () => {
+    // Without .enh-artists-wrapper the two sections stack, and without
+    // .enh-artist-section each grows the card chrome (border, background,
+    // shadow) that the design strips from exactly these two.
+    renderResults({
+      dbArtists: [{ id: 1, name: 'Owned' }],
+      artists: [{ id: 'sp1', name: 'Found', source: 'spotify' }],
+    });
+    const wrapper = document.querySelector('.enh-artists-wrapper');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.querySelectorAll('.enh-dropdown-section')).toHaveLength(2);
+    expect(document.getElementById('enh-db-artists-section')?.className).toContain(
+      'enh-artist-section',
+    );
+    expect(document.getElementById('enh-spotify-artists-section')?.className).toContain(
+      'enh-artist-section',
+    );
+    // Albums are NOT in the wrapper and keep the normal card chrome.
+    expect(document.getElementById('enh-albums-section')).toBeNull();
+  });
+
+  it('leaves out the wrapper entirely when neither artist section has results', () => {
+    // The wrapper carries its own 24px margin-bottom, so an empty one is a gap
+    // above Albums with nothing in it.
+    renderResults({ albums: [album()] });
+    expect(document.querySelector('.enh-artists-wrapper')).toBeNull();
+  });
+
+  it('keeps the wrapper when only one of the two has results', () => {
+    renderResults({ artists: [{ id: 'sp1', name: 'Found', source: 'spotify' }] });
+    expect(document.querySelector('.enh-artists-wrapper')).not.toBeNull();
+    expect(document.getElementById('enh-db-artists-section')).toBeNull();
+  });
+
+  it('shows ONLY the video grid for the youtube_videos source', () => {
+    // search.js:178-186 hides all six sections for this source. Labels matter
+    // most: they are fetched additively, so without the rule a video search
+    // sprouts a Labels section the vanilla never showed.
+    renderResults({
+      activeSource: 'youtube_videos',
+      videos: [{ video_id: 'v1', title: 'Clip', channel: 'Ch', duration: 215 }],
+      labels: [{ id: 'l1', name: 'Warp' }],
+      albums: [album()],
+      artists: [{ id: 'sp1', name: 'Found', source: 'spotify' }],
+    });
+
+    expect(document.getElementById('enh-videos-section')).not.toBeNull();
+    // Seconds, not milliseconds — a different unit from track durations.
+    expect(screen.getByText('3:35')).toBeInTheDocument();
+    expect(document.getElementById('enh-labels-section')).toBeNull();
+    expect(document.getElementById('enh-albums-section')).toBeNull();
+    expect(document.querySelector('.enh-artists-wrapper')).toBeNull();
+  });
+
+  it('says so when a video search found nothing, rather than going blank', () => {
+    renderResults({ activeSource: 'youtube_videos', videos: [] });
+    expect(document.getElementById('enh-videos-section')).not.toBeNull();
+    expect(screen.getByText('No music videos found')).toBeInTheDocument();
+  });
+
+  it('never renders a video grid under a metadata source', () => {
+    renderResults({ albums: [album()] });
+    expect(document.getElementById('enh-videos-section')).toBeNull();
+  });
+});

--- a/webui/src/routes/search/-ui/search-results.test.tsx
+++ b/webui/src/routes/search/-ui/search-results.test.tsx
@@ -205,7 +205,12 @@ describe('SearchResults', () => {
   it('opens an album, and a track, through their own handlers', () => {
     const onAlbumClick = vi.fn();
     const onTrackClick = vi.fn();
-    renderResults({ albums: [album()], tracks: [{ id: 't1', name: 'Xtal' }], onAlbumClick, onTrackClick });
+    renderResults({
+      albums: [album()],
+      tracks: [{ id: 't1', name: 'Xtal' }],
+      onAlbumClick,
+      onTrackClick,
+    });
 
     fireEvent.click(screen.getByText('Drukqs'));
     fireEvent.click(screen.getByText('Xtal'));
@@ -342,7 +347,10 @@ describe('SearchResults', () => {
   });
 
   it('shows a library artist a resolved image', () => {
-    renderResults({ dbArtists: [{ id: 7, name: 'Owned' }], artistImages: { 7: 'https://cdn/a.jpg' } });
+    renderResults({
+      dbArtists: [{ id: 7, name: 'Owned' }],
+      artistImages: { 7: 'https://cdn/a.jpg' },
+    });
     expect(document.querySelector('img')?.getAttribute('src')).toBe('https://cdn/a.jpg');
   });
 

--- a/webui/src/routes/search/-ui/search-results.test.tsx
+++ b/webui/src/routes/search/-ui/search-results.test.tsx
@@ -113,13 +113,61 @@ describe('SearchResults', () => {
     expect(card?.className).toContain('artist-card');
   });
 
-  it('shows a library artist its track count and a source artist its source', () => {
+  it('names each artist section in its cards, without inventing a count', () => {
+    // db_artists carry only id/name/image_url, so any count would read 0.
     renderResults({
-      dbArtists: [{ id: 1, name: 'Owned', track_count: 12 }],
+      dbArtists: [{ id: 1, name: 'Owned' }],
       artists: [{ id: 'sp1', name: 'Found', source: 'deezer' }],
     });
     const metas = [...document.querySelectorAll('.enh-item-meta')].map((el) => el.textContent);
-    expect(metas).toEqual(['12 tracks', 'Deezer']);
+    expect(metas).toEqual(['In Your Library', 'Artist']);
+  });
+
+  it('badges an artist with the source being VIEWED, not the row’s own', () => {
+    // A Deezer row read under the Spotify tab is still a Spotify result set; the
+    // vanilla derives the badge from the active tab (search.js:465-468).
+    renderResults({
+      activeSource: 'itunes',
+      artists: [{ id: 'sp1', name: 'Found', source: 'deezer' }],
+    });
+    const badge = document.querySelector('.enh-item-badge');
+    expect(badge?.textContent).toBe('Apple Music');
+    expect(badge?.className).toContain('enh-badge-itunes');
+  });
+
+  it('leaves albums, singles and tracks unbadged', () => {
+    // Only the Artists section gets a source badge — search.js passes
+    // `sourceBadge` to that one call. A badge on every card is noise the design
+    // dropped, and the lit picker icon already says where results came from.
+    renderResults({
+      albums: [album(), album({ id: 's1', album_type: 'single' })],
+      tracks: [{ id: 't1', name: 'Xtal', artist: 'Aphex Twin', album: 'SAW 85-92' }],
+    });
+    expect(document.querySelector('.enh-item-badge')).toBeNull();
+  });
+
+  it('reads a track’s album as the plain string the API sends', () => {
+    // sources.py:105 copies Track.album, which is a str. Treating it as an
+    // object drops the album from every track's meta line.
+    renderResults({
+      tracks: [{ id: 't1', name: 'Xtal', artist: 'Aphex Twin', album: 'SAW 85-92' }],
+    });
+    expect(document.querySelector('.enh-item-meta')?.textContent).toBe('Aphex Twin • SAW 85-92');
+  });
+
+  it('gives an album card its year, or N/A', () => {
+    renderResults({
+      albums: [album({ release_date: '2001-10-22' }), album({ id: 'a2', release_date: undefined })],
+    });
+    const metas = [...document.querySelectorAll('.enh-item-meta')].map((el) => el.textContent);
+    expect(metas).toEqual(['Aphex Twin • 2001', 'Aphex Twin • N/A']);
+  });
+
+  it('hides labels under soulseek as well as youtube_videos', () => {
+    // Labels are fetched additively, so both sources need the section hidden
+    // explicitly (search.js:429-434).
+    renderResults({ activeSource: 'soulseek', labels: [{ id: 'l1', name: 'Warp' }] });
+    expect(document.getElementById('enh-labels-section')).toBeNull();
   });
 
   it('marks a needs-image artist for the lazy loader, and a resolved one not', () => {
@@ -177,26 +225,53 @@ describe('SearchResults', () => {
     expect(onTrackClick).not.toHaveBeenCalled();
   });
 
-  it('hands a local file path to the play handler for an owned track', () => {
-    // An owned track plays from disk; the vanilla swapped the button's listener
-    // by cloning it, which is the same decision made messily.
+  it('hands the whole library row to the play handler for an owned track', () => {
+    // playLibraryTrack needs the library id, title, thumb and album/artist
+    // names, none of which the search result carries — only the library check
+    // knows them. The vanilla swapped the button's listener by cloning it; a
+    // prop is the same decision made once.
     const onTrackPlay = vi.fn();
     const track: SearchTrack = { id: 't1', name: 'Xtal', duration_ms: 60_000 };
+    const row = {
+      in_library: true,
+      track_id: 99,
+      title: 'Xtal',
+      file_path: '/music/xtal.flac',
+      album_title: 'SAW 85-92',
+      artist_name: 'Aphex Twin',
+    };
     renderResults({
       tracks: [track],
       onTrackPlay,
       ownership: {
         ...EMPTY_OWNERSHIP,
         ownedTracks: new Set([trackIdentity(track)]),
-        playableTracks: new Map([[trackIdentity(track), '/music/xtal.flac']]),
+        libraryTracks: new Map([[trackIdentity(track), row]]),
       },
     });
 
+    expect(document.querySelector('.enh-item-play-btn')?.getAttribute('title')).toBe(
+      'Play from library',
+    );
     fireEvent.click(document.querySelector('.enh-item-play-btn') as HTMLElement);
-    expect(onTrackPlay).toHaveBeenCalledWith(track, '/music/xtal.flac');
+    expect(onTrackPlay).toHaveBeenCalledWith(track, row);
   });
 
-  it('shows both library and wishlist badges on a track', () => {
+  it('streams a track it does not own, and says so', () => {
+    const onTrackPlay = vi.fn();
+    const track: SearchTrack = { id: 't1', name: 'Xtal', duration_ms: 60_000 };
+    renderResults({ tracks: [track], onTrackPlay });
+
+    expect(document.querySelector('.enh-item-play-btn')?.getAttribute('title')).toBe(
+      'Stream this track',
+    );
+    fireEvent.click(document.querySelector('.enh-item-play-btn') as HTMLElement);
+    expect(onTrackPlay).toHaveBeenCalledWith(track, undefined);
+  });
+
+  it('shows a track ONE badge, never both', () => {
+    // The vanilla's else-if. Both badges are absolutely positioned at the same
+    // corner (style.css:40405/40436), so two would sit on top of each other.
     const track: SearchTrack = { id: 't1', name: 'Xtal' };
     renderResults({
       tracks: [track],
@@ -207,7 +282,68 @@ describe('SearchResults', () => {
       },
     });
     expect(document.querySelector('.enh-item-lib-badge')).not.toBeNull();
-    expect(document.querySelector('.enh-item-wishlist-badge')).not.toBeNull();
+    expect(document.querySelector('.enh-item-wishlist-badge')).toBeNull();
+  });
+
+  it('calls a wishlisted track "In Wishlist"', () => {
+    const track: SearchTrack = { id: 't1', name: 'Xtal' };
+    renderResults({
+      tracks: [track],
+      ownership: { ...EMPTY_OWNERSHIP, wishlistTracks: new Set([trackIdentity(track)]) },
+    });
+    expect(document.querySelector('.enh-item-wishlist-badge')?.textContent).toBe('In Wishlist');
+  });
+
+  it('staggers the badges with one counter across all three sections', () => {
+    // The badges animate on arrival (libBadgeFadeIn); the vanilla's 30ms
+    // setTimeout ladder made them cascade instead of popping together, and it
+    // used ONE counter for albums, singles and tracks alike.
+    const owned = [
+      album({ id: 'a1', album_type: 'album' }),
+      album({ id: 's1', album_type: 'single' }),
+    ];
+    const track: SearchTrack = { id: 't1', name: 'Xtal' };
+    renderResults({
+      albums: owned,
+      tracks: [track],
+      ownership: {
+        ...EMPTY_OWNERSHIP,
+        ownedAlbums: new Set(owned.map(albumIdentity)),
+        ownedTracks: new Set([trackIdentity(track)]),
+      },
+    });
+
+    const delays = [...document.querySelectorAll('.enh-item-lib-badge')].map(
+      (el) => (el as HTMLElement).style.animationDelay,
+    );
+    expect(delays).toEqual(['0ms', '30ms', '60ms']);
+  });
+
+  it('does not spend a stagger slot on an unbadged card', () => {
+    const rows = [album({ id: 'a1' }), album({ id: 'a2' })];
+    renderResults({
+      albums: rows,
+      ownership: { ...EMPTY_OWNERSHIP, ownedAlbums: new Set([albumIdentity(rows[1])]) },
+    });
+    // The owned album is second, but it is the FIRST badge, so it starts at 0.
+    const badge = document.querySelector('.enh-item-lib-badge') as HTMLElement;
+    expect(badge.style.animationDelay).toBe('0ms');
+  });
+
+  it('lets a library artist resolve an image too', () => {
+    // renderCompactSection stamped the lazy-load attributes on every artist card
+    // with an id, library ones included — a server with no thumb is exactly the
+    // case that needs resolving.
+    renderResults({ dbArtists: [{ id: 7, name: 'Owned' }] });
+    const card = document.querySelector('[data-artist-id="7"]');
+    expect(card).not.toBeNull();
+    expect(card?.getAttribute('data-needs-image')).toBe('true');
+    expect(card?.getAttribute('data-artist-name')).toBe('Owned');
+  });
+
+  it('shows a library artist a resolved image', () => {
+    renderResults({ dbArtists: [{ id: 7, name: 'Owned' }], artistImages: { 7: 'https://cdn/a.jpg' } });
+    expect(document.querySelector('img')?.getAttribute('src')).toBe('https://cdn/a.jpg');
   });
 
   it('pairs the two artist sections inside the wrapper that lays them out', () => {

--- a/webui/src/routes/search/-ui/search-results.tsx
+++ b/webui/src/routes/search/-ui/search-results.tsx
@@ -135,7 +135,11 @@ export function SearchResults({
   ownership: OwnershipState;
   /** Lazily-resolved images, keyed by artist id. */
   artistImages: Record<string, string>;
-  onArtistHref: (artist: SearchArtist) => string;
+  /**
+   * `inLibrary` decides the URL, not just the styling: a library artist resolves
+   * under /artist-detail/library/<id>, a found one under its metadata source.
+   */
+  onArtistHref: (artist: SearchArtist, inLibrary: boolean) => string;
   onLabelHref: (label: SearchLabel) => string;
   onAlbumClick: (album: SearchAlbum) => void;
   onTrackClick: (track: SearchTrack) => void;
@@ -204,7 +208,7 @@ export function SearchResults({
                 meta={artistMetaLine(true)}
                 placeholder="📚"
                 image={artistImages[String(artist.id ?? '')] || artistImage(artist)}
-                href={onArtistHref(artist)}
+                href={onArtistHref(artist, true)}
                 badge={{ text: 'Library', className: 'enh-badge-library' }}
                 // Library artists take part in lazy image loading too:
                 // renderCompactSection stamped these attributes on EVERY artist
@@ -235,7 +239,7 @@ export function SearchResults({
                 placeholder="🎤"
                 // A lazily-resolved image wins; otherwise whatever the source gave.
                 image={artistImages[String(artist.id ?? '')] || artistImage(artist)}
-                href={onArtistHref(artist)}
+                href={onArtistHref(artist, false)}
                 // The badge names the source being VIEWED, not the row's own
                 // `source` field — the vanilla derives it from the active tab.
                 badge={sourceBadge(activeSource)}

--- a/webui/src/routes/search/-ui/search-results.tsx
+++ b/webui/src/routes/search/-ui/search-results.tsx
@@ -1,4 +1,5 @@
 import type {
+  LibraryCheckTrack,
   SearchAlbum,
   SearchArtist,
   SearchLabel,
@@ -9,11 +10,13 @@ import type { VideoProgress } from './video-grid';
 
 import {
   albumIdentity,
+  albumMetaLine,
   artistMetaLine,
   formatDuration,
   labelMetaLine,
   splitAlbums,
   trackIdentity,
+  trackMetaLine,
 } from '../-search.helpers';
 import { SOURCE_LABELS } from '../-search.types';
 import { CompactItem, ResultSection } from './compact-item';
@@ -24,23 +27,50 @@ export interface OwnershipState {
   ownedAlbums: ReadonlySet<string>;
   ownedTracks: ReadonlySet<string>;
   wishlistTracks: ReadonlySet<string>;
-  /** Track identity → local file path, when the library has one. */
-  playableTracks: ReadonlyMap<string, string>;
+  /**
+   * Track identity → the library row, for tracks that have a local file.
+   *
+   * The whole row, not just the path: playLibraryTrack wants the library track
+   * id, its title, the album thumb and the album/artist names, and those come
+   * from the library check rather than from the search result.
+   */
+  libraryTracks: ReadonlyMap<string, LibraryCheckTrack>;
 }
 
 export const EMPTY_OWNERSHIP: OwnershipState = {
   ownedAlbums: new Set(),
   ownedTracks: new Set(),
   wishlistTracks: new Set(),
-  playableTracks: new Map(),
+  libraryTracks: new Map(),
 };
 
 const LIBRARY_BADGE = { text: 'In Library', className: 'enh-item-lib-badge' };
-const WISHLIST_BADGE = { text: 'Wishlisted', className: 'enh-item-wishlist-badge' };
+const WISHLIST_BADGE = { text: 'In Wishlist', className: 'enh-item-wishlist-badge' };
 
+/**
+ * The badges cascaded in 30ms apart in the vanilla, which staggered its
+ * setTimeout inserts with ONE counter shared across albums, singles and tracks
+ * (search.js:586-644). They animate on arrival (libBadgeFadeIn,
+ * style.css:40417), so appearing together is a visibly different effect —
+ * an animation-delay is the same thing said declaratively.
+ */
+const BADGE_STAGGER_MS = 30;
+
+/**
+ * The badge naming a source.
+ *
+ * Built from the ACTIVE source, not from each item's own `source` field, and
+ * worn only by the Artists section — search.js:465-499 passes `sourceBadge` to
+ * that one renderCompactSection call and to no other. Albums, singles and tracks
+ * carry no badge at all; the lit icon in the picker is what says where results
+ * came from, and a badge on every card was noise the design deliberately
+ * dropped.
+ */
 function sourceBadge(source: string | undefined) {
   const info = source ? SOURCE_LABELS[source] : undefined;
-  return info ? { text: info.text, className: info.badgeClass } : undefined;
+  const fallback = SOURCE_LABELS.spotify;
+  const chosen = info ?? fallback;
+  return { text: chosen.text, className: chosen.badgeClass };
 }
 
 function artistImage(artist: SearchArtist): string | undefined {
@@ -49,6 +79,13 @@ function artistImage(artist: SearchArtist): string | undefined {
 
 function albumImage(album: SearchAlbum): string | undefined {
   return album.image_url || album.images?.[0]?.url || undefined;
+}
+
+/** True for the two sources that show no metadata sections at all. */
+function suppressesLabels(source: string): boolean {
+  // search.js:429-434 — the Labels section is fetched additively, so it has to
+  // be hidden explicitly for both of these, not merely left unfilled.
+  return source === 'youtube_videos' || source === 'soulseek';
 }
 
 /**
@@ -102,10 +139,17 @@ export function SearchResults({
   onLabelHref: (label: SearchLabel) => string;
   onAlbumClick: (album: SearchAlbum) => void;
   onTrackClick: (track: SearchTrack) => void;
-  onTrackPlay: (track: SearchTrack, filePath: string | undefined) => void;
+  /** The library row is present only for an owned track with a local file. */
+  onTrackPlay: (track: SearchTrack, libraryRow: LibraryCheckTrack | undefined) => void;
   onVideoDownload: (video: SearchVideo) => void;
 }) {
   const { albums: fullAlbums, singlesAndEps } = splitAlbums(albums);
+
+  // One counter across all three badged sections, consumed in render order —
+  // albums, then singles, then tracks — which is the order the vanilla's loops
+  // ran in. Reset every render, so it is deterministic rather than stateful.
+  let badgeSlot = 0;
+  const nextBadgeDelay = () => `${badgeSlot++ * BADGE_STAGGER_MS}ms`;
 
   // The grid carries its own "No music videos found" state, which is the whole
   // reason it can be rendered unconditionally here: a videos search that found
@@ -116,16 +160,17 @@ export function SearchResults({
 
   const albumCard = (album: SearchAlbum, index: number) => {
     const identity = albumIdentity(album);
+    const owned = ownership.ownedAlbums.has(identity);
     return (
       <CompactItem
         key={`${identity}::${index}`}
         kind="album"
         name={album.name ?? ''}
-        meta={[album.artist, album.release_date?.slice(0, 4)].filter(Boolean).join(' • ')}
+        meta={albumMetaLine(album)}
         placeholder={album.album_type === 'single' || album.album_type === 'ep' ? '🎶' : '💿'}
         image={albumImage(album)}
-        badge={sourceBadge(album.source)}
-        extraBadges={ownership.ownedAlbums.has(identity) ? [LIBRARY_BADGE] : undefined}
+        // No source badge: only the Artists section wears one. See sourceBadge.
+        extraBadges={owned ? [{ ...LIBRARY_BADGE, delay: nextBadgeDelay() }] : undefined}
         onClick={() => onAlbumClick(album)}
       />
     );
@@ -156,11 +201,17 @@ export function SearchResults({
                 key={`${artist.id ?? artist.name}::${index}`}
                 kind="artist"
                 name={artist.name ?? ''}
-                meta={artistMetaLine(artist, true)}
+                meta={artistMetaLine(true)}
                 placeholder="📚"
-                image={artistImage(artist)}
+                image={artistImages[String(artist.id ?? '')] || artistImage(artist)}
                 href={onArtistHref(artist)}
                 badge={{ text: 'Library', className: 'enh-badge-library' }}
+                // Library artists take part in lazy image loading too:
+                // renderCompactSection stamped these attributes on EVERY artist
+                // card with an id, and a library artist whose server has no
+                // thumb is exactly the case that needs resolving.
+                artistId={artist.id}
+                artistName={artist.name}
               />
             ))}
           </ResultSection>
@@ -180,12 +231,14 @@ export function SearchResults({
                 key={`${artist.id ?? artist.name}::${index}`}
                 kind="artist"
                 name={artist.name ?? ''}
-                meta={artistMetaLine(artist, false)}
+                meta={artistMetaLine(false)}
                 placeholder="🎤"
                 // A lazily-resolved image wins; otherwise whatever the source gave.
                 image={artistImages[String(artist.id ?? '')] || artistImage(artist)}
                 href={onArtistHref(artist)}
-                badge={sourceBadge(artist.source)}
+                // The badge names the source being VIEWED, not the row's own
+                // `source` field — the vanilla derives it from the active tab.
+                badge={sourceBadge(activeSource)}
                 artistId={artist.id}
                 artistName={artist.name}
               />
@@ -229,27 +282,33 @@ export function SearchResults({
       >
         {tracks.map((track, index) => {
           const identity = trackIdentity(track);
-          const filePath = ownership.playableTracks.get(identity);
-          const extras = [
-            ...(ownership.ownedTracks.has(identity) ? [LIBRARY_BADGE] : []),
-            ...(ownership.wishlistTracks.has(identity) ? [WISHLIST_BADGE] : []),
-          ];
+          const libraryRow = ownership.libraryTracks.get(identity);
+          // Either/or, never both — the vanilla's else-if. On a card where both
+          // badges are absolutely positioned at the same corner, two would
+          // simply cover each other.
+          const owned = ownership.ownedTracks.has(identity);
+          const wished = !owned && ownership.wishlistTracks.has(identity);
+          const extras = owned
+            ? [{ ...LIBRARY_BADGE, delay: nextBadgeDelay() }]
+            : wished
+              ? [{ ...WISHLIST_BADGE, delay: nextBadgeDelay() }]
+              : [];
           return (
             <CompactItem
               key={`${identity}::${index}`}
               kind="track"
               name={track.name ?? ''}
-              meta={[track.artist, track.album?.name].filter(Boolean).join(' • ')}
+              meta={trackMetaLine(track)}
               placeholder="🎵"
-              image={track.image_url || albumImage(track.album ?? {})}
+              image={track.image_url}
               duration={formatDuration(track.duration_ms)}
-              badge={sourceBadge(track.source)}
               extraBadges={extras.length ? extras : undefined}
               onClick={() => onTrackClick(track)}
               // An owned track plays from disk; everything else streams. The
               // vanilla achieved this by cloning the button to drop the stream
               // listener — a prop is the same decision, made once.
-              onPlay={() => onTrackPlay(track, filePath)}
+              onPlay={() => onTrackPlay(track, libraryRow)}
+              playTitle={libraryRow ? 'Play from library' : 'Stream this track'}
             />
           );
         })}
@@ -262,7 +321,7 @@ export function SearchResults({
         icon="🏷️"
         title="Labels"
         kind="label"
-        count={labels.length}
+        count={suppressesLabels(activeSource) ? 0 : labels.length}
       >
         {labels.map((label, index) => (
           <CompactItem

--- a/webui/src/routes/search/-ui/search-results.tsx
+++ b/webui/src/routes/search/-ui/search-results.tsx
@@ -1,0 +1,285 @@
+import type {
+  SearchAlbum,
+  SearchArtist,
+  SearchLabel,
+  SearchTrack,
+  SearchVideo,
+} from '../-search.types';
+import type { VideoProgress } from './video-grid';
+
+import {
+  albumIdentity,
+  artistMetaLine,
+  formatDuration,
+  labelMetaLine,
+  splitAlbums,
+  trackIdentity,
+} from '../-search.helpers';
+import { SOURCE_LABELS } from '../-search.types';
+import { CompactItem, ResultSection } from './compact-item';
+import { VideoGrid } from './video-grid';
+
+/** Ownership carried by IDENTITY, never by list position. See the helpers. */
+export interface OwnershipState {
+  ownedAlbums: ReadonlySet<string>;
+  ownedTracks: ReadonlySet<string>;
+  wishlistTracks: ReadonlySet<string>;
+  /** Track identity → local file path, when the library has one. */
+  playableTracks: ReadonlyMap<string, string>;
+}
+
+export const EMPTY_OWNERSHIP: OwnershipState = {
+  ownedAlbums: new Set(),
+  ownedTracks: new Set(),
+  wishlistTracks: new Set(),
+  playableTracks: new Map(),
+};
+
+const LIBRARY_BADGE = { text: 'In Library', className: 'enh-item-lib-badge' };
+const WISHLIST_BADGE = { text: 'Wishlisted', className: 'enh-item-wishlist-badge' };
+
+function sourceBadge(source: string | undefined) {
+  const info = source ? SOURCE_LABELS[source] : undefined;
+  return info ? { text: info.text, className: info.badgeClass } : undefined;
+}
+
+function artistImage(artist: SearchArtist): string | undefined {
+  return artist.image_url || artist.images?.[0]?.url || undefined;
+}
+
+function albumImage(album: SearchAlbum): string | undefined {
+  return album.image_url || album.images?.[0]?.url || undefined;
+}
+
+/**
+ * The six result sections, in the vanilla's order.
+ *
+ * That order is deliberate on an acquisition surface: what you already own
+ * ("In Your Library") comes first, then artists you could add, then releases.
+ *
+ * Two structural details are load-bearing and easy to lose in a port:
+ *
+ * 1. The two artist sections live inside `.enh-artists-wrapper` and each wears
+ *    `enh-artist-section`, which strips the card chrome every other section has
+ *    (index.html:4203-4226 + style.css:40214-40244). Flat siblings would render
+ *    two bordered cards where the design has two bare columns.
+ * 2. `youtube_videos` is EXCLUSIVE: search.js:178-186 hides all six sections and
+ *    shows only the video grid. It matters because labels are fetched
+ *    additively, so without the rule a video search grows a Labels section the
+ *    vanilla never showed.
+ */
+export function SearchResults({
+  activeSource,
+  dbArtists,
+  artists,
+  albums,
+  tracks,
+  labels,
+  videos,
+  videoProgress,
+  ownership,
+  artistImages,
+  onArtistHref,
+  onLabelHref,
+  onAlbumClick,
+  onTrackClick,
+  onTrackPlay,
+  onVideoDownload,
+}: {
+  /** Required, not derived: it is what makes the videos-only rule unforgettable. */
+  activeSource: string;
+  dbArtists: SearchArtist[];
+  artists: SearchArtist[];
+  albums: SearchAlbum[];
+  tracks: SearchTrack[];
+  labels: SearchLabel[];
+  videos: SearchVideo[];
+  videoProgress: Record<string, VideoProgress>;
+  ownership: OwnershipState;
+  /** Lazily-resolved images, keyed by artist id. */
+  artistImages: Record<string, string>;
+  onArtistHref: (artist: SearchArtist) => string;
+  onLabelHref: (label: SearchLabel) => string;
+  onAlbumClick: (album: SearchAlbum) => void;
+  onTrackClick: (track: SearchTrack) => void;
+  onTrackPlay: (track: SearchTrack, filePath: string | undefined) => void;
+  onVideoDownload: (video: SearchVideo) => void;
+}) {
+  const { albums: fullAlbums, singlesAndEps } = splitAlbums(albums);
+
+  // The grid carries its own "No music videos found" state, which is the whole
+  // reason it can be rendered unconditionally here: a videos search that found
+  // nothing has to say so rather than show a blank panel.
+  if (activeSource === 'youtube_videos') {
+    return <VideoGrid videos={videos} progress={videoProgress} onDownload={onVideoDownload} />;
+  }
+
+  const albumCard = (album: SearchAlbum, index: number) => {
+    const identity = albumIdentity(album);
+    return (
+      <CompactItem
+        key={`${identity}::${index}`}
+        kind="album"
+        name={album.name ?? ''}
+        meta={[album.artist, album.release_date?.slice(0, 4)].filter(Boolean).join(' • ')}
+        placeholder={album.album_type === 'single' || album.album_type === 'ep' ? '🎶' : '💿'}
+        image={albumImage(album)}
+        badge={sourceBadge(album.source)}
+        extraBadges={ownership.ownedAlbums.has(identity) ? [LIBRARY_BADGE] : undefined}
+        onClick={() => onAlbumClick(album)}
+      />
+    );
+  };
+
+  // Rendered only when one of the two has results: the wrapper's own
+  // margin-bottom would otherwise leave 24px of dead space above Albums, which
+  // is exactly what the vanilla's always-present div does.
+  const anyArtists = dbArtists.length > 0 || artists.length > 0;
+
+  return (
+    <>
+      {anyArtists ? (
+        <div className="enh-artists-wrapper">
+          {/* Already yours — first, because this is an acquisition surface. */}
+          <ResultSection
+            id="enh-db-artists-section"
+            listId="enh-db-artists-list"
+            countId="enh-db-artists-count"
+            icon="📚"
+            title="In Your Library"
+            kind="artist"
+            sectionClass="enh-artist-section"
+            count={dbArtists.length}
+          >
+            {dbArtists.map((artist, index) => (
+              <CompactItem
+                key={`${artist.id ?? artist.name}::${index}`}
+                kind="artist"
+                name={artist.name ?? ''}
+                meta={artistMetaLine(artist, true)}
+                placeholder="📚"
+                image={artistImage(artist)}
+                href={onArtistHref(artist)}
+                badge={{ text: 'Library', className: 'enh-badge-library' }}
+              />
+            ))}
+          </ResultSection>
+
+          <ResultSection
+            id="enh-spotify-artists-section"
+            listId="enh-spotify-artists-list"
+            countId="enh-spotify-artists-count"
+            icon="🎤"
+            title="Artists"
+            kind="artist"
+            sectionClass="enh-artist-section"
+            count={artists.length}
+          >
+            {artists.map((artist, index) => (
+              <CompactItem
+                key={`${artist.id ?? artist.name}::${index}`}
+                kind="artist"
+                name={artist.name ?? ''}
+                meta={artistMetaLine(artist, false)}
+                placeholder="🎤"
+                // A lazily-resolved image wins; otherwise whatever the source gave.
+                image={artistImages[String(artist.id ?? '')] || artistImage(artist)}
+                href={onArtistHref(artist)}
+                badge={sourceBadge(artist.source)}
+                artistId={artist.id}
+                artistName={artist.name}
+              />
+            ))}
+          </ResultSection>
+        </div>
+      ) : null}
+
+      <ResultSection
+        id="enh-albums-section"
+        listId="enh-albums-list"
+        countId="enh-albums-count"
+        icon="💿"
+        title="Albums"
+        kind="album"
+        count={fullAlbums.length}
+      >
+        {fullAlbums.map(albumCard)}
+      </ResultSection>
+
+      <ResultSection
+        id="enh-singles-section"
+        listId="enh-singles-list"
+        countId="enh-singles-count"
+        icon="🎶"
+        title="Singles & EPs"
+        kind="album"
+        count={singlesAndEps.length}
+      >
+        {singlesAndEps.map(albumCard)}
+      </ResultSection>
+
+      <ResultSection
+        id="enh-tracks-section"
+        listId="enh-tracks-list"
+        countId="enh-tracks-count"
+        icon="🎵"
+        title="Tracks"
+        kind="track"
+        count={tracks.length}
+      >
+        {tracks.map((track, index) => {
+          const identity = trackIdentity(track);
+          const filePath = ownership.playableTracks.get(identity);
+          const extras = [
+            ...(ownership.ownedTracks.has(identity) ? [LIBRARY_BADGE] : []),
+            ...(ownership.wishlistTracks.has(identity) ? [WISHLIST_BADGE] : []),
+          ];
+          return (
+            <CompactItem
+              key={`${identity}::${index}`}
+              kind="track"
+              name={track.name ?? ''}
+              meta={[track.artist, track.album?.name].filter(Boolean).join(' • ')}
+              placeholder="🎵"
+              image={track.image_url || albumImage(track.album ?? {})}
+              duration={formatDuration(track.duration_ms)}
+              badge={sourceBadge(track.source)}
+              extraBadges={extras.length ? extras : undefined}
+              onClick={() => onTrackClick(track)}
+              // An owned track plays from disk; everything else streams. The
+              // vanilla achieved this by cloning the button to drop the stream
+              // listener — a prop is the same decision, made once.
+              onPlay={() => onTrackPlay(track, filePath)}
+            />
+          );
+        })}
+      </ResultSection>
+
+      <ResultSection
+        id="enh-labels-section"
+        listId="enh-labels-list"
+        countId="enh-labels-count"
+        icon="🏷️"
+        title="Labels"
+        kind="label"
+        count={labels.length}
+      >
+        {labels.map((label, index) => (
+          <CompactItem
+            key={`${label.id ?? label.name}::${index}`}
+            kind="label"
+            name={label.name ?? ''}
+            meta={labelMetaLine(label)}
+            placeholder="🏷️"
+            href={onLabelHref(label)}
+          />
+        ))}
+      </ResultSection>
+
+      {/* No video grid down here on purpose. Only the youtube_videos source ever
+          fills `videos`, and that source returns above — so a grid rendered here
+          would be a branch that cannot be reached, which is worse than none. The
+          vanilla agrees: it hides #enh-videos-section for every other source. */}
+    </>
+  );
+}

--- a/webui/src/routes/search/-ui/source-row.test.tsx
+++ b/webui/src/routes/search/-ui/source-row.test.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SearchControllerState } from '../-search.use-controller';
+
+import { emptySourceResults } from '../-search.helpers';
+import { SourceRow } from './source-row';
+
+function stateOf(over: Partial<SearchControllerState> = {}): SearchControllerState {
+  return {
+    query: 'aphex',
+    activeSource: 'spotify',
+    sources: {},
+    fallbacks: {},
+    loadingSources: new Set(),
+    configuredSources: {},
+    enabledExperimental: new Set(),
+    ...over,
+  };
+}
+
+function renderRow(
+  over: Partial<SearchControllerState> = {},
+  handlers: { onSelect?: () => void; onOpenSettings?: () => void } = {},
+) {
+  const onSelect = handlers.onSelect ?? vi.fn();
+  const onOpenSettings = handlers.onOpenSettings ?? vi.fn();
+  render(<SourceRow state={stateOf(over)} onSelect={onSelect} onOpenSettings={onOpenSettings} />);
+  return { onSelect, onOpenSettings };
+}
+
+const icon = (source: string) =>
+  document.querySelector(`[data-source="${source}"]`) as HTMLButtonElement;
+
+afterEach(cleanup);
+
+describe('SourceRow', () => {
+  it('hides experimental sources until they are enabled', () => {
+    renderRow();
+    expect(icon('jiosaavn')).toBeNull();
+    expect(icon('bandcamp')).toBeNull();
+    // A non-experimental source is always in the row.
+    expect(icon('deezer')).not.toBeNull();
+
+    cleanup();
+    renderRow({ enabledExperimental: new Set(['bandcamp']) });
+    expect(icon('bandcamp')).not.toBeNull();
+    // Enabling one does not reveal the other.
+    expect(icon('jiosaavn')).toBeNull();
+  });
+
+  it('marks the active source, and only it', () => {
+    renderRow({ activeSource: 'deezer' });
+    expect(icon('deezer').className).toContain('active');
+    expect(icon('deezer').getAttribute('aria-selected')).toBe('true');
+    expect(icon('spotify').className).not.toContain('active');
+    expect(icon('spotify').getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('keeps the tablist semantics the vanilla had', () => {
+    // The vanilla row was role=tablist with role=tab children; losing that turns
+    // a keyboard-navigable picker into a pile of unlabelled buttons.
+    renderRow();
+    expect(document.getElementById('enh-source-row')?.getAttribute('role')).toBe('tablist');
+    expect(icon('spotify').getAttribute('role')).toBe('tab');
+  });
+
+  it('marks a cached source, a loading one, and a fallen-back one', () => {
+    renderRow({
+      sources: { deezer: emptySourceResults() },
+      loadingSources: new Set(['itunes']),
+      fallbacks: { discogs: 'deezer' },
+    });
+    expect(icon('deezer').className).toContain('cached');
+    expect(icon('itunes').className).toContain('loading');
+    expect(icon('discogs').className).toContain('fallback-warning');
+    // Untouched sources wear none of the three.
+    expect(icon('musicbrainz').className).toBe('enh-source-icon');
+  });
+
+  it('names both sources in a fallback tooltip', () => {
+    renderRow({ fallbacks: { discogs: 'deezer' } });
+    expect(icon('discogs').getAttribute('title')).toBe('Discogs unavailable — showing Deezer');
+  });
+
+  it('selects a configured source', () => {
+    const { onSelect, onOpenSettings } = renderRow();
+    fireEvent.click(icon('deezer'));
+    expect(onSelect).toHaveBeenCalledWith('deezer');
+    expect(onOpenSettings).not.toHaveBeenCalled();
+  });
+
+  it('sends an unconfigured source to Settings instead of making it active', () => {
+    // The important state: activating it would show an empty result set and
+    // leave the user blaming the provider.
+    const { onSelect, onOpenSettings } = renderRow({ configuredSources: { deezer: false } });
+    const button = icon('deezer');
+    expect(button.className).toContain('unconfigured');
+    expect(button.getAttribute('title')).toContain('not configured');
+
+    fireEvent.click(button);
+    expect(onOpenSettings).toHaveBeenCalledWith('deezer');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('treats an unknown source as configured rather than dimming it', () => {
+    // configuredSources is filled in asynchronously; a missing key means "not
+    // answered yet", and dimming on that flashes the whole row on every load.
+    renderRow({ configuredSources: {} });
+    expect(icon('deezer').className).not.toContain('unconfigured');
+  });
+
+  it('stops the click from reaching the document', () => {
+    // The page closes its dropdown on any document click; without this the row
+    // would dismiss the very results it just asked for.
+    const onDocumentClick = vi.fn();
+    document.addEventListener('click', onDocumentClick);
+    try {
+      renderRow();
+      fireEvent.click(icon('deezer'));
+      expect(onDocumentClick).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('click', onDocumentClick);
+    }
+  });
+
+  it('renders a brand logo where there is one and a glyph where there is not', () => {
+    renderRow();
+    expect(icon('spotify').querySelector('img')?.getAttribute('src')).toBe(
+      '/static/img/brands/spotify.png',
+    );
+    // Amazon has no logo file; the emoji is the fallback, not an empty span.
+    expect(icon('amazon').querySelector('img')).toBeNull();
+    expect(icon('amazon').querySelector('.enh-source-icon-glyph')?.textContent).toBe('🛒');
+  });
+
+  it('calls Soulseek "Basic Search", as the UI always has', () => {
+    renderRow();
+    expect(icon('soulseek').querySelector('.enh-source-icon-label')?.textContent).toBe(
+      'Basic Search',
+    );
+  });
+});

--- a/webui/src/routes/search/-ui/source-row.test.tsx
+++ b/webui/src/routes/search/-ui/source-row.test.tsx
@@ -15,6 +15,7 @@ function stateOf(over: Partial<SearchControllerState> = {}): SearchControllerSta
     loadingSources: new Set(),
     configuredSources: {},
     enabledExperimental: new Set(),
+    userPickedSource: false,
     ...over,
   };
 }
@@ -79,8 +80,25 @@ describe('SourceRow', () => {
   });
 
   it('names both sources in a fallback tooltip', () => {
+    // "served from" on the icon; the banner over the results says "showing".
+    // Two different strings in the vanilla, and both are user-visible.
     renderRow({ fallbacks: { discogs: 'deezer' } });
-    expect(icon('discogs').getAttribute('title')).toBe('Discogs unavailable — showing Deezer');
+    expect(icon('discogs').getAttribute('title')).toBe('Discogs unavailable — served from Deezer');
+  });
+
+  it('swaps a loading source’s logo for an hourglass', () => {
+    // The `loading` class animates the button, but the glyph swap is what makes
+    // an in-flight source unmistakable (shared-helpers.js:325-330).
+    renderRow({ loadingSources: new Set(['spotify']) });
+    expect(icon('spotify').querySelector('img')).toBeNull();
+    expect(icon('spotify').querySelector('.enh-source-icon-glyph')?.textContent).toBe('⏳');
+    // Its neighbour keeps its logo.
+    expect(icon('deezer').querySelector('img')).not.toBeNull();
+  });
+
+  it('lazy-loads the brand logos', () => {
+    renderRow();
+    expect(icon('spotify').querySelector('img')?.getAttribute('loading')).toBe('lazy');
   });
 
   it('selects a configured source', () => {
@@ -96,7 +114,7 @@ describe('SourceRow', () => {
     const { onSelect, onOpenSettings } = renderRow({ configuredSources: { deezer: false } });
     const button = icon('deezer');
     expect(button.className).toContain('unconfigured');
-    expect(button.getAttribute('title')).toContain('not configured');
+    expect(button.getAttribute('title')).toBe('Deezer — set up in Settings');
 
     fireEvent.click(button);
     expect(onOpenSettings).toHaveBeenCalledWith('deezer');

--- a/webui/src/routes/search/-ui/source-row.tsx
+++ b/webui/src/routes/search/-ui/source-row.tsx
@@ -1,0 +1,79 @@
+import type { SearchControllerState } from '../-search.use-controller';
+
+import { sourceLabel, visibleSources } from '../-search.helpers';
+import { SOURCE_LABELS } from '../-search.types';
+
+/**
+ * The source picker.
+ *
+ * Five states stack on one icon, and each means something different:
+ *   active    — the source whose results are on screen
+ *   cached    — already fetched for this query; clicking is instant
+ *   loading   — in flight
+ *   fallback  — the server served something ELSE for this source
+ *   unconfigured — no credentials; clicking goes to Settings, NOT to a search
+ *
+ * The last one is the important one: an unconfigured icon must not become the
+ * active source, or the page shows an empty result set and blames the provider.
+ */
+export function SourceRow({
+  state,
+  onSelect,
+  onOpenSettings,
+}: {
+  state: SearchControllerState;
+  onSelect: (source: string) => void;
+  onOpenSettings: (source: string) => void;
+}) {
+  return (
+    <div className="enh-source-row" id="enh-source-row" role="tablist">
+      {visibleSources(state.enabledExperimental).map((source) => {
+        const info = SOURCE_LABELS[source];
+        if (!info) return null;
+
+        const configured = state.configuredSources[source] !== false;
+        const classes = ['enh-source-icon'];
+        if (source === state.activeSource) classes.push('active');
+        if (state.sources[source]) classes.push('cached');
+        if (state.loadingSources.has(source)) classes.push('loading');
+        if (state.fallbacks[source]) classes.push('fallback-warning');
+        if (!configured) classes.push('unconfigured');
+
+        const served = state.fallbacks[source];
+        const title = !configured
+          ? `${info.text} — not configured. Click to set it up.`
+          : served
+            ? `${info.text} unavailable — showing ${sourceLabel(served)}`
+            : info.text;
+
+        return (
+          <button
+            key={source}
+            type="button"
+            className={classes.join(' ')}
+            data-source={source}
+            title={title}
+            role="tab"
+            aria-selected={source === state.activeSource}
+            onClick={(event) => {
+              // The row re-renders on click, which detaches the node the event
+              // came from; stopping propagation here is what keeps the
+              // document-level outside-click handler from also firing.
+              event.stopPropagation();
+              if (!configured) {
+                onOpenSettings(source);
+                return;
+              }
+              onSelect(source);
+            }}
+          >
+            <span className="enh-source-icon-glyph">
+              {info.logo ? <img src={info.logo} alt="" /> : info.icon}
+            </span>
+            <span className="enh-source-icon-label">{info.text}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/webui/src/routes/search/-ui/source-row.tsx
+++ b/webui/src/routes/search/-ui/source-row.tsx
@@ -32,18 +32,22 @@ export function SourceRow({
         if (!info) return null;
 
         const configured = state.configuredSources[source] !== false;
+        const loading = state.loadingSources.has(source);
         const classes = ['enh-source-icon'];
         if (source === state.activeSource) classes.push('active');
         if (state.sources[source]) classes.push('cached');
-        if (state.loadingSources.has(source)) classes.push('loading');
+        if (loading) classes.push('loading');
         if (state.fallbacks[source]) classes.push('fallback-warning');
         if (!configured) classes.push('unconfigured');
 
         const served = state.fallbacks[source];
+        // The wording is the vanilla's, and the two phrasings differ on purpose:
+        // the ICON says "served from" (shared-helpers.js:316) while the banner
+        // above the results says "showing" (search.js:98).
         const title = !configured
-          ? `${info.text} — not configured. Click to set it up.`
+          ? `${info.text} — set up in Settings`
           : served
-            ? `${info.text} unavailable — showing ${sourceLabel(served)}`
+            ? `${info.text} unavailable — served from ${sourceLabel(served)}`
             : info.text;
 
         return (
@@ -68,7 +72,10 @@ export function SourceRow({
             }}
           >
             <span className="enh-source-icon-glyph">
-              {info.logo ? <img src={info.logo} alt="" /> : info.icon}
+              {/* An in-flight source shows an hourglass INSTEAD of its logo —
+                  shared-helpers.js:325-330. The `loading` class animates the
+                  button, but the glyph swap is what makes it unmistakable. */}
+              {loading ? '⏳' : info.logo ? <img src={info.logo} alt="" loading="lazy" /> : info.icon}
             </span>
             <span className="enh-source-icon-label">{info.text}</span>
           </button>

--- a/webui/src/routes/search/-ui/source-row.tsx
+++ b/webui/src/routes/search/-ui/source-row.tsx
@@ -75,7 +75,13 @@ export function SourceRow({
               {/* An in-flight source shows an hourglass INSTEAD of its logo —
                   shared-helpers.js:325-330. The `loading` class animates the
                   button, but the glyph swap is what makes it unmistakable. */}
-              {loading ? '⏳' : info.logo ? <img src={info.logo} alt="" loading="lazy" /> : info.icon}
+              {loading ? (
+                '⏳'
+              ) : info.logo ? (
+                <img src={info.logo} alt="" loading="lazy" />
+              ) : (
+                info.icon
+              )}
             </span>
             <span className="enh-source-icon-label">{info.text}</span>
           </button>

--- a/webui/src/routes/search/-ui/video-grid.test.tsx
+++ b/webui/src/routes/search/-ui/video-grid.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { SearchVideo } from '../-search.types';
+import type { VideoProgress } from './video-grid';
+
+import { VideoGrid } from './video-grid';
+
+const video = (over: Partial<SearchVideo> = {}): SearchVideo => ({
+  video_id: 'v1',
+  title: 'Windowlicker',
+  channel: 'Warp',
+  thumbnail: 'https://i.ytimg.com/v1.jpg',
+  duration: 215,
+  view_count: 1_500_000,
+  ...over,
+});
+
+function renderGrid(videos: SearchVideo[], progress: Record<string, VideoProgress> = {}) {
+  const onDownload = vi.fn();
+  render(<VideoGrid videos={videos} progress={progress} onDownload={onDownload} />);
+  return { onDownload };
+}
+
+const card = () => document.querySelector('.enh-video-card') as HTMLElement;
+const ring = () => document.querySelector('.enh-video-progress-bar') as SVGCircleElement;
+
+afterEach(cleanup);
+
+describe('VideoGrid', () => {
+  it('renders a card with its duration in SECONDS and its view count', () => {
+    // The unit trap: track durations are milliseconds, video durations seconds.
+    // Read as ms, 215 would render 0:00.
+    renderGrid([video()]);
+    expect(screen.getByText('3:35')).toBeInTheDocument();
+    expect(document.querySelector('.enh-video-channel')?.textContent).toBe('Warp · 1.5M views');
+  });
+
+  it('heads its section like the other five', () => {
+    renderGrid([video()]);
+    const title = document.querySelector('.enh-section-title');
+    expect(title?.tagName).toBe('H4');
+    expect(title?.textContent).toBe('Music Videos');
+  });
+
+  it('omits the duration chip rather than printing an empty one', () => {
+    renderGrid([video({ duration: undefined })]);
+    expect(document.querySelector('.enh-video-duration')).toBeNull();
+  });
+
+  it('shows an empty state when the stream returned nothing', () => {
+    renderGrid([]);
+    expect(screen.getByText('No music videos found')).toBeInTheDocument();
+    expect(document.getElementById('enh-videos-count')?.textContent).toBe('0');
+  });
+
+  it('downloads on click and on keyboard activation', () => {
+    const item = video();
+    const { onDownload } = renderGrid([item]);
+
+    fireEvent.click(card());
+    fireEvent.keyDown(card(), { key: 'Enter' });
+    fireEvent.keyDown(card(), { key: ' ' });
+    expect(onDownload).toHaveBeenCalledTimes(3);
+    // The whole object, not a serialised copy — a title with a quote in it used
+    // to break the vanilla's inline onclick attribute.
+    expect(onDownload).toHaveBeenCalledWith(item);
+  });
+
+  it('ignores keys that are not activation keys', () => {
+    const { onDownload } = renderGrid([video()]);
+    fireEvent.keyDown(card(), { key: 'Tab' });
+    expect(onDownload).not.toHaveBeenCalled();
+  });
+
+  it('hides the ring, tick and cross while idle', () => {
+    renderGrid([video()]);
+    expect(document.querySelector('.enh-video-progress-ring')?.className).toContain('hidden');
+    expect(document.querySelector('.enh-video-done')?.className).toContain('hidden');
+    expect(document.querySelector('.enh-video-error')?.className).toContain('hidden');
+    expect(card().className).toBe('enh-video-card');
+  });
+
+  it('fills the ring as the download progresses', () => {
+    // strokeDashoffset counts DOWN: the full circumference is an empty ring.
+    renderGrid([video()], { v1: { state: 'downloading', percent: 0 } });
+    expect(Number(ring().getAttribute('stroke-dashoffset'))).toBeCloseTo(97.4);
+    expect(document.querySelector('.enh-video-progress-ring')?.className).not.toContain('hidden');
+    expect(card().className).toContain('downloading');
+
+    cleanup();
+    renderGrid([video()], { v1: { state: 'downloading', percent: 50 } });
+    expect(Number(ring().getAttribute('stroke-dashoffset'))).toBeCloseTo(48.7);
+
+    cleanup();
+    renderGrid([video()], { v1: { state: 'downloading', percent: 100 } });
+    expect(Number(ring().getAttribute('stroke-dashoffset'))).toBeCloseTo(0);
+  });
+
+  it('clamps an over-100 percent instead of overshooting the ring', () => {
+    renderGrid([video()], { v1: { state: 'downloading', percent: 140 } });
+    expect(Number(ring().getAttribute('stroke-dashoffset'))).toBeCloseTo(0);
+  });
+
+  it('shows the tick when complete and the cross when it failed', () => {
+    renderGrid([video()], { v1: { state: 'completed', percent: 100 } });
+    expect(document.querySelector('.enh-video-done')?.className).not.toContain('hidden');
+    expect(card().className).toContain('completed');
+
+    cleanup();
+    renderGrid([video()], { v1: { state: 'errored', percent: 12 } });
+    expect(document.querySelector('.enh-video-error')?.className).not.toContain('hidden');
+    expect(card().className).toContain('errored');
+  });
+
+  it('tracks progress per video, not across the grid', () => {
+    renderGrid(
+      [video({ video_id: 'v1' }), video({ video_id: 'v2', title: 'Second' })],
+      { v2: { state: 'downloading', percent: 25 } },
+    );
+    const cards = document.querySelectorAll('.enh-video-card');
+    expect(cards[0].className).not.toContain('downloading');
+    expect(cards[1].className).toContain('downloading');
+  });
+
+  it('drops a thumbnail that fails to load', () => {
+    renderGrid([video()]);
+    const img = document.querySelector('.enh-video-thumb img') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(img.style.display).toBe('none');
+  });
+});

--- a/webui/src/routes/search/-ui/video-grid.test.tsx
+++ b/webui/src/routes/search/-ui/video-grid.test.tsx
@@ -114,10 +114,9 @@ describe('VideoGrid', () => {
   });
 
   it('tracks progress per video, not across the grid', () => {
-    renderGrid(
-      [video({ video_id: 'v1' }), video({ video_id: 'v2', title: 'Second' })],
-      { v2: { state: 'downloading', percent: 25 } },
-    );
+    renderGrid([video({ video_id: 'v1' }), video({ video_id: 'v2', title: 'Second' })], {
+      v2: { state: 'downloading', percent: 25 },
+    });
     const cards = document.querySelectorAll('.enh-video-card');
     expect(cards[0].className).not.toContain('downloading');
     expect(cards[1].className).toContain('downloading');

--- a/webui/src/routes/search/-ui/video-grid.tsx
+++ b/webui/src/routes/search/-ui/video-grid.tsx
@@ -1,0 +1,140 @@
+import type { SearchVideo } from '../-search.types';
+
+import { formatVideoDuration, formatViewCount } from '../-search.helpers';
+
+/**
+ * The YouTube music-video grid.
+ *
+ * Two things differ from the vanilla by construction rather than by choice:
+ *
+ * 1. **The section is a normal part of the tree.** The vanilla CREATED
+ *    #enh-videos-section in JS on first use and appended it to the results
+ *    container, which is why it always landed after Labels and then persisted,
+ *    hidden, for the rest of the session.
+ * 2. **The video object is passed, not serialised into an attribute.** The
+ *    vanilla built `onclick="_downloadMusicVideo(this, ${JSON.stringify(v)…})"`,
+ *    so a title containing a quote or a backslash broke the card. Handing the
+ *    object straight to the handler removes that whole class of failure.
+ */
+export type VideoDownloadState = 'idle' | 'downloading' | 'completed' | 'errored';
+
+export interface VideoProgress {
+  state: VideoDownloadState;
+  /** 0-100, only meaningful while downloading. */
+  percent: number;
+}
+
+/** The ring's circumference, as the vanilla's stroke-dasharray. */
+const RING_LENGTH = 97.4;
+
+export function VideoGrid({
+  videos,
+  progress,
+  onDownload,
+}: {
+  videos: SearchVideo[];
+  progress: Record<string, VideoProgress>;
+  onDownload: (video: SearchVideo) => void;
+}) {
+  return (
+    <div className="enh-dropdown-section" id="enh-videos-section">
+      <div className="enh-section-header">
+        <span className="enh-section-icon">🎬</span>
+        <h4 className="enh-section-title">Music Videos</h4>
+        <span className="enh-section-count" id="enh-videos-count">
+          {videos.length}
+        </span>
+      </div>
+      <div className="enh-video-grid" id="enh-videos-list">
+        {!videos.length ? (
+          <div className="enh-empty-state">No music videos found</div>
+        ) : (
+          videos.map((video) => {
+            const id = String(video.video_id ?? '');
+            const state = progress[id]?.state ?? 'idle';
+            const percent = progress[id]?.percent ?? 0;
+            const duration = formatVideoDuration(video.duration);
+            const views = formatViewCount(video.view_count);
+
+            const classes = ['enh-video-card'];
+            if (state === 'downloading') classes.push('downloading');
+            if (state === 'completed') classes.push('completed');
+            if (state === 'errored') classes.push('errored');
+
+            return (
+              <div
+                key={id || video.title}
+                className={classes.join(' ')}
+                data-video-id={id}
+                role="button"
+                tabIndex={0}
+                onClick={() => onDownload(video)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onDownload(video);
+                  }
+                }}
+              >
+                <div className="enh-video-thumb">
+                  {video.thumbnail ? (
+                    <img
+                      src={video.thumbnail}
+                      alt=""
+                      loading="lazy"
+                      onError={(event) => {
+                        event.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  ) : null}
+                  <div className="enh-video-play">▶</div>
+                  <div
+                    className={`enh-video-progress-ring${state === 'downloading' ? '' : ' hidden'}`}
+                  >
+                    <svg viewBox="0 0 36 36">
+                      <circle
+                        className="enh-video-progress-bg"
+                        cx="18"
+                        cy="18"
+                        r="15.5"
+                        fill="none"
+                        stroke="rgba(255,255,255,0.15)"
+                        strokeWidth="3"
+                      />
+                      <circle
+                        className="enh-video-progress-bar"
+                        cx="18"
+                        cy="18"
+                        r="15.5"
+                        fill="none"
+                        stroke="rgb(var(--accent-rgb))"
+                        strokeWidth="3"
+                        strokeDasharray={RING_LENGTH}
+                        // Counts DOWN as it fills: full offset is empty.
+                        strokeDashoffset={RING_LENGTH * (1 - Math.min(100, percent) / 100)}
+                        strokeLinecap="round"
+                        transform="rotate(-90 18 18)"
+                      />
+                    </svg>
+                  </div>
+                  <div className={`enh-video-done${state === 'completed' ? '' : ' hidden'}`}>✓</div>
+                  <div className={`enh-video-error${state === 'errored' ? '' : ' hidden'}`}>✗</div>
+                  {duration ? <span className="enh-video-duration">{duration}</span> : null}
+                </div>
+                <div className="enh-video-info">
+                  <div className="enh-video-title" title={video.title}>
+                    {video.title}
+                  </div>
+                  <div className="enh-video-channel">
+                    {video.channel}
+                    {views ? ` · ${views} views` : ''}
+                  </div>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/search/route.tsx
+++ b/webui/src/routes/search/route.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { getProfileHomePath } from '@/platform/shell/bridge';
+
+import { SearchPage } from './-ui/search-page';
+
+/**
+ * The Search page.
+ *
+ * No loader: nothing is worth fetching before the user types. The controller
+ * runs its own init on mount (/status then config-status) because the source
+ * picker's initial state depends on both, and a search only happens once there
+ * is a query.
+ */
+export const Route = createFileRoute('/search')({
+  beforeLoad: ({ context }) => {
+    const { bridge } = context.shell;
+
+    if (!bridge.isPageAllowed('search')) {
+      throw redirect({ href: getProfileHomePath(bridge), replace: true });
+    }
+  },
+  component: SearchPage,
+});

--- a/webui/static/core.js
+++ b/webui/static/core.js
@@ -49,6 +49,29 @@ let playlistTrackCache = {}; // Key: playlist_id, Value: tracks array
 let playlistTrackSnapshotCache = {}; // Key: playlist_id, Value: upstream snapshot_id at cache time
 let spotifyPlaylistsLoaded = false;
 let activeDownloadProcesses = {};
+/**
+ * Show the modal of an already-active download process, for the React pages.
+ *
+ * `activeDownloadProcesses` is a top-level `let`, so it lives in the script's
+ * lexical scope and is NOT a window property — a module cannot reach it. The
+ * download modal reopens an existing process by itself
+ * (openDownloadMissingModalForArtistAlbum, shared-helpers.js:1767), but the
+ * search page checks FIRST so it can skip fetching album detail it does not
+ * need. That is not just an optimisation: when the re-click happens while the
+ * metadata source is down, the fetch fails and the user gets an error toast
+ * instead of the modal they already had open.
+ *
+ * Returns whether a modal was shown, so the caller knows to stop.
+ */
+window.reopenActiveDownloadModal = function (virtualPlaylistId) {
+    const process = activeDownloadProcesses[virtualPlaylistId];
+    if (!process || !process.modalElement) return false;
+    if (process.status === 'complete') {
+        showToast('Showing previous results. Close this modal to start a new analysis.', 'info');
+    }
+    process.modalElement.style.display = 'flex';
+    return true;
+};
 let sequentialSyncManager = null;
 
 // --- YouTube Playlist State Management ---

--- a/webui/static/downloads.js
+++ b/webui/static/downloads.js
@@ -5731,6 +5731,12 @@ function _gsNavigateToSearchPage(query, src) {
             if (typeof _searchPageController !== 'undefined' && _searchPageController) {
                 _searchPageController.state.query = query || '';
             }
+            // The React search page's equivalent. It keeps its results across
+            // navigation, so without this the icon click below hands off a
+            // query from a PREVIOUS visit and overwrites what we just wrote.
+            if (typeof window._searchPageSetQuery === 'function') {
+                window._searchPageSetQuery(query || '');
+            }
 
             const soulseekIcon = document.querySelector('#enh-source-row [data-source="soulseek"]');
             if (soulseekIcon) {

--- a/webui/static/init.js
+++ b/webui/static/init.js
@@ -3264,11 +3264,13 @@ async function loadPageData(pageId) {
                 initializeSyncPage();
                 await loadSyncData();
                 break;
-            case 'search':
-                initializeSearch();
-                initializeSearchModeToggle();
-                initializeFilters();
-                break;
+            // No 'search' case: React owns /search, and loadPageData only runs
+            // for legacy-kind pages, so this could never fire again. The React
+            // page calls initializeSearch() and initializeFilters() itself after
+            // it adopts #basic-search-section — those still bind the BASIC
+            // panel, which has not been ported yet. initializeSearchModeToggle
+            // is deliberately not called anywhere: it is the vanilla enhanced
+            // controller React replaces.
             // No 'label-detail' case: React owns /label-detail, and loadPageData
             // only runs for legacy-kind pages. The vanilla renderer it used to
             // call (label-detail.js) is deleted.


### PR DESCRIPTION
# search page → react (1 of 3)

the enhanced/metadata half of `/search` is react now. same page, same behaviour — source picker, the six result sections, video grid, download modal, streaming, ownership badges, lazy artist photos, link/id lookup.

eight commits, phased: types/api/helpers → the source controller → the components → interactions → the page + manifest flip → three rounds of fixes from verification and live testing.

## basic search is still vanilla, and that shapes the whole PR

soulseek/basic search is pr 2. the shell shows a react page by removing `.active` from every `.page`, which would have hidden `#basic-search-section` along with the legacy page it lives in. so the react page **adopts** it — moves the real element into its own tree and puts it back on unmount. same node, same ids, same listeners.

moving the markup was only half of it. `initializeSearch()` is what binds that panel's search button, enter key and cancel, and it only ever ran from `case 'search':` in init.js — which can't fire for a react page. the react page calls it once itself. without that the panel renders perfectly and does nothing.

## fixed rather than ported

- **ownership badges landed by list position.** library-check answers come back in request order; the cards render grouped (albums, then singles). the two disagree the moment types interleave — an "in library" badge on a release you don't own. keyed by identity now.
- library artists would have read **"0 tracks"** — that endpoint only sends id/name/image_url.
- a track's `album` is a **string**, not an object, so it was dropping off every track's meta line.
- `formatViewCount` had no billions branch: a 1.2B-view video read **"1200.0M"**.

## things only a line-by-line read caught

the ✕ is a **clear** button, shown whenever the box has text — not a cancel-search button shown while loading. a fetching source swaps its logo for ⏳. cards glow from their artwork — **all** of them, not just artists (the stylesheet turns that palette into the hover border on album and track cards too). the picker falls forward off an unconfigured primary source instead of opening dimmed and empty. the icon tooltip says "served from" while the banner says "showing" — two different strings, both user-visible.

## worth knowing

- **results survive navigating away and back.** the vanilla page is never torn down, so its cache lives as long as the tab; a react route unmounts, so the cache lives outside it now.
- **the legacy enhanced markup is deleted.** every id in it — `#enhanced-search-input`, `#enhanced-main-results-area`, `#enh-source-row` — was also being rendered by react, and `getElementById` was choosing between them by document order.
- `#enhanced-main-results-area` looks like a dead placeholder and is not: `showSearchDownloadBubbles` draws download progress into it.
- new guard — `tests/test_react_ids_are_not_duplicated.py` fails if a react page renders an id `index.html` also has. it found **five pre-existing collisions** from the artist-detail port, listed as known debt rather than fixed here.

## bugs live testing found

**clicking an artist did nothing.** i wrote the hrefs as placeholders and never checked them: `/artist-detail/<id>`, where the real shape is `/artist-detail/<source>/<id>`. the source segment isn't decoration — `parseArtistDetailPath` rejects anything under three segments and the route is literally `/artist-detail/$source/$id`, so it matched nothing. library artists use the literal `library` in that slot; found artists carry their source and `?name=`.

that prompted an audit of every value this PR emits: 11 api endpoints, 24 dom ids, 14 css classes, every user-visible string — all traced to the vanilla. those two hrefs were the only invented ones, and the only things i'd never traced to a source.

## testing

1,544 vitest / 94 files, tsc clean, bundle clean, python guards clean.

mutation tested throughout — 74 mutants on the logic, 23 on the page. that's what caught **three tests of mine that proved nothing**: an adoption test asserting `document.body.contains()` (true whether or not the node moved), nothing at all covering whether the basic panel becomes *visible*, and a guard asserted synchronously against a request still in flight. `useVideoDownloads` had no tests at all. one surviving mutant is documented in the code as unproven rather than papered over.

live-tested: results render, library tagging, artist/album/track clicks, downloads, basic search.
