### PR TITLE
fix(discovery): give a Wing It stub an id that survives a restart

### DIFF
--- a/core/discovery/wing_it.py
+++ b/core/discovery/wing_it.py
@@ -1,0 +1,42 @@
+"""Wing It stubs — the stand-in a track gets when discovery finds no catalogue match.
+
+When a provider search returns nothing confident enough, discovery stores a stub
+``matched_data`` built from the *source's own* artist/title so the track still
+appears in the mirror and still flows through the download pipeline. The stub is
+identified by an id carrying the ``wing_it_`` prefix.
+
+The id used to be ``f"wing_it_{hash(f'{artist}_{track}') % 100000}"``. ``hash()`` on
+a str is salted per interpreter (PEP 456), so the same track got a different id in
+every process — and ``% 100000`` collides freely on top of that. A stub id is written
+to ``mirrored_playlist_tracks.extra_data.matched_data.id`` and outlives the process
+that produced it, so it has to be reproducible to identify anything at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+STUB_ID_PREFIX = "wing_it_"
+
+
+def stub_track_id(artist_name: Any, track_name: Any) -> str:
+    """Deterministic id for the Wing It stub of ``artist_name`` / ``track_name``.
+
+    Stable across processes and releases: the same pair always yields the same id,
+    so a stub written to the database still resolves after a restart."""
+    key = f"{artist_name or ''}_{track_name or ''}"
+    digest = hashlib.md5(key.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"{STUB_ID_PREFIX}{digest}"
+
+
+def is_stub_id(value: Any) -> bool:
+    """Is ``value`` the id of a Wing It stub (either id scheme)?"""
+    return str(value or "").startswith(STUB_ID_PREFIX)
+
+
+__all__ = [
+    "STUB_ID_PREFIX",
+    "is_stub_id",
+    "stub_track_id",
+]

--- a/core/discovery/wing_it.py
+++ b/core/discovery/wing_it.py
@@ -25,7 +25,11 @@ def stub_track_id(artist_name: Any, track_name: Any) -> str:
 
     Stable across processes and releases: the same pair always yields the same id,
     so a stub written to the database still resolves after a restart."""
-    key = f"{artist_name or ''}_{track_name or ''}"
+    artist = str(artist_name or "")
+    track = str(track_name or "")
+    # Length-prefixed, not just underscore-joined — ("A_B", "C") and ("A", "B_C")
+    # must not collide just because they'd concatenate to the same string.
+    key = f"{len(artist)}:{artist}{len(track)}:{track}"
     digest = hashlib.md5(key.encode("utf-8", errors="replace")).hexdigest()[:12]
     return f"{STUB_ID_PREFIX}{digest}"
 

--- a/tests/discovery/test_wing_it_stub_id.py
+++ b/tests/discovery/test_wing_it_stub_id.py
@@ -32,9 +32,9 @@ def test_same_input_gives_same_id():
 @pytest.mark.parametrize("artist,track,expected", [
     # Pinned so a future change of hashing scheme is a deliberate, visible act:
     # stub ids already persisted in user databases would stop resolving.
-    ("Yorushika", "Ghost in a Flower", "wing_it_e6e3736d43fb"),
-    ("LiSA", "紅蓮華 - Gurenge", "wing_it_bc442918ee92"),
-    ("", "", "wing_it_b14a7b8059d9"),
+    ("Yorushika", "Ghost in a Flower", "wing_it_4099cdee0c37"),
+    ("LiSA", "紅蓮華 - Gurenge", "wing_it_19ec3ec87a86"),
+    ("", "", "wing_it_d8f6008c2af3"),
 ])
 def test_id_is_pinned_to_a_known_value(artist, track, expected):
     assert stub_track_id(artist, track) == expected
@@ -96,6 +96,13 @@ def test_different_tracks_get_different_ids():
 def test_none_and_empty_are_the_same_track():
     # Both mean "the source gave us nothing", so they must not split into two ids.
     assert stub_track_id(None, None) == stub_track_id("", "")
+
+
+def test_underscore_in_name_does_not_collide_across_the_boundary():
+    # A literal "_" in either field used to be indistinguishable from the
+    # artist/track separator: ("A_B", "C") and ("A", "B_C") both built the key
+    # "A_B_C". Length-prefixing fixes that.
+    assert stub_track_id("A_B", "C") != stub_track_id("A", "B_C")
 
 
 # ── is_stub_id ────────────────────────────────────────────────────────────

--- a/tests/discovery/test_wing_it_stub_id.py
+++ b/tests/discovery/test_wing_it_stub_id.py
@@ -10,6 +10,7 @@ trivially inside a single process either way.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
@@ -55,10 +56,12 @@ def test_id_survives_a_different_hash_seed():
     )
     ids = set()
     for seed in ("0", "1", "12345"):
+        env = dict(os.environ)
+        env["PYTHONHASHSEED"] = seed
         out = subprocess.run(
             [sys.executable, "-c", script, str(REPO_ROOT)],
             capture_output=True, text=True, check=True,
-            env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"},
+            env=env,
         )
         ids.add(out.stdout.strip())
     assert len(ids) == 1, f"stub id varies with PYTHONHASHSEED: {ids}"

