### PR TITLE
fix(tools): post-flip hardening — vanilla handlers stop writing React…

### DIFF
--- a/tests/test_tools_page_selectors.py
+++ b/tests/test_tools_page_selectors.py
@@ -440,7 +440,11 @@ def _handler_body(filename: str, handler: str, *, strip_comments: bool = False) 
     `.index()` matches inside a comment and reports the wrong order.
     """
     source = (STATIC / filename).read_text(encoding="utf-8")
-    body = source.split(f"function {handler}")[1].split("\nfunction ")[0]
+    tail = source.split(f"function {handler}")[1]
+    # End at the NEXT top-level definition — async or not. Splitting only on
+    # "\nfunction " let a following `async function` leak whole neighbouring
+    # functions into the body, which breaks any NOT-contains assertion.
+    body = re.split(r"\n(?:async )?function ", tail)[0]
     if not strip_comments:
         return body
     return "\n".join(
@@ -528,18 +532,59 @@ def test_media_scan_completion_requires_a_previous_scanning_frame() -> None:
     assert "if (!wasScanning) return;" in body
 
 
-def test_media_scan_button_recovers_on_any_return_to_idle() -> None:
-    """The completion GUARD must not swallow the button re-enable.
+# ── Post-flip hardening: vanilla may not write React-owned tools DOM ─────────
+#
+# Before the P7 flip every tools id sat (hidden) in index.html at all times, so
+# these handlers writing them was the page working. After the flip those nodes
+# exist only while the React page is mounted — and React renders them from the
+# very frames these handlers re-broadcast. A second writer is at best redundant
+# and at worst destructive: the old repair-progress body REPLACED React's Stop
+# button via outerHTML and innerHTML-wiped #repair-jobs-list via its 30s
+# loadRepairJobs timer, mutating nodes React still reconciles against. (This
+# also retires the button-recovery ordering guard that lived here: the button
+# is React-rendered now and its recovery is pinned in server-cards.test.tsx.)
 
