### PR TITLE
Read music.youtube.com playlists from the YouTube Music catalog

### DIFF
--- a/core/playlists/sources/youtube.py
+++ b/core/playlists/sources/youtube.py
@@ -75,7 +75,9 @@ class YouTubePlaylistSource(PlaylistSource):
             position=position,
             track_name=track.get("name", "Unknown Track"),
             artist_name=artist_name,
-            album_name=None,
+            # Only the YouTube Music catalog path fills this in; yt-dlp's flat
+            # extraction has no album concept, so it stays None there.
+            album_name=(track.get("album") or "").strip() or None,
             duration_ms=int(track.get("duration_ms", 0) or 0),
             source_track_id=str(track.get("id", "")),
             needs_discovery=False,
@@ -83,5 +85,6 @@ class YouTubePlaylistSource(PlaylistSource):
                 "url": track.get("url"),
                 "raw_title": track.get("raw_title"),
                 "raw_artist": track.get("raw_artist"),
+                "video_type": track.get("video_type"),
             },
         )

--- a/core/youtube_cookies.py
+++ b/core/youtube_cookies.py
@@ -18,12 +18,34 @@ the seam is unit-testable without I/O. The web layer owns *where* the file lives
 
 from __future__ import annotations
 
+import hashlib
 import os
-from typing import Any, Dict
+import time
+from typing import Any, Dict, Optional
 
 # Sentinel dropdown value meaning "use a pasted cookies.txt file" rather than a
 # browser name. Anything else non-empty is treated as a browser for cookiesfrombrowser.
 PASTE_MODE = "custom"
+
+# ytmusicapi speaks to the same YouTube backend but wants HEADERS, not a cookie
+# file, so the pasted cookies.txt has to be projected into them (below).
+
+# The cookie that signs a YouTube API request. Google issues several aliases;
+# any one of them works, so take the first present in this order.
+_SAPISID_NAMES = ("__Secure-3PAPISID", "__Secure-1PAPISID", "SAPISID")
+
+# A browser export can carry 90 KB+ of cookies across every Google property,
+# and YouTube rejects a request whose headers are that large (HTTP 413). Only
+# these actually matter for auth.
+_ESSENTIAL_COOKIES = frozenset({
+    "APISID", "HSID", "SSID", "SID", "SAPISID",
+    "__Secure-1PAPISID", "__Secure-3PAPISID",
+    "__Secure-1PSID", "__Secure-3PSID",
+    "LOGIN_INFO", "PREF", "SOCS", "VISITOR_INFO1_LIVE", "YSC",
+})
+
+# Must match the Origin header ytmusicapi sends, or the hash is rejected.
+_YTMUSIC_ORIGIN = "https://music.youtube.com"
 
 
 def build_youtube_cookie_opts(
@@ -97,9 +119,91 @@ def write_pasted_cookiefile(content: Any, dest_path: str) -> str:
         return ""
 
 
+def parse_netscape_cookies(content: Any) -> Dict[str, str]:
+    """Parse a Netscape ``cookies.txt`` into ``{name: value}``. Pure.
+
+    Deliberately ignores the domain column. The cookies that authenticate a
+    YouTube request are Google-wide and an export taken on any Google property
+    carries the same values — a jar exported from ``google.de`` authenticates
+    music.youtube.com fine. Filtering on "youtube" in the domain silently
+    yields zero cookies for those exports, which reads as "not logged in".
+
+    Later rows win, matching how a browser resolves duplicate names.
+    """
+    cookies: Dict[str, str] = {}
+    if not content or not isinstance(content, str):
+        return cookies
+    for raw in content.splitlines():
+        line = raw.rstrip("\n")
+        if not line or line.lstrip().startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) < 7:
+            continue
+        name, value = fields[5].strip(), fields[6].strip()
+        if name:
+            cookies[name] = value
+    return cookies
+
+
+def ytmusic_auth_headers(
+    cookies: Dict[str, str], *, timestamp: Optional[int] = None
+) -> Optional[Dict[str, str]]:
+    """Build ytmusicapi browser-auth headers from parsed cookies, or ``None``. Pure.
+
+    ``None`` means "no usable auth" — the caller then goes anonymous, which
+    still resolves public playlists. Only a signed-in request can see a private
+    one, and Liked Music (``list=LM``) is always private.
+
+    The ``Authorization: SAPISIDHASH <ts>_<sha1(ts SAPISID origin)>`` scheme is
+    YouTube's own; SHA-1 is not a choice we get to make here. ``timestamp`` is
+    injectable so the header is reproducible in tests.
+    """
+    if not isinstance(cookies, dict) or not cookies:
+        return None
+    sapisid = next((cookies[n] for n in _SAPISID_NAMES if cookies.get(n)), "")
+    if not sapisid:
+        return None
+
+    stamp = str(int(timestamp if timestamp is not None else time.time()))
+    digest = hashlib.sha1(  # noqa: S324 - required by YouTube's auth scheme
+        f"{stamp} {sapisid} {_YTMUSIC_ORIGIN}".encode("utf-8")
+    ).hexdigest()
+
+    essential = {k: v for k, v in cookies.items() if k in _ESSENTIAL_COOKIES}
+    return {
+        "Cookie": "; ".join(f"{k}={v}" for k, v in essential.items()),
+        "Authorization": f"SAPISIDHASH {stamp}_{digest}",
+        "Content-Type": "application/json",
+        "Accept": "*/*",
+        "Accept-Language": "en-US,en;q=0.5",
+        "X-Goog-AuthUser": "0",
+        "Origin": _YTMUSIC_ORIGIN,
+    }
+
+
+def ytmusic_auth_from_cookiefile(path: Any) -> Optional[Dict[str, str]]:
+    """Read ``path`` and project it into ytmusicapi auth headers, or ``None``.
+
+    The one impure entry point: everything it can't do (missing file, unreadable,
+    logged-out export) collapses to ``None`` so the caller just goes anonymous.
+    """
+    if not path or not isinstance(path, str) or not os.path.exists(path):
+        return None
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            content = fh.read()
+    except OSError:
+        return None
+    return ytmusic_auth_headers(parse_netscape_cookies(content))
+
+
 __all__ = [
     "PASTE_MODE",
     "build_youtube_cookie_opts",
     "looks_like_cookiefile",
     "write_pasted_cookiefile",
+    "parse_netscape_cookies",
+    "ytmusic_auth_headers",
+    "ytmusic_auth_from_cookiefile",
 ]

--- a/core/youtube_music_meta.py
+++ b/core/youtube_music_meta.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Mapping, Optional
 from urllib.parse import parse_qs, urlparse
 
+from core.youtube_track_meta import strip_topic_suffix
 from utils.logging_config import get_logger
 
 logger = get_logger("youtube_music_meta")
@@ -65,13 +66,21 @@ def playlist_id_from_url(url: Any) -> str:
 
 
 def _artist_names(track: Mapping[str, Any]) -> List[str]:
-    """Non-empty artist names, in the API's order (primary first)."""
+    """Non-empty artist names, in the API's order (primary first).
+
+    Tracks whose artist has no canonical catalog entry come back with the raw
+    auto-generated channel name instead — ``"Example Band - Topic"``. Left alone that
+    reaches the mirror verbatim and never matches the ``Example Band`` already in the
+    library, so the suffix is stripped with the same helper the yt-dlp path
+    uses. Observed on 10 of 1995 tracks across one user's playlists.
+    """
     names = []
     for entry in track.get("artists") or []:
         if isinstance(entry, Mapping):
             name = str(entry.get("name") or "").strip()
         else:
             name = str(entry or "").strip()
+        name = strip_topic_suffix(name)
         if name and name not in names:
             names.append(name)
     return names

--- a/core/youtube_music_meta.py
+++ b/core/youtube_music_meta.py
@@ -1,0 +1,209 @@
+"""Read a music.youtube.com playlist from the YouTube Music catalog API.
+
+``parse_youtube_playlist`` gets its data from yt-dlp's *flat* playlist
+extraction, which is a video-oriented view: per entry it returns a title, an
+id, a duration and a channel. That is enough to guess an artist (see
+``core.youtube_track_meta``) but it can never produce an **album**, because
+videos don't have one — and the whole downstream pipeline (library matching,
+Soulseek search, MusicBrainz release preflight) is album-shaped.
+
+YouTube Music serves the same playlist from a music catalog that already has
+those fields. ``ytmusicapi`` speaks that API. Measured on one user's library:
+
+    playlist        yt-dlp flat                 YT Music catalog
+    a 69-track      68/69 artists, 0 albums     69/69 artists, 69 albums
+    liked songs     210 tracks (page-capped)    1421 tracks, 0 unknown artists
+
+so this is both a metadata and a *completeness* win — the InnerTube paging
+ytmusicapi uses isn't subject to the flat-extraction page cap that #908 works
+around.
+
+Scope, deliberately narrow:
+
+- **music.youtube.com only.** A youtube.com playlist is a video playlist; it
+  has no catalog entry and asking for one would 404. The caller gates on
+  ``is_music_youtube_url`` and youtube.com keeps the yt-dlp path untouched.
+- **Best-effort.** ytmusicapi is an OPTIONAL dependency and the API can fail
+  (private playlist, no cookies, upstream shape change — it raises ``KeyError``
+  on a response it can't walk). Every failure returns ``None`` so the caller
+  falls back to yt-dlp. The feature can only add data, never remove it.
+- **User-generated content still works.** A UGC track in a YT Music playlist
+  comes back with the uploader's channel as the artist and no album — exactly
+  what the yt-dlp path would have produced, so those entries are no worse.
+
+The projection (``ytmusic_playlist_to_payload``) is a pure function over the
+API's response so the field mapping is unit-testable without network.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+from urllib.parse import parse_qs, urlparse
+
+from utils.logging_config import get_logger
+
+logger = get_logger("youtube_music_meta")
+
+# YouTube Music's own id for "the signed-in user's Liked Music". It is not a
+# real playlist id and never appears in a ``list=`` parameter as anything else.
+LIKED_MUSIC_ID = "LM"
+
+
+def playlist_id_from_url(url: Any) -> str:
+    """Extract the ``list=`` playlist id from a YouTube URL, or ``''``.
+
+    ytmusicapi wants the bare id, not the URL.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return ""
+    try:
+        parsed = urlparse(url.strip())
+    except ValueError:
+        return ""
+    values = parse_qs(parsed.query or "").get("list") or []
+    return (values[0] or "").strip() if values else ""
+
+
+def _artist_names(track: Mapping[str, Any]) -> List[str]:
+    """Non-empty artist names, in the API's order (primary first)."""
+    names = []
+    for entry in track.get("artists") or []:
+        if isinstance(entry, Mapping):
+            name = str(entry.get("name") or "").strip()
+        else:
+            name = str(entry or "").strip()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _album_name(track: Mapping[str, Any]) -> str:
+    """Album name, or ``''``. Singles and UGC legitimately have none."""
+    album = track.get("album")
+    if isinstance(album, Mapping):
+        return str(album.get("name") or "").strip()
+    return str(album or "").strip()
+
+
+def ytmusic_playlist_to_payload(
+    raw: Optional[Mapping[str, Any]], url: str
+) -> Optional[Dict[str, Any]]:
+    """Project a ytmusicapi ``get_playlist`` response into the dict shape
+    ``parse_youtube_playlist`` returns, so callers can't tell which path ran.
+
+    Pure — no network, no config. Returns ``None`` when the response carries no
+    usable track, so the caller can fall back rather than mirror an empty
+    playlist over a good one.
+
+    Tracks with neither a title nor a videoId are dropped: they're the API's
+    placeholder rows for deleted/region-blocked entries and would land in the
+    mirror as empty rows (which ``mirror_playlist`` rejects wholesale).
+    """
+    if not isinstance(raw, Mapping):
+        return None
+
+    tracks: List[Dict[str, Any]] = []
+    for track in raw.get("tracks") or []:
+        if not isinstance(track, Mapping):
+            continue
+        title = str(track.get("title") or "").strip()
+        video_id = str(track.get("videoId") or "").strip()
+        if not title and not video_id:
+            continue
+
+        names = _artist_names(track)
+        seconds = track.get("duration_seconds")
+        try:
+            duration_ms = int(seconds) * 1000 if seconds else 0
+        except (TypeError, ValueError):
+            duration_ms = 0
+
+        tracks.append({
+            "id": video_id,
+            "name": title or "Unknown Track",
+            # Same shape as the yt-dlp path: a list whose FIRST entry is the
+            # primary artist. Extra names are kept for callers that want the
+            # full credit rather than just artists[0].
+            "artists": names or ["Unknown Artist"],
+            "album": _album_name(track),
+            "duration_ms": duration_ms,
+            "raw_title": title,
+            "raw_artist": names[0] if names else "",
+            # ATV = catalog audio, OMV = official video, UGC = user upload.
+            # Passed through so a caller can weight or filter by provenance.
+            "video_type": str(track.get("videoType") or ""),
+            "url": f"https://www.youtube.com/watch?v={video_id}" if video_id else "",
+        })
+
+    if not tracks:
+        return None
+
+    thumbnails = raw.get("thumbnails") or []
+    image_url = ""
+    if thumbnails and isinstance(thumbnails[-1], Mapping):
+        image_url = str(thumbnails[-1].get("url") or "")
+
+    return {
+        "id": str(raw.get("id") or playlist_id_from_url(url)),
+        "name": str(raw.get("title") or "YouTube Music Playlist"),
+        "tracks": tracks,
+        "track_count": len(tracks),
+        "url": url,
+        "source": "youtube",
+        "image_url": image_url,
+    }
+
+
+def fetch_ytmusic_playlist(
+    url: str, auth: Optional[Dict[str, str]] = None
+) -> Optional[Dict[str, Any]]:
+    """Fetch ``url`` from the YouTube Music catalog, or ``None`` on any failure.
+
+    ``auth`` is a ytmusicapi browser-auth header dict; without it only public
+    playlists resolve — notably Liked Music (``list=LM``) needs it to exist at
+    all.
+
+    Never raises: a missing ytmusicapi, a private playlist, a network blip and
+    an upstream response-shape change (ytmusicapi raises a bare ``KeyError``
+    while walking the JSON) all mean the same thing to the caller — use yt-dlp.
+    """
+    playlist_id = playlist_id_from_url(url)
+    if not playlist_id:
+        return None
+
+    try:
+        from ytmusicapi import YTMusic
+    except ImportError:
+        logger.debug("ytmusicapi not installed — using yt-dlp for %s", url)
+        return None
+
+    try:
+        client = YTMusic(auth) if auth else YTMusic()
+        # limit=None pages the whole playlist; the default stops at 100.
+        raw = client.get_playlist(playlist_id, limit=None)
+    except Exception as e:  # noqa: BLE001 - see docstring: all failures fall back
+        logger.info(
+            "YouTube Music lookup failed for %s (%s: %s) — falling back to yt-dlp",
+            playlist_id, type(e).__name__, e,
+        )
+        return None
+
+    payload = ytmusic_playlist_to_payload(raw, url)
+    if payload is None:
+        logger.info("YouTube Music returned no usable tracks for %s — falling back", playlist_id)
+        return None
+
+    logger.info(
+        "YouTube Music: '%s' — %d tracks, %d with an album",
+        payload["name"], len(payload["tracks"]),
+        sum(1 for t in payload["tracks"] if t["album"]),
+    )
+    return payload
+
+
+__all__ = [
+    "LIKED_MUSIC_ID",
+    "playlist_id_from_url",
+    "ytmusic_playlist_to_payload",
+    "fetch_ytmusic_playlist",
+]