--- a/tests/discovery/test_wing_it_stub_id.py
+++ b/tests/discovery/test_wing_it_stub_id.py
@@ -1,0 +1,121 @@
+"""Wing It stub ids must be reproducible.
+
+The id identifies a stub that is written to
+``mirrored_playlist_tracks.extra_data.matched_data.id`` and read back in a later
+process. It used to be ``hash(f"{artist}_{track}") % 100000``; ``hash()`` on a str
+is salted per interpreter (PEP 456), so the id changed on every restart. The
+cross-process test below is the one that pins the actual regression — it passes
+trivially inside a single process either way.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from core.discovery.wing_it import STUB_ID_PREFIX, is_stub_id, stub_track_id
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# ── determinism ───────────────────────────────────────────────────────────
+
+def test_same_input_gives_same_id():
+    assert stub_track_id("Yorushika", "Ghost in a Flower") == \
+        stub_track_id("Yorushika", "Ghost in a Flower")
+
+
+@pytest.mark.parametrize("artist,track,expected", [
+    # Pinned so a future change of hashing scheme is a deliberate, visible act:
+    # stub ids already persisted in user databases would stop resolving.
+    ("Yorushika", "Ghost in a Flower", "wing_it_e6e3736d43fb"),
+    ("LiSA", "紅蓮華 - Gurenge", "wing_it_bc442918ee92"),
+    ("", "", "wing_it_b14a7b8059d9"),
+])
+def test_id_is_pinned_to_a_known_value(artist, track, expected):
+    assert stub_track_id(artist, track) == expected
+
+
+def test_id_survives_a_different_hash_seed():
+    """The regression: two interpreters must agree.
+
+    PYTHONHASHSEED has to be set before the process starts, so this shells out.
+    On the old `hash()`-based id the two runs disagree and this fails."""
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.path.insert(0, sys.argv[1])
+        from core.discovery.wing_it import stub_track_id
+        print(stub_track_id("Yorushika", "Ghost in a Flower"))
+        """
+    )
+    ids = set()
+    for seed in ("0", "1", "12345"):
+        out = subprocess.run(
+            [sys.executable, "-c", script, str(REPO_ROOT)],
+            capture_output=True, text=True, check=True,
+            env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin"},
+        )
+        ids.add(out.stdout.strip())
+    assert len(ids) == 1, f"stub id varies with PYTHONHASHSEED: {ids}"
+
+
+# ── shape ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("artist,track", [
+    ("Yorushika", "Ghost in a Flower"),
+    ("", ""),
+    (None, None),
+    ("A" * 500, "B" * 500),
+    ("Ado", "可愛くてごめん"),
+    ("Sigur Rós", "Untitled #1 (Vaka)"),
+])
+def test_id_is_always_a_usable_stub_id(artist, track):
+    tid = stub_track_id(artist, track)
+    assert tid.startswith(STUB_ID_PREFIX)
+    assert is_stub_id(tid)
+    # No separator/whitespace surprises for callers that put it in a URL or SQL.
+    assert tid.isascii() and tid.strip() == tid and " " not in tid
+
+
+def test_different_tracks_get_different_ids():
+    ids = {
+        stub_track_id("Yorushika", "Ghost in a Flower"),
+        stub_track_id("Yorushika", "Matasaburo"),
+        stub_track_id("Ado", "Ghost in a Flower"),
+        stub_track_id("", "Ghost in a Flower"),
+        stub_track_id("Ghost in a Flower", "Yorushika"),
+    }
+    assert len(ids) == 5
+
+
+def test_none_and_empty_are_the_same_track():
+    # Both mean "the source gave us nothing", so they must not split into two ids.
+    assert stub_track_id(None, None) == stub_track_id("", "")
+
+
+# ── is_stub_id ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("value", [
+    "wing_it_e6e3736d43fb",
+    "wing_it_53014",          # the legacy hash()-based scheme still reads as a stub
+    "wing_it_",
+])
+def test_is_stub_id_accepts_both_schemes(value):
+    assert is_stub_id(value) is True
+
+
+@pytest.mark.parametrize("value", [
+    "3315608251",             # a real Deezer id
+    "",
+    None,
+    "spotify:track:abc",
+    "WING_IT_e6e3736d43fb",   # prefix is case-sensitive
+    " wing_it_abc",
+])
+def test_is_stub_id_rejects_everything_else(value):
+    assert is_stub_id(value) is False

--- a/web_server.py
+++ b/web_server.py
@@ -27747,9 +27747,14 @@ def update_youtube_discovery_match():
 
 def _build_discovery_wing_it_stub(track_name, artist_name, duration_ms=0, image_url=''):
     """Build stub matched_data for tracks that failed metadata discovery.
-    Used as automatic Wing It fallback so tracks still flow through the download pipeline."""
+    Used as automatic Wing It fallback so tracks still flow through the download pipeline.
+
+    The id comes from core.discovery.wing_it so it is stable — the previous
+    `hash(...) % 100000` was salted per interpreter, so a stub written to
+    mirrored_playlist_tracks.extra_data resolved to a different id after a restart."""
+    from core.discovery.wing_it import stub_track_id
     return {
-        'id': f"wing_it_{hash(f'{artist_name}_{track_name}') % 100000}",
+        'id': stub_track_id(artist_name, track_name),
         'name': track_name,
         'artists': [{'name': artist_name}] if isinstance(artist_name, str) else artist_name,
         'album': {'name': '', 'album_type': 'single', 'images': [], 'release_date': ''},


### PR DESCRIPTION
Wing It stub ids were built as `f"wing_it_{hash(f'{artist}_{track}') % 100000}"`. `hash()` on a string is salted per interpreter (PEP 456), so the same track got a different id every restart — and `% 100000` collided freely on top of that. The id is persisted (`mirrored_playlist_tracks.extra_data.matched_data.id`) and read back later, so it needs to be reproducible.

**Fix:** MD5 digest of a length-prefixed key (so `("A_B","C")` and `("A","B_C")` can't collide), matching the id style already used elsewhere in the codebase.

**Scope:** latent today — nothing currently keys off the stub id — but becomes load-bearing for a follow-up PR that lets these stubs join the wishlist.

**Tests:** `tests/discovery/test_wing_it_stub_id.py`, 23 cases, including a cross-interpreter check with different `PYTHONHASHSEED` values that fails on the old code.