-    handleMediaScanButtonClick (api-monitor.js) disables the button and nothing
-    else undoes it, so a scheduled scan that is cancelled — which never reaches
-    'scanning' — would strand it disabled.
-    """
+REACT_OWNED_SEAM_HANDLERS = {
+    ("enrichment.js", "updateRepairJobProgressFromData"),
+    ("media-player.js", "updateMediaScanFromData"),
+}
+
+
+@pytest.mark.parametrize("filename,handler", sorted(REACT_OWNED_SEAM_HANDLERS))
+def test_seam_handlers_do_not_touch_the_dom(filename: str, handler: str) -> None:
+    body = _handler_body(filename, handler, strip_comments=True)
+    offenders = [
+        needle
+        for needle in ("getElementById", "querySelector", "innerHTML", "outerHTML", "appendChild")
+        if needle in body
+    ]
+    assert not offenders, (
+        f"{handler} touches the DOM again ({offenders}) — every node it can reach "
+        "is rendered by the React tools page, which already consumes the same "
+        "frame via the ss: dispatch"
+    )
+
+
+def test_repair_status_handler_keeps_the_orb_and_leaves_reacts_nodes() -> None:
+    """updateRepairStatusFromData serves the DASHBOARD (orb + tooltip + orb
+    badge) and must keep doing so — but the findings TAB badge and the master
+    toggle are React-owned, and writing `checked` on a React-controlled input
+    from outside is the exact desync the hardening removed."""
+    body = _handler_body("enrichment.js", "updateRepairStatusFromData", strip_comments=True)
+    for keep in ("repair-button", "repair-tooltip-status", "repair-findings-badge"):
+        assert keep in body, f"the orb seam lost its '{keep}' writer"
+    for gone in ("repair-findings-tab-badge", "repair-master-toggle", "repair-master-label"):
+        assert gone not in body, f"'{gone}' is React-owned; the vanilla writer is back"
+
+
+def test_media_scan_completion_toast_defers_to_the_react_card_on_tools() -> None:
+    """One completion, one toast: the React card announces it on /tools, the
+    vanilla handler everywhere else."""
     body = _handler_body("media-player.js", "updateMediaScanFromData", strip_comments=True)
-    idle_arm = body.split("else if (statusKey === 'idle')")[1]
-    enable_at = idle_arm.index("button.disabled = false")
-    guard_at = idle_arm.index("if (!wasScanning) return;")
-    assert enable_at < guard_at, (
-        "the button re-enable sits behind the completion guard; a cancelled "
-        "scheduled scan would leave Scan Library dead"
+    assert "showToast" in body, "the app-wide completion toast is gone entirely"
+    toast_at = body.index("showToast")
+    gate_at = body.index("currentPage === 'tools'")
+    assert gate_at < toast_at, (
+        "the vanilla completion toast no longer defers to the tools page, so a "
+        "scan finishing there announces twice"
     )

--- a/webui/src/routes/tools/-ui/maintenance-hero.tsx
+++ b/webui/src/routes/tools/-ui/maintenance-hero.tsx
@@ -8,13 +8,13 @@
  *
  * Two contracts from the P0 that outlive this file:
  *
- * 1. `.repair-job-card[data-job-id]` is how the vanilla socket handler finds a
- *    card to write progress into. P6 added the `ss:repair-progress` seam this
- *    component actually reads, but it was purely ADDITIVE — the vanilla handler
- *    still runs and still queries that selector. It only stops mattering when P7
- *    deletes the vanilla tools markup, at which point the selector finds nothing
- *    and its `if (!card) continue` makes it a no-op. Keep the attribute until
- *    then.
+ * 1. `.repair-job-card[data-job-id]` — the vanilla socket handler used to find
+ *    cards by this selector and write progress into them. My P6-era claim that
+ *    the markup deletion would make that a no-op was WRONG: this component
+ *    re-renders the very selector it queries, so the vanilla body was stomping
+ *    React-managed nodes. The post-flip hardening reduced that handler to its
+ *    ss:repair-progress dispatch; the attribute stays as the stable per-job
+ *    hook the tests (and any future e2e) key on.
  *
  * 2. The class on the card is NOT the class on the status dot. An idle enabled
  *    job gets dot 'enabled' and card class '' — see repairJobCardClass.

--- a/webui/src/routes/tools/-ui/server-cards.test.tsx
+++ b/webui/src/routes/tools/-ui/server-cards.test.tsx
@@ -621,6 +621,49 @@ describe('MediaScanCard — live scan:media frames', () => {
     expect(toastSpy).toHaveBeenCalledWith('✅ Media scan completed', 'success', 3000);
   });
 
+  it('announces a completion ONCE when the poll and the event both detect it', async () => {
+    // finish() is reachable from two detectors that race: the HTTP poll a
+    // manual scan starts, and the scanning→idle frame. Whichever fires second
+    // must not toast again.
+    vi.useFakeTimers();
+    routes({
+      'active-media-server': server('plex'),
+      '/api/scan/request': { success: true, scan_info: { delay_seconds: 1 } },
+      '/api/scan/status': { success: true, status: { status: 'idle' } },
+    });
+    const { container } = render(<MediaScanCard />);
+    await act(async () => {});
+    fireEvent.click(container.querySelector('#media-scan-button') as HTMLElement);
+    await act(async () => {});
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000); // countdown ends -> polling starts
+    });
+    // A scanning frame arrives (re-arms the latch, marks lastScanKey).
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('ss:media-scan', {
+          detail: { success: true, status: { status: 'scanning' } },
+        }),
+      );
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(2000); // poll sees idle -> finish() -> toast #1
+    });
+    // Then the scanning→idle FRAME lands — the second detector.
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('ss:media-scan', { detail: { success: true, status: { status: 'idle' } } }),
+      );
+    });
+
+    const completions = toastSpy.mock.calls.filter((call) =>
+      String(call[0]).includes('Media scan completed'),
+    );
+    expect(completions).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
   it('reports a completion once, not on every idle frame that follows', async () => {
     await mounted();
     await push({ status: 'scanning' });

--- a/webui/src/routes/tools/-ui/server-cards.tsx
+++ b/webui/src/routes/tools/-ui/server-cards.tsx
@@ -105,6 +105,14 @@ export function MediaScanCard() {
 
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  /**
+   * `finish()` is reachable from BOTH detectors — the HTTP poll a manual scan
+   * starts, and the ss:media-scan event — and neither knows the other fired.
+   * Without this latch a manual scan's completion toasted twice (poll sees
+   * idle, then the scanning→idle frame arrives). Re-armed whenever a scan is
+   * running again.
+   */
+  const completionAnnouncedRef = useRef(false);
 
   const clearTimers = useCallback(() => {
     if (countdownRef.current) {
@@ -128,7 +136,10 @@ export function MediaScanCard() {
     setPercent(0);
     setDetails('Ready for next scan');
     setStatus({ text: 'Idle', color: IDLE_STATUS_COLOR });
-    toast('✅ Media scan completed', 'success', 3000);
+    if (!completionAnnouncedRef.current) {
+      completionAnnouncedRef.current = true;
+      toast('✅ Media scan completed', 'success', 3000);
+    }
   }, [clearTimers]);
 
   const startPolling = useCallback(() => {
@@ -142,12 +153,16 @@ export function MediaScanCard() {
         setPercent(0);
         setDetails('Ready for next scan');
         setStatus({ text: 'Idle', color: IDLE_STATUS_COLOR });
-        toast('✅ Media scan completed', 'success', 3000);
+        if (!completionAnnouncedRef.current) {
+          completionAnnouncedRef.current = true;
+          toast('✅ Media scan completed', 'success', 3000);
+        }
         return;
       }
       void fetchMediaScanStatus().then((state) => {
         if (!state) return; // a blip is not a result
         if (state.status === 'scanning') {
+          completionAnnouncedRef.current = false;
           setPhase('Media server scanning...');
           setDetails(state.progress_message || 'Scan in progress');
         } else if (state.status === 'idle') {
@@ -172,6 +187,7 @@ export function MediaScanCard() {
         lastScanKey.current = key;
 
         if (key === 'scanning') {
+          completionAnnouncedRef.current = false;
           setPhase('Media server scanning...');
           setDetails(frame.status.progress_message || 'Scan in progress');
           return;
@@ -190,6 +206,7 @@ export function MediaScanCard() {
   );
 
   const onClick = useCallback(async () => {
+    completionAnnouncedRef.current = false;
     setBusy(true);
     setPhase('Requesting scan...');
     setPercent(30);

--- a/webui/static/enrichment.js
+++ b/webui/static/enrichment.js
@@ -1830,17 +1830,11 @@ function updateRepairStatusFromData(data) {
         badge.textContent = findingsPending;
         badge.style.display = findingsPending > 0 ? '' : 'none';
     }
-    const tabBadge = document.getElementById('repair-findings-tab-badge');
-    if (tabBadge) {
-        tabBadge.textContent = findingsPending;
-        tabBadge.style.display = findingsPending > 0 ? '' : 'none';
-    }
-
-    // Update master toggle in modal if open
-    const masterToggle = document.getElementById('repair-master-toggle');
-    const masterLabel = document.getElementById('repair-master-label');
-    if (masterToggle) masterToggle.checked = data.enabled || false;
-    if (masterLabel) masterLabel.textContent = data.enabled ? 'Enabled' : 'Disabled';
+    // The findings TAB badge and the master toggle are React-owned since the
+    // P7 flip (the hero drives both from the ss:repair-status dispatch above).
+    // Writing them from here again would set `checked` on a React-controlled
+    // input behind React's back. This handler keeps only what the dashboard
+    // owns: the orb, its tooltip, and the orb's own badge.
 
     // Update button state
     if (!data.enabled) {
@@ -2333,128 +2327,18 @@ async function stopRepairJobNow(jobId) {
 }
 
 // ── Repair Job Live Progress ──
-const _repairProgressLogCounts = {};
-const _repairProgressHideTimers = {};
 
 function updateRepairJobProgressFromData(data) {
-    // Same reasoning as updateRepairStatusFromData: openRepairModal replays the
-    // in-flight frames through here on a 300ms timer, so bridging only the socket
-    // would drop that replay.
+    // Dispatch-only since the P7 flip. The maintenance hero is React and it
+    // renders the SAME selectors this handler used to drive — .repair-job-card
+    // [data-job-id], .repair-job-status, .repair-flow-badge, .repair-stop-btn
+    // and its own .repair-job-progress panel — so the old body was live-mutating
+    // React-managed nodes: appending duplicate log lines into React's log
+    // container, replacing React's Stop button via outerHTML (a node React
+    // still thinks it owns), and 30s after completion innerHTML-wiping
+    // #repair-jobs-list out from under React via loadRepairJobs(). The hero
+    // renders every one of those states itself from this same frame.
     window.dispatchEvent(new CustomEvent('ss:repair-progress', { detail: data }));
-
-    for (const [jobId, state] of Object.entries(data)) {
-        const card = document.querySelector(`.repair-job-card[data-job-id="${jobId}"]`);
-        if (!card) continue;
-
-        // Update status dot
-        const statusDot = card.querySelector('.repair-job-status');
-        if (statusDot) {
-            if (state.status === 'running') statusDot.className = 'repair-job-status running';
-            else if (state.status === 'finished') statusDot.className = 'repair-job-status enabled';
-            else if (state.status === 'error') statusDot.className = 'repair-job-status enabled';
-        }
-
-        // Update flow badge to show running state
-        const firstBadge = card.querySelector('.repair-flow-badge.scan');
-        if (firstBadge) {
-            if (state.status === 'running') firstBadge.innerHTML = '&#9654; Running';
-            else if (state.status === 'finished') firstBadge.innerHTML = '&#10003; Complete';
-            else if (state.status === 'error') firstBadge.innerHTML = '&#10007; Error';
-        }
-
-        // Add/update card running class
-        card.classList.toggle('running', state.status === 'running');
-        card.classList.remove('disabled');
-
-        // Create or find progress panel (bar-first layout like automation)
-        let panel = card.querySelector('.repair-job-progress');
-        if (!panel) {
-            panel = document.createElement('div');
-            panel.className = 'repair-job-progress';
-            panel.innerHTML = `
-                <div class="repair-progress-bar-wrap">
-                    <div class="repair-progress-bar" style="width:0%"></div>
-                </div>
-                <div class="repair-progress-phase"></div>
-                <div class="repair-progress-log"></div>
-            `;
-            card.appendChild(panel);
-        }
-
-        // Show panel
-        panel.classList.add('visible');
-        panel.classList.toggle('finished', state.status === 'finished');
-        panel.classList.toggle('error', state.status === 'error');
-
-        if (state.status === 'running') {
-            panel.classList.remove('finished', 'error');
-            if (_repairProgressHideTimers[jobId]) {
-                clearTimeout(_repairProgressHideTimers[jobId]);
-                delete _repairProgressHideTimers[jobId];
-            }
-            // Reset log for re-run
-            if (_repairProgressLogCounts[jobId] > 0 && state.log && state.log.length < _repairProgressLogCounts[jobId]) {
-                const existingLog = panel.querySelector('.repair-progress-log');
-                if (existingLog) existingLog.innerHTML = '';
-                _repairProgressLogCounts[jobId] = 0;
-            }
-        }
-
-        // Update progress bar
-        const bar = panel.querySelector('.repair-progress-bar');
-        if (bar) bar.style.width = (state.progress || 0) + '%';
-
-        // Update phase
-        const phaseEl = panel.querySelector('.repair-progress-phase');
-        if (phaseEl && state.phase) phaseEl.textContent = state.phase;
-
-        // Update log
-        const logEl = panel.querySelector('.repair-progress-log');
-        if (logEl && state.log) {
-            const prevCount = _repairProgressLogCounts[jobId] || 0;
-            if (state.log.length > prevCount) {
-                const newLines = state.log.slice(prevCount);
-                for (const line of newLines) {
-                    const div = document.createElement('div');
-                    div.className = 'repair-log-line ' + (line.type || 'info');
-                    div.textContent = line.text;
-                    logEl.appendChild(div);
-                }
-                logEl.scrollTop = logEl.scrollHeight;
-            }
-            _repairProgressLogCounts[jobId] = state.log.length;
-        }
-
-        // #970: the moment a run ends (finished OR stopped), flip the Stop button
-        // back to Run here — don't wait on the 30s auto-hide reload or the next
-        // poll tick, or a stopped job's button looks stuck on "Stopping…".
-        if (state.status === 'finished' || state.status === 'error') {
-            const stopBtn = card.querySelector('.repair-stop-btn');
-            if (stopBtn) {
-                stopBtn.outerHTML = `<button class="repair-run-btn" onclick="runRepairJobNow('${jobId}')" title="Run now">&#9654;</button>`;
-            }
-        }
-
-        // Auto-hide panel after completion
-        if (state.status === 'finished' || state.status === 'error') {
-            if (!_repairProgressHideTimers[jobId]) {
-                _repairProgressHideTimers[jobId] = setTimeout(() => {
-                    panel.classList.remove('visible');
-                    card.classList.remove('running');
-                    delete _repairProgressHideTimers[jobId];
-                    delete _repairProgressLogCounts[jobId];
-                    // Reload to get updated stats
-                    loadRepairJobs();
-                }, 30000);
-            }
-        } else {
-            // Clear any existing hide timer if job restarts
-            if (_repairProgressHideTimers[jobId]) {
-                clearTimeout(_repairProgressHideTimers[jobId]);
-                delete _repairProgressHideTimers[jobId];
-            }
-        }
-    }
 }
 
 async function loadRepairFindingsDashboard() {

--- a/webui/static/media-player.js
+++ b/webui/static/media-player.js
@@ -562,48 +562,26 @@ function updateMediaScanFromData(data) {
     // `is_scanning` is a phantom field. Both this socket frame and
     // /api/scan/status return web_scan_manager.get_scan_status(), which reports
     // status: 'idle' | 'scheduled' | 'scanning' and has NEVER carried
-    // is_scanning. Branching on it made the "Media server scanning..." arm below
-    // unreachable, so the live progress message never appeared.
+    // is_scanning.
     const statusKey = status.status || 'unknown';
     const wasScanning = _lastMediaScanStatus === 'scanning';
     if (_lastMediaScanStatus === statusKey && statusKey !== 'scanning') return;
     _lastMediaScanStatus = statusKey;
 
-    const phaseLabel = document.getElementById('media-scan-phase-label');
-    const progressLabel = document.getElementById('media-scan-progress-label');
-    // `media-scan-btn` is the CLASS; the id is `media-scan-button`. Reading the
-    // class as an id made this always null, so the websocket completion path
-    // never re-enabled the button and Scan Library stayed dead after one click.
-    const button = document.getElementById('media-scan-button');
-    const progressBar = document.getElementById('media-scan-progress-bar');
-    const statusValue = document.getElementById('media-scan-status');
-
-    if (statusKey === 'scanning') {
-        if (phaseLabel) phaseLabel.textContent = 'Media server scanning...';
-        if (progressLabel) progressLabel.textContent = status.progress_message || 'Scan in progress';
-    } else if (statusKey === 'idle') {
-        // Re-enable on ANY return to idle, as the original did. A scheduled scan
-        // that is cancelled never reaches 'scanning', and handleMediaScanButtonClick
-        // (api-monitor.js) disables the button with nothing else to undo it —
-        // gating this behind wasScanning would strand it disabled, which is the
-        // exact bug class the bugfix PR already fixed once.
-        if (button) button.disabled = false;
-        // The MESSAGING is what needs the guard. The server pushes scan:media
-        // every two seconds whether or not anything is running (web_server.py's
-        // status loop), and a bare idle payload is what it sends when nothing has
-        // ever run — so without this, every page load popped "Media scan
-        // completed" about two seconds in and relabelled the card as though a
-        // scan had just finished.
-        if (!wasScanning) return;
-        if (phaseLabel) phaseLabel.textContent = 'Scan completed successfully';
-        if (progressBar) progressBar.style.width = '0%';
-        if (progressLabel) progressLabel.textContent = 'Ready for next scan';
-        if (statusValue) {
-            statusValue.textContent = 'Idle';
-            statusValue.style.color = '#b3b3b3';
-        }
-        showToast('✅ Media scan completed', 'success', 3000);
-    }
+    // P7 hardening: every element this handler used to write (#media-scan-*,
+    // #media-scan-button) exists only inside the React tools page now, and the
+    // card renders this same frame itself via ss:media-scan — a second writer
+    // here would be mutating React-owned DOM. What survives app-wide is the
+    // completion toast:
+    if (statusKey !== 'idle') return;
+    // A bare idle frame is not a finished scan — the server pushes scan:media
+    // every 2s regardless of activity, and without this guard every page load
+    // announced a completed scan.
+    if (!wasScanning) return;
+    // On the tools page the React card announces it; everywhere else this is
+    // the only messenger.
+    if (typeof currentPage !== 'undefined' && currentPage === 'tools') return;
+    showToast('✅ Media scan completed', 'success', 3000);
 }
 
 let _wishlistAutoProcessingNotified = false;


### PR DESCRIPTION
# tools post-flip hardening

follow-up to #1117. a final review of the merged port found one invariant the
flip quietly changed: before, every tools id sat hidden in index.html at all
times, so the surviving vanilla handlers writing them was just the page
working. now those nodes only exist while the react page is mounted — and
react renders them from the very frames those handlers re-broadcast. three
handlers were still writing into react's DOM.

## the bad one

the `repair:progress` socket handler still drove job cards by
`.repair-job-card[data-job-id]` — a selector the react hero deliberately
re-renders. so with /tools open while a maintenance job ran, it was mutating
react-managed nodes: duplicate log lines appended into react's log panel, the
stop button **replaced via outerHTML**, and 30s after completion the whole
`#repair-jobs-list` **innerHTML-wiped** by the old `loadRepairJobs` timer.
jobs run on a schedule, so this fired any time one finished with the page
open. the handler is dispatch-only now — react renders every one of those
states itself from the same frame.

## the other two

- the repair status handler keeps what the dashboard owns (worker orb,
  tooltip, orb badge) and stops writing the findings tab badge + master
  toggle, which are react's.
- the media scan handler is now dispatch + the app-wide completion toast,
  gated off /tools where the react card announces it. the card also latches
  its own toast — its two completion detectors (manual-scan poll and the
  scanning→idle frame) could each fire, so a completion on /tools could toast
  up to three times. now: exactly once, anywhere.

## guards

new pytest pins: the two seam handlers contain no DOM access at all, the
status handler keeps its orb writers and never regrows the react-owned ones,
and the vanilla toast defers to /tools. each fix was reverted to prove its
pin fails.

## notes

- touches `webui/static/*.js` → **server restart**
- full vitest 5,084 green, 132 python tests across the touched seams
- worth one live glance: run a maintenance job from /tools and watch its
  progress panel — that's the exact path that was being stomped