--- a/core/youtube_track_meta.py
+++ b/core/youtube_track_meta.py
@@ -53,6 +53,24 @@ _TOPIC_RE = re.compile(r'\s*-\s*topic\s*$', re.IGNORECASE)
 _TITLE_SPLIT_RE = re.compile(r'^\s*(?P<artist>.+?)\s+[-–—]\s+(?P<title>.+?)\s*$')
 
 
+def strip_topic_suffix(name: Any) -> str:
+    """Strip a trailing ``" - Topic"`` from an auto-generated channel name.
+
+    Shared so the yt-dlp path and the YouTube Music catalog path agree: the
+    catalog hands back the raw channel name for artists without a canonical
+    entry, so ``"Example Band - Topic"`` reaches the mirror and never matches the
+    ``Example Band`` already in the library. Returns the input stripped of the suffix,
+    or unchanged when there isn't one.
+    """
+    text = str(name or '').strip()
+    if not text:
+        return ''
+    stripped = _TOPIC_RE.sub('', text).strip()
+    # A channel literally named "- Topic" would strip to nothing; keep the
+    # original rather than inventing an empty artist.
+    return stripped or text
+
+
 def _first_music_field(entry: Mapping[str, Any]) -> str:
     """First non-empty value from yt-dlp's music-metadata fields."""
     artists = entry.get('artists')
