### PR TITLE
Tools page bugfixes

### DIFF
--- a/tests/test_tools_page_selectors.py
+++ b/tests/test_tools_page_selectors.py
@@ -119,13 +119,57 @@ def _all_classes() -> set[str]:
     return classes
 
 
+# The `.page` divs are flat siblings inside #main-content, so each one runs from
+# its own opening tag to the next one — and the last runs to the /main-content
+# marker. That beats depth-counting the tags: an HTML tag walker has to get void
+# elements, self-closing SVG children, multi-line comment banners and quoted
+# attributes all correct, and getting any of them wrong silently truncates a
+# region (mine closed #tools-page at 248 lines instead of 424, which quietly
+# hid three of the seven help buttons from the coverage test below).
+_MAIN_CONTENT_END = "<!-- /main-content -->"
+
+
+def _page_spans() -> dict[str, tuple[int, int]]:
+    """page id -> (first line, last line) of its `<div class="page">` block."""
+    lines = _html().split("\n")
+    starts: list[tuple[int, str]] = []
+    end_of_pages = len(lines)
+    for lineno, line in enumerate(lines, 1):
+        match = re.search(r'<div class="page" id="([^"]+)"', line)
+        if match:
+            starts.append((lineno, match.group(1)))
+        elif _MAIN_CONTENT_END in line and starts:
+            end_of_pages = lineno - 1
+            break
+
+    assert starts, "found no `<div class=\"page\">` blocks in index.html"
+    spans: dict[str, tuple[int, int]] = {}
+    for position, (lineno, page_id) in enumerate(starts):
+        following = starts[position + 1][0] - 1 if position + 1 < len(starts) else end_of_pages
+        spans[page_id] = (lineno, following)
+    return spans
+
+
+def _page_of_id() -> dict[str, str]:
+    """id -> the page id containing it. Ids outside every page are absent."""
+    spans = _page_spans()
+    mapping: dict[str, str] = {}
+    for lineno, line in enumerate(_html().split("\n"), 1):
+        found = re.findall(r'\bid="([^"]+)"', line)
+        if not found:
+            continue
+        for page_id, (start, end) in spans.items():
+            if start <= lineno <= end:
+                for element_id in found:
+                    mapping.setdefault(element_id, page_id.replace("-page", ""))
+                break
+    return mapping
+
+
 def _tools_region() -> str:
     """The #tools-page markup, start tag through its matching close."""
-    html = _html()
-    start = html.index(f'<div class="page" id="{TOOLS_PAGE_ID}">')
-    # The region ends at the next sibling at the same indentation.
-    end = html.index("\n            <!--", start)
-    return html[start:end]
+    start, end = _page_spans()[TOOLS_PAGE_ID]
+    return "\n".join(_html().split("\n")[start - 1 : end])
 
 
 def test_get_element_by_id_never_names_a_css_class():
@@ -238,16 +282,7 @@ def test_helper_page_hints_never_route_to_a_page_without_the_element():
                     return page
         return None
 
-    # Map each id in index.html to the .page that contains it.
-    html_lines = _html().split("\n")
-    page_of: dict[str, str] = {}
-    current: str | None = None
-    for line in html_lines:
-        page = re.search(r'<div class="page" id="([^"]+)-page"', line)
-        if page:
-            current = page.group(1)
-        for found in re.findall(r'\bid="([^"]+)"', line):
-            page_of.setdefault(found, current)
+    page_of = _page_of_id()
 
     offenders = []
     for selector in re.findall(r"^\s{4}'(#[^']+)':\s*\{", src, re.M):
@@ -265,15 +300,7 @@ def test_setup_step_selectors_live_on_the_page_the_step_names():
     """SETUP_STEPS navigates to `page` then highlights `selector`; the first-scan
     step pointed at the dashboard while #db-updater-card is on the tools page."""
     src = _read(STATIC / "helper.js")
-    html_lines = _html().split("\n")
-    page_of: dict[str, str] = {}
-    current: str | None = None
-    for line in html_lines:
-        page = re.search(r'<div class="page" id="([^"]+)-page"', line)
-        if page:
-            current = page.group(1)
-        for found in re.findall(r'\bid="([^"]+)"', line):
-            page_of.setdefault(found, current)
+    page_of = _page_of_id()
 
     steps = re.search(r"const SETUP_STEPS = \[(.*?)\n\];", src, re.S)
     assert steps, "could not find SETUP_STEPS in helper.js"

