### PR TITLE
Use configured search timeout instead of hardcoded 15 seconds for Prowlarr searches

### DIFF
--- a/core/prowlarr_client.py
+++ b/core/prowlarr_client.py
@@ -100,7 +100,7 @@ class ProwlarrSearchResult:
 class ProwlarrClient:
     """Thin sync-backed async wrapper around the Prowlarr v1 API."""
 
-    DEFAULT_TIMEOUT = 15
+    DEFAULT_TIMEOUT = 120
 
     def __init__(self) -> None:
         self._load_config()

--- a/core/prowlarr_client.py
+++ b/core/prowlarr_client.py
@@ -100,8 +100,6 @@ class ProwlarrSearchResult:
 class ProwlarrClient:
     """Thin sync-backed async wrapper around the Prowlarr v1 API."""
 
-    DEFAULT_TIMEOUT = 120
-
     def __init__(self) -> None:
         self._load_config()
 
@@ -243,7 +241,7 @@ class ProwlarrClient:
                 url,
                 headers={'X-Api-Key': self._api_key, 'Accept': 'application/json'},
                 params=params,
-                timeout=self.DEFAULT_TIMEOUT,
+                timeout=getattr(self._config, 'get_source_search_timeout', lambda: None)() or 60,
             )
             if not resp.ok:
                 logger.warning("Prowlarr %s returned HTTP %s", path, resp.status_code)


### PR DESCRIPTION
The search timeout setting that was recently added didn't apply to Prowlarr. This PR sets it to use that config, with a fallback of 60 seconds (Prowlarr usually returns results around the 45 second mark in my experience). I haven't been able to test this, but it should be fairly stable, as I just copied the config block from deezer_download_client.py.