@@ -114,8 +132,8 @@ def derive_artist_and_title(
     # 2. "<Artist> - Topic" auto-channel — the channel name IS the artist.
     channel = str(entry.get('uploader') or entry.get('channel') or '').strip()
     if _TOPIC_RE.search(channel):
-        stripped = _TOPIC_RE.sub('', channel).strip()
-        if stripped:
+        stripped = strip_topic_suffix(channel)
+        if stripped and stripped != channel:
             return stripped, title
 
     # 3. "<Artist> - <Title>" embedded in the title.
@@ -135,4 +153,4 @@ def derive_artist_and_title(
     return '', title
 
 
-__all__ = ['derive_artist_and_title', 'is_music_youtube_url']
+__all__ = ['derive_artist_and_title', 'is_music_youtube_url', 'strip_topic_suffix']

--- a/core/youtube_track_meta.py
+++ b/core/youtube_track_meta.py
@@ -13,18 +13,35 @@ The artist is usually recoverable from one of, in priority order:
    populated for YouTube Music tracks.
 2. An auto-generated ``"<Artist> - Topic"`` channel name.
 3. The classic ``"<Artist> - <Title>"`` form embedded in the video title.
+4. The per-entry channel — but ONLY on music.youtube.com (see below).
 
 This module is the single, pure place that decides which signal wins, so the
 precedence is unit-testable instead of buried in the web_server endpoint. It
 deliberately does NOT fall back to the channel/uploader as the artist — on a
-playlist that's the owner, and mislabelling every track is worse than an honest
-"Unknown Artist" (which downstream MusicBrainz discovery can still try to fix).
+youtube.com playlist that's the owner, and mislabelling every track is worse
+than an honest "Unknown Artist" (which downstream MusicBrainz discovery can
+still try to fix).
+
+That #863 rule is right for youtube.com and wrong for music.youtube.com. On a
+YT Music playlist every flat entry carries its OWN channel — the artist's
+channel — not the playlist owner's, because YT Music serves one channel per
+track rather than one per playlist. Measured on a 69-track YT Music playlist:
+68 entries carried the correct artist in ``channel``, and all 69 were stored as
+"Unknown Artist" because this module refused to look. So the fallback is
+available behind ``allow_channel_artist``, which the caller sets from the
+playlist URL's host — never inferred here, since an entry alone cannot tell you
+which kind of playlist it came from.
 """
 
 from __future__ import annotations
 
 import re
 from typing import Any, Mapping, Tuple
+from urllib.parse import urlparse
+
+# Hosts whose playlists serve a per-TRACK channel (the artist), not the
+# playlist owner's channel. Bare "youtube.com" is deliberately absent.
+_MUSIC_HOSTS = frozenset({'music.youtube.com', 'music.youtube.co.uk'})
 
 # Trailing "- Topic" on an auto-generated YouTube Music channel.
 _TOPIC_RE = re.compile(r'\s*-\s*topic\s*$', re.IGNORECASE)
@@ -51,13 +68,38 @@ def _first_music_field(entry: Mapping[str, Any]) -> str:
     return ''
 
 
-def derive_artist_and_title(entry: Mapping[str, Any]) -> Tuple[str, str]:
+def is_music_youtube_url(url: Any) -> bool:
+    """True when ``url`` points at music.youtube.com.
+
+    Drives ``allow_channel_artist``. Parsed rather than substring-matched so a
+    youtube.com URL that merely mentions the string (a ``?next=`` parameter, a
+    channel named "music.youtube.com") can't turn the fallback on.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return False
+    try:
+        host = (urlparse(url.strip()).hostname or '').lower()
+    except ValueError:
+        return False
+    return host in _MUSIC_HOSTS
+
+
+def derive_artist_and_title(
+    entry: Mapping[str, Any], allow_channel_artist: bool = False
+) -> Tuple[str, str]:
     """Return ``(artist, title)`` from a yt-dlp (flat) playlist entry.
 
     ``artist`` is ``''`` when no reliable signal exists — the caller defaults
     that to "Unknown Artist" rather than using the playlist owner's channel
     (#863). ``title`` is the raw video title, except when an "Artist - Title"
     split provided the artist, in which case it's the right-hand side.
+
+    ``allow_channel_artist`` opts into the plain channel/uploader as a
+    last-resort artist. Pass ``is_music_youtube_url(playlist_url)`` — on
+    music.youtube.com the per-entry channel IS the artist; on youtube.com it is
+    the playlist owner and must stay off (#863). It is the LAST signal tried, so
+    turning it on can only fill in tracks that would otherwise have been
+    "Unknown Artist" — it never overrides a better one.
     """
     if not isinstance(entry, Mapping):
         return '', 'Unknown Track'
@@ -84,8 +126,13 @@ def derive_artist_and_title(entry: Mapping[str, Any]) -> Tuple[str, str]:
         if artist and rest:
             return artist, rest
 
-    # 4. No reliable artist signal — caller defaults to "Unknown Artist".
+    # 4. Plain channel — the artist on music.youtube.com, the playlist owner on
+    #    youtube.com. Only the caller knows which, hence the flag.
+    if allow_channel_artist and channel:
+        return channel, title
+
+    # 5. No reliable artist signal — caller defaults to "Unknown Artist".
     return '', title
 
 
-__all__ = ['derive_artist_and_title']
+__all__ = ['derive_artist_and_title', 'is_music_youtube_url']

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,12 @@ tzlocal>=5.0
 # it; bare-metal installs need it on PATH: https://docs.deno.com/runtime/
 yt-dlp>=2026.3.17
 
+# music.youtube.com playlist metadata (artist + album per track, and no
+# flat-extraction page cap). Optional at RUNTIME -- core/youtube_music_meta.py
+# falls back to yt-dlp when the import fails -- so an in-place upgrade that
+# skips this line keeps working, just without albums.
+ytmusicapi>=1.10.0
+
 # Lyrics support
 lrclibapi==0.3.1
 

--- a/tests/test_youtube_cookies.py
+++ b/tests/test_youtube_cookies.py
@@ -130,3 +130,93 @@ def test_resolve_cookie_opts_custom_missing_file_is_anonymous(monkeypatch):
     monkeypatch.setattr('config.settings.config_manager.get',
                         lambda k, d=None: cfg.get(k, d))
     assert yt._resolve_cookie_opts() == {}            # not a broken cookiefile arg
+
+
+# ── ytmusicapi browser auth ───────────────────────────────────────────────
+# ytmusicapi wants HEADERS, not a cookie file, so the same pasted cookies.txt
+# is projected into them. Without this, only public playlists resolve — Liked
+# Music (list=LM) is always private.
+
+from core.youtube_cookies import (  # noqa: E402
+    parse_netscape_cookies,
+    ytmusic_auth_from_cookiefile,
+    ytmusic_auth_headers,
+)
+
+# Real export shape. The domain is a non-YouTube Google property on purpose —
+# see test_cookies_are_parsed_regardless_of_domain.
+_JAR = (
+    "# Netscape HTTP Cookie File\n"
+    ".google.de\tTRUE\t/\tTRUE\t1799999999\t__Secure-3PAPISID\tsecret-sapisid\n"
+    ".google.de\tTRUE\t/\tTRUE\t1799999999\tSID\tsid-value\n"
+    ".google.de\tTRUE\t/\tTRUE\t1799999999\tHSID\thsid-value\n"
+)
+
+
+def test_cookies_are_parsed_regardless_of_domain():
+    # The auth cookies are Google-wide; an export taken on google.de signs a
+    # music.youtube.com request fine. Filtering on "youtube" in the domain
+    # yields zero cookies for such a jar and reads as "not logged in".
+    cookies = parse_netscape_cookies(_JAR)
+    assert cookies["__Secure-3PAPISID"] == "secret-sapisid"
+    assert cookies["SID"] == "sid-value"
+
+
+def test_parse_skips_comments_and_short_rows():
+    assert parse_netscape_cookies("# just a header\n") == {}
+    assert parse_netscape_cookies(".x\tTRUE\t/\tTRUE\t1\tNAME\n") == {}  # 6 fields, no value
+    assert parse_netscape_cookies(None) == {}
+    assert parse_netscape_cookies(12345) == {}
+
+
+def test_later_duplicate_row_wins():
+    jar = _JAR + ".youtube.com\tTRUE\t/\tTRUE\t1799999999\tSID\tnewer-sid\n"
+    assert parse_netscape_cookies(jar)["SID"] == "newer-sid"
+
+
+def test_auth_headers_are_reproducible_for_a_fixed_timestamp():
+    import hashlib
+    headers = ytmusic_auth_headers(parse_netscape_cookies(_JAR), timestamp=1_700_000_000)
+    expected = hashlib.sha1(
+        b"1700000000 secret-sapisid https://music.youtube.com").hexdigest()
+    assert headers["Authorization"] == f"SAPISIDHASH 1700000000_{expected}"
+    assert headers["Origin"] == "https://music.youtube.com"
+
+
+def test_auth_headers_drop_non_essential_cookies():
+    # A browser export can be 90 KB+; YouTube 413s on headers that large.
+    jar = _JAR + ".google.de\tTRUE\t/\tTRUE\t1799999999\tNID\tbulky-unrelated-value\n"
+    cookie = ytmusic_auth_headers(parse_netscape_cookies(jar))["Cookie"]
+    assert "__Secure-3PAPISID=secret-sapisid" in cookie
+    assert "bulky-unrelated-value" not in cookie
+
+
+def test_sapisid_aliases_are_accepted_in_priority_order():
+    for name in ("__Secure-3PAPISID", "__Secure-1PAPISID", "SAPISID"):
+        headers = ytmusic_auth_headers({name: "v"}, timestamp=1)
+        assert headers is not None
+        assert "SAPISIDHASH" in headers["Authorization"]
+
+
+def test_no_sapisid_means_no_auth():
+    # A logged-out export must go anonymous, not send a bogus signature.
+    assert ytmusic_auth_headers({"PREF": "x", "YSC": "y"}) is None
+    assert ytmusic_auth_headers({}) is None
+    assert ytmusic_auth_headers(None) is None
+
+
+def test_auth_from_missing_or_bad_file_is_none(tmp_path):
+    assert ytmusic_auth_from_cookiefile(str(tmp_path / "nope.txt")) is None
+    assert ytmusic_auth_from_cookiefile("") is None
+    assert ytmusic_auth_from_cookiefile(None) is None
+    empty = tmp_path / "empty.txt"
+    empty.write_text("# Netscape HTTP Cookie File\n", encoding="utf-8")
+    assert ytmusic_auth_from_cookiefile(str(empty)) is None
+
+
+def test_auth_from_real_file_round_trips(tmp_path):
+    path = tmp_path / "cookies.txt"
+    path.write_text(_JAR, encoding="utf-8")
+    headers = ytmusic_auth_from_cookiefile(str(path))
+    assert headers is not None
+    assert "SAPISIDHASH" in headers["Authorization"]

--- a/tests/test_youtube_music_meta.py
+++ b/tests/test_youtube_music_meta.py
@@ -1,0 +1,151 @@
+"""Seam tests for the YouTube Music catalog path.
+
+yt-dlp's flat playlist extraction is a video view: title, id, duration,
+channel — no album, ever. music.youtube.com playlists have a real catalog
+entry with both, so `parse_youtube_playlist` tries it first and falls back to
+yt-dlp on any failure. These pin the field projection and — more importantly —
+that every failure mode returns None rather than raising or returning a
+half-populated playlist that would overwrite a good mirror.
+
+Fixtures are trimmed copies of real ytmusicapi `get_playlist` responses.
+"""
+
+from __future__ import annotations
+
+from core.youtube_music_meta import (
+    playlist_id_from_url,
+    ytmusic_playlist_to_payload,
+)
+
+URL = "https://music.youtube.com/playlist?list=PLExamplePlaylistId00000000000000"
+
+
+def _raw(*tracks):
+    return {"id": "PL123", "title": "Example Playlist", "trackCount": len(tracks), "tracks": list(tracks)}
+
+
+ATV_TRACK = {
+    "videoId": "exampleVid1",
+    "title": "Example Track",
+    "artists": [{"name": "Example Artist", "id": "UCExampleChannelId000000"}],
+    "album": {"name": "Example Track", "id": "MPREb_ExampleAlbumId"},
+    "duration": "3:45",
+    "duration_seconds": 225,
+    "videoType": "MUSIC_VIDEO_TYPE_ATV",
+    "isAvailable": True,
+}
+
+
+# ── URL parsing ───────────────────────────────────────────────────────────
+
+
+def test_playlist_id_extracted_from_url():
+    assert playlist_id_from_url(URL) == "PLExamplePlaylistId00000000000000"
+    assert playlist_id_from_url("https://music.youtube.com/playlist?list=LM") == "LM"
+
+
+def test_playlist_id_missing_or_bad_input():
+    for bad in (None, "", "   ", 42, "https://music.youtube.com/", "not a url"):
+        assert playlist_id_from_url(bad) == ""
+
+
+# ── projection ────────────────────────────────────────────────────────────
+
+
+def test_catalog_track_projects_all_fields():
+    payload = ytmusic_playlist_to_payload(_raw(ATV_TRACK), URL)
+    assert payload["name"] == "Example Playlist"
+    assert payload["source"] == "youtube"
+    assert payload["track_count"] == 1
+    track = payload["tracks"][0]
+    assert track["id"] == "exampleVid1"
+    assert track["name"] == "Example Track"
+    assert track["artists"] == ["Example Artist"]
+    # The field yt-dlp can never supply — the reason this path exists.
+    assert track["album"] == "Example Track"
+    assert track["duration_ms"] == 225_000
+    assert track["video_type"] == "MUSIC_VIDEO_TYPE_ATV"
+
+
+def test_multiple_artists_keep_primary_first():
+    # Downstream takes artists[0]; a feat. credit must not displace the primary.
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "artists": [{"name": "Primary Artist"}, {"name": "Featured Artist"}]}), URL)
+    assert payload["tracks"][0]["artists"] == ["Primary Artist", "Featured Artist"]
+    assert payload["tracks"][0]["raw_artist"] == "Primary Artist"
+
+
+def test_duplicate_and_blank_artist_names_are_cleaned():
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK,
+              "artists": [{"name": "Solo Artist"}, {"name": ""}, {"name": "Solo Artist"}, {"name": None}]}), URL)
+    assert payload["tracks"][0]["artists"] == ["Solo Artist"]
+
+
+def test_ugc_track_without_album_is_kept():
+    # A user upload inside a YT Music playlist: channel as artist, no album.
+    # That is exactly what the yt-dlp path would have produced, so it must be
+    # kept rather than dropped — otherwise this path LOSES tracks.
+    payload = ytmusic_playlist_to_payload(
+        _raw({"videoId": "abc123", "title": "Some Fan Upload",
+              "artists": [{"name": "Uploader Channel"}], "album": None,
+              "duration_seconds": 190, "videoType": "MUSIC_VIDEO_TYPE_UGC"}), URL)
+    track = payload["tracks"][0]
+    assert track["artists"] == ["Uploader Channel"]
+    assert track["album"] == ""
+    assert track["video_type"] == "MUSIC_VIDEO_TYPE_UGC"
+
+
+def test_track_with_no_artists_falls_back_to_unknown():
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "artists": []}), URL)
+    assert payload["tracks"][0]["artists"] == ["Unknown Artist"]
+    assert payload["tracks"][0]["raw_artist"] == ""
+
+
+def test_missing_duration_is_zero_not_a_crash():
+    for seconds in (None, "", "abc", {}):
+        payload = ytmusic_playlist_to_payload(
+            _raw({**ATV_TRACK, "duration_seconds": seconds}), URL)
+        assert payload["tracks"][0]["duration_ms"] == 0
+
+
+def test_placeholder_rows_are_dropped():
+    # Deleted / region-blocked entries come back with neither title nor id.
+    # mirror_playlist rejects an all-empty payload outright, so they must not
+    # reach it.
+    payload = ytmusic_playlist_to_payload(
+        _raw(ATV_TRACK, {"videoId": None, "title": None, "artists": []}), URL)
+    assert payload["track_count"] == 1
+
+
+# ── fallback contract ─────────────────────────────────────────────────────
+# Everything below must return None so parse_youtube_playlist uses yt-dlp.
+# A partial payload here would overwrite a good mirror with a worse one.
+
+
+def test_none_response_returns_none():
+    assert ytmusic_playlist_to_payload(None, URL) is None
+    assert ytmusic_playlist_to_payload("not a mapping", URL) is None
+
+
+def test_playlist_with_no_tracks_returns_none():
+    assert ytmusic_playlist_to_payload(_raw(), URL) is None
+
+
+def test_playlist_with_only_placeholder_rows_returns_none():
+    assert ytmusic_playlist_to_payload(
+        _raw({"videoId": "", "title": ""}, {"videoId": None, "title": None}), URL) is None
+
+
+def test_malformed_track_entries_are_skipped_not_fatal():
+    payload = ytmusic_playlist_to_payload(_raw("junk", None, 42, ATV_TRACK), URL)
+    assert payload["track_count"] == 1
+
+
+def test_fetch_returns_none_without_a_playlist_id():
+    # Guards before any import of ytmusicapi, so this holds whether or not the
+    # optional dependency is installed.
+    from core.youtube_music_meta import fetch_ytmusic_playlist
+    assert fetch_ytmusic_playlist("https://music.youtube.com/") is None
+    assert fetch_ytmusic_playlist("") is None