--- a/tests/test_tools_page_selectors.py
+++ b/tests/test_tools_page_selectors.py
@@ -1,0 +1,356 @@
+"""Guards for the DOM contract between the vanilla Tools page and its JS.
+
+Every bug these lock in was a silent one: no error, no failing test, just a
+control that quietly stopped working. They are all the same shape — a string
+literal in JS that names something the markup does not actually have.
+
+Written alongside the Tools-page bugfix PR; see tools-p0-notes for the full read.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+WEBUI = Path(__file__).resolve().parent.parent / "webui"
+INDEX = WEBUI / "index.html"
+STATIC = WEBUI / "static"
+
+# The Tools page markup region in index.html (`<div class="page" id="tools-page">`).
+TOOLS_PAGE_ID = "tools-page"
+
+# Files that own Tools-page behaviour (the call closure of #tools-page).
+TOOLS_CLOSURE_FILES = {
+    "enrichment.js",
+    "wishlist-tools.js",
+    "api-monitor.js",
+    "media-player.js",
+    "config-migration.js",
+    "manual-library-match.js",
+    "stats-automations.js",
+    "sync-services.js",
+}
+
+# Pre-existing `getElementById('<a class name>')` calls in OTHER features. Each
+# was verified the same way the media-scan one was: the token is never assigned
+# as an id anywhere (markup, JS templates, `.id =`, setAttribute, or the React
+# sources), so every one of these lookups returns null and whatever it guards
+# silently does nothing.
+#
+# They are NOT fixed here — they belong to the track-detail modal, the retag
+# modal, the downloads stat row and the automations list, none of which this PR
+# audited. Allowlisted so this test is a ratchet rather than a blocker.
+# Shrink this list; never grow it.
+KNOWN_CLASS_AS_ID = {
+    # track-detail modal: audio element, artwork, badges, provenance, actions
+    ("track-detail.js", "td-audio"),
+    ("track-detail.js", "td-thumb"),
+    ("track-detail.js", "td-thumb-ph"),
+    ("track-detail.js", "td-status-badge"),
+    ("track-detail.js", "td-provenance"),
+    ("track-detail.js", "td-reason"),
+    ("track-detail.js", "td-actions"),
+    # retag modal
+    ("wishlist-tools.js", "retag-batch-bar"),
+    ("wishlist-tools.js", "retag-batch-count"),
+    ("wishlist-tools.js", "retag-clear-all-btn"),
+    ("wishlist-tools.js", "retag-modal-body"),
+    ("wishlist-tools.js", "retag-search-results"),
+    # downloads stat row
+    ("downloads.js", "stat-found"),
+    ("downloads.js", "stat-missing"),
+    ("downloads.js", "stat-downloaded"),
+    ("downloads.js", "artists-grid"),
+    # automations list + artist tooling
+    ("stats-automations.js", "automations-list"),
+    ("stats-automations.js", "automations-empty"),
+    ("stats-automations.js", "automations-stats"),
+    ("stats-automations.js", "library-artist-write-image-btn"),
+    ("shared-helpers.js", "artists-search-state"),
+    ("sync-services.js", "expand-indicator"),
+}
+
+# Pre-existing dangling class selectors, same deal.
+KNOWN_DEAD_CLASS_SELECTORS = {
+    ("stats-automations.js", "write-image-text"),
+}
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def _static_js() -> dict[str, str]:
+    return {p.name: _read(p) for p in sorted(STATIC.glob("*.js"))}
+
+
+def _html() -> str:
+    return _read(INDEX)
+
+
+def _all_ids() -> set[str]:
+    """Every id the app can actually produce — markup, JS templates (either quote
+    style), direct `.id =` assignment, setAttribute, and the React sources."""
+    blob = _html() + "".join(_static_js().values())
+    for pattern in ("src/**/*.ts", "src/**/*.tsx"):
+        for path in WEBUI.glob(pattern):
+            blob += _read(path)
+
+    ids: set[str] = set()
+    ids |= set(re.findall(r"""\bid=["']([^"'$<>]+)["']""", blob))
+    ids |= set(re.findall(r"""\bid=\{?["'`]([\w-]+)["'`]\}?""", blob))
+    ids |= set(re.findall(r"""\.id\s*=\s*["'`]([\w-]+)["'`]""", blob))
+    ids |= set(re.findall(r"""setAttribute\(\s*["']id["']\s*,\s*["']([\w-]+)["']""", blob))
+    return ids
+
+
+def _all_classes() -> set[str]:
+    """Class tokens present in markup, JS templates, classList calls or CSS."""
+    blob = _html() + "".join(_static_js().values())
+    classes: set[str] = set()
+    for group in re.findall(r"""\bclass(?:Name)?\s*=\s*["']([^"']+)["']""", blob):
+        classes.update(w for w in group.split() if w and "$" not in w)
+    for args in re.findall(r"classList\.(?:add|toggle|remove|contains)\(([^)]*)\)", blob):
+        classes.update(re.findall(r"""['"]([\w-]+)['"]""", args))
+    for css in STATIC.glob("*.css"):
+        classes.update(re.findall(r"\.([a-zA-Z][\w-]*)\s*[\{,:]", _read(css)))
+    return classes
+
+
+def _tools_region() -> str:
+    """The #tools-page markup, start tag through its matching close."""
+    html = _html()
+    start = html.index(f'<div class="page" id="{TOOLS_PAGE_ID}">')
+    # The region ends at the next sibling at the same indentation.
+    end = html.index("\n            <!--", start)
+    return html[start:end]
+
+
+def test_get_element_by_id_never_names_a_css_class():
+    """`getElementById('x')` where x is only ever a CLASS is always a dead lookup.
+
+    This is exactly how the media-scan button broke: the websocket completion
+    handler looked up `media-scan-btn` (the class) instead of `media-scan-button`
+    (the id), so it never re-enabled the button and Scan Library died after one
+    click.
+    """
+    ids, classes = _all_ids(), _all_classes()
+    offenders = []
+    for name, src in _static_js().items():
+        for lineno, line in enumerate(src.split("\n"), 1):
+            for match in re.finditer(r"""getElementById\(\s*['"]([\w-]+)['"]""", line):
+                token = match.group(1)
+                if token in ids or token not in classes:
+                    continue
+                if (name, token) in KNOWN_CLASS_AS_ID:
+                    continue
+                offenders.append(f"{name}:{lineno} getElementById('{token}') — that's a CSS class, not an id")
+    assert not offenders, "getElementById called with a class name:\n  " + "\n  ".join(offenders)
+
+
+def test_tools_closure_class_selectors_resolve():
+    """A `.foo` selector in the Tools closure must match a class that exists.
+
+    `openRepairModal` scrolled to `.tools-maintenance-section` for however long;
+    the hero's class is `tools-maintenance-hero`, so the scroll never happened.
+    """
+    classes = _all_classes()
+    offenders = []
+    for name, src in _static_js().items():
+        if name not in TOOLS_CLOSURE_FILES:
+            continue
+        for lineno, line in enumerate(src.split("\n"), 1):
+            for match in re.finditer(r"""querySelector(?:All)?\(\s*['"]([^'"$]*)['"]\s*\)""", line):
+                selector = match.group(1)
+                for token in re.findall(r"\.([a-zA-Z][\w-]*)", selector):
+                    if token in classes or (name, token) in KNOWN_DEAD_CLASS_SELECTORS:
+                        continue
+                    offenders.append(f"{name}:{lineno} querySelector('{selector}') — no such class '.{token}'")
+    assert not offenders, "dangling class selector in the Tools closure:\n  " + "\n  ".join(offenders)
+
+
+def test_repair_hero_selector_is_scoped_to_the_music_tools_page():
+    """`.tools-maintenance-hero` exists TWICE — video tools uses it too, and comes
+    first in the document. An unscoped query lands on the wrong hero."""
+    html = _html()
+    assert html.count('class="tools-maintenance-hero"') == 2, (
+        "expected exactly two maintenance heroes (music + video); update this guard if that changed"
+    )
+    enrichment = _read(STATIC / "enrichment.js")
+    assert "'#tools-page .tools-maintenance-hero'" in enrichment, (
+        "openRepairModal must scope its hero lookup to #tools-page, or it scrolls to the video one"
+    )
+
+
+def test_every_tool_help_button_has_help_content():
+    """A `?` button whose data-tool has no TOOL_HELP_CONTENT entry does nothing
+    but log a console warning — a visibly dead control."""
+    region = _tools_region()
+    declared = sorted(set(re.findall(r'data-tool="([^"]+)"', region)))
+    assert declared, "expected the Tools page to carry data-tool help buttons"
+
+    src = _read(STATIC / "wishlist-tools.js")
+    start = src.index("const TOOL_HELP_CONTENT")
+    brace = src.index("{", start)
+    depth, idx = 0, brace
+    while idx < len(src):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        idx += 1
+    keys = set(re.findall(r"^\s{4}'([^']+)':", src[brace:idx], re.M))
+
+    missing = [tool for tool in declared if tool not in keys]
+    assert not missing, f"tools page help buttons with no TOOL_HELP_CONTENT entry: {missing}"
+
+
+def test_helper_page_hints_never_route_to_a_page_without_the_element():
+    """helper.js's search jumps to `_guessPageFromSelector(selector)` and then
+    looks for the element there. All eight tool cards were listed under
+    'dashboard' while living in #tools-page, so every hit navigated away and
+    found nothing.
+
+    A selector with no hint at all is tolerated (it just doesn't navigate); a
+    hint pointing at the WRONG page is not.
+    """
+    src = _read(STATIC / "helper.js")
+    hints_block = re.search(r"const pageHints = \{(.*?)\n    \};", src, re.S)
+    assert hints_block, "could not find pageHints in helper.js"
+
+    hints: list[tuple[str, list[str]]] = []
+    for line in hints_block.group(1).strip().split("\n"):
+        match = re.match(r"\s*'([^']+)':\s*\[(.*)\],?\s*$", line)
+        if match:
+            patterns = [p.strip().strip("'") for p in match.group(2).split(",") if p.strip()]
+            hints.append((match.group(1), patterns))
+    assert hints, "parsed no pageHints entries"
+
+    def guess(selector: str) -> str | None:
+        lowered = selector.lower()
+        for page, patterns in hints:
+            for pattern in patterns:
+                if pattern.lower() in lowered:
+                    return page
+        return None
+
+    # Map each id in index.html to the .page that contains it.
+    html_lines = _html().split("\n")
+    page_of: dict[str, str] = {}
+    current: str | None = None
+    for line in html_lines:
+        page = re.search(r'<div class="page" id="([^"]+)-page"', line)
+        if page:
+            current = page.group(1)
+        for found in re.findall(r'\bid="([^"]+)"', line):
+            page_of.setdefault(found, current)
+
+    offenders = []
+    for selector in re.findall(r"^\s{4}'(#[^']+)':\s*\{", src, re.M):
+        base = selector[1:].split(" ")[0].split(".")[0]
+        actual = page_of.get(base)
+        if actual is None:
+            continue  # not a page-scoped element (global chrome, or JS-created)
+        guessed = guess(selector)
+        if guessed is not None and guessed != actual:
+            offenders.append(f"{selector} routes to '{guessed}' but lives on '{actual}'")
+    assert not offenders, "helper.js page hints point at the wrong page:\n  " + "\n  ".join(offenders)
+
+
+def test_setup_step_selectors_live_on_the_page_the_step_names():
+    """SETUP_STEPS navigates to `page` then highlights `selector`; the first-scan
+    step pointed at the dashboard while #db-updater-card is on the tools page."""
+    src = _read(STATIC / "helper.js")
+    html_lines = _html().split("\n")
+    page_of: dict[str, str] = {}
+    current: str | None = None
+    for line in html_lines:
+        page = re.search(r'<div class="page" id="([^"]+)-page"', line)
+        if page:
+            current = page.group(1)
+        for found in re.findall(r'\bid="([^"]+)"', line):
+            page_of.setdefault(found, current)
+
+    steps = re.search(r"const SETUP_STEPS = \[(.*?)\n\];", src, re.S)
+    assert steps, "could not find SETUP_STEPS in helper.js"
+
+    offenders = []
+    for line in steps.group(1).split("\n"):
+        page = re.search(r"page:\s*'([^']+)'", line)
+        selector = re.search(r"selector:\s*'#([\w-]+)'", line)
+        if not (page and selector):
+            continue
+        actual = page_of.get(selector.group(1))
+        if actual is not None and actual != page.group(1):
+            offenders.append(
+                f"step selector #{selector.group(1)} is on '{actual}' but the step navigates to '{page.group(1)}'"
+            )
+    assert not offenders, "SETUP_STEPS navigates to the wrong page:\n  " + "\n  ".join(offenders)
+
+
+# Files this PR converted end to end. stats-automations.js is deliberately NOT
+# here: it still has one native confirm() at the artist.jpg overwrite prompt
+# (~:5944), which belongs to the artist-image writer, not the Tools page.
+CONFIRM_CLEAN_FILES = {"enrichment.js", "wishlist-tools.js", "config-migration.js", "api-monitor.js"}
+
+
+def test_tools_page_uses_no_native_confirm():
+    """SoulSync uses showConfirmDialog everywhere; window.confirm is a hard no.
+
+    config-migration.js keeps ONE guarded fallback for the case where core.js
+    hasn't defined showConfirmDialog — that's the only permitted use, and it is
+    recognised by the `typeof showConfirmDialog === 'function'` test guarding it.
+    """
+    offenders = []
+    for name, src in _static_js().items():
+        if name not in CONFIRM_CLEAN_FILES:
+            continue
+        lines = src.split("\n")
+        for lineno, line in enumerate(lines, 1):
+            if not re.search(r"(?<![.\w])confirm\s*\(", line) and "window.confirm" not in line:
+                continue
+            if "showConfirmDialog" in line or "confirmText" in line:
+                continue
+            # Permitted: the `else` arm of an explicit availability check. The
+            # guard sits at the head of the if/else chain, so look back far
+            # enough to clear the showConfirmDialog({...}) call in between.
+            window_before = "\n".join(lines[max(0, lineno - 15) : lineno])
+            if "typeof showConfirmDialog" in window_before:
+                continue
+            offenders.append(f"{name}:{lineno} {line.strip()[:90]}")
+    assert not offenders, "native confirm() where showConfirmDialog is required:\n  " + "\n  ".join(offenders)
+
+
+@pytest.mark.parametrize(
+    "helper_name",
+    ["initializeToolHelpButtons"],
+)
+def test_repeat_bound_initialisers_are_idempotent(helper_name: str):
+    """initializeToolsPage() re-runs on every visit to the Tools page, so anything
+    it calls must guard its listener binding. This one used to add a fresh
+    document-level keydown handler per visit."""
+    src = _read(STATIC / "wishlist-tools.js")
+    start = src.index(f"function {helper_name}(")
+    brace = src.index("{", start)
+    depth, idx = 0, brace
+    while idx < len(src):
+        if src[idx] == "{":
+            depth += 1
+        elif src[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        idx += 1
+    body = src[brace : idx + 1]
+
+    assert "document.addEventListener" not in body, (
+        f"{helper_name} binds a document-level listener but runs on every Tools visit — "
+        "the handlers accumulate. Bind it once at module scope instead."
+    )
+    assert "_toolsWired" in body, (
+        f"{helper_name} runs on every Tools visit; guard its bindings with a _toolsWired flag"
+    )

--- a/webui/static/api-monitor.js
+++ b/webui/static/api-monitor.js
@@ -1559,8 +1559,12 @@ async function checkAndHideMetadataUpdaterForNonPlex() {
                     metadataCard.style.display = 'flex';
                     console.log(`Metadata updater shown: ${data.active_server} is active server`);
 
-                    // Update the header text to reflect the current server
-                    const headerElement = metadataCard.querySelector('.card-header h3');
+                    // Update the header text to reflect the current server.
+                    // The card markup is .tool-card-header > h4.tool-card-title —
+                    // the old '.card-header h3' selector matched nothing, so this
+                    // rename never happened. Same pattern the DB updater card uses
+                    // (updateDbUpdaterCardInfo in wishlist-tools.js).
+                    const headerElement = metadataCard.querySelector('.tool-card-title');
                     if (headerElement) {
                         const serverDisplayName = data.active_server.charAt(0).toUpperCase() + data.active_server.slice(1);
                         headerElement.textContent = `${serverDisplayName} Metadata Updater`;
@@ -1693,21 +1697,34 @@ async function handleMediaScanButtonClick() {
                     const maxPolls = 150; // 5 minutes
 
                     pollInterval = setInterval(async () => {
-                        if (socketConnected) return; // Phase 5: WS handles scan status
+                        // Count EVERY tick, including the ones the websocket
+                        // short-circuits below. Counting after that guard meant
+                        // pollCount never advanced on a socket-connected client
+                        // — the normal case — so this clearInterval was
+                        // unreachable and the 2s timer leaked for the life of
+                        // the page, once per Scan Library click.
                         pollCount++;
 
                         if (pollCount > maxPolls) {
                             // Polling timeout after 5 minutes
                             clearInterval(pollInterval);
-                            button.disabled = false;
-                            phaseLabel.textContent = 'Scan completed';
-                            progressBar.style.width = '0%';
-                            progressLabel.textContent = 'Ready for next scan';
-                            statusValue.textContent = 'Idle';
-                            statusValue.style.color = '#b3b3b3';
-                            showToast('✅ Media scan completed', 'success', 3000);
+                            pollInterval = null;
+                            // With a live socket updateMediaScanFromData already
+                            // owns the card, so don't stomp it with a synthetic
+                            // "completed" state we never actually observed.
+                            if (!socketConnected) {
+                                button.disabled = false;
+                                phaseLabel.textContent = 'Scan completed';
+                                progressBar.style.width = '0%';
+                                progressLabel.textContent = 'Ready for next scan';
+                                statusValue.textContent = 'Idle';
+                                statusValue.style.color = '#b3b3b3';
+                                showToast('✅ Media scan completed', 'success', 3000);
+                            }
                             return;
                         }
+
+                        if (socketConnected) return; // Phase 5: WS handles scan status
 
                         try {
                             const statusResponse = await fetch('/api/scan/status');

--- a/webui/static/config-migration.js
+++ b/webui/static/config-migration.js
@@ -73,14 +73,20 @@
         });
 
         overlay.querySelector('#cfgx-secrets').onchange = function () {
-            _withSecrets = this.checked;
-            if (_withSecrets && !window.confirm(
-                'Include credentials?\n\nThe exported file will contain your real API keys, ' +
-                'tokens and passwords in plain text. Only do this for a private migration, ' +
-                'and delete the file afterward.')) {
-                this.checked = false; _withSecrets = false; return;
-            }
-            loadExport();
+            var cb = this;
+            _withSecrets = cb.checked;
+            if (!_withSecrets) { loadExport(); return; }
+            showConfirmDialog({
+                title: 'Include credentials?',
+                message: 'The exported file will contain your real API keys, tokens and ' +
+                    'passwords in plain text. Only do this for a private migration, and ' +
+                    'delete the file afterward.',
+                confirmText: 'Include them',
+                destructive: true,
+            }).then(function (ok) {
+                if (!ok) { cb.checked = false; _withSecrets = false; return; }
+                loadExport();
+            });
         };
         overlay.querySelector('#cfgx-copy').onclick = function () {
             if (!_bundle) return;

--- a/webui/static/enrichment.js
+++ b/webui/static/enrichment.js
@@ -1914,7 +1914,11 @@ async function openRepairModal() {
     navigateToPage('tools');
     // Scroll to maintenance section
     setTimeout(() => {
-        const section = document.querySelector('.tools-maintenance-section');
+        // The class is `tools-maintenance-hero`, not `-section` — the old
+        // selector matched nothing so this never scrolled. Scope it to
+        // #tools-page: the VIDEO tools subpage carries the same class and comes
+        // first in the document, so an unscoped query lands on the wrong hero.
+        const section = document.querySelector('#tools-page .tools-maintenance-hero');
         if (section) section.scrollIntoView({ behavior: 'smooth' });
     }, 100);
     _repairCurrentTab = 'jobs';
@@ -2818,7 +2822,12 @@ async function _failedMBDelete(entryId) {
 }
 
 async function _failedMBClearAll() {
-    if (!confirm(`Clear all ${_failedMBState.total} failed lookups? They will be retried on next enrichment run.`)) return;
+    if (!await showConfirmDialog({
+        title: 'Clear Failed Lookups',
+        message: `Clear all ${_failedMBState.total} failed lookups? They will be retried on the next enrichment run.`,
+        confirmText: 'Clear All',
+        destructive: true
+    })) return;
     try {
         const resp = await fetch('/api/metadata-cache/clear-musicbrainz?failed_only=true', { method: 'DELETE' });
         const data = await resp.json();

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -306,7 +306,9 @@ const HELPER_CONTENT = {
         description: 'RAM consumed by the SoulSync process. Includes web server, all background workers, metadata caches, and WebSocket connections.',
     },
 
-    // ─── DASHBOARD: TOOL CARDS ──────────────────────────────────────
+    // ─── TOOLS PAGE: TOOL CARDS ─────────────────────────────────────
+    // These all live in #tools-page. They were labelled (and routed) as
+    // dashboard cards, which sent helper search straight to the wrong page.
 
     '#db-updater-card': {
         title: 'Database Updater',
@@ -348,15 +350,9 @@ const HELPER_CONTENT = {
         ],
         docsId: 'discover'
     },
-    '#retag-tool-card': {
-        title: 'Retag Tool',
-        description: 'Queue of tracks needing metadata corrections. When enrichment detects better metadata than what\'s in your files, corrections appear here for batch review.',
-        tips: [
-            'Groups corrections by artist for efficient processing',
-            'Preview all changes before applying',
-            'Writes corrected tags directly to audio files'
-        ]
-    },
+    // (#retag-tool-card removed — no element with that id exists anywhere, so
+    // the entry could only ever produce a helper search result that goes
+    // nowhere. Library re-tagging is the `library_retag` maintenance job now.)
     '#media-scan-card': {
         title: 'Media Server Scan',
         description: 'Manually trigger a library scan on your media server. SoulSync auto-scans after downloads, but this is useful after bulk imports or external changes.',
@@ -3000,7 +2996,7 @@ const SETUP_STEPS = [
     { id: 'media-server',    label: 'Connect Media Server',         desc: 'Plex, Jellyfin, or Navidrome',                       icon: '🖥️', page: 'settings' },
     { id: 'download-source', label: 'Set Up Download Source',       desc: 'Soulseek, YouTube, Tidal, Qobuz, HiFi, or Deezer',  icon: '⬇️', page: 'settings', settingsTab: 'downloads' },
     { id: 'download-paths',  label: 'Configure Download Paths',     desc: 'Where music is saved and organized',                 icon: '📁', page: 'settings', settingsTab: 'downloads' },
-    { id: 'first-scan',      label: 'Run First Library Scan',       desc: 'Import your existing collection from media server',  icon: '🔍', page: 'dashboard', selector: '#db-updater-card' },
+    { id: 'first-scan',      label: 'Run First Library Scan',       desc: 'Import your existing collection from media server',  icon: '🔍', page: 'tools', selector: '#db-updater-card' },
     { id: 'first-download',  label: 'Download Your First Track',    desc: 'Search for and download something',                  icon: '🎶', page: 'search' },
     { id: 'watchlist',       label: 'Add an Artist to Watchlist',   desc: 'Monitor for new releases automatically',             icon: '👁️', page: 'library' },
     { id: 'automation',      label: 'Create an Automation',         desc: 'Schedule tasks and build workflows',                 icon: '🤖', page: 'automations' },
@@ -3456,11 +3452,22 @@ function _guessPageFromSelector(selector) {
         'artists':     ['artists-search', 'artists-hero', 'artist-detail', 'similar-artists'],
         'automations': ['automations-', 'auto-', 'builder-'],
         'library':     ['library-', 'alphabet-selector', 'watchlist-filter'],
-        'stats':       ['stats-'],
+        // '#stats-' not 'stats-': the bare prefix also matched
+        // #listening-stats-enabled, which is a Settings control, so its helper
+        // search result navigated to the Stats page and found nothing.
+        'stats':       ['#stats-'],
         'import':      ['import-page-'],
         'settings':    ['settings-', 'stg-tab', 'api-service', 'server-toggle', 'save-button', 'spotify-client', 'soulseek-url', 'quality-profile'],
         'issues':      ['issues-'],
-        'dashboard':   ['dashboard-', 'service-card', 'watchlist-button', 'wishlist-button', 'db-updater', 'metadata-updater', 'duplicate-cleaner', 'discovery-pool-card', 'retag-tool', 'media-scan', 'backup-manager', 'metadata-cache'],
+        // The tool cards live in #tools-page, NOT on the dashboard. They were
+        // listed under 'dashboard' here, so a helper search hit navigated to the
+        // dashboard and then found nothing to point at. Must stay ABOVE
+        // 'dashboard' so 'metadata-cache'/'metadata-updater' win over any
+        // future 'dashboard-' style prefix.
+        // NB: no 'repair-' pattern here — #repair-button is the worker orb in the
+        // dashboard's markup, not a tools-page element.
+        'tools':       ['db-updater', 'reconcile-ids', 'duplicate-cleaner', 'discovery-pool-card', 'manual-library-match', 'metadata-updater', 'media-scan', 'backup-manager', 'config-migration', 'metadata-cache', 'blacklist-card'],
+        'dashboard':   ['dashboard-', 'service-card', 'watchlist-button', 'wishlist-button'],
     };
 
     const selectorLower = selector.toLowerCase();

--- a/webui/static/media-player.js
+++ b/webui/static/media-player.js
@@ -560,7 +560,10 @@ function updateMediaScanFromData(data) {
 
     const phaseLabel = document.getElementById('media-scan-phase-label');
     const progressLabel = document.getElementById('media-scan-progress-label');
-    const button = document.getElementById('media-scan-btn');
+    // `media-scan-btn` is the CLASS; the id is `media-scan-button`. Reading the
+    // class as an id made this always null, so the websocket completion path
+    // never re-enabled the button and Scan Library stayed dead after one click.
+    const button = document.getElementById('media-scan-button');
     const progressBar = document.getElementById('media-scan-progress-bar');
     const statusValue = document.getElementById('media-scan-status');
 

--- a/webui/static/wishlist-tools.js
+++ b/webui/static/wishlist-tools.js
@@ -2572,11 +2572,13 @@ async function handleReconcileIdsButtonClick() {
     if (!button) return;
     if (button.textContent.trim() !== 'Scan Library') return; // already running
 
-    const ok = confirm(
-        'Scan every library file for embedded provider IDs and fill any that are ' +
-        'missing in the database?\n\nEach file is read once. Existing matches are ' +
-        'never overwritten. This can take a while on large libraries.'
-    );
+    const ok = await showConfirmDialog({
+        title: 'Import IDs from File Tags',
+        message: 'Scan every library file for embedded provider IDs and fill any that are ' +
+            'missing in the database?\n\nEach file is read once. Existing matches are ' +
+            'never overwritten. This can take a while on large libraries.',
+        confirmText: 'Scan Library'
+    });
     if (!ok) return;
 
     try {
@@ -4938,7 +4940,12 @@ function toggleMcacheClearDropdown(event) {
 }
 
 async function clearMetadataCache() {
-    if (!confirm('Clear ALL cached metadata? This removes all cached API responses.')) return;
+    if (!await showConfirmDialog({
+        title: 'Clear Metadata Cache',
+        message: 'Clear ALL cached metadata? This removes every cached API response — lookups will have to be made again.',
+        confirmText: 'Clear All',
+        destructive: true
+    })) return;
     document.getElementById('mcache-clear-dropdown-menu').style.display = 'none';
 
     try {
@@ -4958,7 +4965,12 @@ async function clearMetadataCache() {
 }
 
 async function clearMetadataCacheBySource(source) {
-    if (!confirm(`Clear all ${source} cached metadata?`)) return;
+    if (!await showConfirmDialog({
+        title: 'Clear Cache by Source',
+        message: `Clear all ${source} cached metadata?`,
+        confirmText: 'Clear',
+        destructive: true
+    })) return;
     document.getElementById('mcache-clear-dropdown-menu').style.display = 'none';
 
     try {
@@ -4979,7 +4991,12 @@ async function clearMetadataCacheBySource(source) {
 
 async function clearMusicBrainzCache(failedOnly = false) {
     const label = failedOnly ? 'failed MusicBrainz lookups' : 'ALL MusicBrainz cache entries';
-    if (!confirm(`Clear ${label}?`)) return;
+    if (!await showConfirmDialog({
+        title: 'Clear MusicBrainz Cache',
+        message: `Clear ${label}?`,
+        confirmText: 'Clear',
+        destructive: !failedOnly
+    })) return;
     document.getElementById('mcache-clear-dropdown-menu').style.display = 'none';
 
     try {
@@ -5074,6 +5091,34 @@ const TOOL_HELP_CONTENT = {
 
             <h4>Note</h4>
             <p>Available for <strong>Plex</strong> and <strong>Jellyfin</strong> media servers. Each enrichment worker only runs if its service is authenticated.</p>
+        `
+    },
+    'reconcile-ids': {
+        title: 'Import IDs from File Tags',
+        content: `
+            <h4>What does this tool do?</h4>
+            <p>Reads provider IDs that are already embedded in your audio files — Spotify, MusicBrainz, iTunes, Deezer and friends — and fills them into the database where they're missing.</p>
+
+            <h4>Why it's worth running</h4>
+            <p>Every ID it recovers is one the enrichment workers no longer have to go looking for. On a large library that's a lot of API calls skipped, and matches that were already correct in your tags get used instead of being re-guessed.</p>
+
+            <h4>How safe is it?</h4>
+            <ul>
+                <li><strong>Only fills blanks.</strong> An existing match is never overwritten.</li>
+                <li><strong>Read-only on your files.</strong> Each file is opened once to read tags; nothing is written back to disk.</li>
+                <li><strong>Conflicts are skipped, not applied.</strong> If a tag disagrees with a stored ID, the row is counted under Conflicts and left alone.</li>
+            </ul>
+
+            <h4>The counters</h4>
+            <ul>
+                <li><strong>IDs Filled:</strong> individual provider IDs written</li>
+                <li><strong>Rows Updated:</strong> database rows touched (a row can gain several IDs)</li>
+                <li><strong>Conflicts:</strong> tag disagreed with an existing match — skipped</li>
+                <li><strong>Unreadable:</strong> files whose tags could not be parsed</li>
+            </ul>
+
+            <h4>Note</h4>
+            <p>Reads every file in the library, so it can take a while on large collections. Safe to re-run — a second pass only picks up what's still blank.</p>
         `
     },
     'duplicate-cleaner': {
@@ -6283,22 +6328,30 @@ const TOOL_HELP_CONTENT = {
     }
 };
 
+// Called from initializeToolsPage() on EVERY visit to the Tools page, so every
+// binding here has to be idempotent. It used to add a fresh listener per call —
+// including a document-level keydown — so N visits left N keydown handlers and N
+// click handlers per help button. Guarded the same way the tool buttons in
+// initializeToolsPage are (`_toolsWired`).
 function initializeToolHelpButtons() {
-    const helpButtons = document.querySelectorAll('.tool-help-button');
-    const modal = document.getElementById('tool-help-modal');
-    const closeButton = modal.querySelector('.tool-help-modal-close');
-
-    // Attach click handlers to all help buttons
-    helpButtons.forEach(button => {
+    document.querySelectorAll('.tool-help-button').forEach(button => {
+        if (button._toolsWired) return;
         button.addEventListener('click', (e) => {
             e.stopPropagation();
-            const toolId = button.getAttribute('data-tool');
-            openToolHelpModal(toolId);
+            openToolHelpModal(button.getAttribute('data-tool'));
         });
+        button._toolsWired = true;
     });
 
-    // Close modal when clicking close button
-    closeButton.addEventListener('click', closeToolHelpModal);
+    // The modal itself lives outside #tools-page (index.html), so it survives
+    // navigation — bind it once and never again. Also guard the lookup: a throw
+    // here used to abort initializeToolsPage before the DB/cache/pool stats and
+    // switchRepairTab('jobs') ever ran.
+    const modal = document.getElementById('tool-help-modal');
+    if (!modal || modal._toolsWired) return;
+
+    const closeButton = modal.querySelector('.tool-help-modal-close');
+    if (closeButton) closeButton.addEventListener('click', closeToolHelpModal);
 
     // Close modal when clicking outside content
     modal.addEventListener('click', (e) => {
@@ -6307,12 +6360,7 @@ function initializeToolHelpButtons() {
         }
     });
 
-    // Close modal on Escape key
-    document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && modal.classList.contains('active')) {
-            closeToolHelpModal();
-        }
-    });
+    modal._toolsWired = true;
 }
 
 function openToolHelpModal(toolId) {


### PR DESCRIPTION
# tools page — six dead controls

read the whole tools page before starting the react port and found six things
quietly broken. all the same shape: a string in the js naming something the
markup doesn't actually have — so no error, no failing test, the control just
does nothing.

fixing these first so the port has a working page to port.

## the six

**1. media scan sticks + leaks a timer.** two things stacked. the websocket
handler looked up `media-scan-btn` — that's the *class*, the id is
`media-scan-button` — so it never re-enabled the button. and the fallback poll
had `if (socketConnected) return` sitting above `pollCount++`, so on a normal
socket-connected client the counter never moved and its `clearInterval` was
unreachable. one 2s timer leaked per click, for the life of the page. plex-only
card, which is why nobody hit it.

**2. helper search sent every tool card to the dashboard.** all eight are listed
under the `dashboard` page hint but they live in `#tools-page`, so searching
"backup manager" navigated to the dashboard and then found nothing to point at.
same for the "run first library scan" setup step. also `stats-` was matching
`#listening-stats-enabled`, which is a settings control.

**3. the repair button never scrolled to the maintenance section.** it queried
`.tools-maintenance-section`; the class is `tools-maintenance-hero`. scoped it to
`#tools-page` as well — the video tools page uses the same class and comes first
in the document, so an unscoped query grabs the wrong hero.

**4. the `?` on "import ids from file tags" did nothing** — no help entry for
`data-tool="reconcile-ids"`. written.

**5. the metadata updater never renamed itself** to "plex metadata updater" /
"jellyfin metadata updater" — it queried `.card-header h3`, the card is
`.tool-card-header` > `h4.tool-card-title`. the db updater card does the same
thing correctly two files over.

**6. tool help buttons re-bound on every visit**, including a document-level
keydown, so handlers piled up. that function could also throw and abort
`initializeToolsPage` before the db / cache / discovery-pool stats ever loaded.

also swapped the six native `confirm()` calls in this closure for
`showConfirmDialog`.

## tests

new `tests/test_tools_page_selectors.py` — eight guards over the dom contract
between the markup and the js. two of them are general ratchets:

- `getElementById('x')` where x is only ever a css class
- a `.foo` selector in the tools closure matching no real class

## heads up — 22 more of these elsewhere

that first guard found **22 further dead lookups** outside this page: the whole
track-detail modal (`td-audio`, `td-thumb`, `td-status-badge`, `td-provenance`,
`td-reason`, `td-actions`), the retag modal, the downloads stat row, the
automations list, the artists grid. verified each the same way — the token is
never assigned as an id anywhere in markup, js templates, `.id =`,
`setAttribute` or the react sources.

i did **not** touch them; they're allowlisted with a comment naming the feature.
worth its own pass — the track-detail one looks like a whole modal's controls.

also left alone: one native `confirm()` in `stats-automations.js` at the
artist.jpg overwrite prompt, outside this page.

## verification

- full python suite: **11,090 passed, 13 skipped, 0 failed** (1h02m)
- full webui suite: **216 files / 4,659 tests**, all green
- all six changed vanilla files parse (`node --check`)
- **10/10 mutations killed** — each reintroduces one of the bugs, each kills its
  guard, tree clean after restore
- the helper routing change diffed selector-by-selector against the old logic:
  exactly the 9 intended selectors moved, the other 195 untouched

third commit is a self-review fix to my own test helper. it attributed every id
below the last `.page` div (~250 global modal / player ids) to `tools`, and the
tag-depth fix i first reached for was worse — it closed `#tools-page` at 248
lines instead of 424, so the help-button test was only seeing 4 of the 7
buttons. now bounded by the actual sibling delimiter: 84 ids in scope, which
matches the page's real id count exactly.

not smoke-tested live yet. index.html is untouched — this is static js only, so a
hard refresh should be enough to pick it up.
