### PR TITLE
feat: add genre enrichment repair job

### DIFF
--- a/core/genre_filter.py
+++ b/core/genre_filter.py
@@ -4,6 +4,8 @@ When strict mode is enabled, only genres on the whitelist pass through
 during enrichment. When disabled (default), all genres pass unchanged.
 """
 
+import re
+import unicodedata
 from utils.logging_config import get_logger
 
 logger = get_logger("genre_filter")
@@ -95,8 +97,10 @@ DEFAULT_GENRES = [
     "Lounge", "Psychedelic", "Progressive",
 ]
 
-# Normalized lookup set — built once, used for O(1) matching
-_DEFAULT_LOOKUP = {g.lower() for g in DEFAULT_GENRES}
+_GENRE_ALIASES = {
+    'hiphop': 'hip hop', 'hip hop': 'hip hop', 'rnb': 'r and b',
+    'r b': 'r and b', 'r and b': 'r and b', 'rhythm and blues': 'r and b',
+}
 
 
 def _normalize_for_match(genre: str) -> str:
@@ -104,10 +108,20 @@ def _normalize_for_match(genre: str) -> str:
 
     Handles common variations: 'R&B' vs 'RnB', 'Hip-Hop' vs 'Hip Hop'.
     """
-    g = genre.lower().strip()
-    g = g.replace('-', ' ').replace('&', ' and ')
-    # Collapse multiple spaces
-    return ' '.join(g.split())
+    if genre is None:
+        return ''
+    g = unicodedata.normalize('NFKC', str(genre)).lower().strip()
+    g = g.replace('\u2010', '-').replace('\u2011', '-').replace('\u2012', '-')
+    g = g.replace('\u2013', '-').replace('\u2014', '-').replace('\u2212', '-')
+    g = g.replace('&', ' and ')
+    g = re.sub(r'[-_/.,;:|]+', ' ', g)
+    g = re.sub(r"[’'\"`()\[\]{}!?]+", '', g)
+    g = ' '.join(g.split())
+    return _GENRE_ALIASES.get(g, g)
+
+
+# Normalized lookup set — built once, used for O(1) matching
+_DEFAULT_LOOKUP = {_normalize_for_match(g) for g in DEFAULT_GENRES}
 
 
 def _build_lookup(genre_list):

--- a/core/metadata/cache.py
+++ b/core/metadata/cache.py
@@ -138,6 +138,47 @@ class MetadataCache:
             logger.debug(f"Cache lookup error ({source}/{entity_type}/{entity_id}): {e}")
             return None
 