--- a/tests/test_youtube_music_meta.py
+++ b/tests/test_youtube_music_meta.py
@@ -149,3 +149,37 @@ def test_fetch_returns_none_without_a_playlist_id():
     from core.youtube_music_meta import fetch_ytmusic_playlist
     assert fetch_ytmusic_playlist("https://music.youtube.com/") is None
     assert fetch_ytmusic_playlist("") is None
+
+
+# ── "- Topic" channel names ───────────────────────────────────────────────
+# An artist with no canonical catalog entry comes back as the raw auto-channel
+# name. Left alone it reaches the mirror as "Example Band - Topic" and never matches
+# the "Example Band" already in the library. Seen on 10 of 1995 real tracks.
+
+
+def test_topic_suffix_stripped_from_catalog_artist():
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "artists": [{"name": "Example Band - Topic"}]}), URL)
+    assert payload["tracks"][0]["artists"] == ["Example Band"]
+    assert payload["tracks"][0]["raw_artist"] == "Example Band"
+
+
+def test_topic_stripping_dedupes_against_the_canonical_name():
+    # Same artist credited both ways must collapse to one name, not two.
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "artists": [{"name": "Second Artist"}, {"name": "Second Artist - Topic"}]}),
+        URL)
+    assert payload["tracks"][0]["artists"] == ["Second Artist"]
+
+
+def test_artist_named_only_topic_is_not_emptied():
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "artists": [{"name": "- Topic"}]}), URL)
+    assert payload["tracks"][0]["artists"] == ["- Topic"]
+
+
+def test_missing_video_type_is_empty_not_none():
+    # 160 of 1995 real tracks carry no videoType; it must not become "None".
+    payload = ytmusic_playlist_to_payload(
+        _raw({**ATV_TRACK, "videoType": None}), URL)
+    assert payload["tracks"][0]["video_type"] == ""

--- a/tests/test_youtube_track_meta.py
+++ b/tests/test_youtube_track_meta.py
@@ -9,7 +9,7 @@ the best available signal instead. These pin the precedence + the
 
 from __future__ import annotations
 
-from core.youtube_track_meta import derive_artist_and_title
+from core.youtube_track_meta import derive_artist_and_title, is_music_youtube_url
 
 
 def test_music_artists_field_wins():
@@ -92,3 +92,82 @@ def test_empty_artists_list_falls_through():
         {'title': 'Koven - Worlds Apart', 'artists': ['', None]})
     assert artist == 'Koven'
     assert title == 'Worlds Apart'
+
+
+# ── music.youtube.com channel fallback ────────────────────────────────────
+# On youtube.com the entry channel is the playlist OWNER (#863, pinned above).
+# On music.youtube.com it is the TRACK's own channel, so the #863 rule was
+# discarding a correct artist on every YT Music track. These pin the split.
+
+
+def test_channel_not_used_as_artist_by_default():
+    # Default stays the #863 behaviour: youtube.com callers pass nothing.
+    artist, title = derive_artist_and_title({'title': 'Forgiven', 'channel': 'Wing It'})
+    assert artist == ''
+    assert title == 'Forgiven'
+
+
+def test_channel_used_as_artist_when_allowed():
+    # The real music.youtube.com shape — flat entry, no music fields, plain
+    # per-track channel.
+    artist, title = derive_artist_and_title(
+        {'title': 'Example Track', 'channel': 'Example Artist'},
+        allow_channel_artist=True)
+    assert artist == 'Example Artist'
+    assert title == 'Example Track'
+
+
+def test_channel_fallback_is_last_and_never_overrides_a_better_signal():
+    # Music fields still win, so enabling the fallback can only ADD artists.
+    artist, _ = derive_artist_and_title(
+        {'title': 'Forgiven', 'artists': ['Within Temptation'], 'channel': 'Some Label'},
+        allow_channel_artist=True)
+    assert artist == 'Within Temptation'
+    # ...and so does an "Artist - Title" split.
+    artist, title = derive_artist_and_title(
+        {'title': 'Koven - Worlds Apart', 'channel': 'Monstercat'},
+        allow_channel_artist=True)
+    assert artist == 'Koven'
+    assert title == 'Worlds Apart'
+
+
+def test_topic_suffix_still_stripped_when_channel_fallback_on():
+    # The Topic branch must win, otherwise the artist keeps the " - Topic".
+    artist, _ = derive_artist_and_title(
+        {'title': 'Revolte', 'uploader': 'Paul Kalkbrenner - Topic'},
+        allow_channel_artist=True)
+    assert artist == 'Paul Kalkbrenner'
+
+
+def test_channel_fallback_with_no_channel_is_still_empty():
+    artist, title = derive_artist_and_title({'title': 'Forgiven'}, allow_channel_artist=True)
+    assert artist == ''
+    assert title == 'Forgiven'
+
+
+# ── URL host detection ────────────────────────────────────────────────────
+
+
+def test_music_host_detected():
+    assert is_music_youtube_url('https://music.youtube.com/playlist?list=PL123')
+    assert is_music_youtube_url('HTTPS://MUSIC.YOUTUBE.COM/playlist?list=LM')
+
+
+def test_plain_youtube_is_not_music():
+    # The #863 host — the channel fallback must stay OFF here.
+    assert not is_music_youtube_url('https://www.youtube.com/playlist?list=PL123')
+    assert not is_music_youtube_url('https://youtube.com/playlist?list=PL123')
+    assert not is_music_youtube_url('https://m.youtube.com/playlist?list=PL123')
+
+
+def test_music_host_must_be_the_host_not_a_substring():
+    # A youtube.com URL that merely mentions the music host (redirect param,
+    # lookalike domain) must not switch the fallback on.
+    assert not is_music_youtube_url(
+        'https://www.youtube.com/playlist?list=PL1&next=music.youtube.com')
+    assert not is_music_youtube_url('https://music.youtube.com.evil.test/playlist?list=PL1')
+
+
+def test_bad_url_input_is_safe():
+    for bad in (None, '', '   ', 123, {}, 'not a url'):
+        assert not is_music_youtube_url(bad)

--- a/tests/test_youtube_track_meta.py
+++ b/tests/test_youtube_track_meta.py
@@ -171,3 +171,16 @@ def test_music_host_must_be_the_host_not_a_substring():
 def test_bad_url_input_is_safe():
     for bad in (None, '', '   ', 123, {}, 'not a url'):
         assert not is_music_youtube_url(bad)
+
+
+def test_strip_topic_suffix_helper():
+    from core.youtube_track_meta import strip_topic_suffix
+    assert strip_topic_suffix('Example Band - Topic') == 'Example Band'
+    assert strip_topic_suffix('Fifth Artist - Topic') == 'Fifth Artist'
+    assert strip_topic_suffix('Fourth Artist  -  TOPIC') == 'Fourth Artist'
+    # No suffix — unchanged.
+    assert strip_topic_suffix('Third Artist') == 'Third Artist'
+    # Would strip to nothing: keep the original rather than invent an empty artist.
+    assert strip_topic_suffix('- Topic') == '- Topic'
+    assert strip_topic_suffix('') == ''
+    assert strip_topic_suffix(None) == ''