+    def get_genre_translation(self, whitelist_hash: str, normalized_source_genre: str) -> Optional[dict]:
+        """Return and touch a persisted genre translation outcome."""
+        try:
+            db = self._get_db(); conn = db._get_connection()
+            try:
+                cur = conn.cursor()
+                cur.execute("SELECT * FROM genre_translation_cache WHERE whitelist_hash=? AND normalized_source_genre=?",
+                            (whitelist_hash, normalized_source_genre))
+                row = cur.fetchone()
+                if not row:
+                    return None
+                cur.execute("UPDATE genre_translation_cache SET last_accessed_at=CURRENT_TIMESTAMP, access_count=access_count+1 WHERE id=?", (row['id'],))
+                conn.commit()
+                return dict(row)
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.debug("Genre translation cache lookup failed: %s", e)
+            return None
+
+    def store_genre_translation(self, whitelist_hash: str, source_genre: str,
+                                normalized_source_genre: str, outcome: dict) -> None:
+        try:
+            db = self._get_db(); conn = db._get_connection()
+            try:
+                conn.execute("""INSERT INTO genre_translation_cache
+                    (whitelist_hash,source_genre,normalized_source_genre,status,matched_genre,score,margin,candidates_json)
+                    VALUES (?,?,?,?,?,?,?,?)
+                    ON CONFLICT(whitelist_hash,normalized_source_genre) DO UPDATE SET
+                    source_genre=excluded.source_genre,status=excluded.status,matched_genre=excluded.matched_genre,
+                    score=excluded.score,margin=excluded.margin,candidates_json=excluded.candidates_json,
+                    updated_at=CURRENT_TIMESTAMP,last_accessed_at=CURRENT_TIMESTAMP,access_count=genre_translation_cache.access_count+1""",
+                    (whitelist_hash, source_genre, normalized_source_genre, outcome.get('status'),
+                     outcome.get('matched_genre'), outcome.get('score'), outcome.get('margin'),
+                     json.dumps(outcome.get('candidates', []))))
+                conn.commit()
+            finally:
+                conn.close()
+        except Exception as e:
+            logger.debug("Genre translation cache store failed: %s", e)
+
     # Names that indicate junk/placeholder data — should not be cached
     _JUNK_NAMES = frozenset({
         '', 'unknown', 'unknown artist', 'unknown album', 'unknown track',

--- a/core/metadata/genre_enrichment.py
+++ b/core/metadata/genre_enrichment.py
@@ -1,0 +1,168 @@
+"""Reusable, conservative genre candidate collection and translation."""
+
+import hashlib
+import json
+from difflib import SequenceMatcher
+
+from core.genre_filter import DEFAULT_GENRES, _normalize_for_match
+from core.metadata.cache import MetadataCache
+
+PROVIDER_CONFIDENCE = {
+    'canonical': 1.0, 'discogs': .90, 'spotify': .85, 'deezer': .80,
+    'lastfm': .75, 'itunes': .70, 'audiodb': .65, 'embedded': .60,
+}
+
+
+def parse_values(value):
+    if not value:
+        return []
+    if isinstance(value, (list, tuple)):
+        return [str(x).strip() for x in value if str(x).strip()]
+    try:
+        parsed = json.loads(str(value))
+        if isinstance(parsed, list):
+            return [str(x).strip() for x in parsed if str(x).strip()]
+        if isinstance(parsed, dict):
+            return [str(parsed.get('name')).strip()] if parsed.get('name') else []
+    except (TypeError, ValueError):
+        pass
+    return [x.strip() for x in str(value).split(',') if x.strip()]
+
+
+def whitelist_from_config(config_manager) -> list[str]:
+    values = config_manager.get('genre_whitelist.genres', None) if config_manager else None
+    return [str(x).strip() for x in (values if isinstance(values, list) else DEFAULT_GENRES) if str(x).strip()]
+
+
+def whitelist_hash(whitelist: list[str]) -> str:
+    return hashlib.sha256(json.dumps(whitelist, ensure_ascii=False, separators=(',', ':')).encode()).hexdigest()
+
+
+def translate_genre(raw: str, whitelist: list[str], cache=None, run_cache=None) -> dict:
+    normalized = _normalize_for_match(raw)
+    key = (whitelist_hash(whitelist), normalized)
+    if run_cache is not None and key in run_cache:
+        return dict(run_cache[key], cache_hit=True)
+    cached = cache.get_genre_translation(*key) if cache else None
+    if cached:
+        result = {'status': cached['status'], 'matched_genre': cached.get('matched_genre'),
+                  'score': cached.get('score'), 'margin': cached.get('margin'),
+                  'candidates': json.loads(cached.get('candidates_json') or '[]'), 'cache_hit': True}
+        if run_cache is not None: run_cache[key] = result
+        return result
+
+    exact = next((g for g in whitelist if _normalize_for_match(g) == normalized), None)
+    if exact:
+        result = {'status': 'accepted', 'matched_genre': exact, 'score': 1.0, 'margin': 1.0, 'candidates': [exact]}
+    else:
+        tokens = set(normalized.split())
+        scored = []
+        for candidate in whitelist:
+            cn = _normalize_for_match(candidate)
+            char = SequenceMatcher(None, normalized, cn).ratio()
+            ct = set(cn.split())
+            overlap = len(tokens & ct) / max(1, len(tokens | ct))
+            score = .7 * char + .3 * overlap
+            scored.append((score, candidate))
+        scored.sort(key=lambda x: (-x[0], _normalize_for_match(x[1])))
+        best = scored[0] if scored else (0.0, None)
+        second = scored[1][0] if len(scored) > 1 else 0.0
+        margin = best[0] - second
+        status = 'accepted' if best[0] >= .90 or (best[0] >= .84 and margin >= .08) else ('ambiguous' if best[0] > .70 else 'rejected')
+        result = {'status': status, 'matched_genre': best[1] if status == 'accepted' else None,
+                  'score': round(best[0], 4), 'margin': round(margin, 4),
+                  'candidates': [x[1] for x in scored[:5]]}
+    if cache:
+        cache.store_genre_translation(key[0], raw, normalized, result)
+    if run_cache is not None: run_cache[key] = result
+    return result
+
+
+def extract_provider_genres(source: str, entity_type: str, payload: dict) -> list[str]:
+    if not isinstance(payload, dict): return []
+    if source == 'spotify': return parse_values(payload.get('genres'))
+    if source == 'itunes': return parse_values(payload.get('primaryGenreName') or payload.get('genre'))
+    if source == 'deezer':
+        genres = payload.get('genres', {})
+        genres = genres.get('data', []) if isinstance(genres, dict) else genres
+        values = [g.get('name') for g in genres if isinstance(g, dict) and g.get('name')] if isinstance(genres, list) else []
+        if values:
+            return values
+        genre_id = payload.get('genre_id')
+        try:
+            mapped = MetadataCache._DEEZER_GENRE_MAP.get(int(genre_id)) if genre_id is not None else None
+        except (TypeError, ValueError):
+            mapped = None
+        return [mapped] if mapped else []
+    if source == 'discogs': return parse_values(payload.get('genres')) + parse_values(payload.get('styles'))
+    if source == 'audiodb': return parse_values(payload.get('strGenre'))
+    if source == 'lastfm': return parse_values(payload.get('lastfm_tags') or payload.get('tags'))
+    return []  # MusicBrainz is deliberately not a genre source here.
+
+
+def collect_local_candidates(row: dict) -> list[dict]:
+    out = []
+    for source, field, id_field in [
+        ('discogs', 'discogs_genres', 'discogs_id'),
+        ('discogs', 'discogs_styles', 'discogs_id'),
+        ('lastfm', 'lastfm_tags', None),
+    ]:
+        for value in parse_values(row.get(field)):
+            out.append({'raw_genre': value, 'source': source,
+                        'source_entity_id': row.get(id_field) if id_field else None,
+                        'origin': 'library'})
+    return out
+
+
+def collect_cached_candidates(cache, row: dict, entity_type: str) -> tuple[list[dict], int]:
+    out, hits = [], 0
+    id_fields = {'spotify': 'spotify_' + ('artist_id' if entity_type == 'artist' else 'album_id'),
+                 'itunes': 'itunes_' + ('artist_id' if entity_type == 'artist' else 'album_id'),
+                 'deezer': 'deezer_id',
+                 'discogs': 'discogs_id', 'audiodb': 'audiodb_id'}
+    for source in ('spotify', 'itunes', 'deezer', 'discogs', 'audiodb'):
+        source_id = row.get(id_fields[source])
+        if source == 'deezer' and not source_id:
+            source_id = row.get('deezer_artist_id' if entity_type == 'artist' else 'deezer_album_id')
+        if not source_id or not cache: continue
+        payload = cache.get_entity(source, entity_type, str(source_id))
+        if payload is None: continue
+        hits += 1
+        for value in extract_provider_genres(source, entity_type, payload):
+            out.append({'raw_genre': value, 'source': source, 'source_entity_id': str(source_id), 'origin': 'metadata_cache'})
+    return out, hits
+
+
+def propose_genres(existing: list[str], candidates: list[dict], whitelist: list[str], max_genres: int, cache=None, run_cache=None) -> dict:
+    original = list(existing or [])
+    translated = []
+    for candidate in candidates:
+        result = translate_genre(candidate['raw_genre'], whitelist, cache, run_cache)
+        item = dict(candidate, translated_genre=result.get('matched_genre'), score=result.get('score'), status=result['status'], candidates=result.get('candidates', []), cache_hit=result.get('cache_hit', False))
+        translated.append(item)
+    existing_norm = {_normalize_for_match(x) for x in original}
+    support = {}
+    for item in translated:
+        if item['status'] == 'accepted' and item['translated_genre']:
+            key = _normalize_for_match(item['translated_genre'])
+            support.setdefault(key, {'genre': item['translated_genre'], 'sources': set(), 'confidence': 0,
+                                     'translation_confidence': 0, 'order': len(support)})
+            support[key]['sources'].add(item['source'])
+            support[key]['confidence'] = max(support[key]['confidence'], PROVIDER_CONFIDENCE.get(item['source'], .60))
+            support[key]['translation_confidence'] = max(support[key]['translation_confidence'], item.get('score') or 0)
+    additions = []
+    omitted = []
+    ranked = sorted(support.values(), key=lambda x: (-len(x['sources']), -x['confidence'],
+        -x['translation_confidence'], x['order'], _normalize_for_match(x['genre'])))
+    if len(original) > max_genres:
+        omitted = [x['genre'] for x in ranked if _normalize_for_match(x['genre']) not in existing_norm]
+    else:
+        for item in ranked:
+            if _normalize_for_match(item['genre']) in existing_norm: continue
+            if len(original) + len(additions) < max_genres: additions.append(item)
+            else: omitted.append(item['genre'])
+    return {'original_genres': original, 'added_genres': [x['genre'] for x in additions],
+            'proposed_genres': original + [x['genre'] for x in additions], 'omitted_due_to_cap': omitted,
+            'ambiguous_genres': [x for x in translated if x['status'] == 'ambiguous'],
+            'rejected_genres': [x['raw_genre'] for x in translated if x['status'] == 'rejected'],
+            'sources': {x['genre']: sorted(x['sources']) for x in additions}, 'translations': translated}

--- a/core/repair_jobs/__init__.py
+++ b/core/repair_jobs/__init__.py
@@ -55,6 +55,7 @@ _JOB_MODULES = [
     'core.repair_jobs.short_preview_track',
     'core.repair_jobs.audio_corruption_detector',
     'core.repair_jobs.genre_cleanup',
+    'core.repair_jobs.genre_enrichment',
     'core.repair_jobs.comma_artist_splitter',
 ]
 

--- a/core/repair_jobs/genre_enrichment.py
+++ b/core/repair_jobs/genre_enrichment.py
@@ -1,0 +1,150 @@
+"""Findings-based, additive genre enrichment."""
+import json
+from core.repair_jobs import register_job
+from core.repair_jobs.base import JobContext, JobResult, RepairJob
+from core.metadata.genre_enrichment import (collect_cached_candidates, collect_local_candidates,
+    extract_provider_genres, parse_values, propose_genres, whitelist_from_config)
+
+
+@register_job
+class GenreEnrichmentJob(RepairJob):
+    job_id = 'genre_enrichment'
+    display_name = 'Genre Enrichment'
+    description = 'Adds conservatively translated genres from stored metadata and caches'
+    default_enabled = False
+    default_interval_hours = 168
+    default_settings = {'max_genres': 5, 'include_artists': True, 'include_albums': True, 'allow_live_calls': False}
+    auto_fix = False
+    help_text = ('Adds genres without removing existing values. Local fields and cached provider data are used first; '
+                 'live enrichment calls are disabled by default. Fuzzy translations are conservative and ambiguous '
+                 'values are shown for review. The maximum limits additions only while there is capacity.')
+
+    def _settings(self, context):
+        raw = context.config_manager.get('repair.jobs.genre_enrichment.settings', {}) if context.config_manager else {}
+        out = dict(self.default_settings)
+        if isinstance(raw, dict): out.update(raw)
+        try:
+            value = out['max_genres']
+            if isinstance(value, bool) or not isinstance(value, int): raise ValueError
+            if not 1 <= value <= 20: raise ValueError
+            out['max_genres'] = value
+        except (TypeError, ValueError): out['max_genres'] = 5
+        for key in ('include_artists', 'include_albums', 'allow_live_calls'):
+            if not isinstance(out[key], bool): out[key] = self.default_settings[key]
+        return out
+
+    def scan(self, context: JobContext) -> JobResult:
+        result, settings = JobResult(), self._settings(context)
+        cfg = context.config_manager
+        if not (cfg and cfg.get('genre_whitelist.enabled', False)):
+            result.skipped = 1
+            if context.report_progress: context.report_progress(phase='Skipped — genre whitelist is disabled', log_type='info')
+            return result
+        whitelist = whitelist_from_config(cfg)
+        if not whitelist:
+            result.skipped = 1
+            if context.report_progress: context.report_progress(phase='Skipped — genre whitelist is empty', log_type='info')
+            return result
+        conn = context.db._get_connection()
+        conn.row_factory = None
+        entity_specs = []
+        if settings['include_artists']:
+            entity_specs.append(('artist', 'artists'))
+        if settings['include_albums']:
+            entity_specs.append(('album', 'albums'))
+        total = 0
+        for _, table in entity_specs:
+            count_row = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+            total += int(count_row[0] or 0)
+        if context.update_progress: context.update_progress(0, total)
+
+        def iter_entities():
+            for kind, table in entity_specs:
+                cur = conn.cursor()
+                cur.execute(f"SELECT * FROM {table}")
+                columns = [x[0] for x in cur.description]
+                for raw_row in cur:
+                    yield kind, dict(zip(columns, raw_row))
+
+        run_cache, stats = {}, {'entities_scanned': 0, 'entities_with_existing_genres': 0,
+            'local_candidates': 0, 'metadata_cache_hits': 0, 'translation_cache_hits': 0,
+            'translation_cache_misses': 0, 'live_calls': 0, 'live_call_failures': 0,
+            'accepted_additions': 0, 'ambiguous_candidates': 0, 'rejected_candidates': 0,
+            'cap_limited_entities': 0}
+        try:
+            for index, (kind, row) in enumerate(iter_entities(), start=1):
+                if context.check_stop(): return result
+                result.scanned += 1; stats['entities_scanned'] += 1
+                existing = parse_values(row.get('genres'))
+                if existing: stats['entities_with_existing_genres'] += 1
+                local = collect_local_candidates(row)
+                stats['local_candidates'] += len(local)
+                cached, hits = collect_cached_candidates(context.metadata_cache, row, kind)
+                stats['metadata_cache_hits'] += hits
+                live = []
+                live_calls = live_failures = 0
+                if settings['allow_live_calls']:
+                    live, live_calls, live_failures = self._live_candidates(context, row, kind)
+                    stats['live_calls'] += live_calls
+                    stats['live_call_failures'] += live_failures
+                proposal = propose_genres(existing, local + cached + live, whitelist, settings['max_genres'], context.metadata_cache, run_cache)
+                for value in proposal['translations']:
+                    if value.get('cache_hit'): stats['translation_cache_hits'] += 1
+                    else: stats['translation_cache_misses'] += 1
+                stats['accepted_additions'] += len(proposal['added_genres'])
+                stats['ambiguous_candidates'] += len(proposal['ambiguous_genres'])
+                stats['rejected_candidates'] += len(proposal['rejected_genres'])
+                if proposal['omitted_due_to_cap']: stats['cap_limited_entities'] += 1
+                if not proposal['added_genres'] and not proposal['ambiguous_genres']: continue
+                entity_id, name = row.get('id'), row.get('name') or row.get('title')
+                details = dict(proposal, entity=kind, name=name, max_genres=settings['max_genres'],
+                               cache_stats={'metadata_cache_hits': hits, 'translation_cache_hits': sum(1 for x in proposal['translations'] if x.get('cache_hit')), 'live_calls': live_calls, 'live_call_failures': live_failures},
+                               artist_id=row.get('artist_id') if kind == 'album' else row.get('id'),
+                               artist_name=row.get('artist_name') if kind == 'album' else name,
+                               album_title=name if kind == 'album' else None)
+                if context.create_finding:
+                    inserted = context.create_finding(job_id=self.job_id, finding_type=self.job_id,
+                        severity='warning' if proposal['ambiguous_genres'] else 'info', entity_type=kind,
+                        entity_id=str(entity_id), file_path=None, title=f'Enrich genres: {name}',
+                        description=f"{len(proposal['added_genres'])} genre(s) can be added to {kind} {name}", details=details)
+                    if inserted: result.findings_created += 1
+                    else: result.findings_skipped_dedup += 1
+                if context.update_progress and index % 100 == 0: context.update_progress(index, total)
+            if context.update_progress: context.update_progress(total, total)
+            if context.report_progress: context.report_progress(phase=f'Done — {result.findings_created} enrichment finding(s)', log_line=json.dumps(stats), log_type='info')
+            return result
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _live_candidates(context, row, kind):
+        """Fetch detail by an existing provider ID only; never search by name."""
+        from core.metadata import get_client_for_source
+        ids = {'spotify': row.get('spotify_artist_id' if kind == 'artist' else 'spotify_album_id'),
+               'itunes': row.get('itunes_artist_id' if kind == 'artist' else 'itunes_album_id'),
+               'deezer': row.get('deezer_id') or row.get('deezer_artist_id' if kind == 'artist' else 'deezer_album_id'),
+               'discogs': row.get('discogs_id')}
+        methods = {'spotify': 'get_artist' if kind == 'artist' else 'get_album',
+                   'itunes': 'get_artist' if kind == 'artist' else 'get_album',
+                   'deezer': 'get_artist_info' if kind == 'artist' else 'get_album_raw',
+                   'discogs': 'get_artist' if kind == 'artist' else 'get_album'}
+        found, calls, failures = [], 0, 0
+        for source in ('spotify', 'itunes', 'deezer', 'discogs'):
+            source_id = ids.get(source)
+            if not source_id: continue
+            if context.metadata_cache and context.metadata_cache.get_entity(source, kind, str(source_id)) is not None:
+                continue
+            client = context.spotify_client if source == 'spotify' else context.itunes_client if source == 'itunes' else get_client_for_source(source)
+            method = getattr(client, methods[source], None) if client else None
+            if not method: continue
+            try:
+                calls += 1
+                payload = method(str(source_id))
+                if isinstance(payload, dict):
+                    for value in extract_provider_genres(source, kind, payload):
+                        found.append({'raw_genre': value, 'source': source, 'source_entity_id': str(source_id), 'origin': 'live_api'})
+            except Exception:
+                # A provider failure is local to this entity/source; the scan continues.
+                failures += 1
+                continue
+        return found, calls, failures

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -147,6 +147,7 @@ JOB_CATEGORIES = {
     'album_tag_consistency': 'Tags & metadata',
     'mbid_mismatch_detector': 'Tags & metadata',
     'genre_cleanup': 'Tags & metadata',
+    'genre_enrichment': 'Tags & metadata',
     'comma_artist_splitter': 'Tags & metadata',
     'unknown_artist_fixer': 'Tags & metadata',
     'metadata_gap_filler': 'Tags & metadata',

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -497,11 +497,20 @@ class RepairWorker:
         if interval_hours is not None:
             self._config_manager.set(f'repair.jobs.{job_id}.interval_hours', interval_hours)
         if settings is not None:
+            if not isinstance(settings, dict):
+                settings = {}
             current = self._config_manager.get(f'repair.jobs.{job_id}.settings', {})
             if isinstance(current, dict):
                 current.update(settings)
             else:
                 current = settings
+            if job_id == 'genre_enrichment':
+                defaults = self._jobs.get(job_id).default_settings if self._jobs.get(job_id) else {
+                    'max_genres': 5, 'include_artists': True, 'include_albums': True, 'allow_live_calls': False}
+                value = current.get('max_genres')
+                current['max_genres'] = value if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 20 else defaults['max_genres']
+                for key in ('include_artists', 'include_albums', 'allow_live_calls'):
+                    if not isinstance(current.get(key), bool): current[key] = defaults[key]
             self._config_manager.set(f'repair.jobs.{job_id}.settings', current)
 
     def get_all_job_info(self) -> List[dict]:
@@ -1514,6 +1523,7 @@ class RepairWorker:
             'corrupt_audio': self._fix_corrupt_audio,
             'canonical_version': self._fix_canonical_version,
             'genre_cleanup': self._fix_genre_cleanup,
+            'genre_enrichment': self._fix_genre_enrichment,
             'comma_artist_split': self._fix_comma_artist_split,
         }
 
@@ -1557,6 +1567,36 @@ class RepairWorker:
         finally:
             if conn:
                 conn.close()
+
+    def _fix_genre_enrichment(self, entity_type, entity_id, file_path, details):
+        """Merge scanned additions with current genres without deleting anything."""
+        additions = details.get('added_genres')
+        table = {'artist': 'artists', 'album': 'albums'}.get(entity_type)
+        if not isinstance(additions, list) or table is None:
+            return {'success': False, 'error': 'Invalid genre enrichment finding'}
+        if not additions:
+            return {'success': False, 'error': 'No unambiguous genres are available to apply'}
+        conn = None
+        try:
+            conn = self.db._get_connection(); cur = conn.cursor()
+            cur.execute(f"SELECT genres FROM {table} WHERE id = ?", (entity_id,))
+            row = cur.fetchone()
+            if not row:
+                conn.close(); return {'success': False, 'error': f'{entity_type} {entity_id} no longer exists'}
+            from core.metadata.genre_enrichment import parse_values
+            from core.genre_filter import _normalize_for_match
+            current = parse_values(row[0]); seen = {_normalize_for_match(g) for g in current}
+            for genre in additions:
+                if genre and _normalize_for_match(genre) not in seen:
+                    current.append(genre); seen.add(_normalize_for_match(genre))
+            cur.execute(f"UPDATE {table} SET genres = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", (json.dumps(current), entity_id))
+            conn.commit(); conn.close()
+            return {'success': True, 'action': 'genres_applied'}
+        except Exception as e:
+            logger.error("Genre enrichment fix failed for %s %s: %s", entity_type, entity_id, e)
+            try: conn.close()
+            except Exception: pass
+            return {'success': False, 'error': str(e)}
 
     def _fix_comma_artist_split(self, entity_type, entity_id, file_path, details):
         """Split a separator-joined artist tag into properly separated artists (jadux).

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -678,6 +678,26 @@ class MusicDatabase:
             # Repair worker v2 tables (findings + job runs)
             self._add_repair_worker_tables(cursor)
 
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS genre_translation_cache (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    whitelist_hash TEXT NOT NULL,
+                    source_genre TEXT NOT NULL,
+                    normalized_source_genre TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    matched_genre TEXT,
+                    score REAL,
+                    margin REAL,
+                    candidates_json TEXT NOT NULL DEFAULT '[]',
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    access_count INTEGER DEFAULT 1,
+                    UNIQUE(whitelist_hash, normalized_source_genre)
+                )
+            """)
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_gtc_hash ON genre_translation_cache (whitelist_hash)")
+
             # Mirrored playlists — persistent backup of parsed playlists from any service
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS mirrored_playlists (

--- a/tests/test_genre_enrichment.py
+++ b/tests/test_genre_enrichment.py
@@ -1,0 +1,112 @@
+import json
+
+from core.genre_filter import _normalize_for_match, filter_genres
+from core.metadata.genre_enrichment import (
+    collect_local_candidates,
+    propose_genres,
+    translate_genre,
+)
+from core.repair_worker import RepairWorker
+from database.music_database import MusicDatabase
+
+
+def test_provider_aliases_are_exact_matches():
+    whitelist = ['Hip Hop', 'R&B']
+    assert translate_genre('hip-hop', whitelist)['matched_genre'] == 'Hip Hop'
+    assert translate_genre('HipHop', whitelist)['matched_genre'] == 'Hip Hop'
+    assert translate_genre('RnB', whitelist)['matched_genre'] == 'R&B'
+    assert _normalize_for_match('  R‑B  ') == 'r and b'
+
+
+def test_conservative_match_records_ambiguous_and_rejected():
+    whitelist = ['Alternative Rock', 'Indie Rock']
+    ambiguous = translate_genre('alternative ro', whitelist)
+    assert ambiguous['status'] == 'ambiguous'
+    assert translate_genre('zzzz unrelated', whitelist)['status'] == 'rejected'
+
+
+def test_ranking_preserves_existing_and_caps_additions():
+    proposal = propose_genres(
+        ['Rock'],
+        [{'raw_genre': 'hip-hop', 'source': 'spotify'},
+         {'raw_genre': 'hip-hop', 'source': 'discogs'},
+         {'raw_genre': 'indie rock', 'source': 'lastfm'}],
+        ['Rock', 'Hip Hop', 'Indie Rock'], 2)
+    assert proposal['proposed_genres'] == ['Rock', 'Hip Hop']
+    assert proposal['sources']['Hip Hop'] == ['discogs', 'spotify']
+    over = propose_genres(['Rock', 'Hip Hop', 'Indie Rock'],
+                          [{'raw_genre': 'pop', 'source': 'spotify'}],
+                          ['Rock', 'Hip Hop', 'Indie Rock', 'Pop'], 2)
+    assert over['proposed_genres'] == over['original_genres']
+    assert over['omitted_due_to_cap'] == ['Pop']
+
+
+def test_deezer_genre_id_is_mapped():
+    from core.metadata.genre_enrichment import extract_provider_genres
+    assert extract_provider_genres('deezer', 'album', {'genre_id': 73}) == ['Metal']
+
+
+def test_deezer_library_id_is_used_for_cache_lookup():
+    from core.metadata.genre_enrichment import collect_cached_candidates
+
+    class Cache:
+        def __init__(self): self.calls = []
+        def get_entity(self, *args):
+            self.calls.append(args)
+            return {'genres': ['Metal']} if args == ('deezer', 'artist', '73') else None
+
+    cache = Cache()
+    collect_cached_candidates(cache, {'deezer_id': '73'}, 'artist')
+    assert ('deezer', 'artist', '73') in cache.calls
+
+
+def test_lastfm_local_candidates_do_not_require_a_lastfm_id_column():
+    candidates = collect_local_candidates({
+        'lastfm_tags': json.dumps(['indie rock']),
+        'lastfm_id': 'must-not-be-read',
+    })
+    assert candidates == [{
+        'raw_genre': 'indie rock',
+        'source': 'lastfm',
+        'source_entity_id': None,
+        'origin': 'library',
+    }]
+
+
+class _GenreConfig:
+    def __init__(self, enabled, genres=None):
+        self.values = {
+            'genre_whitelist.enabled': enabled,
+            'genre_whitelist.genres': genres,
+        }
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+def test_strict_filter_keeps_existing_case_and_whitespace_matches():
+    assert filter_genres([' rock ', 'R&B', 'unlisted'],
+                         _GenreConfig(True, ['Rock', 'R&B'])) == [' rock ', 'R&B']
+    assert filter_genres(['unlisted', 'Rock'],
+                         _GenreConfig(False, ['Rock'])) == ['unlisted', 'Rock']
+
+
+def test_ambiguous_only_fix_does_not_report_success(tmp_path):
+    db = MusicDatabase(str(tmp_path / 'music.db'))
+    with db._get_connection() as conn:
+        conn.execute("INSERT INTO artists (id, name, genres) VALUES (?, ?, ?)",
+                     ('artist-1', 'Artist', json.dumps(['Rock'])))
+        conn.commit()
+
+    worker = RepairWorker.__new__(RepairWorker)
+    worker.db = db
+    result = worker._fix_genre_enrichment(
+        'artist', 'artist-1', None,
+        {'added_genres': [], 'ambiguous_genres': [{'raw': 'alt rock'}]},
+    )
+
+    assert result['success'] is False
+    with db._get_connection() as conn:
+        assert json.loads(conn.execute(
+            "SELECT genres FROM artists WHERE id = ?", ('artist-1',)
+        ).fetchone()['genres']) == ['Rock']

--- a/tests/test_genre_enrichment.py
+++ b/tests/test_genre_enrichment.py
@@ -6,7 +6,7 @@ from core.metadata.genre_enrichment import (
     propose_genres,
     translate_genre,
 )
-from core.repair_worker import RepairWorker
+from core.repair_worker import RepairWorker, job_category
 from database.music_database import MusicDatabase
 
 
@@ -110,3 +110,7 @@ def test_ambiguous_only_fix_does_not_report_success(tmp_path):
         assert json.loads(conn.execute(
             "SELECT genres FROM artists WHERE id = ?", ('artist-1',)
         ).fetchone()['genres']) == ['Rock']
+
+
+def test_genre_enrichment_belongs_to_tags_and_metadata_category():
+    assert job_category('genre_enrichment') == 'Tags & metadata'

--- a/webui/src/routes/tools/-tools.core.test.ts
+++ b/webui/src/routes/tools/-tools.core.test.ts
@@ -177,14 +177,15 @@ describe('finding labels', () => {
     // know only `critical`, which nothing has ever emitted. Both map to the
     // same icon and the same CSS class while old rows exist.
     expect(Object.keys(FINDING_SEVERITY_ICONS)).toHaveLength(4);
-    expect(Object.keys(FINDING_TYPE_LABELS)).toHaveLength(22);
-    expect(Object.keys(FINDING_FIXABLE_TYPES)).toHaveLength(20);
-    expect(Object.keys(FINDING_ACTION_LABELS)).toHaveLength(12);
+    expect(Object.keys(FINDING_TYPE_LABELS)).toHaveLength(23);
+    expect(Object.keys(FINDING_FIXABLE_TYPES)).toHaveLength(21);
+    expect(Object.keys(FINDING_ACTION_LABELS)).toHaveLength(13);
   });
 
   it('labels known finding types', () => {
     expect(findingTypeLabel('acoustid_mismatch')).toBe('Wrong Song');
     expect(findingTypeLabel('short_preview_track')).toBe('Preview Clip');
+    expect(findingTypeLabel('genre_enrichment')).toBe('Genre Enrichment');
     expect(findingTypeLabel('comma_artist_split')).toBe('Comma Artist');
   });
 
@@ -194,6 +195,7 @@ describe('finding labels', () => {
 
   it('gives fixable types their button label and others none', () => {
     expect(findingFixLabel('duplicate_tracks')).toBe('Keep Best');
+    expect(findingFixLabel('genre_enrichment')).toBe('Apply Genres');
     expect(findingFixLabel('comma_artist_split')).toBe('Split Artists');
     expect(findingFixLabel('fake_lossless')).toBeNull();
     expect(findingFixLabel('path_mismatch')).toBeNull();

--- a/webui/src/routes/tools/-tools.core.ts
+++ b/webui/src/routes/tools/-tools.core.ts
@@ -218,6 +218,7 @@ export const FINDING_TYPE_LABELS: Record<string, string> = {
   quality_upgrade: 'Low Quality',
   short_preview_track: 'Preview Clip',
   genre_cleanup: 'Genres',
+  genre_enrichment: 'Genre Enrichment',
   comma_artist_split: 'Comma Artist',
 };
 
@@ -249,6 +250,7 @@ export const FINDING_FIXABLE_TYPES: Record<string, string> = {
   library_retag: 'Apply Tags',
   short_preview_track: 'Re-download',
   genre_cleanup: 'Clean Genres',
+  genre_enrichment: 'Apply Genres',
   comma_artist_split: 'Split Artists',
 };
 
@@ -269,6 +271,7 @@ export const FINDING_ACTION_LABELS: Record<string, string> = {
   applied_lyrics: 'Lyrics Applied',
   deleted_expired: 'Deleted',
   removed_duplicates: 'Duplicates Removed',
+  genres_applied: 'Genres Applied',
 };
 
 /** The badge shown on a non-pending finding: the user action if we have a label

--- a/webui/src/routes/tools/-ui/finding-detail.tsx
+++ b/webui/src/routes/tools/-ui/finding-detail.tsx
@@ -262,6 +262,57 @@ export function FindingDetail({ finding, onKeepDuplicate, onApplyCoverArt }: Fin
       );
     }
 
+    case 'genre_enrichment': {
+      const proposed = list<string>(d.proposed_genres);
+      const added = list<string>(d.added_genres);
+      const ambiguous = list<{
+        raw_genre?: unknown;
+        raw?: unknown;
+        candidates?: unknown[];
+        score?: unknown;
+      }>(d.ambiguous_genres);
+      const omitted = list<string>(d.omitted_due_to_cap);
+      const rejected = list<string>(d.rejected_genres);
+      rows.push(['Current genres', list<string>(d.original_genres).join(', ') || '— none']);
+      rows.push(['Proposed genres', proposed.join(', ') || '— none']);
+      rows.push(['Added', added.join(', ') || '— none']);
+      rows.push(['Omitted at cap', omitted.join(', ') || '— none']);
+      rows.push(['Rejected', rejected.join(', ') || '— none']);
+      if (ambiguous.length) {
+        rows.push([
+          'Ambiguous',
+          ambiguous
+            .map((item) => {
+              const candidates = list<string>(item.candidates).join(', ');
+              const score = Math.round((Number(item.score) || 0) * 100);
+              return `${text(item.raw_genre || item.raw)}: ${candidates} (${score}%)`;
+            })
+            .join('; '),
+        ]);
+      }
+      if (d.sources && typeof d.sources === 'object') {
+        rows.push([
+          'Sources',
+          Object.entries(d.sources as Record<string, unknown>)
+            .map(([genre, sources]) => `${genre}: ${list<string>(sources).join(', ')}`)
+            .join('; '),
+        ]);
+      }
+      if (d.cache_stats && typeof d.cache_stats === 'object') {
+        const stats = d.cache_stats as Record<string, unknown>;
+        rows.push([
+          'Cache / external calls',
+          `metadata ${text(stats.metadata_cache_hits) || '0'}, live ${text(stats.live_calls) || '0'}`,
+        ]);
+      }
+      return (
+        <>
+          {media}
+          <DetailGrid rows={rows} />
+        </>
+      );
+    }
+
     case 'comma_artist_split': {
       // jadux — the contract: exactly what the artist tag becomes.
       const parts = list<string>(d.split_artists);

--- a/webui/src/routes/tools/-ui/findings-surface.test.tsx
+++ b/webui/src/routes/tools/-ui/findings-surface.test.tsx
@@ -112,12 +112,7 @@ const typeInfo = (over: Record<string, unknown> = {}) => ({
 function renderSurface(jobs: RepairJob[] = JOBS) {
   const onStatusChanged = vi.fn();
   const result = render(
-    <FindingsSurface
-      jobs={jobs}
-      runs={[]}
-      trackCount={10000}
-      onStatusChanged={onStatusChanged}
-    />,
+    <FindingsSurface jobs={jobs} runs={[]} trackCount={10000} onStatusChanged={onStatusChanged} />,
   );
   return { ...result, onStatusChanged };
 }
@@ -252,7 +247,9 @@ describe('the health hero', () => {
     renderSurface();
     await flush();
     // The 20 orphans move files; only the 10 art rows are safe.
-    expect(document.querySelector('.repair-health-fix-safe')?.textContent).toBe('Fix all safe (10)');
+    expect(document.querySelector('.repair-health-fix-safe')?.textContent).toBe(
+      'Fix all safe (10)',
+    );
   });
 
   it('sends safe_only — never a fix_action — when Fix all safe runs', async () => {
@@ -325,7 +322,9 @@ describe('the status segmented control', () => {
 
     fireEvent.click(screen.getByText('Dismissed').closest('button') as HTMLElement);
     await flush();
-    const url = fetchMock.mock.calls.map((call) => String(call[0])).findLast((u) => u.includes('?'));
+    const url = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .findLast((u) => u.includes('?'));
     expect(url).toContain('status=dismissed');
   });
 });
@@ -594,7 +593,9 @@ describe('filters', () => {
     });
     await flush();
 
-    const url = fetchMock.mock.calls.map((call) => String(call[0])).findLast((u) => u.includes('?'));
+    const url = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .findLast((u) => u.includes('?'));
     expect(url).toContain('severity=warning');
     expect(url).toContain('status=pending');
     expect(url).toContain('sort=newest');
@@ -607,7 +608,11 @@ describe('filters', () => {
   });
 
   it('a search replaces the inbox rather than filtering it', async () => {
-    routes({ [GROUPS]: { groups: [group()] }, [TYPES]: { types: [typeInfo()] }, [FINDINGS]: page([]) });
+    routes({
+      [GROUPS]: { groups: [group()] },
+      [TYPES]: { types: [typeInfo()] },
+      [FINDINGS]: page([]),
+    });
     await renderList();
     expect(document.querySelector('.repair-inbox')).toBeNull();
     expect(document.querySelector('.repair-search-note')).not.toBeNull();
@@ -621,7 +626,9 @@ describe('filters', () => {
       target: { value: 'path' },
     });
     await flush();
-    const url = fetchMock.mock.calls.map((call) => String(call[0])).findLast((u) => u.includes('?'));
+    const url = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .findLast((u) => u.includes('?'));
     expect(url).toContain('sort=path');
   });
 
@@ -635,7 +642,9 @@ describe('filters', () => {
     await flush();
 
     expect(localStorage.getItem('repairFindingsPageSize')).toBe('100');
-    const url = fetchMock.mock.calls.map((call) => String(call[0])).findLast((u) => u.includes('?'));
+    const url = fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .findLast((u) => u.includes('?'));
     expect(url).toContain('limit=100');
   });
 
@@ -815,7 +824,7 @@ describe('the finding list', () => {
     fireEvent.click(document.querySelector('.repair-finding-expand-btn') as HTMLElement);
     await flush();
     expect(
-      (panel().querySelector('.repair-finding-detail-inner')?.children.length || 0),
+      panel().querySelector('.repair-finding-detail-inner')?.children.length || 0,
     ).toBeGreaterThan(0);
   });
 
@@ -840,9 +849,7 @@ describe('the finding list', () => {
     await flush();
 
     fireEvent.click(document.querySelector('.repair-finding-expand-btn') as HTMLElement);
-    expect((document.getElementById('repair-detail-5') as HTMLElement).className).toContain(
-      'open',
-    );
+    expect((document.getElementById('repair-detail-5') as HTMLElement).className).toContain('open');
     fireEvent.click(document.querySelector('.repair-finding-expand-btn') as HTMLElement);
     expect((document.getElementById('repair-detail-5') as HTMLElement).className).not.toContain(
       'open',
@@ -1585,6 +1592,35 @@ describe('the detail renderer', () => {
       details: { kept_genres: [], removed_genres: ['x'] },
     });
     expect(gridPairs(detail)[0][1]).toBe('— none (all genres are off your whitelist)');
+  });
+
+  it('genre_enrichment shows the proposal, review items, and provenance', async () => {
+    const detail = await openDetail({
+      finding_type: 'genre_enrichment',
+      details: {
+        original_genres: ['Rock'],
+        proposed_genres: ['Rock', 'Alternative Rock'],
+        added_genres: ['Alternative Rock'],
+        ambiguous_genres: [
+          { raw: 'alt rock', candidates: ['Alternative Rock', 'Indie Rock'], score: 0.82 },
+        ],
+        rejected_genres: ['unrelated tag'],
+        omitted_due_to_cap: ['Post-Rock'],
+        sources: { 'Alternative Rock': ['spotify', 'discogs'] },
+        cache_stats: { metadata_cache_hits: 2, live_calls: 0 },
+      },
+    });
+
+    expect(gridPairs(detail)).toEqual([
+      ['Current genres', 'Rock'],
+      ['Proposed genres', 'Rock, Alternative Rock'],
+      ['Added', 'Alternative Rock'],
+      ['Omitted at cap', 'Post-Rock'],
+      ['Rejected', 'unrelated tag'],
+      ['Ambiguous', 'alt rock: Alternative Rock, Indie Rock (82%)'],
+      ['Sources', 'Alternative Rock: spotify, discogs'],
+      ['Cache / external calls', 'metadata 2, live 0'],
+    ]);
   });
 
   it('comma_artist_split shows the resulting tag and clickable library chips', async () => {

--- a/webui/src/routes/tools/-ui/operations.test.tsx
+++ b/webui/src/routes/tools/-ui/operations.test.tsx
@@ -78,6 +78,11 @@ describe('the containers', () => {
   it('groups jobs into their served families, in the house order', () => {
     const { container } = renderOps([
       job({ job_id: 'genre_cleanup', display_name: 'Genre Cleanup', category: 'Tags & metadata' }),
+      job({
+        job_id: 'genre_enrichment',
+        display_name: 'Genre Enrichment',
+        category: 'Tags & metadata',
+      }),
       job({ job_id: 'orphan_file_detector', category: 'Files & storage' }),
       job({ job_id: 'cache_evictor', display_name: 'Cache Maintenance', category: 'System' }),
     ]);
@@ -85,6 +90,11 @@ describe('the containers', () => {
       node.getAttribute('data-category'),
     );
     expect(families).toEqual(['Files & storage', 'Tags & metadata', 'System']);
+    expect(
+      container
+        .querySelector('[data-category="Tags & metadata"]')
+        ?.querySelector('[data-job-id="genre_enrichment"]'),
+    ).not.toBeNull();
   });
 
   it('files a job with no category under Other, at the end', () => {
@@ -243,6 +253,21 @@ describe('the tile', () => {
 
     const second = renderOps([job({ settings: { dry_run: false } })]);
     expect(second.container.querySelector('.repair-settings-btn')).not.toBeNull();
+  });
+
+  it('renders the settings panel below the tile content, not beside the actions', () => {
+    const { container } = renderOps([job({ settings: { dry_run: false } })]);
+    const card = container.querySelector('.repair-job-card') as HTMLElement;
+    const actions = card.querySelector('.repair-job-actions') as HTMLElement;
+    const foot = card.querySelector('.repair-tile-foot') as HTMLElement;
+    const button = card.querySelector('.repair-settings-btn') as HTMLElement;
+
+    fireEvent.click(button);
+
+    const panel = card.querySelector('.repair-job-settings') as HTMLElement;
+    expect(actions.contains(panel)).toBe(false);
+    expect(foot.compareDocumentPosition(panel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(panel.style.display).toBe('');
   });
 
   it('runs a job', async () => {

--- a/webui/src/routes/tools/-ui/operations.tsx
+++ b/webui/src/routes/tools/-ui/operations.tsx
@@ -166,9 +166,16 @@ function CadenceEditor({ job, onSaved }: { job: RepairJob; onSaved: () => void }
 
 // ── Job settings drawer ──────────────────────────────────────────────────────
 
-function JobSettings({ job, onSaved }: { job: RepairJob; onSaved: () => void }) {
+function JobSettings({
+  job,
+  onSaved,
+  open,
+}: {
+  job: RepairJob;
+  onSaved: () => void;
+  open: boolean;
+}) {
   const [values, setValues] = useState<Record<string, unknown>>(() => ({ ...job.settings }));
-  const [open, setOpen] = useState(false);
 
   const save = useCallback(async () => {
     const settings: Record<string, unknown> = {};
@@ -190,20 +197,11 @@ function JobSettings({ job, onSaved }: { job: RepairJob; onSaved: () => void }) 
   }, [job.interval_hours, job.job_id, onSaved, values]);
 
   return (
-    <>
-      <button
-        className="repair-settings-btn"
-        type="button"
-        title="Settings"
-        onClick={() => setOpen((previous) => !previous)}
-      >
-        &#9881;
-      </button>
-      <div
-        className="repair-job-settings"
-        id={`repair-settings-${job.job_id}`}
-        style={{ display: open ? '' : 'none' }}
-      >
+    <div
+      className="repair-job-settings"
+      id={`repair-settings-${job.job_id}`}
+      style={{ display: open ? '' : 'none' }}
+    >
         {Object.entries(job.settings || {}).map(([key, value]) => {
           const field = repairSettingInput(key, value, job.setting_options?.[key]);
           if (field.kind === 'section') {
@@ -281,8 +279,7 @@ function JobSettings({ job, onSaved }: { job: RepairJob; onSaved: () => void }) 
         <button className="repair-save-settings-btn" type="button" onClick={() => void save()}>
           Save Settings
         </button>
-      </div>
-    </>
+    </div>
   );
 }
 
@@ -308,6 +305,7 @@ export function OperationTile({
 }: OperationTileProps) {
   const [enabled, setEnabled] = useState(job.enabled);
   const [stopping, setStopping] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   useEffect(() => setEnabled(job.enabled), [job.enabled]);
 
   const badge = repairJobBadge(job);
@@ -462,7 +460,19 @@ export function OperationTile({
               &#9654;
             </button>
           )}
-          {hasSettings ? <JobSettings job={job} onSaved={onChanged} /> : null}
+          {hasSettings ? (
+            <button
+              className="repair-settings-btn"
+              type="button"
+              title="Settings"
+              onClick={(event) => {
+                event.stopPropagation();
+                setSettingsOpen((previous) => !previous);
+              }}
+            >
+              &#9881;
+            </button>
+          ) : null}
           <button
             className="repair-help-btn"
             type="button"
@@ -493,6 +503,7 @@ export function OperationTile({
           </div>
         </div>
       ) : null}
+      {hasSettings ? <JobSettings job={job} onSaved={onChanged} open={settingsOpen} /> : null}
     </div>
   );
 }


### PR DESCRIPTION
 ## Summary

  Adds a disabled-by-default `genre_enrichment` repair job that identifies missing or incomplete artist and album genres and proposes
  safe, reviewable additions.

  The job uses existing library metadata and cached provider payloads first, supports optional live enrichment by existing provider
  IDs, translates provider genre names against the configured whitelist, and never removes existing canonical genres.

## Screenshots
<img width="349" height="170" alt="image" src="https://github.com/user-attachments/assets/1738f55b-db6c-44cd-bdd2-98ee31dcbef2" />
<img width="345" height="400" alt="image" src="https://github.com/user-attachments/assets/d300f5b7-c782-4913-bbaf-0c9df246b3f7" />
<img width="472" height="334" alt="image" src="https://github.com/user-attachments/assets/79f55b53-c94d-498a-859a-df62de50b598" />
<img width="697" height="89" alt="image" src="https://github.com/user-attachments/assets/2aee570b-9788-4a15-8956-46ce76d670c3" />
<img width="706" height="956" alt="image" src="https://github.com/user-attachments/assets/69068fb7-4cef-4ad7-bcec-731d768e0a69" />
<img width="697" height="307" alt="image" src="https://github.com/user-attachments/assets/1fa5d32e-de5d-4792-8e76-ab0ce1073239" />


  ## What changed

  ### New genre enrichment service

  Added `core/metadata/genre_enrichment.py`, providing reusable functionality for:

  - Reading the configured genre whitelist
  - Hashing whitelist versions for translation-cache isolation
  - Parsing genre values from database fields and provider payloads
  - Collecting local and metadata-cache candidates
  - Extracting provider-specific genres
  - Translating provider genres to whitelist values
  - Ranking and deduplicating candidates
  - Applying per-entity genre limits
  - Preserving provenance, scores, ambiguity, and rejection details

  Supported provider mappings include:

  - Spotify artist and album `genres`
  - iTunes `primaryGenreName` and equivalent genre fields
  - Deezer nested genre payloads and genre ID mappings
  - Discogs `genres` and `styles`
  - Last.fm stored tags
  - AudioDB `strGenre`

  MusicBrainz is intentionally not treated as a genre source until its existing metadata payload shape is explicitly mapped.

  ### New repair job

  Added and registered `genre_enrichment` with:

  - Display name: `Genre Enrichment`
  - Default state: disabled
  - Default interval: 168 hours
  - Auto-fix: disabled
  - Default maximum: 5 genres per artist or album

  Available settings:

  - `max_genres`: integer from 1 through 20
  - `include_artists`
  - `include_albums`
  - `allow_live_calls`

  Invalid settings are normalized to safe defaults server-side.

  The job skips cleanly when the genre whitelist is disabled or empty.

  ### Non-destructive genre behavior

  The job:

  - Preserves all existing canonical genres
  - Adds only translated whitelist genres
  - Avoids duplicates using shared normalized comparison
  - Stops adding when the configured maximum is reached
  - Leaves entities with existing genre counts above the cap unchanged
  - Reports genres omitted because of the cap
  - Does not rewrite audio files

  The fix handler re-reads the current database value before applying changes, preserving genres added after the scan and avoiding
  stale overwrites.

  ### Candidate-source and cache behavior

  Candidates are collected in this order:

  1. Existing canonical genres
  2. Stored Discogs and Last.fm fields
  3. Cached provider entity payloads
  4. Optional live provider detail lookups

  Live lookups only use existing provider IDs. The job does not perform speculative name searches.

  Cached entities are checked before making live calls. Provider failures are isolated to the affected entity/source so one provider
  failure does not abort the complete library scan.

  ### Persistent translation cache

  Added the `genre_translation_cache` table to the normal database initialization path.

  The cache stores:

  - Accepted translations
  - Ambiguous matches
  - Rejected/no-match values
  - Whitelist hash
  - Normalized source genre
  - Matched genre
  - Score
  - Margin
  - Top candidate list
  - Access timestamps and counts

  The whitelist hash ensures translations are not reused after the configured whitelist changes.

  A per-run in-memory cache also prevents duplicate translation work during a single scan.

  ### Conservative genre matching

  Extended shared genre normalization to support:

  - Case-insensitive matching
  - Unicode normalization
  - Hyphen and dash variants
  - Ampersand variants
  - Common punctuation
  - Repeated whitespace
  - Safe aliases such as:
    - `hip-hop` → `Hip Hop`
    - `HipHop` → `Hip Hop`
    - `RnB` → `R&B`
    - `R&B` → `R&B`

  For values that do not match exactly, the service uses `SequenceMatcher` combined with token overlap.

  Results are classified as:

  - Accepted for high-confidence matches
  - Ambiguous when a plausible match exists but confidence or margin is insufficient
  - Rejected for low-confidence values

  Ambiguous values are surfaced for review rather than silently applied.

  ### Candidate ranking

  Accepted genres are ranked using:

  1. Number of independent provider sources
  2. Provider confidence
  3. Translation confidence
  4. Original provider order
  5. Stable normalized alphabetical ordering

  Provider confidence weights include:

  - Discogs: `0.90`
  - Spotify: `0.85`
  - Deezer: `0.80`
  - Last.fm: `0.75`
  - iTunes: `0.70`
  - AudioDB: `0.65`
  - Other/embedded sources: `0.60`

  Genres supported by multiple providers receive higher priority.

  ### Findings and repair actions

  The job creates one finding per artist or album when it has:

  - At least one applicable genre addition, or
  - An ambiguous candidate requiring review

  Finding details include:

  - Current genres
  - Proposed genres
  - Added genres
  - Ambiguous candidates and scores
  - Rejected values
  - Genres omitted due to the cap
  - Provider provenance
  - Cache and live-call statistics
  - Maximum genre setting

  Added the `genre_enrichment` fix handler, which:

  - Validates the finding
  - Re-reads the current entity
  - Merges additions without deleting existing genres
  - Deduplicates values
  - Fails safely if the entity no longer exists
  - Resolves the finding only after a successful database update

  ### Maintenance UI

  Updated the existing repair-job UI to support:

  - Genre Enrichment job display
  - Genre enrichment settings
  - `Apply Genres` action
  - `Genres Applied` resolution label
  - Current and proposed genres
  - Added, ambiguous, rejected, and cap-omitted genres
  - Provider source information
  - Cache and external-call counts
  - Fuzzy match scores

  No new API endpoints were required.

  ## Safety and rollout

  - Disabled by default
  - Live API calls disabled by default
  - Existing genres are never removed
  - No audio files are modified
  - The whitelist must be enabled and non-empty
  - Provider calls only use existing source IDs
  - Findings must be reviewed before applying changes

  The existing `genre_cleanup` job remains unchanged and continues to provide removal-only whitelist cleanup.

  ## Tests

  Added focused tests covering:

  - Case-insensitive exact matching
  - Hyphen and punctuation normalization
  - `HipHop`, `hip-hop`, `R&B`, and `RnB` aliases
  - Ambiguous and rejected fuzzy matches
  - Stable ranking
  - Provider support weighting
  - Maximum genre behavior
  - Preservation of existing genres above the cap
  - Deezer genre ID mapping
  - Cached provider ID lookup

  