--- a/web_server.py
+++ b/web_server.py
@@ -16902,7 +16902,11 @@ def parse_youtube_playlist(url):
     Uses flat playlist extraction to avoid rate limits and get all tracks
     Returns a list of track dictionaries compatible with our Track structure
     """
-    from core.youtube_track_meta import derive_artist_and_title
+    from core.youtube_track_meta import derive_artist_and_title, is_music_youtube_url
+    # On music.youtube.com each flat entry carries the ARTIST's channel; on
+    # youtube.com it carries the playlist owner's (#863). Decided once here from
+    # the URL because the per-entry data can't distinguish the two.
+    allow_channel_artist = is_music_youtube_url(url)
     try:
         # Configure yt-dlp options for flat playlist extraction (avoids rate limits)
         ydl_opts = {
@@ -16950,7 +16954,8 @@ def parse_youtube_playlist(url):
                 # instead of blindly using `uploader`, which on a playlist is the
                 # OWNER, not the track artist (#863: every track became "Wing It"
                 # / "Unknown Artist"). Returns ('' , title) when nothing reliable.
-                derived_artist, derived_title = derive_artist_and_title(entry)
+                derived_artist, derived_title = derive_artist_and_title(
+                    entry, allow_channel_artist=allow_channel_artist)
 
                 # Clean the track title and artist using our cleaning functions.
                 if derived_artist:
@@ -16973,13 +16978,17 @@ def parse_youtube_playlist(url):
                 
                 tracks.append(track_data)
 
-            # NOTE: current yt-dlp flat extraction returns ONLY the title per entry
-            # (no uploader/artist), so tracks whose title isn't "Artist - Title"
-            # land here as "Unknown Artist". The per-video artist recovery does NOT
-            # run here — it would block this request for minutes on a big playlist
-            # and risk the 120s worker timeout. It runs in the async discovery
-            # worker instead (which already iterates every track with a progress
-            # bar). See run_youtube_discovery_worker / recover_youtube_artist (#863).
+            # NOTE: on youtube.com, flat extraction gives no trustworthy per-entry
+            # artist (the channel is the playlist owner), so tracks whose title
+            # isn't "Artist - Title" land here as "Unknown Artist". The per-video
+            # artist recovery does NOT run here — it would block this request for
+            # minutes on a big playlist and risk the 120s worker timeout. It runs
+            # in the async discovery worker instead (which already iterates every
+            # track with a progress bar). See run_youtube_discovery_worker /
+            # recover_youtube_artist (#863).
+            #
+            # music.youtube.com does NOT have that problem: its entries carry a
+            # per-track channel, so `allow_channel_artist` resolves them inline.
 
             # Create playlist object matching GUI structure
             playlist_data = {

--- a/web_server.py
+++ b/web_server.py
@@ -16854,9 +16854,35 @@ def _youtube_cookie_opts():
         mode = config_manager.get('youtube.cookies_browser', '')
         path = config_manager.get('youtube.cookies_file', '')
         exists = bool(path) and os.path.exists(path)
+        if path and not exists:
+            # Silently degrading to anonymous here looks identical to "YouTube
+            # is rate-limiting us": private playlists come back empty or short
+            # and every track resolves badly. Say so once, out loud.
+            logger.warning(
+                "[YouTube] Configured cookies file does not exist: %s — continuing "
+                "anonymously. Private playlists (Liked Music, list=LM) will be "
+                "incomplete or invisible. Re-paste cookies in Settings → YouTube.",
+                path,
+            )
         return build_youtube_cookie_opts(mode, path, cookiefile_exists=exists)
     except Exception:  # noqa: S110 - cookie config is best-effort; resolve still works without it
         return {}
+
+
+def _ytmusic_auth_headers():
+    """ytmusicapi browser-auth headers from the same pasted cookies.txt, or None.
+
+    ytmusicapi can't take a cookie FILE, so the jar is projected into the header
+    form it wants. Only PASTE_MODE can feed it: `cookiesfrombrowser` is yt-dlp's
+    own browser-store reader and there's no cookie file to read in that case.
+    None means anonymous — public playlists still resolve."""
+    from core.youtube_cookies import PASTE_MODE, ytmusic_auth_from_cookiefile
+    try:
+        if str(config_manager.get('youtube.cookies_browser', '') or '').strip() != PASTE_MODE:
+            return None
+        return ytmusic_auth_from_cookiefile(config_manager.get('youtube.cookies_file', ''))
+    except Exception:  # noqa: S110 - auth is best-effort; anonymous still works
+        return None
 
 
 def _fetch_youtube_video_artist(video_id, cookie_opts):
@@ -16914,7 +16940,7 @@ def parse_youtube_playlist(url):
     # attempted for youtube.com: a video playlist has no catalog entry.
     if allow_channel_artist:
         from core.youtube_music_meta import fetch_ytmusic_playlist
-        ytm_playlist = fetch_ytmusic_playlist(url)
+        ytm_playlist = fetch_ytmusic_playlist(url, _ytmusic_auth_headers())
         if ytm_playlist:
             return ytm_playlist
 

--- a/web_server.py
+++ b/web_server.py
@@ -16907,6 +16907,17 @@ def parse_youtube_playlist(url):
     # youtube.com it carries the playlist owner's (#863). Decided once here from
     # the URL because the per-entry data can't distinguish the two.
     allow_channel_artist = is_music_youtube_url(url)
+
+    # A music.youtube.com playlist has a real catalog entry — artist AND album
+    # per track, and no flat-extraction page cap (#908). Try it first; it
+    # returns None on any failure so yt-dlp below stays the fallback. Never
+    # attempted for youtube.com: a video playlist has no catalog entry.
+    if allow_channel_artist:
+        from core.youtube_music_meta import fetch_ytmusic_playlist
+        ytm_playlist = fetch_ytmusic_playlist(url)
+        if ytm_playlist:
+            return ytm_playlist
+
     try:
         # Configure yt-dlp options for flat playlist extraction (avoids rate limits)
         ydl_opts = {


### PR DESCRIPTION
Unapologetically vibe coded, might be worth running a verify on the changes. They work well for me.

# Read music.youtube.com playlists from the YouTube Music catalog

Mirrored YouTube playlists resolve badly: on my install **91% of tracks across 13
mirrored playlists were stored as `artist_name = "Unknown Artist"`**, and
`album_name` was empty on all 578 of them. An "Unknown Artist" track can't match
the library and can't be searched, so those playlists were effectively inert.

Worse, the Deezer discovery fallback then "resolves" them. One real row from my DB:
a track titled *Memories* with artist *Unknown Artist* was matched to a band
literally named **"An Unknown Artist"** at `confidence: 0.85`. 250 of 578 rows
carry Deezer matches built on that input.

## Root cause

`core/youtube_track_meta.py` deliberately refuses to use an entry's channel:

> It deliberately does NOT fall back to the channel/uploader as the artist — on a
> playlist that's the owner, and mislabelling every track is worse than an honest
> "Unknown Artist"

That is **correct for youtube.com** (#863: `uploader` is the playlist owner, so every
track became "Wing It"). But the same rule is applied to **music.youtube.com**, where
each flat entry carries its *own* channel — the artist's. YT Music serves one channel
per track, not one per playlist.

Measured on a 69-track YT Music playlist, current yt-dlp (2026.07.04):

```
entries with 'artists' populated:  0 / 69   <- checked by _first_music_field
entries with 'artist'  populated:  0 / 69   <- checked
entries with 'creator' populated:  0 / 69   <- checked
entries with 'channel' populated: 68 / 69   <- ignored
entries with 'album'   populated:  0 / 69   <- flat extraction has no album, ever
```

So the correct artist was fetched and discarded on every track.

## Why not just wait for yt-dlp?

I checked before writing any code — this is not a "your yt-dlp is old" problem.

| approach | artist | album | liked songs | cost |
|---|---|---|---|---|
| yt-dlp flat, today | 0/69 (fields read by the code) | **0, ever** | 214 | fast |
| yt-dlp flat + read `channel` | 68/69 | **0, ever** | 214 | fast |
| yt-dlp full per-video | yes | yes | 1421 | **~1.0 s/video** |
| YT Music catalog | **69/69** canonical | **69/69** | **1421** | one paged call |

- **Album is unreachable via flat extraction at any yt-dlp version** — videos don't
  have one. Only per-video extraction or the catalog API has it, and the whole
  downstream pipeline (library matching, Soulseek search, MusicBrainz release
  preflight) is album-shaped.
- **Flat extraction caps the liked-songs playlist at 214 entries** where the catalog
  returns 1421.
  I verified this with *identical working cookies* on both, so it's the #908 page cap,
  not an auth difference.
- **Per-video extraction gets the same data** but costs ~1.0 s/video sequentially —
  ~24 minutes for a 1421-track liked-songs playlist, against the 120 s worker timeout this
  codebase already notes as the reason it isn't done inline.

## Changes

Four commits, each independently revertable.

**1 — `fix(youtube): use the per-track channel as artist on music.youtube.com`**

`derive_artist_and_title` takes `allow_channel_artist`, defaulting to `False` so
youtube.com behaviour is byte-for-byte unchanged. The caller sets it from the playlist
URL host — an entry alone cannot tell you which kind of playlist it came from. It is
the *last* signal tried, so it can only fill in tracks that would have been "Unknown
Artist"; music fields, `- Topic` channels and `Artist - Title` splits all still win.

`is_music_youtube_url` parses the host rather than substring-matching, so a youtube.com
URL carrying `music.youtube.com` in a query parameter can't switch the fallback on.

**2 — `feat(youtube): read music.youtube.com playlists from the YT Music catalog`**

New `core/youtube_music_meta.py`, tried before yt-dlp for music.youtube.com only.
`NormalizedTrack.album_name` was hardcoded `None`; it now carries the album.

Deliberately narrow so nothing that works today can regress:

- **youtube.com is never routed here.** A video playlist has no catalog entry; gating
  on `is_music_youtube_url` leaves the yt-dlp path untouched for it.
- **`ytmusicapi` is optional at runtime.** A missing import, a private playlist, a
  network failure, and an upstream shape change (ytmusicapi raises a bare `KeyError`
  while walking the JSON) all return `None`, and yt-dlp runs. An in-place upgrade that
  skips the new requirement keeps working, just without albums.
- **UGC inside a YT Music playlist is kept.** It comes back with the uploader channel
  as artist and no album — exactly what the yt-dlp path would have produced — so those
  entries are never dropped.
- **An empty or all-placeholder response returns `None`**, not a partial payload, so a
  good mirror is never overwritten with a worse one.

The projection is a pure function over the API response, tested without network against
trimmed real responses.

**4 — `fix(youtube): strip "- Topic" from catalog artist names too`**

An artist with no canonical catalog entry comes back from `get_playlist` as the raw
auto-generated channel name — `"<Artist> - Topic"`. The yt-dlp
path has stripped that since #863; the catalog path passed it through, so those tracks
reached the mirror with an artist matching nothing (the library has `<Artist>`).

Found by running all 19 of my subscribed playlists through the new path: 10 of 1995
tracks, and not rare artists — after stripping, three of them collapse into 12, 13 and 25
tracks by artists already in that library, all of which would otherwise have
re-downloaded as new artists.

The logic moves into a shared `strip_topic_suffix` so both paths agree by construction
rather than by having the same regex twice. A channel named literally `"- Topic"` keeps
its name rather than becoming empty, and de-duplication runs after stripping so an
artist credited both ways collapses to one.

**3 — `fix(youtube): feed the pasted cookies.txt to ytmusicapi, warn when it's gone`**

ytmusicapi takes auth *headers*, not a cookie file, so the catalog path ran anonymously
even with cookies configured — and the liked-songs playlist (`list=LM`) is always private.

Domain is deliberately ignored while parsing. The cookies that sign a YouTube request
are Google-wide, so a jar exported from `google.de` authenticates music.youtube.com
fine — filtering for `"youtube"` in the domain yields **zero** cookies for such an
export and reads as "logged out". My own jar is exactly that shape. Only essential
cookie names are forwarded: a browser export can carry 90 KB+ across every Google
property and YouTube 413s on headers that large.

Separately, a configured-but-*missing* cookies file degraded to anonymous silently.
That is indistinguishable from rate-limiting at the symptom level — short playlists,
badly resolved tracks — and it goes missing easily (moved config dir, bind mount not
remounted, container rebuild). Found live on an install whose `youtube.cookies_file`
had pointed at a deleted path for months. It now logs a warning naming the path.

## Results

All 19 of my subscribed playlists, run through both paths end to end:

| | catalog path | yt-dlp flat |
|---|---|---|
| playlists resolved | **19/19** | 19/19 |
| tracks returned | **1995** | 721 |
| unknown artist | **0** | 585 |
| with album | **1966** (99%) | **0** |

yt-dlp under-returns badly on private playlists, independently of the #908 page cap:
30 -> 1, 11 -> 1, 28 -> 2, and the liked-songs playlist 1421 -> 214. I checked the largest
gap directly: YouTube's own `trackCount` is 30, that playlist is PRIVATE and owned by
me, the catalog returns all 30, and yt-dlp's single entry *is* in that set.

Matching all 1995 resolved tracks against my 17390-track library index:

```
exact artist+title already in library : 1256 (62%)
artist known, track missing           :  204 (10%)
fully new                             :  535 (26%)
```

1256 tracks resolve with no download at all. Today every one of them is
"Unknown Artist" and matches nothing.

Data sanity over all 1995: 0 empty artists, 0 empty titles, 0 "Unknown Artist",
0 artist==title parse smells. videoType spread: 1798 ATV, 160 absent, 30 UGC, 6 OMV,
1 official-source.

youtube.com, same playlist addressed via `www.youtube.com`, old vs new
`derive_artist_and_title` across all 69 entries:

```
is_music_youtube_url(youtube.com) = False  -> ytmusicapi SKIPPED, yt-dlp path
entries: 69 | identical to pre-patch: True
unknown-artist count unchanged: 61 -> 61
```

## Tests

New tests in `tests/test_youtube_music_meta.py` plus additions to
`test_youtube_track_meta.py` and `test_youtube_cookies.py`, covering the field
projection, every fallback path, the host gate, `- Topic` stripping, and auth-header
construction with an injected timestamp so it's reproducible.

The fallback contract is also exercised against the live API surface: a missing
ytmusicapi, `KeyError`/`RuntimeError`/`ValueError` from `get_playlist`, and
`{}` / `{"tracks": []}` / placeholder-only / `None` / non-mapping responses all return
`None` and hand over to yt-dlp.

Full suite on this branch vs pristine `dev`: **43 failures on both, identical sets** —
all pre-existing JS/webui integrity tests. 12181 passed vs 12149 (the +32 is new tests).

## One open question for you

`derive_artist_and_title`'s docstring and #863 describe flat extraction returning the
playlist-level uploader on every entry. On current yt-dlp that is **no longer true for
youtube.com either** — entries carry a real per-video channel. The same youtube.com
playlist above would drop from 61 unknown to 1 if the fallback were allowed there too.

I left it conservative and gated strictly on host, because I can't verify against the
original #863 playlist and getting it wrong re-mislabels every track. But if you know
the #863 reproduction, widening this is probably a much bigger win than the
music.youtube.com case alone. Your call — happy to follow up in a separate PR.

Two smaller things I noticed and did **not** touch:

- `_first_music_field` checks `creator` (singular). yt-dlp emits `creators` (plural) as
  a key on flat entries — currently always `None`, so it changes nothing today, but the
  singular lookup will silently miss it if upstream ever populates it.
- The Deezer discovery fallback writes `extra_data.matched_data` without ever updating
  `artist_name`, so an explored playlist still reads "Unknown Artist" in the mirror. On
  my install the one explored playlist was still 75% unknown.
