### PR TITLE
feat(youtube): Improve quality matching and support YT Premium formats

### DIFF
--- a/core/download_orchestrator.py
+++ b/core/download_orchestrator.py
@@ -381,11 +381,15 @@ class DownloadOrchestrator:
             logger.warning(f"No results found for: {query}")
             return None
 
-        # 2. Filter and validate results
+        # 2. Filter and validate results. Score each source family with its
+        # own checker — a Soulseek peer first must not force Tidal/YouTube
+        # through the P2P path (and vice versa).
         _streaming_sources = ('youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'lidarr', 'soundcloud', 'amazon')
-        is_streaming = tracks[0].username in _streaming_sources if tracks else False
+        streaming = [t for t in tracks if getattr(t, 'username', None) in _streaming_sources]
+        p2p = [t for t in tracks if getattr(t, 'username', None) not in _streaming_sources]
 
-        if is_streaming and expected_track:
+        stream_kept = []
+        if streaming and expected_track:
             # Score streaming results against expected track metadata
             from core.matching_engine import MusicMatchingEngine
             me = MusicMatchingEngine()
@@ -400,7 +404,7 @@ class DownloadOrchestrator:
             expected_is_version = any(kw in expected_title_lower for kw in _version_kw)
 
             scored = []
-            for r in tracks:
+            for r in streaming:
                 confidence, _ = me.score_track_match(
                     source_title=expected_title,
                     source_artists=expected_artists,
@@ -425,23 +429,55 @@ class DownloadOrchestrator:
                 scored.sort(key=lambda x: x._match_confidence, reverse=True)
                 # Match filter done (right track); now prefer the best quality
                 # among the confidence-passing survivors so streaming isn't
-                # quality-blind like Soulseek already isn't. Stable ranking
-                # keeps confidence order within an equal quality tier; the
-                # `or scored` fail-safe never leaves us with nothing to try.
-                from core.quality.selection import rank_for_profile
-                ranked, _ = rank_for_profile(scored)
-                filtered_results = ranked or scored
-                logger.info(f"Streaming validation: {len(scored)}/{len(tracks)} passed "
-                            f"(best: {scored[0]._match_confidence:.2f}, "
-                            f"quality pick: {filtered_results[0].audio_quality.label()})")
+                # quality-blind like Soulseek already isn't. An empty rank
+                # with fallback off means skip this source — do not download
+                # a rejected hit.
+                to_rank = scored
+                if any(getattr(r, 'username', None) == 'youtube' for r in scored):
+                    from core.youtube_client import youtube_quality_rank_band
+                    yt = [r for r in scored if getattr(r, 'username', None) == 'youtube']
+                    other = [r for r in scored if getattr(r, 'username', None) != 'youtube']
+                    yt_band = youtube_quality_rank_band(yt) if yt else []
+                    to_rank = other + yt_band
+                    youtube = self.client('youtube')
+                    if yt_band and youtube is not None and hasattr(youtube, 'refresh_claimed_quality'):
+                        try:
+                            probe_targets = None
+                            try:
+                                from core.quality.selection import load_profile_targets
+                                probe_targets, _ = load_profile_targets()
+                            except Exception:  # noqa: BLE001 - probe still works with search claims
+                                probe_targets = None
+                            youtube.refresh_claimed_quality(yt_band, targets=probe_targets)
+                        except Exception as e:  # noqa: BLE001 - ranking still uses the search claim
+                            logger.info("YouTube format probe skipped (%s: %s)", type(e).__name__, e)
+                stream_kept = to_rank
+                logger.info(f"Streaming validation: {len(scored)}/{len(streaming)} passed "
+                            f"(best: {scored[0]._match_confidence:.2f})")
             else:
                 logger.warning(f"No streaming results passed validation for: {query}")
-                return None
-        elif is_streaming:
-            filtered_results = tracks
-        else:
+        elif streaming:
+            stream_kept = list(streaming)
+
+        p2p_kept = []
+        if p2p:
             soulseek = self.client('soulseek')
-            filtered_results = soulseek.filter_results_by_quality_preference(tracks) if soulseek else tracks
+            p2p_kept = list(
+                soulseek.filter_results_by_quality_preference(p2p) if soulseek else p2p
+            )
+
+        combined = stream_kept + p2p_kept
+        if stream_kept:
+            from core.quality.selection import rank_for_profile
+            ranked, _ = rank_for_profile(combined)
+            if not ranked:
+                logger.warning(
+                    "No streaming results match the quality profile for: %s", query,
+                )
+                return None
+            filtered_results = ranked
+        else:
+            filtered_results = p2p_kept
 
         if not filtered_results:
             logger.warning(f"No suitable quality results found for: {query}")

--- a/core/downloads/candidates.py
+++ b/core/downloads/candidates.py
@@ -184,7 +184,7 @@ def attempt_download_with_candidates(task_id, candidates, track, batch_id=None,
         source_order = list(getattr(orch, 'hybrid_order', None) or [])
     if not source_order:
         try:
-            from config.settings import config_manager
+            from core.settings import config_manager
             source_order = list(
                 config_manager.get('download_source.hybrid_order') or []
             )

--- a/core/downloads/candidates.py
+++ b/core/downloads/candidates.py
@@ -47,6 +47,45 @@ from core.runtime_state import (
 logger = logging.getLogger(__name__)
 
 
+# Streaming plugins identify themselves via ``TrackResult.username``. Soulseek
+# peers use the sharing username, so they are everything else. Keep this list
+# in sync with ``core.downloads.validation._STREAMING_USERNAMES`` — imported
+# lazily would cycle (validation → candidates).
+_STREAMING_USERNAMES = frozenset({
+    'youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'soundcloud',
+    'amazon', 'torrent', 'usenet', 'lidarr',
+})
+
+
+def _candidate_source_name(r) -> str:
+    """Map a search hit onto a hybrid-chain source id."""
+    name = (getattr(r, 'username', None) or '').lower()
+    if name in _STREAMING_USERNAMES:
+        return name
+    return 'soulseek'
+
+
+def _is_mixed_source_pool(candidates) -> bool:
+    """True when the walk contains more than one download source."""
+    sources = {
+        _candidate_source_name(c)
+        for c in candidates
+        if getattr(c, 'username', None)
+    }
+    return len(sources) > 1
+
+
+def _source_order_index(r, source_order) -> int:
+    """Position in the user's hybrid chain. Unknown sources sort last."""
+    if not source_order:
+        return 0
+    name = _candidate_source_name(r)
+    try:
+        return list(source_order).index(name)
+    except ValueError:
+        return len(source_order)
+
+
 def _priority_sort_key(r):
     """Today's confidence-first key: never download a high-quality WRONG file."""
     return (
@@ -59,7 +98,7 @@ def _priority_sort_key(r):
     )
 
 
-def _quality_first_sort_key(r, targets):
+def _quality_first_sort_key(r, targets, source_order=None):
     """Best-quality key: the user's profile quality rank dominates; all the
     priority-mode signals (confidence, speed, …) become tiebreakers.
 
@@ -68,6 +107,11 @@ def _quality_first_sort_key(r, targets):
     Candidates with no usable quality info, or that match no target, sort last
     (never dropped). Lower target index = better target, so it's negated to fit
     the descending (reverse=True) sort.
+
+    After target index, the hybrid chain order breaks ties so "YouTube first"
+    actually prefers YouTube when two hits satisfy the same rung (Opus 256 vs
+    Opus 256), without letting a later-source FLAC outrank a first-source hit
+    that matches a higher-priority target.
     """
     from core.quality.model import rank_candidate
 
@@ -79,21 +123,30 @@ def _quality_first_sort_key(r, targets):
             target_idx, tier = rank_candidate(aq, targets)
         except Exception:
             target_idx, tier = len(targets), 0.0
-    return (-target_idx, tier) + _priority_sort_key(r)
+    src = _source_order_index(r, source_order)
+    return (-target_idx, -src, tier) + _priority_sort_key(r)
 
 
-def order_candidates(candidates, *, quality_first=False, targets=None):
+def order_candidates(candidates, *, quality_first=False, targets=None,
+                     source_order=None):
     """Return *candidates* ordered best-first for the download walk.
 
     ``quality_first=False`` (priority mode) → confidence-first, byte-for-byte
     today's behaviour. ``quality_first=True`` (best-quality mode) → the user's
     profile quality rank dominates, confidence/peer signals break ties.
+
+    Mixed-source pools (YouTube + Soulseek from best-quality search) always
+    use the profile rank. The legacy ``quality_score`` puts FLAC at 1.0 and
+    Opus at 0.3, so a confidence-first walk would download Soulseek even when
+    YouTube itag 774 matches the top target.
     """
-    if quality_first:
-        key = lambda r: _quality_first_sort_key(r, targets or [])
+    rows = list(candidates)
+    use_quality = quality_first or _is_mixed_source_pool(rows)
+    if use_quality:
+        key = lambda r: _quality_first_sort_key(r, targets or [], source_order)
     else:
         key = _priority_sort_key
-    return sorted(candidates, key=key, reverse=True)
+    return sorted(rows, key=key, reverse=True)
 
 
 @dataclass
@@ -125,8 +178,22 @@ def attempt_download_with_candidates(task_id, candidates, track, batch_id=None,
     # scores are close; preserve that signal instead of flattening ties back to
     # arbitrary slskd response order. Best-quality mode: profile quality rank
     # dominates (all candidates here already passed match filtering).
+    source_order = None
+    orch = getattr(deps, 'download_orchestrator', None) if deps else None
+    if orch is not None:
+        source_order = list(getattr(orch, 'hybrid_order', None) or [])
+    if not source_order:
+        try:
+            from config.settings import config_manager
+            source_order = list(
+                config_manager.get('download_source.hybrid_order') or []
+            )
+        except Exception:  # noqa: BLE001 - ranking still works without chain order
+            source_order = None
+
     candidates = order_candidates(
         candidates, quality_first=quality_first, targets=quality_targets,
+        source_order=source_order,
     )
     
     with tasks_lock:

--- a/core/downloads/post_processing.py
+++ b/core/downloads/post_processing.py
@@ -316,7 +316,8 @@ def run_post_processing_worker(task_id: str, batch_id: str, deps: PostProcessDep
         file_location = None
 
         # CRITICAL FIX: For YouTube downloads, the filename in task is 'id||title' (metadata),
-        # but the actual file on disk is 'Title.mp3'. We must ask the client for the real path.
+        # but the actual file on disk is the remuxed/transcoded audio (e.g. Title.mp3).
+        # We must ask the client for the real path.
         # Torrent/usenet also use opaque "url||display" filenames. Their completed
         # job may contain a full release, so choose the best matching audio file
         # and copy it to transfer before importing instead of moving the client's

--- a/core/downloads/task_worker.py
+++ b/core/downloads/task_worker.py
@@ -54,6 +54,44 @@ def _cand_user_file(candidate):
     return getattr(candidate, 'username', None), getattr(candidate, 'filename', None)
 
 
+def _youtube_ytsearch_fallback(deps, query, track, tracks_result):
+    """ytsearch after a YouTube Music catalog batch that the matcher rejected.
+
+    Catalog ``filter=songs`` misses remixes/lives that only exist as videos.
+    One extra YouTube search. Skipped when this result set was not a catalog
+    batch (empty catalog already fell through to ytsearch inside search()).
+    """
+    if not any(
+        getattr(t, 'username', None) == 'youtube'
+        and (getattr(t, '_source_metadata', None) or {}).get('catalog')
+        for t in (tracks_result or [])
+    ):
+        return None
+    orch = getattr(deps, 'download_orchestrator', None)
+    if orch is None or not hasattr(orch, 'client'):
+        return None
+    try:
+        youtube = orch.client('youtube')
+    except Exception:
+        return None
+    if youtube is None or not hasattr(youtube, 'search'):
+        return None
+    try:
+        extra, _ = deps.run_async(youtube.search(query, timeout=30, use_catalog=False))
+    except TypeError:
+        extra, _ = deps.run_async(youtube.search(query, timeout=30))
+    except Exception as e:
+        logger.debug("YouTube ytsearch fallback skipped: %s", e)
+        return None
+    if not extra:
+        return None
+    logger.info(
+        "YouTube catalog missed the matcher; ytsearch returned %d rows",
+        len(extra),
+    )
+    return deps.get_valid_candidates(extra, track, query) or None
+
+
 def _candidate_ordering(track_info: Optional[dict] = None):
     """Return ``(quality_first, targets)`` for the active search mode + toggle.
 
@@ -548,6 +586,15 @@ def download_track_worker(task_id: str, batch_id: Optional[str], deps: TaskWorke
                     result_count = len(tracks_result)
                     # Validate candidates using GUI's get_valid_candidates logic
                     candidates = deps.get_valid_candidates(tracks_result, track, query)
+                    if not candidates:
+                        # Catalog-first YouTube can return official songs that
+                        # all fail the matcher (obscure remix, live, etc.).
+                        # ytsearch still finds those as videos.
+                        extra = _youtube_ytsearch_fallback(
+                            deps, query, track, tracks_result,
+                        )
+                        if extra:
+                            candidates = extra
                     if candidates:
                         logger.debug(f"[Modal Worker] Found {len(candidates)} valid candidates for query '{query}'")
 

--- a/core/downloads/validation.py
+++ b/core/downloads/validation.py
@@ -17,12 +17,83 @@ logger = logging.getLogger(__name__)
 matching_engine = None
 download_orchestrator = None
 
+# Structured-metadata sources. Soulseek peers use the sharing username, so they
+# are everything else. A mixed best-quality pool must score each family with
+# its own checker — not whoever happens to be results[0].
+_STREAMING_USERNAMES = frozenset({
+    'youtube', 'tidal', 'qobuz', 'hifi', 'deezer_dl', 'soundcloud',
+    'amazon', 'torrent', 'usenet',
+})
+
 
 def init(matching_engine_obj, download_orchestrator_obj):
     """Bind the matching engine and download orchestrator from web_server."""
     global matching_engine, download_orchestrator
     matching_engine = matching_engine_obj
     download_orchestrator = download_orchestrator_obj
+
+
+def _youtube_probe_targets():
+    """Profile targets for YouTube itag probing. None if the DB is unavailable."""
+    try:
+        from core.quality.selection import load_profile_targets
+        targets, _ = load_profile_targets()
+        return targets
+    except Exception:  # noqa: BLE001 - probe still works with search claims
+        return None
+
+
+def _filter_youtube_by_quality(candidates):
+    """Pre-download: keep YouTube hits the quality profile would accept.
+
+    Called from ``get_valid_candidates`` after match scoring (and on the
+    YouTube filename-matching fallback). There is no file yet — ranking
+    uses ``youtube_claimed_quality`` (re-encode on → converted output such
+    as MP3 320; re-encode off → original Opus/AAC). Only hits within 0.05
+    confidence of the top match are probed and ranked, so a distant cover
+    cannot beat a better title match on itags. The import quality guard
+    later verifies the real file on disk.
+
+    Empty result means the profile rejected them (fallback off). Test stubs
+    without ``audio_quality`` pass through unchanged so match-only tests
+    stay isolated. Non-YouTube rows in a mixed best-quality pool are kept
+    and never enter the YouTube confidence band.
+    """
+    if not candidates:
+        return []
+    if not all(hasattr(c, 'audio_quality') for c in candidates):
+        return list(candidates)
+    yt = [c for c in candidates if getattr(c, 'username', None) == 'youtube']
+    other = [c for c in candidates if getattr(c, 'username', None) != 'youtube']
+    if not yt:
+        return list(other)
+    youtube = None
+    if download_orchestrator is not None:
+        try:
+            youtube = download_orchestrator.client('youtube')
+        except Exception:  # noqa: BLE001 - probe is optional
+            youtube = None
+    from core.youtube_client import youtube_quality_rank_band
+    band = youtube_quality_rank_band(yt)
+    if youtube is not None and hasattr(youtube, 'refresh_claimed_quality'):
+        try:
+            youtube.refresh_claimed_quality(band, targets=_youtube_probe_targets())
+        except Exception as e:  # noqa: BLE001 - ranking still uses the search claim
+            logger.info("YouTube format probe skipped (%s: %s)", type(e).__name__, e)
+    from core.quality.selection import rank_for_profile
+    ranked, _ = rank_for_profile(band)
+    if not ranked:
+        if other:
+            return list(other)
+        logger.error(
+            "[Youtube] No candidates match quality profile - download will fail per user preferences"
+        )
+        return []
+    logger.info(
+        "[Youtube] Quality filter: %d/%d candidates remain (best: %s)",
+        len(ranked), len(yt), ranked[0].audio_quality.label(),
+    )
+    return list(other) + list(ranked)
 
 
 def _torrent_usenet_artist_is_fallback(result):
@@ -147,10 +218,11 @@ def _title_words_are_expected(candidate_title, expected_title, expected_artists)
 
 
 def get_valid_candidates(results, spotify_track, query):
-    """
-    This function is a direct port from sync.py. It scores and filters
-    Soulseek search results against a Spotify track to find the best, most
-    accurate download candidates.
+    """Score each source with its own checker, then return match-passing hits.
+
+    Streaming/torrent rows use title/artist/duration. Soulseek peers use the
+    file-path matcher. A mixed best-quality pool must not pick one recipe from
+    ``results[0]`` and apply it to every source.
     """
     if not results:
         return []
@@ -162,201 +234,220 @@ def get_valid_candidates(results, spotify_track, query):
     if not results:
         return []
 
-    # Streaming sources (YouTube, Tidal, Qobuz, HiFi, Deezer, SoundCloud) return structured API results
-    # with proper artist/title metadata — score using the same matching engine as Soulseek.
-    # Torrent / usenet results also belong here: their filename field is a download URL, not
-    # a slskd-style ``Artist/Album/Track.flac`` path, so the Soulseek matcher would extract
-    # garbage segments from it. Routing them through the streaming path means score_track_match
-    # reads ``r.title`` and ``r.artist`` directly (which the torrent/usenet projections pre-fill).
-    _streaming_sources = ("youtube", "tidal", "qobuz", "hifi", "deezer_dl", "soundcloud", "amazon", "torrent", "usenet")
-    if results[0].username in _streaming_sources:
-        source_label = results[0].username.replace('_dl', '').title()
-        expected_artists = spotify_track.artists if spotify_track else []
-        expected_title = spotify_track.name if spotify_track else ''
-        expected_duration = spotify_track.duration_ms if spotify_track else 0
+    streaming = [r for r in results if getattr(r, 'username', None) in _STREAMING_USERNAMES]
+    p2p = [r for r in results if getattr(r, 'username', None) not in _STREAMING_USERNAMES]
 
-        # Detect if the expected track is a specific version (live, remix, acoustic, etc.)
-        expected_title_lower = (expected_title or '').lower()
-        _version_keywords = _VERSION_KEYWORDS
-        expected_is_version = any(_has_version_kw(expected_title_lower, kw)
-                                  for kw in _version_keywords)
-
-        scored = []
-        _strict_duration_sources = {'tidal', 'qobuz', 'hifi', 'deezer_dl', 'amazon'}
-        for r in results:
-            if (
-                r.username in _strict_duration_sources
-                and _duration_mismatch_exceeds_integrity_tolerance(expected_duration, r.duration or 0)
-            ):
-                logger.info(
-                    "[%s] Rejecting candidate due to duration mismatch before download: "
-                    "expected %.1fs, candidate %.1fs",
-                    source_label,
-                    expected_duration / 1000.0,
-                    (r.duration or 0) / 1000.0,
-                )
-                continue
-
-            # Score using matching engine's generic scorer (same weights as Soulseek).
-            # Torrent/usenet release projections sometimes only have the indexer name
-            # in the artist field when a title did not parse as "Artist - Release".
-            # Treat that as unknown artist, not as a real mismatch.
-            has_only_fallback_artist = _torrent_usenet_artist_is_fallback(r)
-            candidate_artists = [] if has_only_fallback_artist else ([r.artist] if r.artist else [])
-            confidence, match_type = matching_engine.score_track_match(
-                source_title=expected_title,
-                source_artists=expected_artists,
-                source_duration_ms=expected_duration,
-                candidate_title=r.title or '',
-                candidate_artists=candidate_artists,
-                candidate_duration_ms=r.duration or 0,
+    accepted = []
+    if streaming:
+        scored = _score_streaming_candidates(streaming, spotify_track)
+        if scored:
+            if any(getattr(r, 'username', None) == 'youtube' for r in scored):
+                scored = _filter_youtube_by_quality(scored)
+            accepted.extend(scored)
+        elif any(getattr(r, 'username', None) == 'youtube' for r in streaming):
+            # YouTube artist data is unreliable; Tidal/Qobuz/etc. do not fall through.
+            yt = [r for r in streaming if getattr(r, 'username', None) == 'youtube']
+            logger.warning(
+                "[Youtube] No streaming results passed validation — falling through to filename matching"
+            )
+            accepted.extend(_match_filename_candidates(yt, spotify_track))
+        else:
+            logger.warning(
+                "[Streaming] No streaming results passed validation "
+                "(threshold: 0.60, artist gate: 0.50) — rejecting streaming candidates"
             )
 
-            # Album-name fallback for torrent / usenet per-track results.
-            #
-            # When this fallback runs: hybrid mode + non-album batch (single
-            # track wishlist / playlist of singles). Album-context batches
-            # never reach here — the album-bundle gate in
-            # core/downloads/album_bundle_dispatch.py engages the bulk-
-            # download flow in single-source mode, and the hybrid chain
-            # filter in core/downloads/task_worker.py strips torrent /
-            # usenet from album batches in hybrid mode. What's left is the
-            # single-track-in-hybrid case where a user is searching for one
-            # track and the only torrent / usenet result is the album that
-            # contains it.
-            #
-            # Without this fallback, "Luther (with SZA)" against a
-            # candidate titled "GNX (2024) [FLAC]" scores ~0 on track-title
-            # alone — even though the album torrent does in fact contain
-            # the wanted track. Scoring the candidate title against the
-            # wanted track's ALBUM name and taking the max gives album-
-            # level releases a fair shot. The Auto-Import sweep then picks
-            # the right file out of the downloaded album folder.
-            expected_album = getattr(spotify_track, 'album', None) if spotify_track else None
-            if r.username in ('torrent', 'usenet') and expected_album:
-                album_conf, _ = matching_engine.score_track_match(
-                    source_title=expected_album,
-                    source_artists=expected_artists,
-                    source_duration_ms=0,            # albums don't have one duration
-                    candidate_title=r.title or '',
-                    candidate_artists=candidate_artists,
-                    candidate_duration_ms=0,
-                )
-                if album_conf > confidence:
-                    confidence = album_conf
-                    match_type = 'album_release'
+    if p2p:
+        accepted.extend(_match_filename_candidates(p2p, spotify_track))
+    return accepted
 
-            # Version detection penalty — reject live/remix/acoustic when expecting original
-            r_title_lower = (r.title or '').lower()
-            is_wrong_version = False
-            if not expected_is_version:
-                # Expecting original — penalize versions
-                for kw in _version_keywords:
-                    if _has_version_kw(r_title_lower, kw) and not _has_version_kw(expected_title_lower, kw):
-                        confidence *= 0.4  # Heavy penalty
-                        is_wrong_version = True
-                        break
-            else:
-                # Expecting specific version — penalize results that don't have it
-                for kw in _version_keywords:
-                    if _has_version_kw(expected_title_lower, kw) and not _has_version_kw(r_title_lower, kw):
-                        confidence *= 0.5
-                        is_wrong_version = True
-                        break
 
-            # Artist gate — streaming APIs (Tidal/Qobuz/HiFi/Deezer) have reliable metadata,
-            # so "My Will" by "B. Starr" should never match expected "B小町".
-            # Torrent/usenet must also pass this gate so title-only matches
-            # from the wrong artist do not get downloaded. YouTube gets a SOFT
-            # version below: its artist field (title-parse or channel) is
-            # unreliable, but "no artist evidence at all" now raises the bar
-            # instead of waiving it — the old full exemption downloaded
-            # "We Were Shameless" by the wrong band for "We're Shameless"
-            # (apostrophe folding made the titles near-identical, and nothing
-            # else was checked).
-            if not has_only_fallback_artist:
-                from difflib import SequenceMatcher
-                import re as _re
-                _cand_artist_raw = r.artist or ''
-                _cand_artist = matching_engine.normalize_string(_cand_artist_raw)
-                _best_artist = 0.0
-                for _ea in expected_artists:
-                    _ea_norm = matching_engine.normalize_string(_ea)
-                    if not _ea_norm:
-                        continue
-                    # For short normalized names (e.g. "B小町"→"b"), containment is useless.
-                    # Compare original Unicode strings directly via similarity instead.
-                    if len(_ea_norm) <= 2:
-                        _best_artist = max(_best_artist, SequenceMatcher(None, _ea.lower(), _cand_artist_raw.lower()).ratio())
-                    elif _re.search(r'\b' + _re.escape(_ea_norm) + r'\b', _cand_artist):
-                        _best_artist = 1.0
-                        break
-                    elif _ea_norm == _cand_artist:
-                        _best_artist = 1.0
-                        break
-                    else:
-                        _best_artist = max(_best_artist, SequenceMatcher(None, _ea_norm, _cand_artist).ratio())
-                # Raised from 0.4 → 0.5 to close a fencepost bug: SequenceMatcher
-                # returns exactly 0.400 for "maduk" vs "tom walker" (5 chars vs
-                # 10 chars with 2 coincidental char matches), which bypassed the
-                # strict `< 0.4` check and let Tom Walker through as a candidate
-                # for a Maduk track. The word-boundary containment check above
-                # already short-circuits legitimate formatting variations
-                # ("Beatles"/"The Beatles", "Maduk"/"Maduk feat. X") to sim=1.0,
-                # so falling to SequenceMatcher means the strings are genuinely
-                # different. 0.5 gives a safer buffer without blocking real
-                # matches that would have scored above 0.85 anyway.
-                if r.username == 'youtube':
-                    if _best_artist < 0.5:
-                        # No artist evidence (random channel, unparsable video
-                        # title). The title must then carry the WHOLE identity:
-                        # near-exact confidence AND no significant words beyond
-                        # the wanted title/artist + upload noise. This is what
-                        # rejects "We Were Shameless" (the extra 'we'), reaction
-                        # videos and mislabeled uploads while keeping legit
-                        # "Song by Artist (lyrics)"-style uploads alive.
-                        if confidence < 0.75 or not _title_words_are_expected(
-                                r.title, expected_title, expected_artists):
-                            logger.info(
-                                "[%s] Rejecting candidate without artist evidence: "
-                                "expected=%s candidate_artist=%r title=%r conf=%.2f",
-                                source_label, list(expected_artists),
-                                _cand_artist_raw, r.title or '', confidence,
-                            )
-                            continue
-                elif r.username in ('torrent', 'usenet') and _best_artist < 0.5:
-                    logger.info(
-                        "[%s] Rejecting candidate due to artist mismatch: "
-                        "expected=%s candidate=%r title=%r",
-                        source_label,
-                        list(expected_artists),
-                        _cand_artist_raw,
-                        r.title or '',
-                    )
-                    continue
-                elif _best_artist < 0.5 and confidence < 0.85:
-                    continue
+def _score_streaming_candidates(results, spotify_track):
+    """Match-filter structured-metadata hits (YouTube, Tidal, torrent, …)."""
+    source_label = results[0].username.replace('_dl', '').title()
+    expected_artists = spotify_track.artists if spotify_track else []
+    expected_title = spotify_track.name if spotify_track else ''
+    expected_duration = spotify_track.duration_ms if spotify_track else 0
 
-            r.confidence = confidence
-            r.version_type = 'wrong_version' if is_wrong_version else match_type
-            if confidence >= 0.60:
-                scored.append(r)
+    # Detect if the expected track is a specific version (live, remix, acoustic, etc.)
+    expected_title_lower = (expected_title or '').lower()
+    _version_keywords = _VERSION_KEYWORDS
+    expected_is_version = any(_has_version_kw(expected_title_lower, kw)
+                              for kw in _version_keywords)
 
-        if scored:
-            # Sort by confidence (best match first)
-            scored.sort(key=lambda x: x.confidence, reverse=True)
-            best = scored[0]
-            logger.info(f"[{source_label}] {len(scored)}/{len(results)} candidates passed validation "
-                  f"(best: {best.confidence:.2f} '{best.artist} - {best.title}')")
-            return scored
+    scored = []
+    _strict_duration_sources = {'tidal', 'qobuz', 'hifi', 'deezer_dl', 'amazon'}
+    for r in results:
+        if (
+            r.username in _strict_duration_sources
+            and _duration_mismatch_exceeds_integrity_tolerance(expected_duration, r.duration or 0)
+        ):
+            logger.info(
+                "[%s] Rejecting candidate due to duration mismatch before download: "
+                "expected %.1fs, candidate %.1fs",
+                source_label,
+                expected_duration / 1000.0,
+                (r.duration or 0) / 1000.0,
+            )
+            continue
+
+        # Score using matching engine's generic scorer (same weights as Soulseek).
+        # Torrent/usenet release projections sometimes only have the indexer name
+        # in the artist field when a title did not parse as "Artist - Release".
+        # Treat that as unknown artist, not as a real mismatch.
+        has_only_fallback_artist = _torrent_usenet_artist_is_fallback(r)
+        candidate_artists = [] if has_only_fallback_artist else ([r.artist] if r.artist else [])
+        confidence, match_type = matching_engine.score_track_match(
+            source_title=expected_title,
+            source_artists=expected_artists,
+            source_duration_ms=expected_duration,
+            candidate_title=r.title or '',
+            candidate_artists=candidate_artists,
+            candidate_duration_ms=r.duration or 0,
+        )
+
+        # Album-name fallback for torrent / usenet per-track results.
+        #
+        # When this fallback runs: hybrid mode + non-album batch (single
+        # track wishlist / playlist of singles). Album-context batches
+        # never reach here — the album-bundle gate in
+        # core/downloads/album_bundle_dispatch.py engages the bulk-
+        # download flow in single-source mode, and the hybrid chain
+        # filter in core/downloads/task_worker.py strips torrent /
+        # usenet from album batches in hybrid mode. What's left is the
+        # single-track-in-hybrid case where a user is searching for one
+        # track and the only torrent / usenet result is the album that
+        # contains it.
+        #
+        # Without this fallback, "Luther (with SZA)" against a
+        # candidate titled "GNX (2024) [FLAC]" scores ~0 on track-title
+        # alone — even though the album torrent does in fact contain
+        # the wanted track. Scoring the candidate title against the
+        # wanted track's ALBUM name and taking the max gives album-
+        # level releases a fair shot. The Auto-Import sweep then picks
+        # the right file out of the downloaded album folder.
+        expected_album = getattr(spotify_track, 'album', None) if spotify_track else None
+        if r.username in ('torrent', 'usenet') and expected_album:
+            album_conf, _ = matching_engine.score_track_match(
+                source_title=expected_album,
+                source_artists=expected_artists,
+                source_duration_ms=0,            # albums don't have one duration
+                candidate_title=r.title or '',
+                candidate_artists=candidate_artists,
+                candidate_duration_ms=0,
+            )
+            if album_conf > confidence:
+                confidence = album_conf
+                match_type = 'album_release'
+
+        # Version detection penalty — reject live/remix/acoustic when expecting original
+        r_title_lower = (r.title or '').lower()
+        is_wrong_version = False
+        if not expected_is_version:
+            # Expecting original — penalize versions
+            for kw in _version_keywords:
+                if _has_version_kw(r_title_lower, kw) and not _has_version_kw(expected_title_lower, kw):
+                    confidence *= 0.4  # Heavy penalty
+                    is_wrong_version = True
+                    break
         else:
-            if results[0].username == 'youtube':
-                logger.warning(f"[{source_label}] No streaming results passed validation — falling through to filename matching")
-                # YouTube artist data is unreliable, allow fallback to filename-based matching
-            else:
-                logger.warning(f"[{source_label}] No streaming results passed validation (threshold: 0.60, artist gate: 0.50) — rejecting all candidates")
-                return []  # Tidal/Qobuz/HiFi/Deezer have structured metadata; don't fall back to filename matching
+            # Expecting specific version — penalize results that don't have it
+            for kw in _version_keywords:
+                if _has_version_kw(expected_title_lower, kw) and not _has_version_kw(r_title_lower, kw):
+                    confidence *= 0.5
+                    is_wrong_version = True
+                    break
 
+        # Artist gate — streaming APIs (Tidal/Qobuz/HiFi/Deezer) have reliable metadata,
+        # so "My Will" by "B. Starr" should never match expected "B小町".
+        # Torrent/usenet must also pass this gate so title-only matches
+        # from the wrong artist do not get downloaded. YouTube gets a SOFT
+        # version below: its artist field (title-parse or channel) is
+        # unreliable, but "no artist evidence at all" now raises the bar
+        # instead of waiving it — the old full exemption downloaded
+        # "We Were Shameless" by the wrong band for "We're Shameless"
+        # (apostrophe folding made the titles near-identical, and nothing
+        # else was checked).
+        if not has_only_fallback_artist:
+            from difflib import SequenceMatcher
+            import re as _re
+            _cand_artist_raw = r.artist or ''
+            _cand_artist = matching_engine.normalize_string(_cand_artist_raw)
+            _best_artist = 0.0
+            for _ea in expected_artists:
+                _ea_norm = matching_engine.normalize_string(_ea)
+                if not _ea_norm:
+                    continue
+                # For short normalized names (e.g. "B小町"→"b"), containment is useless.
+                # Compare original Unicode strings directly via similarity instead.
+                if len(_ea_norm) <= 2:
+                    _best_artist = max(_best_artist, SequenceMatcher(None, _ea.lower(), _cand_artist_raw.lower()).ratio())
+                elif _re.search(r'\b' + _re.escape(_ea_norm) + r'\b', _cand_artist):
+                    _best_artist = 1.0
+                    break
+                elif _ea_norm == _cand_artist:
+                    _best_artist = 1.0
+                    break
+                else:
+                    _best_artist = max(_best_artist, SequenceMatcher(None, _ea_norm, _cand_artist).ratio())
+            # Raised from 0.4 → 0.5 to close a fencepost bug: SequenceMatcher
+            # returns exactly 0.400 for "maduk" vs "tom walker" (5 chars vs
+            # 10 chars with 2 coincidental char matches), which bypassed the
+            # strict `< 0.4` check and let Tom Walker through as a candidate
+            # for a Maduk track. The word-boundary containment check above
+            # already short-circuits legitimate formatting variations
+            # ("Beatles"/"The Beatles", "Maduk"/"Maduk feat. X") to sim=1.0,
+            # so falling to SequenceMatcher means the strings are genuinely
+            # different. 0.5 gives a safer buffer without blocking real
+            # matches that would have scored above 0.85 anyway.
+            if r.username == 'youtube':
+                if _best_artist < 0.5:
+                    # No artist evidence (random channel, unparsable video
+                    # title). The title must then carry the WHOLE identity:
+                    # near-exact confidence AND no significant words beyond
+                    # the wanted title/artist + upload noise. This is what
+                    # rejects "We Were Shameless" (the extra 'we'), reaction
+                    # videos and mislabeled uploads while keeping legit
+                    # "Song by Artist (lyrics)"-style uploads alive.
+                    if confidence < 0.75 or not _title_words_are_expected(
+                            r.title, expected_title, expected_artists):
+                        logger.info(
+                            "[%s] Rejecting candidate without artist evidence: "
+                            "expected=%s candidate_artist=%r title=%r conf=%.2f",
+                            source_label, list(expected_artists),
+                            _cand_artist_raw, r.title or '', confidence,
+                        )
+                        continue
+            elif r.username in ('torrent', 'usenet') and _best_artist < 0.5:
+                logger.info(
+                    "[%s] Rejecting candidate due to artist mismatch: "
+                    "expected=%s candidate=%r title=%r",
+                    source_label,
+                    list(expected_artists),
+                    _cand_artist_raw,
+                    r.title or '',
+                )
+                continue
+            elif _best_artist < 0.5 and confidence < 0.85:
+                continue
+
+        r.confidence = confidence
+        r.version_type = 'wrong_version' if is_wrong_version else match_type
+        if confidence >= 0.60:
+            scored.append(r)
+
+    if scored:
+        # Sort by confidence (best match first)
+        scored.sort(key=lambda x: x.confidence, reverse=True)
+        best = scored[0]
+        logger.info(f"[{source_label}] {len(scored)}/{len(results)} candidates passed validation "
+              f"(best: {best.confidence:.2f} '{best.artist} - {best.title}')")
+        return scored
+    return []
+
+
+def _match_filename_candidates(results, spotify_track):
+    """Soulseek path matcher, or YouTube structured-score fallthrough."""
     # Uses the existing, powerful matching engine for scoring (Soulseek P2P results)
     _max_q = config_manager.get('soulseek.max_peer_queue', 0) or 0
     initial_candidates = matching_engine.find_best_slskd_matches_enhanced(spotify_track, results, max_peer_queue=_max_q)
@@ -364,12 +455,18 @@ def get_valid_candidates(results, spotify_track, query):
         return []
 
     # Skip quality filtering for streaming source results that somehow got here
-    is_streaming_source = initial_candidates[0].username in _streaming_sources if initial_candidates else False
+    is_streaming_source = initial_candidates[0].username in _STREAMING_USERNAMES if initial_candidates else False
 
     if is_streaming_source:
         source_label = initial_candidates[0].username.title()
-        logger.info(f"[{source_label}] Skipping quality filter - streaming source handles quality internally")
-        quality_filtered_candidates = initial_candidates
+        if any(getattr(c, 'username', None) == 'youtube' for c in initial_candidates):
+            quality_filtered_candidates = _filter_youtube_by_quality(initial_candidates)
+            if not quality_filtered_candidates:
+                logger.error("[Quality Filter] No YouTube candidates match quality profile - download will fail per user preferences")
+                return []
+        else:
+            logger.info(f"[{source_label}] Skipping quality filter - streaming source handles quality internally")
+            quality_filtered_candidates = initial_candidates
     else:
         # Filter by user's quality profile before artist verification (Soulseek only)
         # Use existing download_orchestrator to avoid re-initializing (which accesses download_path filesystem)

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -314,8 +314,84 @@ def cleanup_empty_directories(download_path, moved_file_path):
         logger.error(f"An error occurred during directory cleanup: {e}")
 
 
-def get_audio_quality_string(file_path):
-    """Return a compact audio quality string for the given file."""
+def _kbps_from_stream_info(info, file_path: str, *, estimate: bool = True):
+    """Bitrate in kbps from mutagen, optionally a size/duration estimate.
+
+    Ogg Opus headers have no bitrate field (mutagen.oggopus only exposes
+    length + channels). YouTube remux writes ``.opus``.
+    """
+    if info is not None:
+        raw = getattr(info, "bitrate", None)
+        try:
+            if raw:
+                return max(1, int(raw) // 1000)
+        except (TypeError, ValueError):
+            pass
+    if not estimate:
+        return None
+    length = getattr(info, "length", None) or getattr(info, "duration", None) or 0 if info is not None else 0
+    try:
+        length = float(length)
+    except (TypeError, ValueError):
+        length = 0
+    try:
+        size = os.path.getsize(file_path)
+    except OSError:
+        size = 0
+    if length > 0.05 and size > 0:
+        return max(1, int(size * 8 / length / 1000))
+    return None
+
+
+def _claim_kbps(on_disk_format: str, claimed_format, claimed_bitrate):
+    """YouTube (and other streaming) itag/API bitrate, if the file codec matches.
+
+    Mutagen cannot read Opus bitrate; the player-response probe already has it.
+    Never copy an Opus/AAC claim onto an MP3 — that is the transcode case.
+    """
+    disk = (on_disk_format or "").lower()
+    claim = (claimed_format or "").lower()
+    if not claim or not disk:
+        return None
+    aliases = {
+        "opus": {"opus", "ogg", "webm"},
+        "ogg": {"opus", "ogg"},
+        "aac": {"aac", "m4a", "mp4"},
+        "m4a": {"aac", "m4a", "mp4"},
+        "mp3": {"mp3"},
+    }
+    if disk not in aliases.get(claim, {claim}):
+        return None
+    try:
+        kbps = int(claimed_bitrate)
+    except (TypeError, ValueError):
+        return None
+    return kbps if kbps > 0 else None
+
+
+def _lossy_kbps(info, file_path, on_disk_format, claimed_format, claimed_bitrate):
+    """Prefer mutagen, then the source's probed claim, then a size estimate."""
+    kbps = _kbps_from_stream_info(info, file_path, estimate=False)
+    if kbps:
+        return kbps
+    claimed = _claim_kbps(on_disk_format, claimed_format, claimed_bitrate)
+    if claimed:
+        return claimed
+    return _kbps_from_stream_info(info, file_path, estimate=True)
+
+
+def _chip_lossy(fmt: str, kbps) -> str:
+    if kbps:
+        return f"{fmt}-{kbps}"
+    return fmt
+
+
+def get_audio_quality_string(file_path, *, claimed_format=None, claimed_bitrate=None):
+    """Return a compact audio quality string for the given file.
+
+    ``claimed_*`` is the pre-download probe (YouTube itags, Tidal tier, …).
+    Used only when the file itself has no bitrate (Opus) and the codec matches.
+    """
     try:
         ext = os.path.splitext(file_path)[1].lower()
 
@@ -331,26 +407,56 @@ def get_audio_quality_string(file_path):
             from mutagen.mp3 import MP3, BitrateMode
 
             audio = MP3(file_path)
-            bitrate_kbps = audio.info.bitrate // 1000
-            if audio.info.bitrate_mode == BitrateMode.VBR:
+            bitrate_kbps = _lossy_kbps(
+                audio.info, file_path, "mp3", claimed_format, claimed_bitrate,
+            )
+            if getattr(audio.info, "bitrate_mode", None) == BitrateMode.VBR:
                 return "MP3-VBR"
-            return f"MP3-{bitrate_kbps}"
+            return _chip_lossy("MP3", bitrate_kbps)
 
         if ext in (".m4a", ".aac", ".mp4"):
             from mutagen.mp4 import MP4
             audio = MP4(file_path)
-            return f"M4A-{audio.info.bitrate // 1000}"
+            return _chip_lossy(
+                "M4A",
+                _lossy_kbps(audio.info, file_path, "aac", claimed_format, claimed_bitrate),
+            )
 
         if ext == ".ogg":
-            from mutagen.oggvorbis import OggVorbis
-            audio = OggVorbis(file_path)
-            return f"OGG-{audio.info.bitrate // 1000}"
+            try:
+                from mutagen.oggvorbis import OggVorbis
+                audio = OggVorbis(file_path)
+                return _chip_lossy(
+                    "OGG",
+                    _lossy_kbps(audio.info, file_path, "ogg", claimed_format, claimed_bitrate),
+                )
+            except Exception:
+                from mutagen.oggopus import OggOpus
+                audio = OggOpus(file_path)
+                return _chip_lossy(
+                    "OPUS",
+                    _lossy_kbps(audio.info, file_path, "opus", claimed_format, claimed_bitrate),
+                )
 
         if ext == ".opus":
             from mutagen.oggopus import OggOpus
 
             audio = OggOpus(file_path)
-            return f"OPUS-{audio.info.bitrate // 1000}"
+            return _chip_lossy(
+                "OPUS",
+                _lossy_kbps(audio.info, file_path, "opus", claimed_format, claimed_bitrate),
+            )
+
+        if ext in (".webm", ".weba"):
+            aq = probe_audio_quality(file_path)
+            kbps = (aq.bitrate if aq else None) or _claim_kbps(
+                "opus", claimed_format, claimed_bitrate,
+            )
+            if kbps:
+                return _chip_lossy("OPUS", kbps)
+            if aq is None:
+                return ""
+            return _chip_lossy(aq.format.upper(), aq.bitrate)
 
         return ""
     except Exception as e:
@@ -409,21 +515,38 @@ def probe_audio_quality(file_path: str):
             )
 
         if ext == 'ogg':
-            from mutagen.oggvorbis import OggVorbis
-            audio = OggVorbis(file_path)
-            return AudioQuality(
-                format='ogg',
-                bitrate=audio.info.bitrate // 1000,
-                sample_rate=audio.info.sample_rate,
-            )
+            try:
+                from mutagen.oggvorbis import OggVorbis
+                audio = OggVorbis(file_path)
+                return AudioQuality(
+                    format='ogg',
+                    bitrate=_kbps_from_stream_info(audio.info, file_path),
+                    sample_rate=getattr(audio.info, 'sample_rate', None),
+                )
+            except Exception:
+                from mutagen.oggopus import OggOpus
+                audio = OggOpus(file_path)
+                return AudioQuality(
+                    format='opus',
+                    bitrate=_kbps_from_stream_info(audio.info, file_path),
+                    sample_rate=getattr(audio.info, 'sample_rate', None) or 48000,
+                )
 
-        if ext == 'opus':
-            from mutagen.oggopus import OggOpus
-            audio = OggOpus(file_path)
+        if ext in ('opus', 'webm', 'weba'):
+            # .opus: FFmpegExtractAudio remux of YouTube itag 251/774.
+            # mutagen.oggopus has no bitrate/sample_rate attributes.
+            # .webm leftover is Matroska, not Ogg — don't fake a probe.
+            info = None
+            try:
+                from mutagen.oggopus import OggOpus
+                info = OggOpus(file_path).info
+            except Exception:
+                if ext != 'opus':
+                    return None
             return AudioQuality(
                 format='opus',
-                bitrate=audio.info.bitrate // 1000,
-                sample_rate=audio.info.sample_rate,
+                bitrate=_kbps_from_stream_info(info, file_path),
+                sample_rate=(getattr(info, 'sample_rate', None) or 48000) if info is not None else 48000,
             )
 
         if ext in ('wav', 'aiff', 'aif'):

--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -314,6 +314,78 @@ def cleanup_empty_directories(download_path, moved_file_path):
         logger.error(f"An error occurred during directory cleanup: {e}")
 
 
+def estimate_bitrate_kbps(*, size_bytes=None, duration_seconds=None, duration_ms=None, file_path=None):
+    """Effective kbps from file size and duration.
+
+    Used when the container has no bitrate header (Ogg Opus) and for
+    already-imported library rows stored as 0.
+    """
+    size = size_bytes
+    if not size and file_path:
+        try:
+            size = os.path.getsize(file_path)
+        except OSError:
+            size = 0
+    try:
+        size = int(size or 0)
+    except (TypeError, ValueError):
+        size = 0
+    length = duration_seconds
+    if not length and duration_ms:
+        try:
+            length = float(duration_ms) / 1000.0
+        except (TypeError, ValueError):
+            length = 0
+    try:
+        length = float(length or 0)
+    except (TypeError, ValueError):
+        length = 0
+    if length > 0.05 and size > 0:
+        return max(1, int(size * 8 / length / 1000))
+    return None
+
+
+def stream_uses_vbr_display(file_path, info=None) -> bool:
+    """True when the library bitrate cell should show an average (``~N kbps``).
+
+    Opus/Vorbis are always VBR. AAC/WMA store mutagen's average (MP4 esds
+    ``avgBitrate``), not a CBR constant. MP3 is VBR only when mutagen says so.
+    """
+    ext = os.path.splitext(file_path or "")[1].lower()
+    if ext in {".opus", ".ogg", ".m4a", ".aac", ".wma"}:
+        return True
+    if ext == ".mp3" and info is not None:
+        try:
+            from mutagen.mp3 import BitrateMode
+            return getattr(info, "bitrate_mode", None) == BitrateMode.VBR
+        except Exception:
+            return False
+    return False
+
+
+def fill_missing_track_bitrate(track: dict) -> dict:
+    """If the DB row has no bitrate, fill an average from size and duration.
+
+    The enhanced library table reads ``tracks.bitrate``. Opus import used
+    to store 0 because mutagen.oggopus has no bitrate attribute.
+    """
+    try:
+        existing = int(track.get("bitrate") or 0)
+    except (TypeError, ValueError):
+        existing = 0
+    if existing <= 0:
+        kbps = estimate_bitrate_kbps(
+            size_bytes=track.get("file_size"),
+            duration_ms=track.get("duration"),
+            file_path=track.get("file_path"),
+        )
+        if kbps:
+            track["bitrate"] = kbps
+    if stream_uses_vbr_display(track.get("file_path")):
+        track["bitrate_vbr"] = 1
+    return track
+
+
 def _kbps_from_stream_info(info, file_path: str, *, estimate: bool = True):
     """Bitrate in kbps from mutagen, optionally a size/duration estimate.
 
@@ -329,18 +401,10 @@ def _kbps_from_stream_info(info, file_path: str, *, estimate: bool = True):
             pass
     if not estimate:
         return None
-    length = getattr(info, "length", None) or getattr(info, "duration", None) or 0 if info is not None else 0
-    try:
-        length = float(length)
-    except (TypeError, ValueError):
-        length = 0
-    try:
-        size = os.path.getsize(file_path)
-    except OSError:
-        size = 0
-    if length > 0.05 and size > 0:
-        return max(1, int(size * 8 / length / 1000))
-    return None
+    length = None
+    if info is not None:
+        length = getattr(info, "length", None) or getattr(info, "duration", None)
+    return estimate_bitrate_kbps(file_path=file_path, duration_seconds=length)
 
 
 def _claim_kbps(on_disk_format: str, claimed_format, claimed_bitrate):

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -627,7 +627,11 @@ def post_process_matched_download(context_key, context, file_path, runtime, meta
         # audio quality is recorded on the context (→ quarantine sidecar) for
         # EVERY trigger, so it's known when reviewing/approving any quarantined
         # file. force_import still never fires on a quality mismatch.
-        context['_audio_quality'] = get_audio_quality_string(file_path)
+        context['_audio_quality'] = get_audio_quality_string(
+            file_path,
+            claimed_format=(get_import_original_search(context) or {}).get('quality'),
+            claimed_bitrate=(get_import_original_search(context) or {}).get('bitrate'),
+        )
         if context['_audio_quality']:
             logger.info(f"Audio quality detected: {context['_audio_quality']}")
 

--- a/core/imports/side_effects.py
+++ b/core/imports/side_effects.py
@@ -492,26 +492,27 @@ def record_soulsync_library_entry(context: Dict[str, Any], artist_context: Dict[
             genres = _filter_genres(genres, _get_config_manager())
         genres_json = json.dumps(genres) if genres else ""
 
-        bitrate = 0
-        try:
-            from mutagen import File as MutagenFile
-
-            audio = MutagenFile(final_path)
-            if audio and hasattr(audio, "info") and audio.info and hasattr(audio.info, "bitrate"):
-                bitrate = int(audio.info.bitrate / 1000) if audio.info.bitrate else 0
-        except Exception as e:
-            logger.debug("bitrate read failed: %s", e)
-
         # File size on disk (powers Library Disk Usage card on Stats).
-        # SoulSync standalone is the only path where the file is local
-        # at insert time, so we read it directly via os.path.getsize.
-        # Mirrors what JellyfinTrack/NavidromeTrack pull from API
-        # responses for the media-server flows.
         file_size = None
         try:
             file_size = os.path.getsize(final_path) or None
         except OSError:
             pass
+
+        bitrate = 0
+        try:
+            from mutagen import File as MutagenFile
+            from core.imports.file_ops import _kbps_from_stream_info, estimate_bitrate_kbps
+
+            audio = MutagenFile(final_path)
+            info = audio.info if audio is not None and getattr(audio, "info", None) else None
+            kbps = _kbps_from_stream_info(info, final_path)
+            if not kbps:
+                kbps = estimate_bitrate_kbps(size_bytes=file_size, duration_ms=duration_ms)
+            if kbps:
+                bitrate = int(kbps)
+        except Exception as e:
+            logger.debug("bitrate read failed: %s", e)
 
         artist_id = _stable_soulsync_id(artist_name.lower().strip())
         album_id = _stable_soulsync_id(f"{artist_name}::{album_name}".lower().strip())

--- a/core/quality/source_map.py
+++ b/core/quality/source_map.py
@@ -3,9 +3,9 @@ API values into a unified :class:`~core.quality.model.AudioQuality`.
 
 Every streaming source describes quality differently (Tidal/HiFi use tier
 strings, Qobuz reports real kHz + bit depth, Deezer uses config codes,
-Amazon mixes real values with HD/UHD tiers). Centralising the knowledge
-here keeps the per-client code to a single call and keeps the tier tables
-in one auditable place.
+Amazon mixes real values with HD/UHD tiers, YouTube reports Opus/AAC
+bestaudio). Centralising the knowledge here keeps the per-client code to
+a single call and keeps the tier tables in one auditable place.
 
 Each value is a *claim*: the download client populates its ``TrackResult``
 from it so the global ranker can choose a source, and the post-download
@@ -143,6 +143,70 @@ def quality_from_amazon(
     )
 
 
+# ── YouTube (lossy bestaudio; never MP3 320) ────────────────────────────────
+#
+# YouTube does not offer 320 kbps MP3. There is no MP3 DASH itag; streams are
+# Opus (webm) or AAC (m4a). Audio-only DASH itags:
+#   139  m4a  AAC HE   ~48 kbps
+#   140  m4a  AAC LC   128 kbps     (free, ubiquitous)
+#   141  m4a  AAC LC   256 kbps     (YouTube / Music Premium cookies)
+#   171/172 webm Vorbis ~128/192    (legacy; retired ~2018, rare on old videos)
+#   249  webm Opus     ~50 kbps
+#   250  webm Opus     ~70 kbps
+#   251  webm Opus     ~160 kbps    (typical bestaudio without Premium)
+#   599  m4a  AAC      ~30 kbps     (ultra-low)
+#   600  webm Opus     ~35 kbps     (ultra-low)
+#   774  webm Opus     ~256 kbps    (Music Premium, not always present)
+# Muxed fallback (format=best): itag 18 (360p AAC ~96) / 22 (720p AAC ~192).
+# Search uses extract_flat, so format metadata is usually missing — claim the
+# typical Opus 160 (itag 251) rather than pretending the stream is MP3.
+# Premium itags (141 / 774) are stamped only when a real format dict has them.
+
+_YOUTUBE_TYPICAL = AudioQuality(format='opus', bitrate=160)
+_YOUTUBE_AAC_TYPICAL = AudioQuality(format='aac', bitrate=128)
+
+
+def _youtube_abr(audio_format: dict) -> Optional[int]:
+    for key in ('abr', 'tbr'):
+        raw = audio_format.get(key)
+        if raw is None or raw == '':
+            continue
+        try:
+            bitrate = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if bitrate:
+            return bitrate
+    return None
+
+
+def quality_from_youtube(audio_format: Optional[dict] = None) -> AudioQuality:
+    """Map a yt-dlp audio format dict to the stream's real AudioQuality.
+
+    Missing format metadata (extract_flat / Music catalog search) claims
+    typical Opus 160 kbps (itag 251) — never invented MP3 320, never assumed
+    Premium from cookies. YouTube does not serve 320 kbps MP3.
+    """
+    if not audio_format:
+        return AudioQuality(format='opus', bitrate=160)
+
+    acodec = str(audio_format.get('acodec') or '').lower()
+    ext = str(audio_format.get('ext') or '').lower()
+    bitrate = _youtube_abr(audio_format)
+
+    if 'vorbis' in acodec:
+        # Legacy itags 171/172 (Vorbis in webm). Check before ext=webm so
+        # they are not misread as Opus.
+        return AudioQuality(format='ogg', bitrate=bitrate)
+    if 'opus' in acodec or ext in ('webm', 'opus'):
+        return AudioQuality(format='opus', bitrate=bitrate or _YOUTUBE_TYPICAL.bitrate)
+    if 'mp4a' in acodec or 'aac' in acodec or ext in ('m4a', 'aac'):
+        return AudioQuality(format='aac', bitrate=bitrate or _YOUTUBE_AAC_TYPICAL.bitrate)
+
+    # Unknown codec: still don't claim MP3 320.
+    return AudioQuality(format='opus', bitrate=bitrate or _YOUTUBE_TYPICAL.bitrate)
+
+
 # ── Profile-driven download tier (replaces per-source quality settings) ─────
 #
 # Each source's selectable download tiers, ordered best → worst, with the
@@ -178,6 +242,12 @@ _SOURCE_TIER_LADDERS: dict[str, list[tuple[str, AudioQuality]]] = {
     'amazon': [
         ('flac', AudioQuality('flac', sample_rate=48000, bit_depth=24)),
         ('opus', AudioQuality('aac', bitrate=320)),
+    ],
+    'youtube': [
+        ('opus_256', AudioQuality('opus', bitrate=256)),
+        ('aac_256', AudioQuality('aac', bitrate=256)),
+        ('opus_160', AudioQuality('opus', bitrate=160)),
+        ('aac_128', AudioQuality('aac', bitrate=128)),
     ],
 }
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -833,6 +833,12 @@ class ConfigManager:
             "youtube": {
                 "cookies_browser": "",      # "", "chrome", "firefox", "edge", "brave", "opera", "safari"
                 "download_delay": 3,        # seconds between sequential downloads
+                # Default: convert to MP3 320 after download. YouTube audio is
+                # Opus/AAC; re-encode does not add quality but matches common
+                # players. The quality profile ranks the file on disk.
+                "transcode": True,
+                "transcode_codec": "mp3",
+                "transcode_bitrate": "320",
             },
             "hydrabase": {
                 "url": "",

--- a/core/soulsync_client.py
+++ b/core/soulsync_client.py
@@ -59,12 +59,15 @@ def _read_tags(file_path: str) -> Dict[str, Any]:
                 except (ValueError, TypeError):
                     pass
 
-            # Duration and bitrate from audio info
+            # Duration from audio info. Bitrate: mutagen header when present,
+            # else a size/duration average (Ogg Opus has no bitrate field).
             if hasattr(audio, 'info') and audio.info:
                 if hasattr(audio.info, 'length'):
                     result['duration_ms'] = int(audio.info.length * 1000)
-                if hasattr(audio.info, 'bitrate'):
-                    result['bitrate'] = int(audio.info.bitrate / 1000) if audio.info.bitrate else 0
+                from core.imports.file_ops import _kbps_from_stream_info
+                kbps = _kbps_from_stream_info(audio.info, file_path)
+                if kbps:
+                    result['bitrate'] = int(kbps)
     except Exception as e:
         logger.debug(f"Could not read tags from {os.path.basename(file_path)}: {e}")
 

--- a/core/youtube_client.py
+++ b/core/youtube_client.py
@@ -13,6 +13,7 @@ This client provides:
 import sys
 import os
 import re
+import copy
 import time
 import platform
 import uuid
@@ -34,6 +35,9 @@ from core.spotify_client import Track as SpotifyTrack
 
 # Import Soulseek data structures for drop-in replacement compatibility
 from core.download_plugins.types import SearchResult, TrackResult, AlbumResult, DownloadStatus
+from core.quality.model import AudioQuality, rank_candidate
+from core.quality.source_map import quality_from_youtube, quality_tier_for_source
+from core.quality.selection import quality_meets_profile
 
 logger = get_logger("youtube_client")
 
@@ -50,6 +54,353 @@ def _resolve_cookie_opts() -> dict:
     cookiefile = config_manager.get('youtube.cookies_file', '')
     exists = bool(cookiefile) and os.path.exists(cookiefile)
     return build_youtube_cookie_opts(mode, cookiefile, cookiefile_exists=exists)
+
+
+_TRANSCODE_CODECS = frozenset({'mp3', 'opus', 'aac', 'm4a', 'ogg'})
+_EXTRACTED_AUDIO_EXTS = ('.opus', '.m4a', '.mp3', '.ogg', '.aac', '.wav', '.flac')
+_DOWNLOADED_AUDIO_EXTS = _EXTRACTED_AUDIO_EXTS + ('.webm',)
+
+# Walk-down chain — keys must match ``_SOURCE_TIER_LADDERS['youtube']``.
+_YOUTUBE_QUALITY_MAP = {
+    'opus_256': AudioQuality('opus', bitrate=256),
+    'aac_256': AudioQuality('aac', bitrate=256),
+    'opus_160': AudioQuality('opus', bitrate=160),
+    'aac_128': AudioQuality('aac', bitrate=128),
+}
+_YOUTUBE_QUALITY_CHAIN = list(_YOUTUBE_QUALITY_MAP)
+# Player-response fetches per track search. Soulseek/Qobuz already have
+# per-hit quality; YouTube does not. 3 is enough to find a better encode
+# of the same recording without walking a 10–20 result search.
+_YOUTUBE_PROBE_BUDGET = 3
+# Quality may beat the top match only when confidence is this close.
+# 0.92 vs 0.88 can take a better encode; 0.92 vs 0.62 cannot.
+_YOUTUBE_QUALITY_CONFIDENCE_MARGIN = 0.05
+
+
+def _youtube_match_confidence(candidate) -> float:
+    return float(
+        getattr(candidate, 'confidence', None)
+        or getattr(candidate, '_match_confidence', None)
+        or 0
+    )
+
+
+def youtube_quality_rank_band(
+    candidates,
+    *,
+    margin: float = _YOUTUBE_QUALITY_CONFIDENCE_MARGIN,
+):
+    """Keep match-passing hits close enough to the top score for quality ranking.
+
+    Distant survivors (covers, similar titles) stay out of the itag pick so a
+    256 kbps wrong recording cannot beat a 0.92 match at 160.
+    """
+    rows = list(candidates or [])
+    if not rows:
+        return []
+    top = max(_youtube_match_confidence(c) for c in rows)
+    floor = top - margin
+    return [c for c in rows if _youtube_match_confidence(c) >= floor]
+
+# yt-dlp format strings: requested rung first, then the rest of the ladder
+# (same walk-down as Qobuz/Deezer), then any audio / muxed.
+_YOUTUBE_TIER_SELECTORS = {
+    'opus_256': (
+        'bestaudio[acodec^=opus][abr>=192]/'
+        'bestaudio[ext=m4a][abr>=192]/'
+        'bestaudio[acodec^=opus]/'
+        'bestaudio[ext=m4a]/'
+        'bestaudio/best'
+    ),
+    'aac_256': (
+        'bestaudio[ext=m4a][abr>=192]/'
+        'bestaudio[acodec^=opus][abr>=192]/'
+        'bestaudio[ext=m4a]/'
+        'bestaudio[acodec^=opus]/'
+        'bestaudio/best'
+    ),
+    'opus_160': (
+        'bestaudio[acodec^=opus][abr<=180]/'
+        'bestaudio[ext=m4a][abr<=160]/'
+        'bestaudio[acodec^=opus]/'
+        'bestaudio/best'
+    ),
+    'aac_128': (
+        'bestaudio[ext=m4a][abr<=160]/'
+        'bestaudio[acodec^=opus][abr<=180]/'
+        'bestaudio[ext=m4a]/'
+        'bestaudio/best'
+    ),
+}
+
+
+def _youtube_transcode_settings() -> tuple:
+    """Live YouTube re-encode settings. Never raises — missing config is MP3 320."""
+    try:
+        from config.settings import config_manager
+        transcode = bool(config_manager.get('youtube.transcode', True))
+        codec = str(config_manager.get('youtube.transcode_codec', 'mp3') or 'mp3')
+        bitrate = str(config_manager.get('youtube.transcode_bitrate', '320') or '320')
+        return transcode, codec, bitrate
+    except Exception:  # noqa: BLE001 - download must not depend on settings I/O
+        return True, 'mp3', '320'
+
+
+def youtube_transcode_output_quality() -> Optional[AudioQuality]:
+    """AudioQuality of the file after re-encode, or ``None`` when remuxing.
+
+    Search/import rank against this when re-encode is on, so an MP3-only
+    profile can accept YouTube. The original stream is still fetched at
+    best effort (see ``youtube_requested_tier``); this is the converted
+    output, not a claim that YouTube served MP3.
+    """
+    transcode, codec, bitrate = _youtube_transcode_settings()
+    if not transcode:
+        return None
+    pref = (codec or 'mp3').lower()
+    if pref == 'm4a':
+        pref = 'aac'
+    if pref not in _TRANSCODE_CODECS:
+        pref = 'mp3'
+    try:
+        kbps = int(bitrate)
+    except (TypeError, ValueError):
+        kbps = 320
+    if kbps <= 0:
+        kbps = 320
+    fmt = 'aac' if pref == 'm4a' else pref
+    if fmt not in ('mp3', 'opus', 'aac', 'ogg'):
+        fmt = 'mp3'
+    return AudioQuality(format=fmt, bitrate=kbps)
+
+
+def youtube_claimed_quality(audio_format: Optional[dict] = None) -> AudioQuality:
+    """Quality used for ranking a YouTube hit.
+
+    Re-encode on → converted output (so the profile sees MP3/AAC/Opus as
+    configured). Re-encode off → the original stream claim.
+    """
+    output = youtube_transcode_output_quality()
+    if output is not None:
+        return output
+    return quality_from_youtube(audio_format)
+
+
+def youtube_requested_tier() -> str:
+    """YouTube rung to fetch. Re-encode always takes the best original stream
+    (``opus_256``, walking down if missing). Otherwise the quality profile
+    picks the lowest satisfying rung, same as Tidal/Deezer."""
+    try:
+        if youtube_transcode_output_quality() is not None:
+            return 'opus_256'
+        return quality_tier_for_source('youtube', default='opus_256') or 'opus_256'
+    except Exception:  # noqa: BLE001 - missing DB / profile must not break download
+        return 'opus_256'
+
+
+def youtube_audio_format_selector(tier: Optional[str] = None) -> str:
+    """yt-dlp format string for a YouTube ladder tier (walk-down, then muxed)."""
+    if tier is None:
+        key = youtube_requested_tier()
+    else:
+        key = str(tier).strip().lower()
+    return _YOUTUBE_TIER_SELECTORS.get(key, 'bestaudio/best')
+
+
+def _youtube_format_matches_tier(audio_format: dict, want: AudioQuality) -> bool:
+    """True when *audio_format* is this ladder rung, not a higher one."""
+    got = quality_from_youtube(audio_format)
+    if got.format != want.format:
+        return False
+    bitrate = got.bitrate or 0
+    want_br = want.bitrate or 0
+    if want_br >= 224:
+        return bitrate >= 192
+    return 96 <= bitrate < 192
+
+
+def pick_youtube_audio_format(
+    formats: Optional[List[Dict]],
+    tier: Optional[str] = None,
+) -> Optional[Dict]:
+    """Audio-only itag for *tier*, walking down the YouTube ladder if missing."""
+    if not formats:
+        return None
+    audio_formats = [
+        f for f in formats
+        if f.get('vcodec') == 'none' and f.get('acodec') != 'none'
+    ]
+    if not audio_formats:
+        return None
+
+    key = (tier or youtube_requested_tier() or '').strip().lower()
+    try:
+        start = _YOUTUBE_QUALITY_CHAIN.index(key)
+    except ValueError:
+        start = 0
+
+    def _abr(fmt):
+        return fmt.get('abr') or fmt.get('tbr') or 0
+
+    for name in _YOUTUBE_QUALITY_CHAIN[start:]:
+        want = _YOUTUBE_QUALITY_MAP[name]
+        matching = [f for f in audio_formats if _youtube_format_matches_tier(f, want)]
+        if matching:
+            matching.sort(key=_abr, reverse=True)
+            return matching[0]
+
+    audio_formats.sort(key=_abr, reverse=True)
+    return audio_formats[0]
+
+
+def _claimed_is_youtube_ceiling(claimed: Optional[AudioQuality]) -> bool:
+    """True when this claim is the top YouTube ladder rung (Premium ~256)."""
+    if claimed is None:
+        return False
+    fmt = (claimed.format or '').lower()
+    return fmt in ('opus', 'aac') and (claimed.bitrate or 0) >= 192
+
+
+def _youtube_can_satisfy_targets(targets) -> bool:
+    """False when no YouTube rung can meet the profile (e.g. FLAC-only)."""
+    if not targets:
+        return True
+    return any(quality_meets_profile(aq, targets) for aq in _YOUTUBE_QUALITY_MAP.values())
+
+
+def _should_stop_youtube_probes(claimed, targets, *, seen_passing: bool) -> Tuple[bool, bool]:
+    """Whether further player fetches can change ranking.
+
+    Returns ``(stop, seen_passing)``. Re-encode is the same file for every
+    hit. A 256 claim is the YouTube ceiling. FLAC-only profiles cannot be
+    satisfied by more itags. Otherwise: hunt until something meets the
+    profile, then one look-ahead for a better encode of the same recording.
+    """
+    if youtube_transcode_output_quality() is not None:
+        return True, seen_passing
+    if _claimed_is_youtube_ceiling(claimed):
+        return True, True
+    if targets is None:
+        if seen_passing:
+            return True, True
+        return False, True
+    if not _youtube_can_satisfy_targets(targets):
+        return True, seen_passing
+    if quality_meets_profile(claimed, targets):
+        best = _YOUTUBE_QUALITY_MAP['opus_256']
+        claimed_idx, _ = rank_candidate(claimed, targets)
+        best_idx, _ = rank_candidate(best, targets)
+        if best_idx < claimed_idx:
+            return False, True
+        if seen_passing:
+            return True, True
+        return False, True
+    return False, seen_passing
+
+
+def youtube_audio_postprocessor(
+    transcode: bool = False,
+    codec: str = 'mp3',
+    bitrate: str = '320',
+) -> dict:
+    """yt-dlp FFmpegExtractAudio postprocessor.
+
+    Default is a remux (``preferredcodec='best'``) so Opus/AAC stay in their
+    original codec — YouTube audio is already lossy, and re-encoding to
+    MP3 320 does not add quality. When *transcode* is on, encode to the
+    requested codec/bitrate for player compatibility.
+    """
+    if transcode:
+        pref = (codec or 'mp3').lower()
+        if pref == 'm4a':
+            pref = 'aac'
+        if pref not in _TRANSCODE_CODECS:
+            pref = 'mp3'
+        try:
+            kbps = int(bitrate)
+        except (TypeError, ValueError):
+            kbps = 320
+        if kbps <= 0:
+            kbps = 320
+        return {
+            'key': 'FFmpegExtractAudio',
+            'preferredcodec': pref,
+            'preferredquality': str(kbps),
+        }
+    return {
+        'key': 'FFmpegExtractAudio',
+        'preferredcodec': 'best',
+    }
+
+
+def youtube_audio_postprocessor_from_config() -> dict:
+    """Build the audio extract postprocessor from live YouTube settings."""
+    transcode, codec, bitrate = _youtube_transcode_settings()
+    return youtube_audio_postprocessor(transcode=transcode, codec=codec, bitrate=bitrate)
+
+
+def resolve_downloaded_audio_path(ydl, info) -> Optional[str]:
+    """Final on-disk audio path after yt-dlp + FFmpegExtractAudio.
+
+    ``prepare_filename`` uses the container extension from the downloaded
+    stream (often ``.webm``/``.m4a``). After extract the real file is
+    ``.opus``/``.m4a``/``.mp3``. Prefer filepath from the info dict, then
+    the prepared name, then a sibling with an audio suffix.
+    """
+    candidates = []
+    if isinstance(info, dict):
+        for key in ('filepath', '_filename'):
+            val = info.get(key)
+            if val:
+                candidates.append(Path(val))
+        requested = info.get('requested_downloads') or []
+        if isinstance(requested, list) and requested:
+            first = requested[0]
+            fp = first.get('filepath') if isinstance(first, dict) else None
+            if fp:
+                candidates.append(Path(fp))
+    try:
+        prepared = Path(ydl.prepare_filename(info))
+        candidates.append(prepared)
+        for ext in _DOWNLOADED_AUDIO_EXTS:
+            candidates.append(prepared.with_suffix(ext))
+    except Exception:
+        pass
+    seen = set()
+    existing = []
+    for path in candidates:
+        resolved = str(path)
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if path.exists() and path.is_file():
+            existing.append(path)
+    extracted = [p for p in existing if p.suffix.lower() in _EXTRACTED_AUDIO_EXTS]
+    if extracted:
+        return str(extracted[0])
+    if existing:
+        return str(existing[0])
+    return None
+
+
+def discard_leftover_youtube_containers(audio_path: Optional[str]) -> None:
+    """Unlink DASH/muxed leftovers beside extracted audio (``.webm``/``.mp4``/``.mkv``).
+
+    ``FFmpegExtractAudio`` usually deletes the source container; when it does
+    not, the converted file is what we import. Never delete the chosen audio.
+    """
+    if not audio_path:
+        return
+    chosen = Path(audio_path)
+    if not chosen.is_file() or chosen.suffix.lower() not in _EXTRACTED_AUDIO_EXTS:
+        return
+    for ext in ('.webm', '.mp4', '.mkv'):
+        leftover = chosen.with_suffix(ext)
+        try:
+            if leftover.is_file() and leftover.resolve() != chosen.resolve():
+                leftover.unlink()
+        except OSError:
+            pass
 
 
 @dataclass
@@ -224,11 +575,7 @@ class YouTubeClient(DownloadSourcePlugin):
             'quiet': True,
             'no_warnings': True,
             'extract_flat': False,
-            'postprocessors': [{
-                'key': 'FFmpegExtractAudio',
-                'preferredcodec': 'mp3',
-                'preferredquality': '320',
-            }],
+            'postprocessors': [youtube_audio_postprocessor_from_config()],
             'progress_hooks': [self._progress_hook],  # Track download progress
             'user_agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
             'age_limit': None,  # Don't skip age-restricted
@@ -337,6 +684,8 @@ class YouTubeClient(DownloadSourcePlugin):
             logger.info(f"YouTube download path updated to: {self.download_path}")
 
         logger.info(f"YouTube settings reloaded (delay={self._download_delay}s, cookies={'enabled' if _cookie_opts else 'disabled'})")
+        self._yt_probe_quality = {}
+        self._yt_probe_info = {}
 
     async def check_connection(self) -> bool:
         """
@@ -473,11 +822,11 @@ class YouTubeClient(DownloadSourcePlugin):
                     self.progress_callback(self.current_download_progress)
 
             elif status == 'finished':
-                # Download finished — ffmpeg now converts to MP3. The
-                # engine.worker thread flips to 'Completed, Succeeded'
-                # once _download_sync returns; this just bumps progress
-                # to 95% so the UI doesn't sit at 99.9% during the
-                # ffmpeg post-process.
+                # Download finished — ffmpeg now remuxes (or optionally
+                # transcodes). The engine.worker thread flips to
+                # 'Completed, Succeeded' once _download_sync returns;
+                # this just bumps progress to 95% so the UI doesn't sit
+                # at 99.9% during the ffmpeg post-process.
                 self._engine.update_record('youtube', self.current_download_id, {
                     'progress': 95.0,
                 })
@@ -719,28 +1068,22 @@ class YouTubeClient(DownloadSourcePlugin):
         if best_audio and 'filesize' in best_audio:
             file_size = best_audio.get('filesize', 0) or best_audio.get('filesize_approx', 0) or 0
 
-        # Extract bitrate
-        bitrate = None
-        if best_audio:
-            bitrate = int(best_audio.get('abr', best_audio.get('tbr', 0)))
-
         # Duration in milliseconds (Soulseek uses ms)
         duration_ms = int(entry.get('duration', 0) * 1000) if entry.get('duration') else None
-
-        # Quality string
-        quality_str = self._format_quality_string(best_audio) if best_audio else "unknown"
 
         # Video URL as filename (we'll use this to identify the track later)
         video_id = entry.get('id', '')
         filename = f"{video_id}||{title}"  # Store video_id and title for later download
 
+        claimed = youtube_claimed_quality(best_audio)
+
         track_result = TrackResult(
             username="youtube",  # YouTube doesn't have users - use constant
             filename=filename,
             size=file_size,
-            bitrate=bitrate,
+            bitrate=claimed.bitrate,
             duration=duration_ms,
-            quality="mp3",  # We always convert to MP3
+            quality=claimed.format,
             free_upload_slots=999,  # YouTube always available
             upload_speed=999999,  # High speed indicator
             queue_length=0,  # No queue for YouTube
@@ -749,7 +1092,8 @@ class YouTubeClient(DownloadSourcePlugin):
             album=None,  # YouTube videos don't have album info (will be added from Spotify)
             track_number=None
         )
-        
+        track_result.set_quality(claimed)
+
         # Add thumbnail for frontend (surgical addition)
         # In fast mode (extract_flat), 'thumbnail' might be missing, but 'thumbnails' list exists
         thumbnail = entry.get('thumbnail')
@@ -758,9 +1102,45 @@ class YouTubeClient(DownloadSourcePlugin):
             thumbs = entry.get('thumbnails')
             if isinstance(thumbs, list) and thumbs:
                 thumbnail = thumbs[-1].get('url')
-        
+
         track_result.thumbnail = thumbnail
 
+        return track_result
+
+    def _ytmusic_hit_to_track_result(self, hit: dict) -> TrackResult:
+        """Map a catalog song hit onto TrackResult. Structured artist/title/album.
+
+        ``filename`` stays ``videoId||title`` so ``download()`` is unchanged.
+        Missing format metadata claims typical Opus 160 (itag 251), or the
+        re-encode output when that setting is on.
+        """
+        claimed = youtube_claimed_quality(None)
+        video_id = str(hit.get("id") or "")
+        title = str(hit.get("name") or "")
+        artists = hit.get("artists") or []
+        artist = artists[0] if artists else "Unknown Artist"
+        album = str(hit.get("album") or "").strip() or None
+        duration_ms = hit.get("duration_ms") or None
+
+        track_result = TrackResult(
+            username="youtube",
+            filename=f"{video_id}||{title}",
+            size=0,
+            bitrate=claimed.bitrate,
+            duration=duration_ms,
+            quality=claimed.format,
+            free_upload_slots=999,
+            upload_speed=999999,
+            queue_length=0,
+            artist=artist,
+            title=title,
+            album=album,
+            track_number=None,
+        )
+        track_result.set_quality(claimed)
+        thumbnail = str(hit.get("thumbnail") or "").strip() or None
+        if thumbnail:
+            track_result.thumbnail = thumbnail
         return track_result
 
     async def search_videos(self, query: str, max_results: int = 20) -> List[YouTubeSearchResult]:
@@ -844,6 +1224,17 @@ class YouTubeClient(DownloadSourcePlugin):
         logger.info(f"Searching YouTube for: {query}")
 
         try:
+            def _catalog_search():
+                from core.youtube_cookies import ytmusic_auth_from_config
+                from core.youtube_music_meta import search_ytmusic_songs
+                return search_ytmusic_songs(query, auth=ytmusic_auth_from_config())
+
+            hits = await run_blocking(_catalog_search)
+            if hits:
+                track_results = [self._ytmusic_hit_to_track_result(hit) for hit in hits]
+                logger.info("Found %d YouTube Music catalog tracks", len(track_results))
+                return (track_results, [])
+
             # Run yt-dlp in executor to avoid blocking event loop
             def _search():
                 ydl_opts = {
@@ -899,20 +1290,182 @@ class YouTubeClient(DownloadSourcePlugin):
             self._record_failure(e, f"search for {query!r}")
             return ([], [])
 
-    def _get_best_audio_format(self, formats: List[Dict]) -> Optional[Dict]:
-        """Extract best audio format from available formats"""
-        if not formats:
+    def _get_best_audio_format(
+        self, formats: List[Dict], tier: Optional[str] = None
+    ) -> Optional[Dict]:
+        """Audio-only itag for the profile's YouTube ladder tier.
+
+        Walks down the same rungs as Qobuz/Deezer when the requested itag is
+        missing (Premium 256 → typical 160/128). Last resort is highest-bitrate
+        audio so ranking can still stamp an honest claim.
+        """
+        return pick_youtube_audio_format(formats, tier)
+
+    _PROBE_INFO_TTL_S = 90.0
+
+    @staticmethod
+    def _video_id_from_candidate(candidate) -> str:
+        filename = getattr(candidate, 'filename', None) or ''
+        if '||' not in filename:
+            return ''
+        return filename.split('||', 1)[0].strip()
+
+    @staticmethod
+    def _video_id_from_url(url: str) -> str:
+        if not url:
+            return ''
+        match = re.search(r'(?:v=|/shorts/|youtu\.be/)([\w-]{11})', url)
+        return match.group(1) if match else ''
+
+    def _probe_quality_cache(self) -> dict:
+        cache = getattr(self, '_yt_probe_quality', None)
+        if cache is None:
+            self._yt_probe_quality = cache = {}
+        return cache
+
+    def _probe_info_cache(self) -> dict:
+        cache = getattr(self, '_yt_probe_info', None)
+        if cache is None:
+            self._yt_probe_info = cache = {}
+        return cache
+
+    def _store_probe(self, video_id: str, claimed, info: Optional[dict]) -> None:
+        if not video_id or claimed is None:
+            return
+        self._probe_quality_cache()[video_id] = (time.monotonic(), claimed)
+        if info:
+            self._probe_info_cache()[video_id] = (time.monotonic(), info)
+
+    def _cached_quality(self, video_id: str):
+        packed = self._probe_quality_cache().get(video_id)
+        if packed is None:
             return None
-
-        # Filter for audio-only formats
-        audio_formats = [f for f in formats if f.get('vcodec') == 'none' and f.get('acodec') != 'none']
-
-        if not audio_formats:
+        if not isinstance(packed, tuple) or len(packed) != 2:
+            self._probe_quality_cache().pop(video_id, None)
             return None
+        stored_at, claimed = packed
+        if (time.monotonic() - stored_at) > self._PROBE_INFO_TTL_S:
+            self._probe_quality_cache().pop(video_id, None)
+            return None
+        return claimed
 
-        # Sort by audio bitrate (tbr = total bitrate, abr = audio bitrate)
-        audio_formats.sort(key=lambda f: f.get('abr', f.get('tbr', 0)), reverse=True)
-        return audio_formats[0]
+    def _take_fresh_probe_info(self, video_id: str) -> Optional[dict]:
+        """Pop a recent player response so download can skip a second extract."""
+        if not video_id:
+            return None
+        cache = getattr(self, '_yt_probe_info', None) or {}
+        packed = cache.pop(video_id, None)
+        if not packed:
+            return None
+        stored_at, info = packed
+        if (time.monotonic() - stored_at) > self._PROBE_INFO_TTL_S:
+            return None
+        return info
+
+    def _stamp_probed_quality(self, candidate, claimed) -> None:
+        candidate.set_quality(claimed)
+        candidate._youtube_quality_probed = True
+
+    def refresh_claimed_quality(self, candidates, *, limit: int = _YOUTUBE_PROBE_BUDGET, targets=None) -> None:
+        """Stamp ranking quality on YouTube matches before profile ranking.
+
+        Search uses extract_flat / catalog metadata, so hits start as typical
+        Opus 160 (or the re-encode output when that setting is on). Player
+        fetches are capped (default 3) and stop early when more itags cannot
+        change the pick — same idea as Soulseek ranking every match, without
+        walking a full search. Premium itags are per-video: remux never copies
+        one video's formats onto another. Re-encode on may share the converted
+        claim. Probe failure leaves the existing claim. Download reuses a
+        fresh player response so ranking and fetch share one extract.
+        """
+        youtube = [
+            c for c in (candidates or [])
+            if getattr(c, 'username', None) == 'youtube'
+        ]
+        if not youtube:
+            return
+
+        def _confidence(c):
+            return getattr(c, 'confidence', None) or getattr(c, '_match_confidence', None) or 0
+
+        youtube.sort(key=_confidence, reverse=True)
+        ydl_opts = {
+            'quiet': True,
+            'no_warnings': True,
+            'skip_download': True,
+            'noplaylist': True,
+        }
+        ydl_opts.update(_resolve_cookie_opts())
+
+        max_network = max(0, int(limit))
+        network = 0
+        batch_claim = None
+        seen_passing = False
+
+        for candidate in youtube:
+            if getattr(candidate, '_youtube_quality_probed', False):
+                continue
+            video_id = self._video_id_from_candidate(candidate)
+            if not video_id:
+                continue
+
+            cached = self._cached_quality(video_id)
+            if cached is not None:
+                self._stamp_probed_quality(candidate, cached)
+                if batch_claim is None:
+                    batch_claim = cached
+                stop, seen_passing = _should_stop_youtube_probes(
+                    cached, targets, seen_passing=seen_passing,
+                )
+                if stop:
+                    break
+                continue
+
+            if network >= max_network:
+                continue
+            url = f"https://www.youtube.com/watch?v={video_id}"
+            try:
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    info = ydl.extract_info(url, download=False)
+            except Exception as e:  # noqa: BLE001 - probe is best-effort
+                logger.info(
+                    "YouTube format probe failed for %s (%s: %s) — keeping claimed quality",
+                    video_id, type(e).__name__, e,
+                )
+                network += 1
+                continue
+            network += 1
+            if not info:
+                continue
+            best = self._get_best_audio_format(info.get('formats') or [])
+            if not best:
+                continue
+            claimed = youtube_claimed_quality(best)
+            self._store_probe(video_id, claimed, info)
+            self._stamp_probed_quality(candidate, claimed)
+            if batch_claim is None:
+                batch_claim = claimed
+            logger.info(
+                "YouTube format probe %s: %s",
+                video_id, claimed.label(),
+            )
+            stop, seen_passing = _should_stop_youtube_probes(
+                claimed, targets, seen_passing=seen_passing,
+            )
+            if stop:
+                break
+
+        if batch_claim is None:
+            return
+        if youtube_transcode_output_quality() is None:
+            return
+        for candidate in youtube:
+            if getattr(candidate, '_youtube_quality_probed', False):
+                continue
+            self._stamp_probed_quality(candidate, batch_claim)
+            video_id = self._video_id_from_candidate(candidate)
+            if video_id:
+                self._store_probe(video_id, batch_claim, None)
 
     def _format_quality_string(self, audio_format: Optional[Dict]) -> str:
         """Format quality info string"""
@@ -1116,11 +1669,17 @@ class YouTubeClient(DownloadSourcePlugin):
                     return None
 
                 try:
-                    # Use default download options
+                    # Use default download options, but rebuild the audio
+                    # postprocessor from live settings so a Settings save
+                    # applies without restarting.
                     download_opts = self.download_opts.copy()
+                    download_opts['postprocessors'] = [youtube_audio_postprocessor_from_config()]
                     
-                    # Force best audio format to prevent 'Requested format not available' errors
-                    download_opts['format'] = 'bestaudio/best'
+                    # Profile-driven original stream (same ladder as Tidal/Deezer).
+                    # Retry 3 still falls back to muxed ``best``.
+                    download_opts['format'] = youtube_audio_format_selector(
+                        youtube_requested_tier()
+                    )
                     download_opts['noplaylist'] = True
 
                     # On retry, try different strategies
@@ -1144,17 +1703,35 @@ class YouTubeClient(DownloadSourcePlugin):
                         download_opts.pop('extractor_args', None)
 
 
-                    # Perform download
+                    # Perform download. Reuse a fresh ranking probe when we
+                    # have one so we don't hit the player API twice for the
+                    # same video; retries always extract from scratch.
                     with yt_dlp.YoutubeDL(download_opts) as ydl:
-                        info = ydl.extract_info(youtube_url, download=True)
+                        info = None
+                        if attempt == 0:
+                            cached = self._take_fresh_probe_info(
+                                self._video_id_from_url(youtube_url)
+                            )
+                            process = getattr(ydl, 'process_ie_result', None)
+                            if cached is not None and callable(process):
+                                try:
+                                    info = process(copy.deepcopy(cached), download=True)
+                                except Exception as e:  # noqa: BLE001 - fall back to extract
+                                    logger.info(
+                                        "YouTube download from cached probe failed (%s: %s) — extracting fresh",
+                                        type(e).__name__, e,
+                                    )
+                                    info = None
+                        if info is None:
+                            info = ydl.extract_info(youtube_url, download=True)
 
-                        # Get final filename (will be MP3 after ffmpeg conversion)
-                        filename = Path(ydl.prepare_filename(info)).with_suffix('.mp3')
+                        filename = resolve_downloaded_audio_path(ydl, info)
 
-                        if filename.exists():
-                            return str(filename)
+                        if filename:
+                            discard_leftover_youtube_containers(filename)
+                            return filename
                         else:
-                            logger.error(f"Download completed but file not found: {filename}")
+                            logger.error("Download completed but audio file not found after extract")
                             if attempt < max_retries - 1:
                                 continue  # Retry
                             return None

--- a/core/youtube_client.py
+++ b/core/youtube_client.py
@@ -1751,30 +1751,44 @@ class YouTubeClient(DownloadSourcePlugin):
                     )
                     download_opts['noplaylist'] = True
 
-                    # On retry, try different strategies
+                    # Skip itags whose CDN URL 403s (Premium 774 is listed
+                    # often, then refused) so the selector can walk down
+                    # without failing the whole download.
+                    download_opts['check_formats'] = 'selected'
+
+                    # Keep cookies on every attempt. Stripping them made
+                    # itag 774/141 disappear, so a probe that ranked Opus 256
+                    # then downloaded anonymous Opus 160 (or failed) and
+                    # Soulseek won the walk.
+                    extra = youtube_authenticated_extractor_args(download_opts)
                     if attempt == 0:
-                        extra = youtube_authenticated_extractor_args(download_opts)
                         if extra:
                             download_opts['extractor_args'] = extra
                     elif attempt == 1:
-                        # Drop cookies — authenticated sessions (browser store OR a
-                        # pasted cookies.txt) sometimes get restricted formats.
-                        if 'cookiesfrombrowser' in download_opts or 'cookiefile' in download_opts:
-                            logger.info(f"Retry {attempt + 1}/{max_retries} without cookies")
-                            download_opts.pop('cookiesfrombrowser', None)
-                            download_opts.pop('cookiefile', None)
-                            download_opts.pop('extractor_args', None)
-                        else:
-                            logger.info(f"Retry {attempt + 1}/{max_retries} with web_creator client")
+                        if extra:
+                            logger.info(
+                                "Retry %s/%s with web_music only (keeping cookies)",
+                                attempt + 1, max_retries,
+                            )
                             download_opts['extractor_args'] = {
-                                'youtube': { 'player_client': ['web_creator'] }
+                                'youtube': {'player_client': ['web_music']},
+                            }
+                        else:
+                            logger.info(
+                                "Retry %s/%s with web_creator client",
+                                attempt + 1, max_retries,
+                            )
+                            download_opts['extractor_args'] = {
+                                'youtube': {'player_client': ['web_creator']},
                             }
                     elif attempt >= 2:
-                        logger.info(f"Retry {attempt + 1}/{max_retries} with 'best' format (video fallback)")
+                        logger.info(
+                            "Retry %s/%s with 'best' format (keeping cookies)",
+                            attempt + 1, max_retries,
+                        )
                         download_opts['format'] = 'best'
-                        download_opts.pop('cookiesfrombrowser', None)
-                        download_opts.pop('cookiefile', None)
-                        download_opts.pop('extractor_args', None)
+                        if extra:
+                            download_opts['extractor_args'] = extra
 
 
                     # Perform download. Ranking already probed itags; fetch

--- a/core/youtube_client.py
+++ b/core/youtube_client.py
@@ -13,7 +13,6 @@ This client provides:
 import sys
 import os
 import re
-import copy
 import time
 import platform
 import uuid
@@ -54,6 +53,74 @@ def _resolve_cookie_opts() -> dict:
     cookiefile = config_manager.get('youtube.cookies_file', '')
     exists = bool(cookiefile) and os.path.exists(cookiefile)
     return build_youtube_cookie_opts(mode, cookiefile, cookiefile_exists=exists)
+
+
+def youtube_authenticated_extractor_args(opts: Optional[dict] = None) -> dict:
+    """yt-dlp extractor_args that can surface Music Premium itags.
+
+    itag 774 (Opus ~256) and 141 (AAC ~256) are on the ``web_music`` player,
+    not yt-dlp's default youtube.com clients. Cookies are not Premium: this
+    only adds the client that *can* return those itags. Ranking still stamps
+    whatever the player actually sent (251 stays Opus 160).
+
+    Anonymous extracts skip ``web_music`` — yt-dlp maintainers keep it off
+    the default list because it is an extra request and only useful when
+    authenticated.
+    """
+    opts = opts or {}
+    if not opts.get('cookiefile') and not opts.get('cookiesfrombrowser'):
+        return {}
+    return {
+        'youtube': {
+            'player_client': ['web_music', 'default'],
+        }
+    }
+
+
+def youtube_probe_auth_label(opts: Optional[dict] = None) -> str:
+    """Short probe-log token. Never includes cookie values or paths."""
+    opts = opts or {}
+    if opts.get('cookiefile'):
+        return 'cookiefile'
+    browser = opts.get('cookiesfrombrowser')
+    if browser:
+        name = browser[0] if isinstance(browser, (tuple, list)) else browser
+        return f'browser:{name}'
+    return 'none'
+
+
+class _YtdlpProbeLog:
+    """Forward yt-dlp auth / PO-token warnings without dumping cookies."""
+
+    _KEEP = ('PO Token', 'Skipping client', 'YouTube account', 'Premium')
+
+    def debug(self, msg):
+        text = str(msg)
+        if 'Cookie:' in text or 'SAPISID=' in text:
+            return
+        if any(token in text for token in self._KEEP):
+            logger.info("yt-dlp %s", text)
+
+    info = debug
+
+    def warning(self, msg):
+        text = str(msg)
+        if 'Cookie:' in text or 'SAPISID=' in text:
+            return
+        logger.info("yt-dlp %s", text)
+
+    def error(self, msg):
+        self.warning(msg)
+
+
+def _audio_itag_summary(formats: Optional[List[Dict]]) -> str:
+    ids = []
+    for fmt in formats or []:
+        if fmt.get('vcodec') == 'none' and fmt.get('acodec') not in (None, 'none'):
+            fid = fmt.get('format_id')
+            if fid:
+                ids.append(str(fid))
+    return ','.join(ids) if ids else 'none'
 
 
 _TRANSCODE_CODECS = frozenset({'mp3', 'opus', 'aac', 'm4a', 'ogg'})
@@ -1333,8 +1400,8 @@ class YouTubeClient(DownloadSourcePlugin):
         if not video_id or claimed is None:
             return
         self._probe_quality_cache()[video_id] = (time.monotonic(), claimed)
-        if info:
-            self._probe_info_cache()[video_id] = (time.monotonic(), info)
+        # Player JSON is ranking-only. skip_download URLs (especially itag
+        # 774) 403 when a later YoutubeDL calls process_ie_result.
 
     def _cached_quality(self, video_id: str):
         packed = self._probe_quality_cache().get(video_id)
@@ -1349,19 +1416,6 @@ class YouTubeClient(DownloadSourcePlugin):
             return None
         return claimed
 
-    def _take_fresh_probe_info(self, video_id: str) -> Optional[dict]:
-        """Pop a recent player response so download can skip a second extract."""
-        if not video_id:
-            return None
-        cache = getattr(self, '_yt_probe_info', None) or {}
-        packed = cache.pop(video_id, None)
-        if not packed:
-            return None
-        stored_at, info = packed
-        if (time.monotonic() - stored_at) > self._PROBE_INFO_TTL_S:
-            return None
-        return info
-
     def _stamp_probed_quality(self, candidate, claimed) -> None:
         candidate.set_quality(claimed)
         candidate._youtube_quality_probed = True
@@ -1375,8 +1429,9 @@ class YouTubeClient(DownloadSourcePlugin):
         change the pick — same idea as Soulseek ranking every match, without
         walking a full search. Premium itags are per-video: remux never copies
         one video's formats onto another. Re-encode on may share the converted
-        claim. Probe failure leaves the existing claim. Download reuses a
-        fresh player response so ranking and fetch share one extract.
+        claim. Probe failure leaves the existing claim. Download always
+        extracts fresh — skip_download probe URLs (especially itag 774)
+        403 if a later YoutubeDL tries to fetch them.
         """
         youtube = [
             c for c in (candidates or [])
@@ -1396,6 +1451,18 @@ class YouTubeClient(DownloadSourcePlugin):
             'noplaylist': True,
         }
         ydl_opts.update(_resolve_cookie_opts())
+        extractor_args = youtube_authenticated_extractor_args(ydl_opts)
+        if extractor_args:
+            ydl_opts['extractor_args'] = extractor_args
+        auth_label = youtube_probe_auth_label(ydl_opts)
+        if auth_label == 'none':
+            logger.info(
+                "YouTube format probe auth=none — Premium itags 774/141 need "
+                "Settings → YouTube → Paste cookies.txt (a browser dropdown "
+                "does nothing in Docker)"
+            )
+        ydl_opts['logger'] = _YtdlpProbeLog()
+        ydl_opts['no_warnings'] = False
 
         max_network = max(0, int(limit))
         network = 0
@@ -1446,8 +1513,10 @@ class YouTubeClient(DownloadSourcePlugin):
             if batch_claim is None:
                 batch_claim = claimed
             logger.info(
-                "YouTube format probe %s: %s",
+                "YouTube format probe %s: %s (itags %s, auth=%s)",
                 video_id, claimed.label(),
+                _audio_itag_summary(info.get('formats')),
+                auth_label,
             )
             stop, seen_passing = _should_stop_youtube_probes(
                 claimed, targets, seen_passing=seen_passing,
@@ -1683,13 +1752,18 @@ class YouTubeClient(DownloadSourcePlugin):
                     download_opts['noplaylist'] = True
 
                     # On retry, try different strategies
-                    if attempt == 1:
+                    if attempt == 0:
+                        extra = youtube_authenticated_extractor_args(download_opts)
+                        if extra:
+                            download_opts['extractor_args'] = extra
+                    elif attempt == 1:
                         # Drop cookies — authenticated sessions (browser store OR a
                         # pasted cookies.txt) sometimes get restricted formats.
                         if 'cookiesfrombrowser' in download_opts or 'cookiefile' in download_opts:
                             logger.info(f"Retry {attempt + 1}/{max_retries} without cookies")
                             download_opts.pop('cookiesfrombrowser', None)
                             download_opts.pop('cookiefile', None)
+                            download_opts.pop('extractor_args', None)
                         else:
                             logger.info(f"Retry {attempt + 1}/{max_retries} with web_creator client")
                             download_opts['extractor_args'] = {
@@ -1703,27 +1777,10 @@ class YouTubeClient(DownloadSourcePlugin):
                         download_opts.pop('extractor_args', None)
 
 
-                    # Perform download. Reuse a fresh ranking probe when we
-                    # have one so we don't hit the player API twice for the
-                    # same video; retries always extract from scratch.
+                    # Perform download. Ranking already probed itags; fetch
+                    # always extracts fresh. Probe URLs 403 if reused here.
                     with yt_dlp.YoutubeDL(download_opts) as ydl:
-                        info = None
-                        if attempt == 0:
-                            cached = self._take_fresh_probe_info(
-                                self._video_id_from_url(youtube_url)
-                            )
-                            process = getattr(ydl, 'process_ie_result', None)
-                            if cached is not None and callable(process):
-                                try:
-                                    info = process(copy.deepcopy(cached), download=True)
-                                except Exception as e:  # noqa: BLE001 - fall back to extract
-                                    logger.info(
-                                        "YouTube download from cached probe failed (%s: %s) — extracting fresh",
-                                        type(e).__name__, e,
-                                    )
-                                    info = None
-                        if info is None:
-                            info = ydl.extract_info(youtube_url, download=True)
+                        info = ydl.extract_info(youtube_url, download=True)
 
                         filename = resolve_downloaded_audio_path(ydl, info)
 

--- a/core/youtube_client.py
+++ b/core/youtube_client.py
@@ -1743,6 +1743,14 @@ class YouTubeClient(DownloadSourcePlugin):
                     # applies without restarting.
                     download_opts = self.download_opts.copy()
                     download_opts['postprocessors'] = [youtube_audio_postprocessor_from_config()]
+                    pp = download_opts['postprocessors'][0]
+                    if pp.get('preferredcodec') == 'best':
+                        logger.info("YouTube extract: remux original Opus/AAC (re-encode off)")
+                    else:
+                        logger.info(
+                            "YouTube extract: transcode to %s %s",
+                            pp.get('preferredcodec'), pp.get('preferredquality'),
+                        )
                     
                     # Profile-driven original stream (same ladder as Tidal/Deezer).
                     # Retry 3 still falls back to muxed ``best``.

--- a/core/youtube_client.py
+++ b/core/youtube_client.py
@@ -204,7 +204,7 @@ _YOUTUBE_TIER_SELECTORS = {
 def _youtube_transcode_settings() -> tuple:
     """Live YouTube re-encode settings. Never raises — missing config is MP3 320."""
     try:
-        from config.settings import config_manager
+        from core.settings import config_manager
         transcode = bool(config_manager.get('youtube.transcode', True))
         codec = str(config_manager.get('youtube.transcode_codec', 'mp3') or 'mp3')
         bitrate = str(config_manager.get('youtube.transcode_bitrate', '320') or '320')
@@ -1203,6 +1203,7 @@ class YouTubeClient(DownloadSourcePlugin):
             title=title,
             album=album,
             track_number=None,
+            _source_metadata={"source": "youtube", "catalog": True},
         )
         track_result.set_quality(claimed)
         thumbnail = str(hit.get("thumbnail") or "").strip() or None
@@ -1276,7 +1277,8 @@ class YouTubeClient(DownloadSourcePlugin):
             logger.error(f"YouTube video search failed: {e}")
             return []
 
-    async def search(self, query: str, timeout: int = None, progress_callback=None) -> tuple[List[TrackResult], List[AlbumResult]]:
+    async def search(self, query: str, timeout: int = None, progress_callback=None,
+                     *, use_catalog: bool = True) -> tuple[List[TrackResult], List[AlbumResult]]:
         """
         Search YouTube for tracks matching the query (async, Soulseek-compatible interface).
 
@@ -1284,6 +1286,10 @@ class YouTubeClient(DownloadSourcePlugin):
             query: Search query (e.g., "Artist Name - Song Title")
             timeout: Ignored for YouTube (kept for interface compatibility)
             progress_callback: Optional callback for progress updates
+            use_catalog: When True (default), prefer YouTube Music catalog hits
+                and skip ytsearch. Pass False after a catalog batch that the
+                matcher rejected — remixes that exist as videos but not in the
+                Music catalog only show up on ytsearch.
 
         Returns:
             Tuple of (track_results, album_results). Album results will always be empty for YouTube.
@@ -1291,16 +1297,17 @@ class YouTubeClient(DownloadSourcePlugin):
         logger.info(f"Searching YouTube for: {query}")
 
         try:
-            def _catalog_search():
-                from core.youtube_cookies import ytmusic_auth_from_config
-                from core.youtube_music_meta import search_ytmusic_songs
-                return search_ytmusic_songs(query, auth=ytmusic_auth_from_config())
+            if use_catalog:
+                def _catalog_search():
+                    from core.youtube_cookies import ytmusic_auth_from_config
+                    from core.youtube_music_meta import search_ytmusic_songs
+                    return search_ytmusic_songs(query, auth=ytmusic_auth_from_config())
 
-            hits = await run_blocking(_catalog_search)
-            if hits:
-                track_results = [self._ytmusic_hit_to_track_result(hit) for hit in hits]
-                logger.info("Found %d YouTube Music catalog tracks", len(track_results))
-                return (track_results, [])
+                hits = await run_blocking(_catalog_search)
+                if hits:
+                    track_results = [self._ytmusic_hit_to_track_result(hit) for hit in hits]
+                    logger.info("Found %d YouTube Music catalog tracks", len(track_results))
+                    return (track_results, [])
 
             # Run yt-dlp in executor to avoid blocking event loop
             def _search():
@@ -1764,10 +1771,13 @@ class YouTubeClient(DownloadSourcePlugin):
                     # without failing the whole download.
                     download_opts['check_formats'] = 'selected'
 
-                    # Keep cookies on every attempt. Stripping them made
-                    # itag 774/141 disappear, so a probe that ranked Opus 256
-                    # then downloaded anonymous Opus 160 (or failed) and
-                    # Soulseek won the walk.
+                    # Keep cookies on attempts 1–2 so Premium itags stay in
+                    # the player response. The old cookie-strip on first 403
+                    # made 774/141 vanish and ranked Opus 256 as Opus 160.
+                    # Last attempt drops cookies: expired / bot-flagged
+                    # cookies otherwise poison every retry. Import still
+                    # probes the file on disk, so a last-ditch 160 cannot
+                    # keep an Opus-256 chip.
                     extra = youtube_authenticated_extractor_args(download_opts)
                     if attempt == 0:
                         if extra:
@@ -1790,13 +1800,20 @@ class YouTubeClient(DownloadSourcePlugin):
                                 'youtube': {'player_client': ['web_creator']},
                             }
                     elif attempt >= 2:
-                        logger.info(
-                            "Retry %s/%s with 'best' format (keeping cookies)",
-                            attempt + 1, max_retries,
-                        )
                         download_opts['format'] = 'best'
                         if extra:
-                            download_opts['extractor_args'] = extra
+                            logger.info(
+                                "Retry %s/%s with 'best' format (dropping cookies)",
+                                attempt + 1, max_retries,
+                            )
+                            download_opts.pop('cookiefile', None)
+                            download_opts.pop('cookiesfrombrowser', None)
+                            download_opts.pop('extractor_args', None)
+                        else:
+                            logger.info(
+                                "Retry %s/%s with 'best' format",
+                                attempt + 1, max_retries,
+                            )
 
 
                     # Perform download. Ranking already probed itags; fetch

--- a/core/youtube_cookies.py
+++ b/core/youtube_cookies.py
@@ -198,6 +198,23 @@ def ytmusic_auth_from_cookiefile(path: Any) -> Optional[Dict[str, str]]:
     return ytmusic_auth_headers(parse_netscape_cookies(content))
 
 
+def ytmusic_auth_from_config() -> Optional[Dict[str, str]]:
+    """ytmusicapi headers from Settings → YouTube cookies, or ``None`` (anonymous).
+
+    Same PASTE_MODE + cookies_file rule as the playlist import path: only a
+    pasted cookies.txt can be projected into headers. ``cookiesfrombrowser`` is
+    yt-dlp's reader and leaves no file for us to hash. Public catalog search
+    still works with ``None``.
+    """
+    try:
+        from config.settings import config_manager
+        if str(config_manager.get("youtube.cookies_browser", "") or "").strip() != PASTE_MODE:
+            return None
+        return ytmusic_auth_from_cookiefile(config_manager.get("youtube.cookies_file", ""))
+    except Exception:  # noqa: BLE001 - auth is best-effort; anonymous still works
+        return None
+
+
 __all__ = [
     "PASTE_MODE",
     "build_youtube_cookie_opts",
@@ -206,4 +223,5 @@ __all__ = [
     "parse_netscape_cookies",
     "ytmusic_auth_headers",
     "ytmusic_auth_from_cookiefile",
+    "ytmusic_auth_from_config",
 ]

--- a/core/youtube_cookies.py
+++ b/core/youtube_cookies.py
@@ -207,7 +207,7 @@ def ytmusic_auth_from_config() -> Optional[Dict[str, str]]:
     still works with ``None``.
     """
     try:
-        from config.settings import config_manager
+        from core.settings import config_manager
         if str(config_manager.get("youtube.cookies_browser", "") or "").strip() != PASTE_MODE:
             return None
         return ytmusic_auth_from_cookiefile(config_manager.get("youtube.cookies_file", ""))

--- a/core/youtube_music_meta.py
+++ b/core/youtube_music_meta.py
@@ -31,8 +31,9 @@ Scope, deliberately narrow:
   comes back with the uploader's channel as the artist and no album — exactly
   what the yt-dlp path would have produced, so those entries are no worse.
 
-The projection (``ytmusic_playlist_to_payload``) is a pure function over the
-API's response so the field mapping is unit-testable without network.
+The projection (``ytmusic_playlist_to_payload``, ``ytmusic_search_hit_to_track``)
+is a pure function over the API's response so the field mapping is
+unit-testable without network.
 """
 
 from __future__ import annotations
@@ -92,6 +93,114 @@ def _album_name(track: Mapping[str, Any]) -> str:
     if isinstance(album, Mapping):
         return str(album.get("name") or "").strip()
     return str(album or "").strip()
+
+
+def _parse_duration_string(text: str) -> Optional[int]:
+    """``"M:SS"`` / ``"H:MM:SS"`` → milliseconds, or ``None`` if unparseable."""
+    parts = text.split(":")
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    nums = [int(p) for p in parts]
+    if len(nums) == 2:
+        minutes, seconds = nums
+        return (minutes * 60 + seconds) * 1000
+    if len(nums) == 3:
+        hours, minutes, seconds = nums
+        return (hours * 3600 + minutes * 60 + seconds) * 1000
+    return None
+
+
+def _duration_ms(track: Mapping[str, Any]) -> int:
+    """Milliseconds from ``duration_seconds``, else a ``duration`` timestamp."""
+    seconds = track.get("duration_seconds")
+    try:
+        if seconds:
+            return int(seconds) * 1000
+    except (TypeError, ValueError):
+        pass
+    duration = track.get("duration")
+    if isinstance(duration, str) and duration.strip():
+        parsed = _parse_duration_string(duration.strip())
+        if parsed is not None:
+            return parsed
+    return 0
+
+
+def _thumbnail_url(hit: Mapping[str, Any]) -> str:
+    thumbnails = hit.get("thumbnails") or []
+    if thumbnails and isinstance(thumbnails[-1], Mapping):
+        return str(thumbnails[-1].get("url") or "")
+    return ""
+
+
+def ytmusic_search_hit_to_track(hit: Any) -> Optional[Dict[str, Any]]:
+    """Project one ytmusicapi ``search(filter='songs')`` hit, or ``None``.
+
+    Pure. Requires a ``videoId`` and a title — a song without an id cannot be
+    downloaded, and a nameless row is not a match. Duration prefers
+    ``duration_seconds`` and otherwise parses ``"M:SS"`` / ``"H:MM:SS"``.
+    """
+    if not isinstance(hit, Mapping):
+        return None
+    video_id = str(hit.get("videoId") or "").strip()
+    title = str(hit.get("title") or "").strip()
+    if not video_id or not title:
+        return None
+
+    names = _artist_names(hit)
+    return {
+        "id": video_id,
+        "name": title,
+        "artists": names or ["Unknown Artist"],
+        "album": _album_name(hit),
+        "duration_ms": _duration_ms(hit),
+        "video_type": str(hit.get("videoType") or ""),
+        "thumbnail": _thumbnail_url(hit),
+        "url": f"https://www.youtube.com/watch?v={video_id}",
+    }
+
+
+def search_ytmusic_songs(
+    query: str, auth: Optional[Dict[str, str]] = None, limit: int = 50
+) -> Optional[List[Dict[str, Any]]]:
+    """Search the YouTube Music catalog for songs, or ``None`` on any failure.
+
+    Never raises. A missing ytmusicapi, a network blip, an empty result, and an
+    upstream shape change all mean the same thing to the caller — use yt-dlp
+    ``ytsearch``. A non-empty list means catalog search worked; do not also
+    call ytsearch. Official audio (``MUSIC_VIDEO_TYPE_ATV``) is sorted first.
+    """
+    if not isinstance(query, str) or not query.strip():
+        return None
+
+    try:
+        from ytmusicapi import YTMusic
+    except ImportError:
+        logger.debug("ytmusicapi not installed — using yt-dlp search for %r", query)
+        return None
+
+    try:
+        client = YTMusic(auth) if auth else YTMusic()
+        raw = client.search(query.strip(), filter="songs", limit=limit)
+    except Exception as e:  # noqa: BLE001 - see docstring: all failures fall back
+        logger.info(
+            "YouTube Music song search failed (%s: %s) — falling back to ytsearch",
+            type(e).__name__, e,
+        )
+        return None
+
+    tracks: List[Dict[str, Any]] = []
+    for hit in raw or []:
+        projected = ytmusic_search_hit_to_track(hit)
+        if projected:
+            tracks.append(projected)
+
+    if not tracks:
+        return None
+
+    tracks.sort(key=lambda t: 0 if t.get("video_type") == "MUSIC_VIDEO_TYPE_ATV" else 1)
+    logger.info("YouTube Music search: %d songs for %r", len(tracks), query)
+    return tracks
 
 
 def ytmusic_playlist_to_payload(
@@ -215,4 +324,6 @@ __all__ = [
     "playlist_id_from_url",
     "ytmusic_playlist_to_payload",
     "fetch_ytmusic_playlist",
+    "ytmusic_search_hit_to_track",
+    "search_ytmusic_songs",
 ]

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -15017,7 +15017,8 @@ class MusicDatabase:
                         ORDER BY track_number, title
                     """, (album_data['id'],))
                     track_rows = cursor.fetchall()
-                    album_data['tracks'] = [dict(tr) for tr in track_rows]
+                    from core.imports.file_ops import fill_missing_track_bitrate
+                    album_data['tracks'] = [fill_missing_track_bitrate(dict(tr)) for tr in track_rows]
 
                     # Determine record type from data if not set
                     if not album_data.get('record_type'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,12 @@ ignore = [
 
 [tool.pytest.ini_options]
 # Live/network integration tests are OPT-IN only. A `@pytest.mark.soundcloud_live`
-# does NOT auto-exclude a test — a bare `pytest` still runs it — so the default
-# run (and CI's `python -m pytest`) filters them out here. Run them explicitly
-# with `pytest -m soundcloud_live` (the command-line -m overrides this default).
-addopts = "-m 'not soundcloud_live'"
+# (or youtube_live) does NOT auto-exclude a test — a bare `pytest` still runs it —
+# so the default run (and CI's `python -m pytest`) filters them out here. Run them
+# explicitly with `pytest -m soundcloud_live` / `pytest -m youtube_live`
+# (the command-line -m overrides this default).
+addopts = "-m 'not soundcloud_live and not youtube_live'"
 markers = [
     "soundcloud_live: live SoundCloud integration test (network-dependent, run with -m soundcloud_live)",
+    "youtube_live: live YouTube probe/download test (network-dependent, run with -m youtube_live)",
 ]

--- a/tests/downloads/test_candidate_ordering.py
+++ b/tests/downloads/test_candidate_ordering.py
@@ -67,3 +67,60 @@ def test_quality_first_ranks_unmatched_quality_last():
     ordered = order_candidates([off_list, matched], quality_first=True, targets=TARGETS)
 
     assert [c.name for c in ordered] == ['matched', 'off']  # off-list sorts last despite high confidence
+
+
+# User Audiophile ladder: Opus ≥192 is the top target. YouTube itag 774 is
+# Opus 256. Soulseek FLAC matches a later rung and must not win the walk.
+AUDIOPHILE = [
+    QualityTarget(label='OPUS ≥ 192', format='opus', min_bitrate=192),
+    QualityTarget(label='AAC ≥ 192', format='aac', min_bitrate=192),
+    QualityTarget(label='MP3 ≥ 256', format='mp3', min_bitrate=256),
+    QualityTarget(label='MP3 ≥ 320', format='mp3', min_bitrate=320),
+    QualityTarget(label='FLAC 16', format='flac', bit_depth=16),
+    QualityTarget(label='FLAC 24', format='flac', bit_depth=24, min_sample_rate=44100),
+]
+
+
+class _NamedCand(_Cand):
+    def __init__(self, name, aq, confidence, username, **kw):
+        super().__init__(name, aq, confidence, **kw)
+        self.username = username
+
+
+def test_quality_first_youtube_774_beats_soulseek_flac():
+    yt = _NamedCand('yt', AudioQuality('opus', bitrate=256), 0.80, 'youtube')
+    peer = _NamedCand(
+        'flac', AudioQuality('flac', sample_rate=44100, bit_depth=16), 0.99, 'alice',
+        quality_score=1.0,
+    )
+
+    ordered = order_candidates([peer, yt], quality_first=True, targets=AUDIOPHILE)
+
+    assert [c.name for c in ordered] == ['yt', 'flac']
+
+
+def test_mixed_pool_ranks_by_profile_even_in_priority_mode():
+    """Best-quality search concatenates YouTube + Soulseek. A confidence-first
+    walk uses quality_score (FLAC 1.0, Opus 0.3) and would always pick the
+    peer — even when itag 774 matches the top target."""
+    yt = _NamedCand('yt', AudioQuality('opus', bitrate=256), 0.80, 'youtube')
+    peer = _NamedCand(
+        'flac', AudioQuality('flac', sample_rate=44100, bit_depth=16), 0.99, 'alice',
+        quality_score=1.0,
+    )
+
+    ordered = order_candidates([peer, yt], quality_first=False, targets=AUDIOPHILE)
+
+    assert [c.name for c in ordered] == ['yt', 'flac']
+
+
+def test_same_target_prefers_earlier_hybrid_source():
+    yt = _NamedCand('yt', AudioQuality('mp3', bitrate=320), 0.70, 'youtube')
+    peer = _NamedCand('slsk', AudioQuality('mp3', bitrate=320), 0.95, 'alice')
+
+    ordered = order_candidates(
+        [peer, yt], quality_first=True, targets=AUDIOPHILE,
+        source_order=['youtube', 'soulseek'],
+    )
+
+    assert [c.name for c in ordered] == ['yt', 'slsk']

--- a/tests/downloads/test_download_orchestrator.py
+++ b/tests/downloads/test_download_orchestrator.py
@@ -229,6 +229,286 @@ def test_reload_settings_refreshes_registry_plugins(monkeypatch):
     assert usenet.reload_calls == 1
 
 
+def test_search_and_download_best_does_not_fetch_when_profile_rejects_youtube(monkeypatch):
+    """Fallback off + no matching target must not fall through to `or scored`."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from core.download_plugins.types import TrackResult
+    from core.quality.model import AudioQuality
+
+    hit = TrackResult(
+        username='youtube',
+        filename='vid1||Song',
+        size=0,
+        bitrate=160,
+        duration=180_000,
+        quality='opus',
+        free_upload_slots=1,
+        upload_speed=1,
+        queue_length=0,
+        artist='Artist',
+        title='Song',
+    )
+    hit.set_quality(AudioQuality(format='opus', bitrate=160))
+
+    class _YT(_FakeClient):
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            return None
+
+    youtube = _YT()
+    orch = _build_orchestrator(youtube=youtube)
+    orch.mode = 'youtube'
+
+    async def _search(*_a, **_k):
+        return [hit], []
+
+    downloaded = []
+
+    async def _download(*a, **_k):
+        downloaded.append(a)
+        return 'dl-id'
+
+    orch.search = _search
+    orch.download = _download
+    monkeypatch.setattr(
+        'core.quality.selection.rank_for_profile',
+        lambda _cands: ([], False),
+    )
+    monkeypatch.setattr(
+        'core.matching_engine.MusicMatchingEngine.score_track_match',
+        lambda self, **_kw: (0.99, 'ok'),
+    )
+
+    expected = SimpleNamespace(name='Song', artists=['Artist'], duration_ms=180_000)
+    result = asyncio.run(orch.search_and_download_best('Artist Song', expected))
+    assert result is None
+    assert downloaded == []
+
+
+def test_search_and_download_best_ranks_only_close_youtube_matches(monkeypatch):
+    """Distant YouTube hits must not enter rank_for_profile."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from core.download_plugins.types import TrackResult
+    from core.quality.model import AudioQuality
+
+    def _hit(filename, title, bitrate):
+        row = TrackResult(
+            username='youtube',
+            filename=filename,
+            size=0,
+            bitrate=bitrate,
+            duration=180_000,
+            quality='opus',
+            free_upload_slots=1,
+            upload_speed=1,
+            queue_length=0,
+            artist='Artist',
+            title=title,
+        )
+        row.set_quality(AudioQuality(format='opus', bitrate=bitrate))
+        return row
+
+    top = _hit('aaaaaaaaaaa||Song', 'Song', 160)
+    far = _hit('bbbbbbbbbbb||Other', 'Other', 256)
+    probed = []
+
+    class _YT(_FakeClient):
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            probed.extend(candidates)
+
+    youtube = _YT()
+    orch = _build_orchestrator(youtube=youtube)
+    orch.mode = 'youtube'
+
+    async def _search(*_a, **_k):
+        return [top, far], []
+
+    downloaded = []
+
+    async def _download(*a, **_k):
+        downloaded.append(a)
+        return 'dl-id'
+
+    orch.search = _search
+    orch.download = _download
+    ranked_args = []
+    monkeypatch.setattr(
+        'core.quality.selection.rank_for_profile',
+        lambda cands: (ranked_args.append(list(cands)) or cands, True),
+    )
+    monkeypatch.setattr(
+        'core.matching_engine.MusicMatchingEngine.score_track_match',
+        lambda self, **kw: (0.62, 'ok') if kw.get('candidate_title') == 'Other' else (0.92, 'ok'),
+    )
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([], True),
+    )
+
+    expected = SimpleNamespace(name='Song', artists=['Artist'], duration_ms=180_000)
+    result = asyncio.run(orch.search_and_download_best('Artist Song', expected))
+    assert result == 'dl-id'
+    assert ranked_args and ranked_args[0] == [top]
+    assert probed == [top]
+    assert downloaded and downloaded[0][1] == top.filename
+
+
+def test_search_and_download_best_does_not_band_non_youtube_in_hybrid(monkeypatch):
+    """A closer YouTube hit must not drop a Tidal match in best-quality hybrid."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from core.download_plugins.types import TrackResult
+    from core.quality.model import AudioQuality
+
+    def _hit(username, filename, title, quality, bitrate, duration=180_000):
+        row = TrackResult(
+            username=username,
+            filename=filename,
+            size=0,
+            bitrate=bitrate,
+            duration=duration,
+            quality=quality,
+            free_upload_slots=1,
+            upload_speed=1,
+            queue_length=0,
+            artist='Artist',
+            title=title,
+        )
+        row.set_quality(AudioQuality(format=quality, bitrate=bitrate))
+        return row
+
+    yt_top = _hit('youtube', 'aaaaaaaaaaa||Song', 'Song', 'opus', 160)
+    yt_far = _hit('youtube', 'bbbbbbbbbbb||Other', 'Other', 'opus', 256)
+    tidal = _hit('tidal', 'tid||Song', 'Song', 'flac', 1411, duration=181_000)
+    probed = []
+
+    class _YT(_FakeClient):
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            probed.extend(candidates)
+
+    youtube = _YT()
+    orch = _build_orchestrator(youtube=youtube, tidal=_FakeClient())
+    orch.mode = 'hybrid'
+
+    async def _search(*_a, **_k):
+        return [yt_top, yt_far, tidal], []
+
+    async def _download(*a, **_k):
+        return 'dl-id'
+
+    orch.search = _search
+    orch.download = _download
+    ranked_args = []
+    monkeypatch.setattr(
+        'core.quality.selection.rank_for_profile',
+        lambda cands: (ranked_args.append(list(cands)) or cands, True),
+    )
+
+    def _score(self, **kw):
+        if kw.get('candidate_title') == 'Other':
+            return (0.62, 'ok')
+        if kw.get('candidate_duration_ms') == 181_000:
+            return (0.70, 'ok')
+        return (0.92, 'ok')
+
+    monkeypatch.setattr(
+        'core.matching_engine.MusicMatchingEngine.score_track_match',
+        _score,
+    )
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([], True),
+    )
+
+    expected = SimpleNamespace(name='Song', artists=['Artist'], duration_ms=180_000)
+    result = asyncio.run(orch.search_and_download_best('Artist Song', expected))
+    assert result == 'dl-id'
+    ranked = ranked_args[0]
+    assert tidal in ranked
+    assert yt_top in ranked
+    assert yt_far not in ranked
+    assert probed == [yt_top]
+
+
+def test_search_and_download_best_scores_each_source_when_soulseek_is_first(monkeypatch):
+    """A Soulseek peer first must not send Tidal/YouTube through the P2P quality filter."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from core.download_plugins.types import TrackResult
+    from core.quality.model import AudioQuality
+
+    def _hit(username, filename, title, quality, bitrate):
+        row = TrackResult(
+            username=username,
+            filename=filename,
+            size=0,
+            bitrate=bitrate,
+            duration=180_000,
+            quality=quality,
+            free_upload_slots=1,
+            upload_speed=1,
+            queue_length=0,
+            artist='Artist',
+            title=title,
+        )
+        row.set_quality(AudioQuality(format=quality, bitrate=bitrate))
+        return row
+
+    peer = _hit('alice', 'Artist/Album/01 - Song.flac', 'Song', 'flac', 1411)
+    yt = _hit('youtube', 'aaaaaaaaaaa||Song', 'Song', 'opus', 160)
+    tidal = _hit('tidal', 'tid||Song', 'Song', 'flac', 1411)
+    slsk_filtered = []
+    probed = []
+
+    class _Slsk(_FakeClient):
+        def filter_results_by_quality_preference(self, tracks):
+            slsk_filtered.extend(tracks)
+            return list(tracks)
+
+    class _YT(_FakeClient):
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            probed.extend(candidates)
+
+    orch = _build_orchestrator(soulseek=_Slsk(), youtube=_YT(), tidal=_FakeClient())
+    orch.mode = 'hybrid'
+
+    async def _search(*_a, **_k):
+        return [peer, yt, tidal], []
+
+    async def _download(*a, **_k):
+        return 'dl-id'
+
+    orch.search = _search
+    orch.download = _download
+    ranked_args = []
+    monkeypatch.setattr(
+        'core.quality.selection.rank_for_profile',
+        lambda cands: (ranked_args.append(list(cands)) or cands, True),
+    )
+    monkeypatch.setattr(
+        'core.matching_engine.MusicMatchingEngine.score_track_match',
+        lambda self, **_kw: (0.92, 'ok'),
+    )
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([], True),
+    )
+
+    expected = SimpleNamespace(name='Song', artists=['Artist'], duration_ms=180_000)
+    result = asyncio.run(orch.search_and_download_best('Artist Song', expected))
+    assert result == 'dl-id'
+    assert slsk_filtered == [peer]
+    assert yt in (ranked_args[0] if ranked_args else [])
+    assert tidal in (ranked_args[0] if ranked_args else [])
+    assert peer in (ranked_args[0] if ranked_args else [])
+    assert probed == [yt]
+
+
 # ---------------------------------------------------------------------------
 # Singleton factory (matches Cin's get_metadata_engine pattern)
 # ---------------------------------------------------------------------------

--- a/tests/downloads/test_downloads_task_worker.py
+++ b/tests/downloads/test_downloads_task_worker.py
@@ -824,3 +824,80 @@ def test_duplicate_queries_deduplicated_case_insensitive():
     # 'x' and 'X' dedupe to one search per case-insensitive match
     queries_lower = [q.lower() for q, _ in sk.search_calls]
     assert queries_lower.count('x') == 1
+
+
+class _CatalogHit:
+    username = 'youtube'
+    _source_metadata = {'source': 'youtube', 'catalog': True}
+
+
+class _YtsearchHit:
+    username = 'youtube'
+    _source_metadata = {'source': 'youtube'}
+
+
+class _FakeYouTubeSearch:
+    def __init__(self, extra):
+        self.extra = extra
+        self.calls = []
+
+    async def search(self, query, timeout=30, use_catalog=True):
+        self.calls.append((query, timeout, use_catalog))
+        return (self.extra, [])
+
+
+def test_ytsearch_fallback_after_catalog_matcher_miss():
+    extra = [_YtsearchHit()]
+    yt = _FakeYouTubeSearch(extra)
+    orch = _FakeClient(subclients={'youtube': yt})
+    seen = []
+
+    def _valid(results, track, query):
+        seen.append(results)
+        if results is extra:
+            return [{'username': 'youtube', 'filename': 'remix'}]
+        return []
+
+    deps, _ = _build_deps(soulseek=orch, get_valid_candidates=_valid)
+    got = tw._youtube_ytsearch_fallback(deps, 'Artist Remix', object(), [_CatalogHit()])
+    assert got == [{'username': 'youtube', 'filename': 'remix'}]
+    assert yt.calls == [('Artist Remix', 30, False)]
+    assert seen == [extra]
+
+
+def test_ytsearch_fallback_skips_when_results_were_already_ytsearch():
+    yt = _FakeYouTubeSearch([_YtsearchHit()])
+    orch = _FakeClient(subclients={'youtube': yt})
+    deps, _ = _build_deps(soulseek=orch)
+    assert tw._youtube_ytsearch_fallback(deps, 'q', object(), [_YtsearchHit()]) is None
+    assert yt.calls == []
+
+
+def test_worker_catalog_miss_falls_through_to_ytsearch():
+    extra = [_YtsearchHit()]
+    yt = _FakeYouTubeSearch(extra)
+    orch = _FakeClient(
+        results=[_CatalogHit()],
+        subclients={'youtube': yt},
+    )
+    attempted = []
+
+    def _valid(results, track, query):
+        if results is extra:
+            return [{'username': 'youtube', 'filename': 'remix'}]
+        return []
+
+    def _attempt(task_id, candidates, track, batch_id, **kwargs):
+        attempted.append(candidates)
+        return True
+
+    _seed_task()
+    deps, _ = _build_deps(
+        soulseek=orch,
+        matching=_FakeMatchEngine(queries=['Artist Remix']),
+        get_valid_candidates=_valid,
+        attempt_download_with_candidates=_attempt,
+    )
+    tw.download_track_worker('t1', 'b1', deps)
+    assert attempted == [[{'username': 'youtube', 'filename': 'remix'}]]
+    assert yt.calls == [('Artist Remix', 30, False)]

--- a/tests/downloads/test_downloads_validation.py
+++ b/tests/downloads/test_downloads_validation.py
@@ -167,3 +167,126 @@ def test_keeps_torrent_title_match_when_artist_is_indexer_fallback(monkeypatch):
     result = get_valid_candidates([candidate], expected, 'Olivia Dean The Man I Need')
 
     assert result == [candidate]
+
+
+class _DispatchEngine:
+    """Records which rows hit the streaming scorer vs the Soulseek filename matcher."""
+
+    def __init__(self):
+        self.slskd_usernames = []
+
+    def score_track_match(self, **kwargs):
+        return 0.99, 'core_title_match'
+
+    def normalize_string(self, text):
+        return (text or '').lower()
+
+    def find_best_slskd_matches_enhanced(self, spotify_track, results, max_peer_queue=0):
+        self.slskd_usernames.append([getattr(r, 'username', None) for r in results])
+        return list(results)
+
+
+class _SoulseekQuality:
+    def __init__(self):
+        self.batches = []
+
+    def filter_results_by_quality_preference(self, cands):
+        self.batches.append([getattr(c, 'username', None) for c in cands])
+        return list(cands)
+
+
+def _peer_and_stream_hits():
+    from core.download_plugins.types import TrackResult
+
+    def _tr(**over):
+        base = dict(
+            username='alice',
+            filename='Artist/Album/01 - Song.flac',
+            size=1,
+            bitrate=1411,
+            duration=180_000,
+            quality='flac',
+            free_upload_slots=1,
+            upload_speed=1,
+            queue_length=0,
+            artist='Artist',
+            title='Song',
+        )
+        base.update(over)
+        return TrackResult(**base)
+
+    peer = _tr()
+    youtube = _tr(
+        username='youtube', filename='aaaaaaaaaaa||Song', quality='opus', bitrate=160,
+    )
+    tidal = _tr(
+        username='tidal', filename='tid||Artist - Song', quality='flac', bitrate=1411,
+    )
+    return peer, youtube, tidal
+
+
+def test_soulseek_first_pool_does_not_run_p2p_matcher_on_streaming(monkeypatch):
+    """Best-quality hybrid: a Soulseek peer first must not score Tidal/YouTube as paths."""
+    engine = _DispatchEngine()
+    slsk = _SoulseekQuality()
+
+    class _Orch:
+        def client(self, name):
+            return slsk if name == 'soulseek' else None
+
+    monkeypatch.setattr(validation, 'matching_engine', engine)
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([], True),
+    )
+    peer, youtube, tidal = _peer_and_stream_hits()
+    result = get_valid_candidates(
+        [peer, youtube, tidal], _Track(duration_ms=180_000), 'Artist Song',
+    )
+    assert peer in result
+    assert youtube in result
+    assert tidal in result
+    assert engine.slskd_usernames == [['alice']]
+    assert slsk.batches == [['alice']]
+
+
+def test_soulseek_first_pool_still_duration_gates_tidal(monkeypatch):
+    engine = _DispatchEngine()
+    slsk = _SoulseekQuality()
+
+    class _Orch:
+        def client(self, name):
+            return slsk if name == 'soulseek' else None
+
+    monkeypatch.setattr(validation, 'matching_engine', engine)
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    expected = _Track(duration_ms=338_000)
+    peer, _, tidal = _peer_and_stream_hits()
+    peer.duration = 338_000
+    tidal.duration = 30_000
+    result = get_valid_candidates([peer, tidal], expected, 'Artist Song')
+    assert peer in result
+    assert tidal not in result
+    assert engine.slskd_usernames == [['alice']]
+
+
+def test_failed_streaming_does_not_drop_soulseek_rows(monkeypatch):
+    """Tidal-first + all streaming rejected must still score the Soulseek hit."""
+    engine = _DispatchEngine()
+    slsk = _SoulseekQuality()
+
+    class _Orch:
+        def client(self, name):
+            return slsk if name == 'soulseek' else None
+
+    monkeypatch.setattr(validation, 'matching_engine', engine)
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    expected = _Track(duration_ms=338_000)
+    peer, _, tidal = _peer_and_stream_hits()
+    peer.duration = 338_000
+    tidal.duration = 30_000
+    result = get_valid_candidates([tidal, peer], expected, 'Artist Song')
+    assert peer in result
+    assert tidal not in result
+    assert engine.slskd_usernames == [['alice']]

--- a/tests/downloads/test_youtube_audio_quality.py
+++ b/tests/downloads/test_youtube_audio_quality.py
@@ -390,7 +390,7 @@ def test_refresh_stops_when_youtube_cannot_meet_profile(monkeypatch):
 def test_reload_settings_clears_stale_probe_claims(monkeypatch, tmp_path):
     monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
     monkeypatch.setattr(
-        'config.settings.config_manager.get',
+        'core.settings.config_manager.get',
         lambda key, default=None: default,
     )
     client = _bare_client()
@@ -1340,7 +1340,7 @@ def test_postprocessor_ignores_codec_when_transcode_off(codec, bitrate):
 
 def test_postprocessor_from_config_defaults_to_mp3_320_when_keys_missing(monkeypatch):
     monkeypatch.setattr(
-        'config.settings.config_manager.get',
+        'core.settings.config_manager.get',
         lambda key, default=None: default,
     )
     monkeypatch.setattr(
@@ -2095,10 +2095,12 @@ def test_download_sync_third_retry_uses_muxed_best(tmp_path, monkeypatch):
     audio = tmp_path / 'Song.opus'
     audio.write_bytes(b'x')
     seen = []
+    cookie_keys = []
 
     class _FakeYDL:
         def __init__(self, opts):
             seen.append(opts.get('format'))
+            cookie_keys.append(('cookiefile' in opts, 'cookiesfrombrowser' in opts))
             self.opts = opts
 
         def __enter__(self):
@@ -2133,6 +2135,9 @@ def test_download_sync_third_retry_uses_muxed_best(tmp_path, monkeypatch):
     assert 'opus' in seen[0]
     assert 'opus' in seen[1]  # retry 2 still prefers opus; keeps cookies
     assert seen[2] == 'best'
+    assert cookie_keys[0] == (True, False)
+    assert cookie_keys[1] == (True, False)
+    assert cookie_keys[2] == (False, False)  # last ditch: expired cookies must not poison 'best'
 
 
 def test_download_sync_retry_keeps_cookies_and_tries_web_music_only(tmp_path, monkeypatch):
@@ -2259,7 +2264,7 @@ def test_download_sync_selector_follows_requested_tier(tmp_path, monkeypatch):
 
 
 def test_default_youtube_config_has_no_preferred_audio_format():
-    from config.settings import ConfigManager
+    from core.settings import ConfigManager
     youtube = ConfigManager._get_default_config(None)['youtube']
     assert 'audio_format' not in youtube
     assert youtube['transcode'] is True

--- a/tests/downloads/test_youtube_audio_quality.py
+++ b/tests/downloads/test_youtube_audio_quality.py
@@ -1215,6 +1215,75 @@ def test_get_valid_candidates_probes_youtube_when_soulseek_is_first(monkeypatch)
     assert slsk_batches == [['alice']]
 
 
+def test_mixed_pool_walk_picks_youtube_774_over_soulseek_flac(monkeypatch):
+    """Worker path: probed itag 774 must be tried before a Soulseek FLAC when
+    Opus ≥192 is the top target — even if the walk is not flagged quality_first.
+    """
+    from core.downloads.candidates import order_candidates
+
+    _patch_profile(monkeypatch, [
+        _OPUS_192,
+        QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16),
+    ], False)
+
+    class _YT:
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            for c in candidates:
+                c.set_quality(AudioQuality('opus', bitrate=256))
+
+    class _Slsk:
+        def filter_results_by_quality_preference(self, cands):
+            return list(cands)
+
+    class _Orch:
+        def client(self, name):
+            if name == 'youtube':
+                return _YT()
+            if name == 'soulseek':
+                return _Slsk()
+            return None
+
+    class _Engine:
+        def score_track_match(self, **kwargs):
+            return 0.85, 'ok'
+
+        def normalize_string(self, text):
+            return (text or '').lower()
+
+        def find_best_slskd_matches_enhanced(self, track, results, **_kw):
+            for r in results:
+                r.confidence = 0.99
+            return list(results)
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    monkeypatch.setattr(validation, 'matching_engine', _Engine())
+
+    peer = TrackResult(
+        username='alice',
+        filename='Artist/Album/01 - Song.flac',
+        size=20_000_000,
+        bitrate=1411,
+        duration=180_000,
+        quality='flac',
+        free_upload_slots=1,
+        upload_speed=1,
+        queue_length=0,
+        artist='Artist',
+        title='Song',
+        sample_rate=44100,
+        bit_depth=16,
+    )
+    yt = _yt_track(filename='aaaaaaaaaaa||Song', bitrate=160)
+    result = get_valid_candidates([peer, yt], _Expected(), 'Artist Song')
+    ordered = order_candidates(
+        result, quality_first=False,
+        targets=[_OPUS_192, QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)],
+        source_order=['youtube', 'soulseek'],
+    )
+    assert ordered[0] is yt
+    assert yt.bitrate == 256
+
+
 def test_stubs_without_audio_quality_are_not_rejected():
     """Match-only test doubles omit audio_quality — filter must pass through."""
     from core.downloads.validation import _filter_youtube_by_quality
@@ -2062,15 +2131,16 @@ def test_download_sync_third_retry_uses_muxed_best(tmp_path, monkeypatch):
     assert result == str(audio)
     assert len(seen) == 3
     assert 'opus' in seen[0]
-    assert 'opus' in seen[1]  # retry 2 still prefers opus; only drops cookies
+    assert 'opus' in seen[1]  # retry 2 still prefers opus; keeps cookies
     assert seen[2] == 'best'
 
 
-def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypatch):
+def test_download_sync_retry_keeps_cookies_and_tries_web_music_only(tmp_path, monkeypatch):
     audio = tmp_path / 'Song.m4a'
     audio.write_bytes(b'x')
     cookie_keys = []
     extractor_clients = []
+    check_formats = []
 
     class _FakeYDL:
         def __init__(self, opts):
@@ -2078,6 +2148,7 @@ def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypat
             extractor_clients.append(
                 (opts.get('extractor_args') or {}).get('youtube', {}).get('player_client')
             )
+            check_formats.append(opts.get('check_formats'))
 
         def __enter__(self):
             return self
@@ -2103,9 +2174,10 @@ def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypat
     client.shutdown_check = None
     assert client._download_sync('https://youtu.be/abc', 'Song') == str(audio)
     assert cookie_keys[0] == (True, False)
-    assert cookie_keys[1] == (False, False)
+    assert cookie_keys[1] == (True, False)
     assert extractor_clients[0] == ['web_music', 'default']
-    assert extractor_clients[1] != ['web_music', 'default']
+    assert extractor_clients[1] == ['web_music']
+    assert check_formats == ['selected', 'selected']
 
 
 # ── quality filter + download selector extra edges ─────────────────────────

--- a/tests/downloads/test_youtube_audio_quality.py
+++ b/tests/downloads/test_youtube_audio_quality.py
@@ -26,6 +26,8 @@ from core.youtube_client import (
     youtube_audio_format_selector,
     youtube_audio_postprocessor,
     youtube_audio_postprocessor_from_config,
+    youtube_authenticated_extractor_args,
+    youtube_probe_auth_label,
     youtube_quality_rank_band,
 )
 
@@ -739,6 +741,64 @@ def test_refresh_probe_forwards_cookie_opts(monkeypatch):
     }, calls=calls)
     _bare_client().refresh_claimed_quality([_yt_track()])
     assert calls[0].get('cookiefile') == '/tmp/youtube_cookies.txt'
+
+
+def test_authenticated_extractor_args_asks_web_music_only_with_cookies():
+    """itag 774/141 live on the Music player. Cookies are not Premium —
+    this only adds the client that *can* return those itags."""
+    assert youtube_authenticated_extractor_args({}) == {}
+    assert youtube_authenticated_extractor_args({'quiet': True}) == {}
+    music = youtube_authenticated_extractor_args(
+        {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    assert music['youtube']['player_client'] == ['web_music', 'default']
+    browser = youtube_authenticated_extractor_args(
+        {'cookiesfrombrowser': ('firefox',)},
+    )
+    assert browser['youtube']['player_client'] == ['web_music', 'default']
+
+
+def test_probe_auth_label_never_includes_paths_or_secrets():
+    assert youtube_probe_auth_label({}) == 'none'
+    assert youtube_probe_auth_label({'quiet': True}) == 'none'
+    assert youtube_probe_auth_label(
+        {'cookiefile': '/secret/youtube_cookies.txt'},
+    ) == 'cookiefile'
+    assert youtube_probe_auth_label(
+        {'cookiesfrombrowser': ('firefox',)},
+    ) == 'browser:firefox'
+    assert 'secret' not in youtube_probe_auth_label(
+        {'cookiefile': '/secret/youtube_cookies.txt'},
+    )
+
+
+def test_refresh_probe_requests_web_music_when_cookies(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        youtube_client, '_resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    _bare_client().refresh_claimed_quality([_yt_track()])
+    clients = (calls[0].get('extractor_args') or {}).get('youtube', {}).get('player_client')
+    assert clients == ['web_music', 'default']
+
+
+def test_refresh_probe_skips_web_music_when_anonymous(monkeypatch):
+    calls = []
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    _bare_client().refresh_claimed_quality([_yt_track()])
+    clients = (calls[0].get('extractor_args') or {}).get('youtube', {}).get('player_client', [])
+    assert 'web_music' not in clients
 
 
 def _patch_profile(monkeypatch, targets, fallback):
@@ -1479,7 +1539,8 @@ def test_download_sync_reencode_writes_mp3_320_postprocessor(tmp_path, monkeypat
     }]
 
 
-def test_download_sync_reuses_fresh_probe_info(tmp_path, monkeypatch):
+def test_download_sync_extracts_fresh_after_probe(tmp_path, monkeypatch):
+    """Probe URLs (itag 774 especially) 403 if downloaded later. Fetch extracts again."""
     audio = tmp_path / 'Song.opus'
     audio.write_bytes(b'x')
     seen = {'extract': 0, 'process': 0}
@@ -1496,17 +1557,18 @@ def test_download_sync_reuses_fresh_probe_info(tmp_path, monkeypatch):
 
         def extract_info(self, url, download=True):
             seen['extract'] += 1
+            if download:
+                return {'filepath': str(audio)}
             return {
                 'id': 'jNQXAC9IVRw',
                 'formats': [
-                    {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm'},
+                    {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
                 ],
             }
 
         def process_ie_result(self, info, download=True):
             seen['process'] += 1
-            assert download is True
-            return {'filepath': str(audio)}
+            raise RuntimeError('should not download from cached probe')
 
         def prepare_filename(self, info):
             return str(tmp_path / 'Song.webm')
@@ -1525,8 +1587,8 @@ def test_download_sync_reuses_fresh_probe_info(tmp_path, monkeypatch):
     assert seen['extract'] == 1
     path = client._download_sync('https://www.youtube.com/watch?v=jNQXAC9IVRw', 'Me at the zoo')
     assert path == str(audio)
-    assert seen['extract'] == 1
-    assert seen['process'] == 1
+    assert seen['extract'] == 2
+    assert seen['process'] == 0
 
 
 def test_download_sync_extracts_fresh_when_probe_cache_expired(tmp_path, monkeypatch):
@@ -1667,9 +1729,11 @@ def test_docs_mention_youtube_reencode_default():
     transcode_help = _slice_between(index, 'id="youtube-transcode"', 'id="youtube-transcode-options"')
     assert 'Re-encode YouTube audio' in youtube_docs
     assert 'MP3 320' in youtube_docs
-    assert 'Re-encode to MP3 320 is on by default' in youtube_help
-    assert 'Premium audio qualities' in youtube_help
-    assert 'Premium audio qualities' in youtube_docs
+    assert 'Re-encode to MP3 320 (on by default)' in youtube_help
+    assert 'Netscape cookies.txt' in youtube_help
+    assert 'Premium audio' in youtube_help
+    assert 'Paste cookies.txt' in youtube_docs
+    assert 'Netscape' in youtube_docs
     assert 'Premium audio qualities' in index
     assert 'Opus or AAC' in transcode_help
     assert 'quality list' in transcode_help
@@ -2006,10 +2070,14 @@ def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypat
     audio = tmp_path / 'Song.m4a'
     audio.write_bytes(b'x')
     cookie_keys = []
+    extractor_clients = []
 
     class _FakeYDL:
         def __init__(self, opts):
             cookie_keys.append(('cookiefile' in opts, 'cookiesfrombrowser' in opts))
+            extractor_clients.append(
+                (opts.get('extractor_args') or {}).get('youtube', {}).get('player_client')
+            )
 
         def __enter__(self):
             return self
@@ -2036,6 +2104,8 @@ def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypat
     assert client._download_sync('https://youtu.be/abc', 'Song') == str(audio)
     assert cookie_keys[0] == (True, False)
     assert cookie_keys[1] == (False, False)
+    assert extractor_clients[0] == ['web_music', 'default']
+    assert extractor_clients[1] != ['web_music', 'default']
 
 
 # ── quality filter + download selector extra edges ─────────────────────────

--- a/tests/downloads/test_youtube_audio_quality.py
+++ b/tests/downloads/test_youtube_audio_quality.py
@@ -1,0 +1,2175 @@
+"""YouTube music downloads: original stream vs re-encode.
+
+YouTube does not serve MP3. With re-encode off, search claims Opus/AAC and
+yt-dlp remuxes. With re-encode on (the product default: MP3 320), ranking
+uses the file on disk. Tests that pin original-stream behavior stub
+re-encode off via the autouse fixture.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.download_plugins.types import TrackResult
+from core.downloads import validation
+from core.downloads.validation import _filter_youtube_by_quality, get_valid_candidates
+from core.quality.model import AudioQuality, QualityTarget
+from core import youtube_client
+from core.youtube_client import (
+    YouTubeClient,
+    _youtube_transcode_settings as _real_youtube_transcode_settings,
+    resolve_downloaded_audio_path,
+    youtube_audio_format_selector,
+    youtube_audio_postprocessor,
+    youtube_audio_postprocessor_from_config,
+    youtube_quality_rank_band,
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _bare_client():
+    return YouTubeClient.__new__(YouTubeClient)
+
+
+def _yt_track(**over):
+    base = dict(
+        username='youtube',
+        filename='abc123||Song',
+        size=0,
+        bitrate=160,
+        duration=180_000,
+        quality='opus',
+        free_upload_slots=999,
+        upload_speed=999,
+        queue_length=0,
+        artist='Artist',
+        title='Song',
+    )
+    base.update(over)
+    return TrackResult(**base)
+
+
+@dataclass
+class _Expected:
+    name: str = 'Song'
+    artists: tuple = ('Artist',)
+    duration_ms: int = 180_000
+    album: str | None = None
+
+
+class _MatchingEngine:
+    def score_track_match(self, **kwargs):
+        return 0.99, 'core_title_match'
+
+    def normalize_string(self, text):
+        return (text or '').lower()
+
+
+def _use_tier(monkeypatch, tier: str):
+    monkeypatch.setattr(youtube_client, 'youtube_requested_tier', lambda: tier)
+
+
+@pytest.fixture(autouse=True)
+def _reencode_off(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (False, 'mp3', '320'),
+    )
+
+
+# ── search-result quality stamp ────────────────────────────────────────────
+
+def test_youtube_track_result_without_formats_claims_opus_160_not_mp3():
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+    )
+    assert tr.quality == 'opus'
+    assert tr.bitrate == 160
+    assert tr.audio_quality.format == 'opus'
+    assert tr.audio_quality.bitrate == 160
+
+
+def test_youtube_track_result_with_cookies_still_claims_opus_160_without_formats(monkeypatch):
+    monkeypatch.setattr(
+        'core.youtube_client._resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+    )
+    assert tr.quality == 'opus'
+    assert tr.bitrate == 160
+
+
+def test_cookies_plus_reencode_claim_mp3_320_not_premium_opus(monkeypatch):
+    """Cookies must never be treated as Premium. Re-encode claims the
+    converted file (MP3 320), not Opus 256."""
+    monkeypatch.setattr(
+        'core.youtube_client._resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+    )
+    assert tr.quality == 'mp3'
+    assert tr.bitrate == 320
+    catalog = _bare_client()._ytmusic_hit_to_track_result({
+        'id': 'vid1', 'name': 'Song', 'artists': ['Artist'],
+    })
+    assert catalog.quality == 'mp3'
+    assert catalog.bitrate == 320
+
+
+def test_youtube_track_result_stamps_opus_from_format_dict():
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Song', 'duration': 180},
+        {'acodec': 'opus', 'abr': 160, 'ext': 'webm'},
+    )
+    assert tr.quality == 'opus'
+    assert tr.bitrate == 160
+
+
+def test_youtube_track_result_stamps_aac_from_m4a_format():
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Song', 'duration': 180},
+        {'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a'},
+    )
+    assert tr.quality == 'aac'
+    assert tr.bitrate == 128
+
+
+# ── itag probe before ranking ──────────────────────────────────────────────
+
+def _patch_ydl(monkeypatch, info=None, error=None, calls=None, by_video=None):
+    class _FakeYoutubeDL:
+        def __init__(self, opts):
+            if calls is not None:
+                calls.append(opts)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, url, download=False):
+            if error is not None:
+                raise error
+            if by_video is not None:
+                video_id = url.rsplit('v=', 1)[-1]
+                return by_video[video_id]
+            return info
+
+    monkeypatch.setattr(youtube_client.yt_dlp, 'YoutubeDL', _FakeYoutubeDL)
+
+
+def test_refresh_stamps_opus_256_from_itag_774(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'opus_256')
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 256
+
+
+def test_refresh_stamps_aac_256_from_itag_141(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'aac_256')
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'format_id': '140'},
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 256, 'ext': 'm4a', 'format_id': '141'},
+        ],
+    })
+    cand = _yt_track(quality='opus', bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'aac'
+    assert cand.bitrate == 256
+
+
+def test_refresh_cookies_with_only_itag_251_stay_opus_160(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 160
+    assert calls and 'cookiefile' in calls[0]
+
+
+def test_refresh_probe_error_keeps_opus_160(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, error=RuntimeError('bot check'))
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 160
+
+
+def test_refresh_empty_formats_keeps_opus_160(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {'formats': []})
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.bitrate == 160
+
+
+def test_refresh_stamps_aac_128_from_itag_140(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'format_id': '140'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'aac'
+    assert cand.bitrate == 128
+
+
+def test_refresh_probes_only_top_limit(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    cands = [
+        _yt_track(filename=f'vid{i}||Song')
+        for i in range(4)
+    ]
+    for i, c in enumerate(cands):
+        c.confidence = 0.9 - (i * 0.1)
+    # Profile needs Opus 256 — keep walking until the budget, don't copy 160 onto leftovers.
+    _bare_client().refresh_claimed_quality(
+        cands, limit=3,
+        targets=[QualityTarget(label='Opus 256', format='opus', min_bitrate=256)],
+    )
+    assert len(calls) == 3
+    assert all(c.bitrate == 160 for c in cands[:3])
+    assert cands[3].bitrate == 160
+
+
+def test_refresh_default_stops_at_premium_ceiling(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    }, calls=calls)
+    cands = [_yt_track(filename=f'vid{i}||Song') for i in range(4)]
+    for i, c in enumerate(cands):
+        c.confidence = 0.9 - (i * 0.1)
+    client = _bare_client()
+    client.refresh_claimed_quality(cands)
+    assert len(calls) == 1
+    assert cands[0].bitrate == 256
+    assert all(c.bitrate == 160 for c in cands[1:])
+    client.refresh_claimed_quality([cands[0]])
+    assert len(calls) == 1  # same video-id cache; other videos were not stamped
+
+
+def test_refresh_cache_avoids_second_extract_for_same_video(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    }, calls=calls)
+    client = _bare_client()
+    first = _yt_track(filename='abc123||Song')
+    second = _yt_track(filename='abc123||Song')
+    client.refresh_claimed_quality([first])
+    client.refresh_claimed_quality([second])
+    assert len(calls) == 1
+    assert second.bitrate == 256
+
+
+def test_refresh_probe_failure_does_not_stamp_siblings(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, error=RuntimeError('bot check'))
+    cands = [_yt_track(filename=f'vid{i}||Song') for i in range(3)]
+    _bare_client().refresh_claimed_quality(cands)
+    assert all(c.bitrate == 160 for c in cands)
+
+
+def test_refresh_does_not_copy_premium_itag_onto_other_videos(monkeypatch):
+    """Account-level cookies are not per-video. Video B must not inherit
+    itag 774 from video A when re-encode is off."""
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    })
+    premium = _yt_track(filename='aaaaaaaaaaa||Premium')
+    other = _yt_track(filename='bbbbbbbbbbb||Other')
+    premium.confidence = 0.9
+    other.confidence = 0.8
+    _bare_client().refresh_claimed_quality([premium, other], limit=1)
+    assert premium.bitrate == 256
+    assert other.quality == 'opus'
+    assert other.bitrate == 160
+
+
+def test_refresh_lookahead_picks_better_itag_on_second_video(monkeypatch):
+    """Same recording, worse title match, better itag — one extra player fetch."""
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, calls=calls, by_video={
+        'aaaaaaaaaaa': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ]},
+        'bbbbbbbbbbb': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ]},
+        'ccccccccccc': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ]},
+    })
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    better = _yt_track(filename='bbbbbbbbbbb||Song')
+    leftover = _yt_track(filename='ccccccccccc||Song')
+    top.confidence = 0.9
+    better.confidence = 0.8
+    leftover.confidence = 0.7
+    _bare_client().refresh_claimed_quality(
+        [top, better, leftover],
+        targets=[QualityTarget(label='Opus', format='opus')],
+    )
+    assert len(calls) == 2
+    assert top.bitrate == 160
+    assert better.bitrate == 256
+    assert leftover.bitrate == 160
+
+
+def test_refresh_stops_when_youtube_cannot_meet_profile(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    cands = [_yt_track(filename=f'vid{i}||Song') for i in range(4)]
+    _bare_client().refresh_claimed_quality(
+        cands,
+        targets=[QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)],
+    )
+    assert len(calls) == 1
+
+
+def test_reload_settings_clears_stale_probe_claims(monkeypatch, tmp_path):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    monkeypatch.setattr(
+        'config.settings.config_manager.get',
+        lambda key, default=None: default,
+    )
+    client = _bare_client()
+    client.download_opts = {}
+    client.download_path = tmp_path
+    client._yt_probe_quality = {'vid1': AudioQuality(format='mp3', bitrate=320)}
+    client._yt_probe_info = {'vid1': (0.0, {'id': 'vid1'})}
+    client.reload_settings()
+    assert client._probe_quality_cache() == {}
+    assert client._probe_info_cache() == {}
+
+
+def test_probe_quality_cache_expires_and_reprobes(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    client = _bare_client()
+    now = {'t': 1_000.0}
+    monkeypatch.setattr(youtube_client.time, 'monotonic', lambda: now['t'])
+    client.refresh_claimed_quality([_yt_track(filename='abc123||Song')])
+    assert len(calls) == 1
+    now['t'] += client._PROBE_INFO_TTL_S + 1
+    client.refresh_claimed_quality([_yt_track(filename='abc123||Song')])
+    assert len(calls) == 2
+
+
+def test_video_id_from_url():
+    assert YouTubeClient._video_id_from_url('https://www.youtube.com/watch?v=jNQXAC9IVRw') == 'jNQXAC9IVRw'
+    assert YouTubeClient._video_id_from_url('https://youtu.be/jNQXAC9IVRw') == 'jNQXAC9IVRw'
+    assert YouTubeClient._video_id_from_url('https://www.youtube.com/shorts/jNQXAC9IVRw') == 'jNQXAC9IVRw'
+    assert YouTubeClient._video_id_from_url('') == ''
+    assert YouTubeClient._video_id_from_url('https://example.com') == ''
+
+
+def test_refresh_stamps_aac_128_when_profile_asks_aac_128(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'aac_128')
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'format_id': '140'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'aac'
+    assert cand.bitrate == 128
+
+
+# ── yt-dlp postprocessor ───────────────────────────────────────────────────
+
+def test_postprocessor_default_is_remux_not_mp3_320():
+    pp = youtube_audio_postprocessor()
+    assert pp['key'] == 'FFmpegExtractAudio'
+    assert pp['preferredcodec'] == 'best'
+    assert 'preferredquality' not in pp
+
+
+def test_postprocessor_transcode_uses_configured_codec_bitrate():
+    pp = youtube_audio_postprocessor(transcode=True, codec='mp3', bitrate='320')
+    assert pp['preferredcodec'] == 'mp3'
+    assert pp['preferredquality'] == '320'
+
+
+def test_postprocessor_from_config_respects_live_settings(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (False, 'mp3', '320'),
+    )
+    pp = youtube_audio_postprocessor_from_config()
+    assert pp['preferredcodec'] == 'best'
+
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'aac', '192'),
+    )
+    pp = youtube_audio_postprocessor_from_config()
+    assert pp['preferredcodec'] == 'aac'
+    assert pp['preferredquality'] == '192'
+
+
+def test_download_sync_does_not_hardcode_mp3_suffix(tmp_path, monkeypatch):
+    """_download_sync must resolve the real extracted path, not Title.mp3."""
+    opus_path = tmp_path / 'Song.opus'
+    opus_path.write_bytes(b'opus')
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            self.opts = opts
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def extract_info(self, url, download=True):
+            return {'title': 'Song', 'ext': 'webm', 'filepath': str(opus_path)}
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    result = client._download_sync('https://www.youtube.com/watch?v=abc', 'Song')
+    assert result == str(opus_path)
+    assert not result.endswith('.mp3')
+
+
+# ── resolve_downloaded_audio_path ──────────────────────────────────────────
+
+def test_resolve_prefers_info_filepath(tmp_path):
+    final = tmp_path / 'Song.opus'
+    final.write_bytes(b'x')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(tmp_path / 'Song.webm')
+    assert resolve_downloaded_audio_path(ydl, {'filepath': str(final)}) == str(final)
+
+
+def test_resolve_falls_back_to_sibling_audio_ext(tmp_path):
+    audio = tmp_path / 'Song.m4a'
+    audio.write_bytes(b'x')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(tmp_path / 'Song.webm')
+    assert resolve_downloaded_audio_path(ydl, {}) == str(audio)
+
+
+def test_resolve_prefers_converted_audio_over_leftover_webm(tmp_path):
+    """yt-dlp may leave the DASH .webm beside the extracted .mp3/.opus."""
+    webm = tmp_path / 'Song.webm'
+    mp3 = tmp_path / 'Song.mp3'
+    webm.write_bytes(b'container')
+    mp3.write_bytes(b'converted')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(webm)
+    assert resolve_downloaded_audio_path(ydl, {'filepath': str(webm)}) == str(mp3)
+
+
+def test_discard_leftover_container_beside_extracted_audio(tmp_path):
+    webm = tmp_path / 'Song.webm'
+    mp4 = tmp_path / 'Song.mp4'
+    mp3 = tmp_path / 'Song.mp3'
+    webm.write_bytes(b'container')
+    mp4.write_bytes(b'muxed')
+    mp3.write_bytes(b'converted')
+    discard = getattr(youtube_client, 'discard_leftover_youtube_containers', None)
+    assert callable(discard)
+    discard(str(mp3))
+    assert mp3.exists()
+    assert not webm.exists()
+    assert not mp4.exists()
+
+
+# ── pre-download quality filter ────────────────────────────────────────────
+
+def test_youtube_quality_filter_rejects_when_fallback_off(monkeypatch):
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)], False),
+    )
+    cand = _yt_track()
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == []
+
+
+def test_youtube_quality_filter_keeps_via_fallback(monkeypatch):
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)], True),
+    )
+    cand = _yt_track()
+    result = get_valid_candidates([cand], _Expected(), 'Artist Song')
+    assert result == [cand]
+
+
+def test_youtube_quality_filter_keeps_when_opus_is_a_target(monkeypatch):
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='Opus', format='opus')], False),
+    )
+    cand = _yt_track()
+    result = get_valid_candidates([cand], _Expected(), 'Artist Song')
+    assert result == [cand]
+
+
+def test_transcode_on_does_not_make_search_look_like_mp3(monkeypatch):
+    """Re-encode off: search still claims Opus 160, so a FLAC+MP3 profile
+    with Fallback off still rejects YouTube."""
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([
+            QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16),
+            QualityTarget(label='MP3 320kbps', format='mp3', min_bitrate=320),
+        ], False),
+    )
+    cand = _yt_track()
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 160
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == []
+
+
+def test_mp3_only_profile_skips_youtube_when_reencode_off(monkeypatch):
+    """MP3 320 only + Fallback off + remux: YouTube is not chosen."""
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='MP3 320kbps', format='mp3', min_bitrate=320)], False),
+    )
+    cand = _yt_track()
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == []
+
+
+def test_mp3_only_profile_keeps_youtube_only_as_fallback(monkeypatch):
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='MP3 320kbps', format='mp3', min_bitrate=320)], True),
+    )
+    cand = _yt_track()
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == [cand]
+
+
+def test_reencode_to_mp3_makes_youtube_match_mp3_only_profile(monkeypatch):
+    """Re-encode on: ranking uses the converted MP3 320, so an MP3-only
+    profile with Fallback off accepts YouTube. The fetch is still best Opus."""
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='MP3 320kbps', format='mp3', min_bitrate=320)], False),
+    )
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+    )
+    assert tr.quality == 'mp3'
+    assert tr.bitrate == 320
+    assert get_valid_candidates([tr], _Expected(), 'Artist Song') == [tr]
+
+
+def test_reencode_to_mp3_still_rejected_by_flac_only_profile(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)], False),
+    )
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+    )
+    assert get_valid_candidates([tr], _Expected(), 'Artist Song') == []
+
+
+def test_reencode_probe_stamps_output_not_original_itag(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'mp3'
+    assert cand.bitrate == 320
+
+
+def test_reencode_probe_with_cookies_and_only_itag_251_is_still_mp3_not_256(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(
+        youtube_client, '_resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'mp3'
+    assert cand.bitrate == 320
+
+
+def test_reencode_probe_failure_keeps_search_mp3_claim(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, error=RuntimeError('bot check'))
+    cand = _yt_track(quality='mp3', bitrate=320)
+    cand.set_quality(AudioQuality(format='mp3', bitrate=320))
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'mp3'
+    assert cand.bitrate == 320
+
+
+def test_reencode_siblings_inherit_converted_claim_not_original_itag(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'aac', '256'),
+    )
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    }, calls=calls)
+    cands = [_yt_track(filename=f'vid{i}||Song') for i in range(3)]
+    _bare_client().refresh_claimed_quality(cands)
+    assert len(calls) == 1
+    assert all(c.quality == 'aac' and c.bitrate == 256 for c in cands)
+
+
+def test_refresh_probe_forwards_cookie_opts(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        youtube_client, '_resolve_cookie_opts',
+        lambda: {'cookiefile': '/tmp/youtube_cookies.txt'},
+    )
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ],
+    }, calls=calls)
+    _bare_client().refresh_claimed_quality([_yt_track()])
+    assert calls[0].get('cookiefile') == '/tmp/youtube_cookies.txt'
+
+
+def _patch_profile(monkeypatch, targets, fallback):
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: (list(targets), fallback),
+    )
+
+
+_FLAC = QualityTarget(label='FLAC 16-bit', format='flac', bit_depth=16)
+_MP3_320 = QualityTarget(label='MP3 320kbps', format='mp3', min_bitrate=320)
+_MP3_192 = QualityTarget(label='MP3 192kbps', format='mp3', min_bitrate=192)
+_AAC = QualityTarget(label='AAC', format='aac')
+_AAC_256 = QualityTarget(label='AAC 256kbps', format='aac', min_bitrate=256)
+_AAC_128 = QualityTarget(label='AAC 128kbps', format='aac', min_bitrate=128)
+_OPUS = QualityTarget(label='Opus', format='opus')
+_OPUS_128 = QualityTarget(label='Opus 128kbps', format='opus', min_bitrate=128)
+_OPUS_192 = QualityTarget(label='Opus 192kbps', format='opus', min_bitrate=192)
+
+
+def test_quality_filter_prefers_second_video_with_better_itag(monkeypatch):
+    """Match-passing Video B with Opus 256 beats a better-titled 160."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, by_video={
+        'aaaaaaaaaaa': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ]},
+        'bbbbbbbbbbb': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ]},
+    })
+
+    class _Orch:
+        def client(self, name):
+            return _bare_client()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    weaker = _yt_track(filename='aaaaaaaaaaa||Song')
+    better = _yt_track(filename='bbbbbbbbbbb||Song')
+    result = get_valid_candidates([weaker, better], _Expected(), 'Artist Song')
+    assert result[0] is better
+    assert better.bitrate == 256
+
+
+def test_quality_rank_band_excludes_distant_confidence():
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    close = _yt_track(filename='bbbbbbbbbbb||Song')
+    far = _yt_track(filename='ccccccccccc||Song')
+    top.confidence = 0.92
+    close.confidence = 0.88
+    far.confidence = 0.62
+    assert youtube_quality_rank_band([top, close, far]) == [top, close]
+
+
+def test_quality_rank_band_uses_match_confidence_from_orchestrator():
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    far = _yt_track(filename='bbbbbbbbbbb||Song')
+    top._match_confidence = 0.92
+    far._match_confidence = 0.62
+    assert youtube_quality_rank_band([top, far]) == [top]
+
+
+def test_quality_rank_band_includes_score_exactly_on_margin():
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    edge = _yt_track(filename='bbbbbbbbbbb||Song')
+    below = _yt_track(filename='ccccccccccc||Song')
+    top.confidence = 0.92
+    edge.confidence = 0.87
+    below.confidence = 0.869
+    assert youtube_quality_rank_band([top, edge, below]) == [top, edge]
+
+
+def test_cached_quality_ignores_legacy_nontuple_entry():
+    """Pre-TTL cache stored AudioQuality bare. Lookup must not crash."""
+    client = _bare_client()
+    client._yt_probe_quality = {
+        'vid1': AudioQuality(format='opus', bitrate=256),
+    }
+    assert client._cached_quality('vid1') is None
+    assert client._probe_quality_cache().get('vid1') is None
+
+
+def test_quality_filter_does_not_promote_distant_better_itag(monkeypatch):
+    """A 0.62 cover at Opus 256 must not beat a 0.92 match at 160."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, by_video={
+        'aaaaaaaaaaa': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ]},
+        'bbbbbbbbbbb': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ]},
+    })
+
+    class _Orch:
+        def client(self, name):
+            return _bare_client()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    far = _yt_track(filename='bbbbbbbbbbb||Song')
+    top.confidence = 0.92
+    far.confidence = 0.62
+    result = _filter_youtube_by_quality([top, far])
+    assert result[0] is top
+    assert far not in result
+
+
+def test_quality_filter_promotes_close_better_itag(monkeypatch):
+    """0.88 vs 0.92 is close enough that the better encode can win."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, by_video={
+        'aaaaaaaaaaa': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'},
+        ]},
+        'bbbbbbbbbbb': {'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ]},
+    })
+
+    class _Orch:
+        def client(self, name):
+            return _bare_client()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    top = _yt_track(filename='aaaaaaaaaaa||Song')
+    close = _yt_track(filename='bbbbbbbbbbb||Song')
+    top.confidence = 0.92
+    close.confidence = 0.88
+    result = _filter_youtube_by_quality([top, close])
+    assert result[0] is close
+    assert close.bitrate == 256
+
+
+@pytest.mark.parametrize("codec,bitrate,targets,fallback,kept", [
+    ('mp3', '320', [_MP3_320], False, True),
+    ('mp3', '192', [_MP3_320], False, False),
+    ('mp3', '320', [_MP3_192], False, True),
+    ('aac', '256', [_MP3_320], False, False),
+    ('aac', '256', [_AAC_256], False, True),
+    ('opus', '160', [_OPUS], False, True),
+    ('mp3', '320', [_OPUS], False, False),
+    ('mp3', '320', [_FLAC], False, False),
+    ('mp3', '320', [_FLAC, _MP3_320], False, True),
+    ('opus', '256', [_OPUS_192], False, True),
+])
+def test_reencode_ranking_follows_converted_file_not_stream(
+    monkeypatch, codec, bitrate, targets, fallback, kept,
+):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, codec, bitrate),
+    )
+    _patch_profile(monkeypatch, targets, fallback)
+    tr = _bare_client()._youtube_to_track_result(
+        {'id': 'abc123', 'title': 'Artist - Song', 'duration': 180},
+        {'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+    )
+    result = get_valid_candidates([tr], _Expected(), 'Artist Song')
+    assert (result == [tr]) is kept
+
+
+@pytest.mark.parametrize("quality,bitrate,targets,fallback,kept", [
+    # Default balanced-style ladder (FLAC + MP3): YouTube is fallback-only
+    ('opus', 160, [_FLAC, _MP3_320, _MP3_192], False, False),
+    ('opus', 160, [_FLAC, _MP3_320, _MP3_192], True, True),
+    ('aac', 128, [_FLAC, _MP3_320], False, False),
+    ('aac', 128, [_FLAC, _MP3_320], True, True),
+    # Audiophile FLAC-only
+    ('opus', 160, [_FLAC], False, False),
+    ('aac', 256, [_FLAC], False, False),
+    # Explicit Opus / AAC targets — YouTube counts as a match
+    ('opus', 160, [_FLAC, _OPUS], False, True),
+    ('opus', 160, [_OPUS], False, True),
+    ('opus', 160, [_OPUS_128], False, True),
+    ('opus', 160, [_OPUS_192], False, False),  # 160 < 192
+    ('opus', 256, [_OPUS_192], False, True),   # Premium itag 774 meets 192 floor
+    ('opus', 160, [_OPUS_192], True, True),
+    ('aac', 128, [_AAC], False, True),
+    ('aac', 128, [_AAC_128], False, True),
+    ('aac', 128, [_AAC_256], False, False),  # Premium itag 141 would pass; 140 does not
+    ('aac', 256, [_AAC_256], False, True),
+    ('aac', 128, [_FLAC, _AAC, _MP3_320], False, True),
+    # Format mismatch: high-bitrate Opus is still not MP3
+    ('opus', 256, [_MP3_320], False, False),
+    ('opus', 320, [_MP3_320], False, False),
+    ('aac', 256, [_MP3_320], False, False),
+    # Empty target list = no constraint
+    ('opus', 160, [], False, True),
+    ('opus', 160, [], True, True),
+    # Space-saver MP3-only
+    ('opus', 160, [_MP3_192], False, False),
+    ('aac', 128, [_MP3_192], True, True),
+])
+def test_youtube_quality_filter_matrix(monkeypatch, quality, bitrate, targets, fallback, kept):
+    _patch_profile(monkeypatch, targets, fallback)
+    cand = _yt_track(quality=quality, bitrate=bitrate)
+    result = get_valid_candidates([cand], _Expected(), 'Artist Song')
+    if kept:
+        assert result == [cand]
+    else:
+        assert result == []
+
+
+def test_youtube_quality_filter_prefers_higher_opus_bitrate(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS], False)
+    low = _yt_track(filename='low||Song', bitrate=50, title='Song')
+    high = _yt_track(filename='high||Song', bitrate=160, title='Song')
+    result = get_valid_candidates([low, high], _Expected(), 'Artist Song')
+    assert result[0] is high
+    assert low in result and high in result
+
+
+def test_quality_filter_probes_itag_before_rank(monkeypatch):
+    """A probed Premium itag 774 (Opus 256) satisfies Opus ≥192; search-time 160 would not."""
+    _patch_profile(monkeypatch, [_OPUS_192], False)
+
+    class _Orch:
+        def client(self, name):
+            assert name == 'youtube'
+            return _bare_client()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    result = get_valid_candidates([cand], _Expected(), 'Artist Song')
+    assert result == [cand]
+    assert cand.bitrate == 256
+
+
+def test_quality_filter_rejects_unprobed_160_when_opus_192_required(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS_192], False)
+    cand = _yt_track(bitrate=160)
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == []
+
+
+def test_tidal_is_not_quality_filtered_by_youtube_path(monkeypatch):
+    """Tidal already requested a profile tier — do not run the YouTube filter."""
+    monkeypatch.setattr(validation, 'matching_engine', _MatchingEngine())
+    monkeypatch.setattr(
+        'core.quality.selection.load_profile_targets',
+        lambda: ([_FLAC], False),
+    )
+    tidal = _yt_track(username='tidal', quality='flac', bitrate=1411)
+    # TrackResult needs bit_depth for FLAC match; set_quality isn't required
+    # because the youtube filter is skipped for non-youtube usernames.
+    result = get_valid_candidates([tidal], _Expected(), 'Artist Song')
+    assert result == [tidal]
+
+
+def test_quality_filter_does_not_band_non_youtube_in_hybrid_pool(monkeypatch):
+    """A closer YouTube hit must not drop a Tidal match in a mixed best-quality pool."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+    probed = []
+
+    class _YT:
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            probed.extend(candidates)
+
+    class _Orch:
+        def client(self, name):
+            return _YT()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    yt_top = _yt_track(filename='aaaaaaaaaaa||Song')
+    yt_far = _yt_track(filename='bbbbbbbbbbb||Other', title='Other')
+    tidal = _yt_track(
+        username='tidal', filename='tid||Song', quality='flac', bitrate=1411,
+    )
+    yt_top.confidence = 0.92
+    yt_far.confidence = 0.62
+    tidal.confidence = 0.70
+    result = _filter_youtube_by_quality([yt_top, yt_far, tidal])
+    assert tidal in result
+    assert yt_top in result
+    assert yt_far not in result
+    assert probed == [yt_top]
+
+
+def test_quality_filter_keeps_tidal_when_youtube_misses_profile(monkeypatch):
+    """FLAC-only + remux: rejected YouTube rows must not wipe a Tidal hit."""
+    _patch_profile(monkeypatch, [_FLAC], False)
+    yt = _yt_track()
+    yt.confidence = 0.92
+    tidal = _yt_track(
+        username='tidal', filename='tid||Song', quality='flac', bitrate=1411,
+    )
+    tidal.confidence = 0.70
+    result = _filter_youtube_by_quality([yt, tidal])
+    assert tidal in result
+    assert yt not in result
+
+
+def test_get_valid_candidates_keeps_tidal_in_youtube_first_hybrid_pool(monkeypatch):
+    """Worker path: search_all_sources can list YouTube first, then Tidal."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+
+    class _Scores:
+        def score_track_match(self, **kw):
+            if kw.get('candidate_title') == 'Other':
+                return 0.62, 'ok'
+            if kw.get('candidate_duration_ms') == 181_000:
+                return 0.70, 'ok'
+            return 0.92, 'ok'
+
+        def normalize_string(self, text):
+            return (text or '').lower()
+
+    monkeypatch.setattr(validation, 'matching_engine', _Scores())
+    yt_top = _yt_track(filename='aaaaaaaaaaa||Song')
+    yt_far = _yt_track(filename='bbbbbbbbbbb||Other', title='Other')
+    tidal = _yt_track(
+        username='tidal', filename='tid||Song', quality='flac', bitrate=1411,
+        duration=181_000,
+    )
+    result = get_valid_candidates([yt_top, yt_far, tidal], _Expected(), 'Artist Song')
+    assert tidal in result
+    assert yt_top in result
+    assert yt_far not in result
+
+
+def test_get_valid_candidates_filters_youtube_when_tidal_is_first(monkeypatch):
+    """Tidal-first pool must still band/probe YouTube without dropping Tidal."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+
+    class _Scores:
+        def score_track_match(self, **kw):
+            if kw.get('candidate_title') == 'Other':
+                return 0.62, 'ok'
+            if kw.get('candidate_duration_ms') == 181_000:
+                return 0.70, 'ok'
+            return 0.92, 'ok'
+
+        def normalize_string(self, text):
+            return (text or '').lower()
+
+    monkeypatch.setattr(validation, 'matching_engine', _Scores())
+    yt_top = _yt_track(filename='aaaaaaaaaaa||Song')
+    yt_far = _yt_track(filename='bbbbbbbbbbb||Other', title='Other')
+    tidal = _yt_track(
+        username='tidal', filename='tid||Song', quality='flac', bitrate=1411,
+        duration=181_000,
+    )
+    result = get_valid_candidates([tidal, yt_top, yt_far], _Expected(), 'Artist Song')
+    assert tidal in result
+    assert yt_top in result
+    assert yt_far not in result
+
+
+def test_get_valid_candidates_probes_youtube_when_soulseek_is_first(monkeypatch):
+    """Soulseek-first hybrid pool must still probe YouTube and keep the peer."""
+    _patch_profile(monkeypatch, [_OPUS], False)
+    probed = []
+    slsk_batches = []
+
+    class _YT:
+        def refresh_claimed_quality(self, candidates, **kwargs):
+            probed.extend(candidates)
+
+    class _Slsk:
+        def filter_results_by_quality_preference(self, cands):
+            slsk_batches.append([getattr(c, 'username', None) for c in cands])
+            return list(cands)
+
+    class _Orch:
+        def client(self, name):
+            if name == 'youtube':
+                return _YT()
+            if name == 'soulseek':
+                return _Slsk()
+            return None
+
+    class _Engine:
+        def score_track_match(self, **kwargs):
+            return 0.99, 'ok'
+
+        def normalize_string(self, text):
+            return (text or '').lower()
+
+        def find_best_slskd_matches_enhanced(self, track, results, **_kw):
+            return list(results)
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    monkeypatch.setattr(validation, 'matching_engine', _Engine())
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+
+    peer = TrackResult(
+        username='alice',
+        filename='Artist/Album/01 - Song.flac',
+        size=1,
+        bitrate=1411,
+        duration=180_000,
+        quality='flac',
+        free_upload_slots=1,
+        upload_speed=1,
+        queue_length=0,
+        artist='Artist',
+        title='Song',
+    )
+    yt = _yt_track(filename='aaaaaaaaaaa||Song')
+    result = get_valid_candidates([peer, yt], _Expected(), 'Artist Song')
+    assert peer in result
+    assert yt in result
+    assert probed == [yt]
+    assert slsk_batches == [['alice']]
+
+
+def test_stubs_without_audio_quality_are_not_rejected():
+    """Match-only test doubles omit audio_quality — filter must pass through."""
+    from core.downloads.validation import _filter_youtube_by_quality
+
+    class _Stub:
+        username = 'youtube'
+        title = 'Song'
+
+    stub = _Stub()
+    assert _filter_youtube_by_quality([stub]) == [stub]
+
+
+def test_filter_empty_candidates():
+    from core.downloads.validation import _filter_youtube_by_quality
+    assert _filter_youtube_by_quality([]) == []
+
+
+# ── postprocessor combinations ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("codec,bitrate,want_codec,want_br", [
+    ('mp3', '320', 'mp3', '320'),
+    ('mp3', '192', 'mp3', '192'),
+    ('mp3', '128', 'mp3', '128'),
+    ('opus', '256', 'opus', '256'),
+    ('opus', '160', 'opus', '160'),
+    ('aac', '256', 'aac', '256'),
+    ('aac', '192', 'aac', '192'),
+    ('m4a', '128', 'aac', '128'),
+    ('M4A', '320', 'aac', '320'),
+    ('ogg', '192', 'ogg', '192'),
+    ('flac', '320', 'mp3', '320'),  # unknown codec → mp3
+    ('', '320', 'mp3', '320'),
+    (None, None, 'mp3', '320'),
+    ('mp3', '0', 'mp3', '320'),
+    ('mp3', '-5', 'mp3', '320'),
+    ('mp3', 'bad', 'mp3', '320'),
+])
+def test_postprocessor_transcode_codec_bitrate_matrix(codec, bitrate, want_codec, want_br):
+    pp = youtube_audio_postprocessor(transcode=True, codec=codec, bitrate=bitrate)
+    assert pp['preferredcodec'] == want_codec
+    assert pp['preferredquality'] == want_br
+    assert pp['key'] == 'FFmpegExtractAudio'
+
+
+@pytest.mark.parametrize("codec,bitrate", [
+    ('mp3', '320'),
+    ('opus', '256'),
+    ('aac', '128'),
+])
+def test_postprocessor_ignores_codec_when_transcode_off(codec, bitrate):
+    pp = youtube_audio_postprocessor(transcode=False, codec=codec, bitrate=bitrate)
+    assert pp == {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'}
+
+
+def test_postprocessor_from_config_defaults_to_mp3_320_when_keys_missing(monkeypatch):
+    monkeypatch.setattr(
+        'config.settings.config_manager.get',
+        lambda key, default=None: default,
+    )
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        _real_youtube_transcode_settings,
+    )
+    pp = youtube_audio_postprocessor_from_config()
+    assert pp['preferredcodec'] == 'mp3'
+    assert pp['preferredquality'] == '320'
+
+
+def test_postprocessor_from_config_honours_explicit_off(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (False, 'mp3', '320'),
+    )
+    pp = youtube_audio_postprocessor_from_config()
+    assert pp == {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'}
+
+
+# ── path resolver edge cases ───────────────────────────────────────────────
+
+def test_resolve_prefers_requested_downloads_over_prepare(tmp_path):
+    final = tmp_path / 'out.opus'
+    final.write_bytes(b'x')
+    decoy = tmp_path / 'Song.webm'
+    decoy.write_bytes(b'y')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(decoy)
+    info = {'requested_downloads': [{'filepath': str(final)}]}
+    assert resolve_downloaded_audio_path(ydl, info) == str(final)
+
+
+def test_resolve_uses_underscore_filename(tmp_path):
+    final = tmp_path / 'Song.opus'
+    final.write_bytes(b'x')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(tmp_path / 'missing.webm')
+    assert resolve_downloaded_audio_path(ydl, {'_filename': str(final)}) == str(final)
+
+
+def test_resolve_returns_none_when_nothing_on_disk(tmp_path):
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(tmp_path / 'Song.webm')
+    assert resolve_downloaded_audio_path(ydl, {}) is None
+
+
+def test_resolve_survives_prepare_filename_raising(tmp_path):
+    final = tmp_path / 'ok.m4a'
+    final.write_bytes(b'x')
+    ydl = MagicMock()
+    ydl.prepare_filename.side_effect = RuntimeError('boom')
+    assert resolve_downloaded_audio_path(ydl, {'filepath': str(final)}) == str(final)
+
+
+def test_resolve_non_dict_info_uses_prepare(tmp_path):
+    audio = tmp_path / 'Song.opus'
+    audio.write_bytes(b'x')
+    ydl = MagicMock()
+    ydl.prepare_filename.return_value = str(tmp_path / 'Song.webm')
+    assert resolve_downloaded_audio_path(ydl, None) == str(audio)
+
+
+# ── download_sync edge cases ───────────────────────────────────────────────
+
+def test_download_sync_resolves_m4a(tmp_path, monkeypatch):
+    m4a = tmp_path / 'Song.m4a'
+    m4a.write_bytes(b'aac')
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            self.opts = opts
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def extract_info(self, url, download=True):
+            return {'title': 'Song', 'ext': 'm4a', 'filepath': str(m4a)}
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.m4a')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    assert client._download_sync('https://www.youtube.com/watch?v=abc', 'Song') == str(m4a)
+
+
+def test_download_sync_returns_none_when_file_missing(tmp_path, monkeypatch):
+    class _FakeYDL:
+        def __init__(self, opts):
+            self.opts = opts
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def extract_info(self, url, download=True):
+            return {'title': 'Song', 'ext': 'webm'}
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    assert client._download_sync('https://youtu.be/abc', 'Song') is None
+
+
+def test_download_sync_aborts_on_shutdown(monkeypatch):
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = lambda: True
+    assert client._download_sync('https://youtu.be/abc', 'Song') is None
+
+
+def test_download_sync_rebuilds_postprocessor_from_live_config(tmp_path, monkeypatch):
+    opus = tmp_path / 'Song.opus'
+    opus.write_bytes(b'x')
+    seen = {}
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen['pp'] = opts.get('postprocessors')
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def extract_info(self, url, download=True):
+            return {'filepath': str(opus)}
+        def prepare_filename(self, info):
+            return str(opus)
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {
+        'postprocessors': [{'key': 'FFmpegExtractAudio', 'preferredcodec': 'mp3', 'preferredquality': '320'}],
+    }
+    client.shutdown_check = None
+    client._download_sync('https://youtu.be/abc', 'Song')
+    assert seen['pp'] == [{'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'}]
+
+
+def test_download_sync_uses_preferred_audio_format_selector(tmp_path, monkeypatch):
+    seen = {}
+    audio = tmp_path / 'Song.opus'
+    audio.write_bytes(b'x')
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen['format'] = opts.get('format')
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def extract_info(self, url, download=True):
+            return {'filepath': str(audio)}
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_requested_tier',
+        lambda: 'opus_160',
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    client._download_sync('https://youtu.be/abc', 'Song')
+    assert 'opus' in seen['format']
+
+
+def test_download_sync_reencode_fetches_best_opus_not_profile_rung(tmp_path, monkeypatch):
+    """Re-encode on: ignore an AAC 128 profile rung and fetch best original."""
+    seen = {}
+    audio = tmp_path / 'Song.mp3'
+    audio.write_bytes(b'x')
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen['format'] = opts.get('format')
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'mp3', 'preferredquality': '320'},
+    )
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.quality_tier_for_source',
+        lambda *a, **k: 'aac_128',
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    client._download_sync('https://youtu.be/abc', 'Song')
+    assert 'abr>=192' in seen['format']
+    assert seen['format'] == youtube_audio_format_selector('opus_256')
+
+
+def test_download_sync_reencode_writes_mp3_320_postprocessor(tmp_path, monkeypatch):
+    seen = {}
+    audio = tmp_path / 'Song.mp3'
+    audio.write_bytes(b'x')
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen['pp'] = opts.get('postprocessors')
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    client._download_sync('https://youtu.be/abc', 'Song')
+    assert seen['pp'] == [{
+        'key': 'FFmpegExtractAudio',
+        'preferredcodec': 'mp3',
+        'preferredquality': '320',
+    }]
+
+
+def test_download_sync_reuses_fresh_probe_info(tmp_path, monkeypatch):
+    audio = tmp_path / 'Song.opus'
+    audio.write_bytes(b'x')
+    seen = {'extract': 0, 'process': 0}
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            seen['extract'] += 1
+            return {
+                'id': 'jNQXAC9IVRw',
+                'formats': [
+                    {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm'},
+                ],
+            }
+
+        def process_ie_result(self, info, download=True):
+            seen['process'] += 1
+            assert download is True
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    cand = _yt_track(filename='jNQXAC9IVRw||Me at the zoo')
+    client.refresh_claimed_quality([cand])
+    assert seen['extract'] == 1
+    path = client._download_sync('https://www.youtube.com/watch?v=jNQXAC9IVRw', 'Me at the zoo')
+    assert path == str(audio)
+    assert seen['extract'] == 1
+    assert seen['process'] == 1
+
+
+def test_download_sync_extracts_fresh_when_probe_cache_expired(tmp_path, monkeypatch):
+    audio = tmp_path / 'Song.opus'
+    audio.write_bytes(b'x')
+    seen = {'extract': 0}
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            seen['extract'] += 1
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    client._yt_probe_info = {
+        'jNQXAC9IVRw': (0.0, {'id': 'jNQXAC9IVRw'}),  # expired
+    }
+    path = client._download_sync('https://www.youtube.com/watch?v=jNQXAC9IVRw', 'Song')
+    assert path == str(audio)
+    assert seen['extract'] == 1
+
+
+def test_get_best_audio_format_picks_opus_160_rung():
+    client = _bare_client()
+    formats = [
+        {'vcodec': 'avc1', 'acodec': 'mp4a.40.2', 'abr': 128},  # muxed, skip
+        {'vcodec': 'none', 'acodec': 'opus', 'abr': 50},
+        {'vcodec': 'none', 'acodec': 'opus', 'abr': 160},
+        {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128},
+        {'vcodec': 'none', 'acodec': 'none'},
+    ]
+    best = client._get_best_audio_format(formats, tier='opus_160')
+    assert best['abr'] == 160
+
+
+def test_get_best_audio_format_empty_and_video_only():
+    client = _bare_client()
+    assert client._get_best_audio_format([]) is None
+    assert client._get_best_audio_format([{'vcodec': 'avc1', 'acodec': 'mp4a.40.2'}]) is None
+
+
+def test_get_best_audio_format_opus_160_does_not_upgrade_to_aac_256():
+    client = _bare_client()
+    formats = [
+        {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm'},
+        {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 256, 'ext': 'm4a'},
+    ]
+    best = client._get_best_audio_format(formats, tier='opus_160')
+    assert best['abr'] == 160
+    assert 'opus' in best['acodec']
+
+
+def test_get_best_audio_format_aac_128_does_not_upgrade_to_opus_256():
+    client = _bare_client()
+    formats = [
+        {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm'},
+        {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a'},
+    ]
+    best = client._get_best_audio_format(formats, tier='aac_128')
+    assert best['abr'] == 128
+    assert 'mp4a' in best['acodec']
+
+
+def test_get_best_audio_format_walks_down_when_rung_missing():
+    client = _bare_client()
+    formats = [
+        {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm'},
+    ]
+    best = client._get_best_audio_format(formats, tier='aac_256')
+    assert best['abr'] == 160
+
+
+def test_audio_format_selector_strings():
+    assert youtube_audio_format_selector('opus_160').startswith('bestaudio[acodec^=opus]')
+    assert 'm4a' in youtube_audio_format_selector('aac_128')
+    assert 'abr>=192' in youtube_audio_format_selector('opus_256')
+    assert youtube_audio_format_selector('nope') == 'bestaudio/best'
+
+
+def test_youtube_track_result_strips_topic_suffix_and_parses_title():
+    tr = _bare_client()._youtube_to_track_result({
+        'id': 'vid',
+        'title': 'Some Song',
+        'duration': 200,
+        'uploader': 'Radiohead - Topic',
+    })
+    assert tr.artist == 'Radiohead'
+    assert tr.title == 'Some Song'
+    assert tr.duration == 200_000
+    assert tr.quality == 'opus'
+
+
+def test_youtube_track_result_artist_dash_title():
+    tr = _bare_client()._youtube_to_track_result({
+        'id': 'vid',
+        'title': 'NIN - Hurt',
+        'duration': 90,
+    })
+    assert tr.artist == 'NIN'
+    assert tr.title == 'Hurt'
+
+
+# ── documentation pins ─────────────────────────────────────────────────────
+
+def _slice_between(text, start, end):
+    i = text.find(start)
+    j = text.find(end, i + 1) if i >= 0 else -1
+    assert i >= 0 and j > i, f'missing markers {start!r} / {end!r}'
+    return text[i:j]
+
+
+def test_docs_mention_youtube_reencode_default():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    index = (root / 'webui' / 'index.html').read_text(encoding='utf-8')
+    helper = (root / 'webui' / 'static' / 'helper.js').read_text(encoding='utf-8')
+    docs = (root / 'webui' / 'static' / 'docs.js').read_text(encoding='utf-8')
+    youtube_docs = _slice_between(docs, 'YouTube Configuration', 'UI Appearance')
+    youtube_help = _slice_between(helper, "'#youtube-settings-container'", "'#quality-profile-section'")
+    transcode_help = _slice_between(index, 'id="youtube-transcode"', 'id="youtube-transcode-options"')
+    assert 'Re-encode YouTube audio' in youtube_docs
+    assert 'MP3 320' in youtube_docs
+    assert 'Re-encode to MP3 320 is on by default' in youtube_help
+    assert 'Premium audio qualities' in youtube_help
+    assert 'Premium audio qualities' in youtube_docs
+    assert 'Premium audio qualities' in index
+    assert 'Opus or AAC' in transcode_help
+    assert 'quality list' in transcode_help
+    assert 'minimum confidence threshold' not in youtube_docs.lower()
+    search_yt = _slice_between(docs, 'YouTube settings', 'Downloading Music')
+    assert 'minimum confidence threshold' not in search_yt.lower()
+    assert 'Re-encode' in search_yt or 'MP3 320' in search_yt
+
+
+def test_quality_profile_help_covers_youtube():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    helper = (root / 'webui' / 'static' / 'helper.js').read_text(encoding='utf-8')
+    index = (root / 'webui' / 'index.html').read_text(encoding='utf-8')
+    qp_help = _slice_between(helper, "'#quality-profile-section'", "'.preset-button'")
+    transcode_help = _slice_between(index, 'id="youtube-transcode"', 'id="youtube-transcode-options"')
+    assert 'YouTube' in qp_help
+    assert 'Soulseek downloads' not in qp_help
+    assert 'Opus or AAC' in transcode_help
+    assert 'quality list' in transcode_help
+
+
+def test_settings_ui_has_no_preferred_youtube_audio_control():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    index = (root / 'webui' / 'index.html').read_text(encoding='utf-8')
+    settings = (root / 'webui' / 'static' / 'settings.js').read_text(encoding='utf-8')
+    assert 'id="youtube-audio-format"' not in index
+    assert 'Preferred YouTube audio' not in index
+    assert 'youtube-audio-format' not in settings
+    assert 'id="youtube-transcode" checked' in index
+    assert 'id="youtube-transcode-options" style="display: none;"' not in index
+    assert "settings.youtube?.transcode !== false" in settings
+    assert "transcode_codec: document.getElementById('youtube-transcode-codec')?.value || 'mp3'" in settings
+    assert "transcode_bitrate: document.getElementById('youtube-transcode-bitrate')?.value || '320'" in settings
+
+
+def test_user_facing_youtube_quality_copy_is_not_internal():
+    """YouTube re-encode copy must not mention itags, yt-dlp, probes, or the ladder."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    helper = (root / 'webui' / 'static' / 'helper.js').read_text(encoding='utf-8')
+    docs = (root / 'webui' / 'static' / 'docs.js').read_text(encoding='utf-8')
+    index = (root / 'webui' / 'index.html').read_text(encoding='utf-8')
+
+    youtube_help = _slice_between(helper, "'#youtube-settings-container'", "'#quality-profile-section'")
+    other_docs = _slice_between(docs, 'YouTube Configuration', 'UI Appearance')
+    transcode_help = _slice_between(index, 'id="youtube-transcode"', 'id="youtube-transcode-options"')
+
+    forbidden = ('itag', 'yt-dlp', 'bestaudio', 'extract_flat', 'ladder', 'probe', 'stamp')
+    for chunk in (youtube_help, other_docs, transcode_help):
+        lower = chunk.lower()
+        for word in forbidden:
+            assert word not in lower, f'{word!r} leaked into user-facing copy:\n{chunk}'
+
+
+# ── realistic yt-dlp format lists (typical free / Premium itags) ───────────
+#
+# Shape matches extract_info() on a real watch page: muxed itag 18, video-only,
+# storyboard (acodec/vcodec none), DASH audio 139/140/249/250/251. Premium
+# extras 141/774 are appended only when the account actually has them.
+
+_REAL_FREE_FORMATS = [
+    {'format_id': 'sb0', 'vcodec': 'none', 'acodec': 'none', 'ext': 'mhtml'},
+    {'format_id': '18', 'vcodec': 'avc1.42001E', 'acodec': 'mp4a.40.2', 'abr': 96, 'ext': 'mp4', 'tbr': 200},
+    {'format_id': '137', 'vcodec': 'avc1.640028', 'acodec': 'none', 'ext': 'mp4', 'tbr': 2500},
+    {'format_id': '139', 'vcodec': 'none', 'acodec': 'mp4a.40.5', 'abr': 48, 'ext': 'm4a', 'tbr': 49},
+    {'format_id': '140', 'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'tbr': 129},
+    {'format_id': '249', 'vcodec': 'none', 'acodec': 'opus', 'abr': 50, 'ext': 'webm', 'tbr': 52},
+    {'format_id': '250', 'vcodec': 'none', 'acodec': 'opus', 'abr': 70, 'ext': 'webm', 'tbr': 73},
+    {'format_id': '251', 'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'tbr': 165},
+]
+_REAL_PREMIUM_FORMATS = _REAL_FREE_FORMATS + [
+    {'format_id': '141', 'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 256, 'ext': 'm4a', 'tbr': 257},
+    {'format_id': '774', 'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'tbr': 260},
+]
+
+
+def test_realistic_free_formats_pick_opus_160_not_muxed():
+    best = _bare_client()._get_best_audio_format(_REAL_FREE_FORMATS, tier='opus_256')
+    assert best['format_id'] == '251'
+    from core.quality.source_map import quality_from_youtube
+    aq = quality_from_youtube(best)
+    assert aq.format == 'opus'
+    assert aq.bitrate == 160
+
+
+def test_realistic_premium_opus_256_picks_itag_774():
+    best = _bare_client()._get_best_audio_format(_REAL_PREMIUM_FORMATS, tier='opus_256')
+    assert best['format_id'] == '774'
+    assert best['abr'] == 256
+
+
+def test_realistic_free_aac_128_picks_itag_140():
+    best = _bare_client()._get_best_audio_format(_REAL_FREE_FORMATS, tier='aac_128')
+    assert best['format_id'] == '140'
+    from core.quality.source_map import quality_from_youtube
+    assert quality_from_youtube(best).format == 'aac'
+    assert quality_from_youtube(best).bitrate == 128
+
+
+def test_realistic_premium_aac_256_picks_itag_141_not_opus_774():
+    best = _bare_client()._get_best_audio_format(_REAL_PREMIUM_FORMATS, tier='aac_256')
+    assert best['format_id'] == '141'
+    assert best['abr'] == 256
+
+
+def test_realistic_opus_160_does_not_fetch_premium_256():
+    best = _bare_client()._get_best_audio_format(_REAL_PREMIUM_FORMATS, tier='opus_160')
+    assert best['format_id'] == '251'
+
+
+def test_realistic_he_aac_walks_to_opus_when_140_absent():
+    """HE-AAC 48 is below the aac_128 rung; walk-down prefers Opus 160."""
+    formats = [f for f in _REAL_FREE_FORMATS if f['format_id'] != '140']
+    best = _bare_client()._get_best_audio_format(formats, tier='aac_128')
+    assert best['format_id'] == '251'
+
+
+# ── _get_best_audio_format / selector edge cases ───────────────────────────
+
+def test_get_best_audio_format_none_and_missing_abr_uses_tbr():
+    client = _bare_client()
+    assert client._get_best_audio_format(None) is None
+    best = client._get_best_audio_format(
+        [{'vcodec': 'none', 'acodec': 'opus', 'abr': 0, 'tbr': 160, 'ext': 'webm'}],
+        tier='opus_160',
+    )
+    assert best['tbr'] == 160
+
+
+def test_get_best_audio_format_ext_only_opus_and_aac():
+    client = _bare_client()
+    opus = client._get_best_audio_format(
+        [
+            {'vcodec': 'none', 'acodec': '', 'ext': 'webm', 'abr': 160},
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'ext': 'm4a', 'abr': 128},
+        ],
+        tier='opus_160',
+    )
+    assert opus['abr'] == 160
+    aac = client._get_best_audio_format(
+        [
+            {'vcodec': 'none', 'acodec': '', 'ext': 'm4a', 'abr': 128},
+            {'vcodec': 'none', 'acodec': 'opus', 'ext': 'webm', 'abr': 160},
+        ],
+        tier='aac_128',
+    )
+    assert aac['abr'] == 128
+
+
+def test_get_best_audio_format_vorbis_is_not_an_opus_rung():
+    """Legacy Vorbis 171 is ogg, not an Opus ladder rung — walk to AAC 128."""
+    client = _bare_client()
+    best = client._get_best_audio_format(
+        [
+            {'vcodec': 'none', 'acodec': 'vorbis', 'abr': 128, 'ext': 'webm', 'format_id': '171'},
+            {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'format_id': '140'},
+        ],
+        tier='opus_160',
+    )
+    assert best['format_id'] == '140'
+
+
+def test_audio_format_selector_unknown_is_bestaudio():
+    assert youtube_audio_format_selector('nope') == 'bestaudio/best'
+    assert youtube_audio_format_selector('') == 'bestaudio/best'
+
+
+# ── video id + refresh edge cases ──────────────────────────────────────────
+
+@pytest.mark.parametrize("filename,want", [
+    ('abc123||Song', 'abc123'),
+    ('  vid  ||Song', 'vid'),
+    ('vid||', 'vid'),
+    ('vid||Song||extra', 'vid'),
+    ('nofileseparator', ''),
+    ('', ''),
+    (None, ''),
+    ('||Song', ''),
+    ('   ||Song', ''),
+])
+def test_video_id_from_candidate(filename, want):
+    cand = _yt_track(filename=filename) if filename is not None else _yt_track()
+    if filename is None:
+        cand.filename = None
+    else:
+        cand.filename = filename
+    assert YouTubeClient._video_id_from_candidate(cand) == want
+
+
+def test_refresh_skips_non_youtube_and_missing_id(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'},
+        ],
+    }, calls=calls)
+    tidal = _yt_track(username='tidal', filename='tid||Song', bitrate=1411)
+    bad = _yt_track(filename='nofileseparator', bitrate=160)
+    _bare_client().refresh_claimed_quality([tidal, bad])
+    assert calls == []
+    assert tidal.bitrate == 1411
+    assert bad.bitrate == 160
+
+
+def test_refresh_limit_zero_and_none_candidates(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    calls = []
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm'},
+        ],
+    }, calls=calls)
+    cand = _yt_track(bitrate=160)
+    client = _bare_client()
+    client.refresh_claimed_quality(None)
+    client.refresh_claimed_quality([cand], limit=0)
+    client.refresh_claimed_quality([cand], limit=-1)
+    assert calls == []
+    assert cand.bitrate == 160
+
+
+def test_refresh_info_none_or_missing_formats_keeps_claim(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    cand = _yt_track(bitrate=160)
+    _patch_ydl(monkeypatch, None)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.bitrate == 160
+    _patch_ydl(monkeypatch, {})
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.bitrate == 160
+
+
+def test_refresh_honours_opus_256_on_realistic_premium(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'opus_256')
+    _patch_ydl(monkeypatch, {'formats': _REAL_PREMIUM_FORMATS})
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 256
+
+
+def test_quality_filter_probe_exception_still_ranks_search_claim(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS], False)
+
+    class _Boom:
+        def refresh_claimed_quality(self, candidates, *, limit=3, **kwargs):
+            raise RuntimeError('probe exploded')
+
+    class _Orch:
+        def client(self, name):
+            return _Boom()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    cand = _yt_track(bitrate=160)
+    result = get_valid_candidates([cand], _Expected(), 'Artist Song')
+    assert result == [cand]
+
+
+def test_quality_filter_preferred_aac_128_rejected_by_aac_256_floor(monkeypatch):
+    _patch_profile(monkeypatch, [_AAC_256], False)
+
+    class _Orch:
+        def client(self, name):
+            return _bare_client()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'aac_128')
+    _patch_ydl(monkeypatch, {'formats': _REAL_FREE_FORMATS})
+    cand = _yt_track(bitrate=160)
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == []
+    assert cand.quality == 'aac'
+    assert cand.bitrate == 128
+
+
+# ── download_sync retries ──────────────────────────────────────────────────
+
+def test_download_sync_aborts_on_shutdown(monkeypatch):
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = lambda: True
+    assert client._download_sync('https://youtu.be/abc', 'Song') is None
+
+
+def test_download_sync_third_retry_uses_muxed_best(tmp_path, monkeypatch):
+    audio = tmp_path / 'Song.opus'
+    audio.write_bytes(b'x')
+    seen = []
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen.append(opts.get('format'))
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            if len(seen) < 3:
+                raise RuntimeError('temporary extractor error')
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_requested_tier',
+        lambda: 'opus_160',
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True, 'cookiefile': '/tmp/cookies.txt'}
+    client.shutdown_check = None
+    result = client._download_sync('https://youtu.be/abc', 'Song')
+    assert result == str(audio)
+    assert len(seen) == 3
+    assert 'opus' in seen[0]
+    assert 'opus' in seen[1]  # retry 2 still prefers opus; only drops cookies
+    assert seen[2] == 'best'
+
+
+def test_download_sync_retry_drops_cookies_on_second_attempt(tmp_path, monkeypatch):
+    audio = tmp_path / 'Song.m4a'
+    audio.write_bytes(b'x')
+    cookie_keys = []
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            cookie_keys.append(('cookiefile' in opts, 'cookiesfrombrowser' in opts))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            if len(cookie_keys) == 1:
+                raise RuntimeError('restricted format')
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True, 'cookiefile': '/tmp/cookies.txt'}
+    client.shutdown_check = None
+    assert client._download_sync('https://youtu.be/abc', 'Song') == str(audio)
+    assert cookie_keys[0] == (True, False)
+    assert cookie_keys[1] == (False, False)
+
+
+# ── quality filter + download selector extra edges ─────────────────────────
+
+
+def test_quality_filter_empty_profile_keeps_youtube_even_without_fallback(monkeypatch):
+    _patch_profile(monkeypatch, [], False)
+    cand = _yt_track()
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == [cand]
+
+
+def test_quality_filter_without_orchestrator_ranks_search_claim(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS], False)
+    monkeypatch.setattr(validation, 'download_orchestrator', None)
+    cand = _yt_track(bitrate=160)
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == [cand]
+
+
+def test_quality_filter_when_orchestrator_client_raises(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS], False)
+
+    class _Orch:
+        def client(self, name):
+            raise RuntimeError('youtube client not ready')
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    cand = _yt_track(bitrate=160)
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == [cand]
+
+
+def test_quality_filter_skips_probe_when_client_has_no_refresh(monkeypatch):
+    _patch_profile(monkeypatch, [_OPUS], False)
+
+    class _Orch:
+        def client(self, name):
+            return object()
+
+    monkeypatch.setattr(validation, 'download_orchestrator', _Orch())
+    cand = _yt_track(bitrate=160)
+    assert get_valid_candidates([cand], _Expected(), 'Artist Song') == [cand]
+
+
+def test_download_sync_selector_follows_requested_tier(tmp_path, monkeypatch):
+    audio = tmp_path / 'Song.m4a'
+    audio.write_bytes(b'x')
+    seen = []
+
+    class _FakeYDL:
+        def __init__(self, opts):
+            seen.append(opts.get('format'))
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=True):
+            return {'filepath': str(audio)}
+
+        def prepare_filename(self, info):
+            return str(tmp_path / 'Song.webm')
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _FakeYDL)
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: {'key': 'FFmpegExtractAudio', 'preferredcodec': 'best'},
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_requested_tier',
+        lambda: 'aac_128',
+    )
+    client = _bare_client()
+    client.download_opts = {'quiet': True}
+    client.shutdown_check = None
+    assert client._download_sync('https://youtu.be/abc', 'Song') == str(audio)
+    assert seen[0] == youtube_audio_format_selector('aac_128')
+    assert 'm4a' in seen[0]
+
+
+def test_default_youtube_config_has_no_preferred_audio_format():
+    from config.settings import ConfigManager
+    youtube = ConfigManager._get_default_config(None)['youtube']
+    assert 'audio_format' not in youtube
+    assert youtube['transcode'] is True
+    assert youtube['transcode_codec'] == 'mp3'
+    assert youtube['transcode_bitrate'] == '320'
+
+
+def test_refresh_only_ultra_low_stamps_honest_bitrate_not_160(monkeypatch):
+    monkeypatch.setattr(youtube_client, '_resolve_cookie_opts', lambda: {})
+    _use_tier(monkeypatch, 'opus_256')
+    _patch_ydl(monkeypatch, {
+        'formats': [
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 50, 'ext': 'webm', 'format_id': '249'},
+            {'vcodec': 'none', 'acodec': 'opus', 'abr': 70, 'ext': 'webm', 'format_id': '250'},
+            {'vcodec': 'none', 'acodec': 'mp4a.40.5', 'abr': 48, 'ext': 'm4a', 'format_id': '139'},
+        ],
+    })
+    cand = _yt_track(bitrate=160)
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.quality == 'opus'
+    assert cand.bitrate == 70
+
+
+def test_catalog_hit_claims_opus_160_not_mp3():
+    tr = _bare_client()._ytmusic_hit_to_track_result({
+        'id': 'vid1',
+        'name': 'Song',
+        'artists': ['Artist'],
+        'album': 'Album',
+        'duration_ms': 180_000,
+    })
+    assert tr.quality == 'opus'
+    assert tr.bitrate == 160
+    assert tr.audio_quality.format == 'opus'
+    assert tr.filename == 'vid1||Song'
+    assert tr.album == 'Album'
+
+
+def test_catalog_hit_reencode_claims_mp3_320(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, '_youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    tr = _bare_client()._ytmusic_hit_to_track_result({
+        'id': 'vid1',
+        'name': 'Song',
+        'artists': ['Artist'],
+        'album': 'Album',
+        'duration_ms': 180_000,
+    })
+    assert tr.quality == 'mp3'
+    assert tr.bitrate == 320
+    assert tr.audio_quality.format == 'mp3'
+    assert tr.audio_quality.bitrate == 320
+

--- a/tests/downloads/test_youtube_live_audio.py
+++ b/tests/downloads/test_youtube_live_audio.py
@@ -1,0 +1,259 @@
+"""Live YouTube format-probe and audio-download tests.
+
+Gated behind ``-m youtube_live`` so default CI stays offline. Run locally:
+
+    python -m pytest tests/downloads/test_youtube_live_audio.py -m youtube_live -v -s
+
+Uses a short public video (the first YouTube upload, ~19s) — not copyrighted
+music. Bot-checks, missing ffmpeg/deno, and network errors skip rather than
+fail, matching the SoundCloud live pattern.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from core.download_plugins.types import TrackResult
+from core.quality.source_map import quality_from_youtube
+from core.youtube_client import (
+    YouTubeClient,
+    youtube_audio_postprocessor,
+)
+
+# First YouTube video: "Me at the zoo" — public, ~19 seconds.
+_LIVE_VIDEO_ID = 'jNQXAC9IVRw'
+_LIVE_URL = f'https://www.youtube.com/watch?v={_LIVE_VIDEO_ID}'
+
+_BOT_HINTS = (
+    'sign in to confirm',
+    'confirm you’re not a bot',
+    "confirm you're not a bot",
+    'bot',
+    'http error 429',
+    'http error 403',
+    'too many requests',
+    'requested format is not available',
+    'unable to extract',
+    'video unavailable',
+    'private video',
+    'timed out',
+    'name or service not known',
+    'temporary failure',
+    'network is unreachable',
+    'connection reset',
+    'ssl',
+)
+
+
+pytestmark = pytest.mark.youtube_live
+
+
+def _skip_youtube(exc: BaseException) -> None:
+    msg = f'{type(exc).__name__}: {exc}'.lower()
+    if any(h in msg for h in _BOT_HINTS):
+        pytest.skip(f'YouTube blocked or unavailable ({exc})')
+    pytest.skip(f'YouTube live probe failed ({exc})')
+
+
+def _bare_client(tmp_path: Path | None = None) -> YouTubeClient:
+    client = YouTubeClient.__new__(YouTubeClient)
+    client.shutdown_check = None
+    if tmp_path is not None:
+        client.download_path = tmp_path
+        client.download_opts = {
+            'outtmpl': str(tmp_path / '%(id)s.%(ext)s'),
+            'quiet': True,
+            'no_warnings': True,
+            'noprogress': True,
+            'noplaylist': True,
+        }
+    return client
+
+
+def _yt_track(video_id: str = _LIVE_VIDEO_ID) -> TrackResult:
+    return TrackResult(
+        username='youtube',
+        filename=f'{video_id}||Me at the zoo',
+        size=0,
+        bitrate=160,
+        duration=19_000,
+        quality='opus',
+        free_upload_slots=999,
+        upload_speed=999,
+        queue_length=0,
+        artist='jawed',
+        title='Me at the zoo',
+    )
+
+
+def _extract_or_skip():
+    import yt_dlp
+
+    opts = {
+        'quiet': True,
+        'no_warnings': True,
+        'skip_download': True,
+        'noplaylist': True,
+    }
+    try:
+        from core.youtube_client import _resolve_cookie_opts
+        opts.update(_resolve_cookie_opts())
+    except Exception:
+        pass
+    try:
+        with yt_dlp.YoutubeDL(opts) as ydl:
+            info = ydl.extract_info(_LIVE_URL, download=False)
+    except Exception as exc:  # noqa: BLE001 - live skip
+        _skip_youtube(exc)
+    if not info:
+        pytest.skip('YouTube extract_info returned nothing')
+    return info
+
+
+def test_live_extract_lists_real_dash_audio_itags():
+    """A real watch page must expose audio-only DASH (251 Opus and/or 140 AAC)."""
+    info = _extract_or_skip()
+    formats = info.get('formats') or []
+    audio = [
+        f for f in formats
+        if f.get('vcodec') == 'none' and f.get('acodec') not in (None, 'none')
+    ]
+    assert audio, f'no audio-only formats in {len(formats)} listed formats'
+    ids = {str(f.get('format_id')) for f in audio}
+    assert ids & {'251', '140', '250', '249', '139'}, f'unexpected audio itags: {ids}'
+
+    client = _bare_client()
+    best = client._get_best_audio_format(formats, tier='opus_256')
+    assert best is not None
+    aq = quality_from_youtube(best)
+    assert aq.format in ('opus', 'aac')
+    assert aq.bitrate and aq.bitrate >= 48
+    assert aq.bit_depth is None
+    assert not (aq.format == 'mp3' and aq.bitrate == 320)
+
+
+def test_live_preferred_opus_and_aac_pick_matching_codecs():
+    info = _extract_or_skip()
+    formats = info.get('formats') or []
+    client = _bare_client()
+    opus = client._get_best_audio_format(formats, tier='opus_160')
+    aac = client._get_best_audio_format(formats, tier='aac_128')
+    assert opus is not None and aac is not None
+
+    opus_q = quality_from_youtube(opus)
+    aac_q = quality_from_youtube(aac)
+    has_opus = any(
+        'opus' in str(f.get('acodec') or '').lower()
+        for f in formats
+        if f.get('vcodec') == 'none'
+    )
+    has_aac = any(
+        'mp4a' in str(f.get('acodec') or '').lower() or 'aac' in str(f.get('acodec') or '').lower()
+        for f in formats
+        if f.get('vcodec') == 'none'
+    )
+    if has_opus:
+        assert opus_q.format == 'opus'
+    if has_aac:
+        assert aac_q.format == 'aac'
+    if has_opus and has_aac:
+        assert opus.get('format_id') != aac.get('format_id')
+
+
+def test_live_refresh_stamps_claimed_quality_from_real_itags(monkeypatch):
+    info = _extract_or_skip()
+
+    class _YDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def extract_info(self, url, download=False):
+            assert _LIVE_VIDEO_ID in url
+            assert download is False
+            return info
+
+    monkeypatch.setattr('core.youtube_client.yt_dlp.YoutubeDL', _YDL)
+    monkeypatch.setattr('core.youtube_client._resolve_cookie_opts', lambda: {})
+    cand = _yt_track()
+    _bare_client().refresh_claimed_quality([cand])
+    assert cand.audio_quality.format in ('opus', 'aac')
+    assert cand.bitrate >= 48
+    assert cand.quality != 'mp3'
+
+
+def test_live_download_remuxes_original_audio(tmp_path, monkeypatch):
+    """Download the short public clip and keep the original Opus/AAC stream."""
+    if not shutil.which('ffmpeg') and not shutil.which('ffmpeg.exe'):
+        pytest.skip('ffmpeg not on PATH — remux requires it')
+    _extract_or_skip()  # skip early on bot-check before spending a download
+
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: youtube_audio_postprocessor(transcode=False),
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_requested_tier',
+        lambda: 'opus_256',
+    )
+    monkeypatch.setattr('core.youtube_client._resolve_cookie_opts', lambda: {})
+
+    client = _bare_client(tmp_path)
+    try:
+        path = client._download_sync(_LIVE_URL, 'Me at the zoo')
+    except Exception as exc:  # noqa: BLE001 - live skip
+        _skip_youtube(exc)
+
+    if not path:
+        pytest.skip('YouTube download returned no file (bot-check or format unavailable)')
+
+    out = Path(path)
+    assert out.is_file(), path
+    assert out.stat().st_size > 5_000
+    assert out.suffix.lower() in {'.opus', '.m4a', '.webm', '.ogg', '.aac'}
+    assert out.suffix.lower() != '.mp3'
+
+
+def test_live_download_preferred_opus_keeps_opus_when_available(tmp_path, monkeypatch):
+    if not shutil.which('ffmpeg') and not shutil.which('ffmpeg.exe'):
+        pytest.skip('ffmpeg not on PATH — remux requires it')
+    info = _extract_or_skip()
+    formats = info.get('formats') or []
+    has_opus = any(
+        f.get('vcodec') == 'none' and 'opus' in str(f.get('acodec') or '').lower()
+        for f in formats
+    )
+    if not has_opus:
+        pytest.skip('this video has no Opus DASH audio')
+
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_audio_postprocessor_from_config',
+        lambda: youtube_audio_postprocessor(transcode=False),
+    )
+    monkeypatch.setattr(
+        'core.youtube_client.youtube_requested_tier',
+        lambda: 'opus_160',
+    )
+    monkeypatch.setattr('core.youtube_client._resolve_cookie_opts', lambda: {})
+
+    client = _bare_client(tmp_path)
+    try:
+        path = client._download_sync(_LIVE_URL, 'Me at the zoo')
+    except Exception as exc:  # noqa: BLE001 - live skip
+        _skip_youtube(exc)
+
+    if not path:
+        pytest.skip('YouTube download returned no file (bot-check or format unavailable)')
+
+    out = Path(path)
+    assert out.is_file()
+    assert out.stat().st_size > 5_000
+    assert out.suffix.lower() in {'.opus', '.webm'}

--- a/tests/imports/test_import_file_ops.py
+++ b/tests/imports/test_import_file_ops.py
@@ -522,3 +522,42 @@ def test_opus_chip_ignores_youtube_claim_when_file_is_mp3(tmp_path, monkeypatch)
     assert _fo.get_audio_quality_string(
         str(path), claimed_format="opus", claimed_bitrate=256,
     ) == "MP3-320"
+
+
+def test_estimate_bitrate_kbps_from_size_and_duration():
+    """40 KB over 2s is 160 kbps — the YouTube Opus 160 effective rate."""
+    assert _fo.estimate_bitrate_kbps(size_bytes=40_000, duration_seconds=2.0) == 160
+    assert _fo.estimate_bitrate_kbps(size_bytes=40_000, duration_ms=2000) == 160
+    assert _fo.estimate_bitrate_kbps(size_bytes=0, duration_ms=2000) is None
+    assert _fo.estimate_bitrate_kbps(size_bytes=40_000, duration_ms=0) is None
+
+
+def test_fill_missing_track_bitrate_estimates_when_db_is_zero():
+    """Library enhanced view reads tracks.bitrate; Opus import left it at 0."""
+    track = {
+        "bitrate": 0,
+        "file_size": 40_000,
+        "duration": 2000,
+        "file_path": "Autumnal Embrace.opus",
+    }
+    assert _fo.fill_missing_track_bitrate(track)["bitrate"] == 160
+
+
+def test_fill_missing_track_bitrate_keeps_a_header_value():
+    track = {"bitrate": 320, "file_size": 40_000, "duration": 2000, "file_path": "a.mp3"}
+    filled = _fo.fill_missing_track_bitrate(track)
+    assert filled["bitrate"] == 320
+    assert not filled.get("bitrate_vbr")
+
+
+def test_fill_missing_track_bitrate_flags_aac_as_vbr():
+    track = {"bitrate": 256, "file_path": "song.m4a"}
+    assert _fo.fill_missing_track_bitrate(track).get("bitrate_vbr") == 1
+
+
+def test_stream_uses_vbr_display_for_lossy_averages():
+    assert _fo.stream_uses_vbr_display("a.opus") is True
+    assert _fo.stream_uses_vbr_display("a.m4a") is True
+    assert _fo.stream_uses_vbr_display("a.wma") is True
+    assert _fo.stream_uses_vbr_display("a.mp3") is False
+    assert _fo.stream_uses_vbr_display("a.flac") is False

--- a/tests/imports/test_import_file_ops.py
+++ b/tests/imports/test_import_file_ops.py
@@ -388,7 +388,7 @@ def _enable_lossy(monkeypatch, codec="mp3", bitrate="320"):
     cfg = {"lossy_copy.enabled": True, "lossy_copy.codec": codec,
            "lossy_copy.bitrate": bitrate, "lossy_copy.delete_original": False}
     monkeypatch.setattr(_fo.config_manager, "get", lambda k, d=None: cfg.get(k, d))
-    monkeypatch.setattr(_fo, "get_audio_quality_string", lambda _p: None)
+    monkeypatch.setattr(_fo, "get_audio_quality_string", lambda _p, **_k: None)
 
 
 def test_create_lossy_copy_rejects_non_lossless(monkeypatch, tmp_path):
@@ -435,3 +435,90 @@ def test_create_lossy_copy_skips_when_output_would_overwrite_source(monkeypatch,
     out = _fo.create_lossy_copy(str(src))
     assert out is None                 # skipped — output would overwrite source
     assert ran["called"] is False      # the original was never touched
+
+
+def test_opus_quality_chip_estimates_bitrate_when_header_has_none(tmp_path, monkeypatch):
+    """mutagen.oggopus exposes length, not bitrate. YouTube remux files were
+    importing with a blank quality chip because `info.bitrate // 1000` threw."""
+    path = tmp_path / "song.opus"
+    path.write_bytes(b"x" * 40_000)  # 40 KB over 2s ≈ 160 kbps
+
+    class _Info:
+        length = 2.0
+        channels = 2
+
+    class _Opus:
+        def __init__(self, _p):
+            self.info = _Info()
+
+    monkeypatch.setattr("mutagen.oggopus.OggOpus", _Opus)
+    assert _fo.get_audio_quality_string(str(path)) == "OPUS-160"
+    assert _fo.get_audio_quality_string(
+        str(path), claimed_format="opus", claimed_bitrate=256,
+    ) == "OPUS-256"
+    aq = _fo.probe_audio_quality(str(path))
+    assert aq is not None
+    assert aq.format == "opus"
+    assert aq.bitrate == 160
+
+
+def test_opus_256_estimate_meets_opus_192_target(tmp_path, monkeypatch):
+    path = tmp_path / "premium.opus"
+    path.write_bytes(b"x" * 64_000)  # 64 KB over 2s ≈ 256 kbps
+
+    class _Info:
+        length = 2.0
+        channels = 2
+
+    class _Opus:
+        def __init__(self, _p):
+            self.info = _Info()
+
+    monkeypatch.setattr("mutagen.oggopus.OggOpus", _Opus)
+    from core.quality.model import QualityTarget
+    from core.quality.selection import quality_meets_profile
+
+    aq = _fo.probe_audio_quality(str(path))
+    assert quality_meets_profile(
+        aq, [QualityTarget(label="OPUS ≥ 192", format="opus", min_bitrate=192)],
+    )
+
+
+def test_opus_chip_without_duration_is_still_opus(tmp_path, monkeypatch):
+    path = tmp_path / "nodur.opus"
+    path.write_bytes(b"x" * 100)
+
+    class _Info:
+        length = 0
+        channels = 2
+
+    class _Opus:
+        def __init__(self, _p):
+            self.info = _Info()
+
+    monkeypatch.setattr("mutagen.oggopus.OggOpus", _Opus)
+    assert _fo.get_audio_quality_string(str(path)) == "OPUS"
+    assert _fo.get_audio_quality_string(
+        str(path), claimed_format="opus", claimed_bitrate=256,
+    ) == "OPUS-256"
+
+
+def test_opus_chip_ignores_youtube_claim_when_file_is_mp3(tmp_path, monkeypatch):
+    """Re-encode to MP3 must not inherit the Opus itag bitrate."""
+    path = tmp_path / "song.mp3"
+    path.write_bytes(b"x" * 1000)
+
+    class _Info:
+        bitrate = 320_000
+        bitrate_mode = None
+        length = 2.0
+
+    class _MP3:
+        def __init__(self, _p):
+            self.info = _Info()
+
+    monkeypatch.setattr("mutagen.mp3.MP3", _MP3)
+    monkeypatch.setattr("mutagen.mp3.BitrateMode", type("BM", (), {"VBR": object()}))
+    assert _fo.get_audio_quality_string(
+        str(path), claimed_format="opus", claimed_bitrate=256,
+    ) == "MP3-320"

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -233,7 +233,7 @@ def test_post_process_matched_download_forwards_separate_metadata_runtime(tmp_pa
     )
     monkeypatch.setattr(import_pipeline, "resolve_album_group", lambda artist_context, album_info, original_album: album_info["album_name"])
     monkeypatch.setattr(import_pipeline, "get_import_clean_title", lambda *args, **kwargs: "Track")
-    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda file_path: "")
+    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda file_path, **_k: "")
     monkeypatch.setattr(import_pipeline, "check_flac_bit_depth", lambda *args, **kwargs: None)
     # Bypass integrity check — the 5-byte fixture would fail it; this test
     # exercises the metadata-runtime forwarding path, not file integrity.
@@ -321,7 +321,7 @@ def _wire_post_process_common(monkeypatch, tmp_path, target_path, *, track_numbe
     )
     monkeypatch.setattr(import_pipeline, "resolve_album_group", lambda artist_context, album_info, original_album: album_info["album_name"])
     monkeypatch.setattr(import_pipeline, "get_import_clean_title", lambda *args, **kwargs: "Track")
-    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda file_path: "")
+    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda file_path, **_k: "")
     monkeypatch.setattr(import_pipeline, "check_flac_bit_depth", lambda *args, **kwargs: None)
     from core.imports.file_integrity import IntegrityResult
     monkeypatch.setattr(import_pipeline, "check_audio_integrity",
@@ -422,7 +422,7 @@ def test_quality_gate_runs_before_acoustid(tmp_path, monkeypatch):
     monkeypatch.setattr(import_pipeline, "detect_broken_audio", lambda *_a, **_kw: None)
 
     # Wrong quality → rejection.
-    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda fp: "FLAC 16bit/44.1kHz")
+    monkeypatch.setattr(import_pipeline, "get_audio_quality_string", lambda fp, **_k: "FLAC 16bit/44.1kHz")
     monkeypatch.setattr(import_pipeline, "check_quality_target", lambda fp, ctx: "Quality mismatch: FLAC 16bit")
 
     triggers = []

--- a/tests/imports/test_import_side_effects.py
+++ b/tests/imports/test_import_side_effects.py
@@ -159,6 +159,59 @@ def test_record_soulsync_library_entry_writes_artist_album_and_track(tmp_path, m
     assert track_row["quality_profile_id"] is None
 
 
+def test_record_soulsync_library_entry_estimates_opus_bitrate(tmp_path, monkeypatch):
+    """mutagen.oggopus has no bitrate field. The library enhanced table was
+    storing 0 and rendering a red dash, while completed-download chips
+    already estimated from size/duration."""
+    conn = _make_soulsync_db()
+    fake_db = _FakeDB(conn)
+    final_path = tmp_path / "Autumnal Embrace.opus"
+    final_path.write_bytes(b"x" * 40_000)
+
+    class _Info:
+        length = 2.0
+        channels = 2
+
+    class _Opus:
+        def __init__(self, _p, easy=False):
+            self.info = _Info()
+            self.tags = None
+
+    monkeypatch.setattr(side_effects, "get_database", lambda: fake_db)
+    monkeypatch.setattr(
+        side_effects,
+        "_get_config_manager",
+        lambda: SimpleNamespace(get_active_media_server=lambda: "soulsync"),
+    )
+    monkeypatch.setattr("mutagen.File", _Opus)
+
+    import core.genre_filter as genre_filter
+
+    monkeypatch.setattr(genre_filter, "filter_genres", lambda genres, _cfg: genres)
+
+    context = {
+        "source": "spotify",
+        "artist": {"id": "sp-artist", "name": "Skyforest"},
+        "album": {"id": "sp-album", "name": "Autumn's Dawn"},
+        "track_info": {
+            "id": "sp-track",
+            "name": "Autumnal Embrace",
+            "track_number": 3,
+            "duration_ms": 2000,
+            "_source": "spotify",
+        },
+        "original_search_result": {"title": "Autumnal Embrace", "_source": "spotify"},
+        "_final_processed_path": str(final_path),
+    }
+
+    side_effects.record_soulsync_library_entry(
+        context, {"name": "Skyforest", "genres": []}, {"is_album": True, "album_name": "Autumn's Dawn"},
+    )
+
+    track_row = conn.execute("SELECT bitrate FROM tracks").fetchone()
+    assert track_row["bitrate"] == 160
+
+
 def test_record_soulsync_library_entry_persists_quality_profile_id(tmp_path, monkeypatch):
     """Whatever the pipeline resolved for this item (a wishlist row's or
     Auto-Import's own profile override) must land on the library track row —

--- a/tests/imports/test_quality_guard.py
+++ b/tests/imports/test_quality_guard.py
@@ -138,3 +138,120 @@ def test_quality_quarantine_persists_quality_trigger(monkeypatch, tmp_path):
     assert meta['trigger'] != 'acoustid'
     assert 'wanted FLAC 24-bit/96kHz' in meta['quarantine_reason']
     assert qpath.endswith('.quarantined')
+
+
+# ── YouTube re-encode vs the import quality guard ──────────────────────────
+#
+# With re-encode on, search ranking uses the converted file (e.g. MP3 320).
+# The import guard probes that file, so a profile that asked for Opus will
+# reject a transcoded MP3 when Fallback is off. That is a quality mismatch
+# (quarantine), not corruption.
+
+_WANT_OPUS = {
+    'fallback_enabled': False,
+    'ranked_targets': [{'label': 'Opus', 'format': 'opus'}],
+}
+_WANT_OPUS_FALLBACK = {**_WANT_OPUS, 'fallback_enabled': True}
+_WANT_AAC = {
+    'fallback_enabled': False,
+    'ranked_targets': [{'label': 'AAC', 'format': 'aac', 'min_bitrate': 128}],
+}
+_WANT_MP3_320 = {
+    'fallback_enabled': False,
+    'ranked_targets': [{'label': 'MP3 320kbps', 'format': 'mp3', 'min_bitrate': 320}],
+}
+_WANT_FLAC_THEN_MP3 = {
+    'fallback_enabled': False,
+    'ranked_targets': [
+        {'label': 'FLAC 16-bit', 'format': 'flac', 'bit_depth': 16},
+        {'label': 'MP3 320kbps', 'format': 'mp3', 'min_bitrate': 320},
+    ],
+}
+
+_OPUS_160 = AudioQuality('opus', bitrate=160)
+_AAC_128 = AudioQuality('aac', bitrate=128)
+_MP3_320 = AudioQuality('mp3', bitrate=320)
+_MP3_128 = AudioQuality('mp3', bitrate=128)
+
+
+def test_transcoded_mp3_rejected_when_profile_asked_for_opus(monkeypatch):
+    _patch_guard(monkeypatch, _MP3_320, _WANT_OPUS)
+    reason = guards.check_quality_target('/x/Song.mp3', {})
+    assert reason is not None
+    assert 'Quality mismatch' in reason
+    assert 'MP3 320kbps' in reason
+    assert 'Opus' in reason
+    assert 'corrupt' not in reason.lower()
+
+
+def test_transcoded_mp3_accepted_via_fallback_when_profile_asked_for_opus(monkeypatch):
+    _patch_guard(monkeypatch, _MP3_320, _WANT_OPUS_FALLBACK)
+    assert guards.check_quality_target('/x/Song.mp3', {}) is None
+
+
+def test_remuxed_opus_accepted_when_profile_asked_for_opus(monkeypatch):
+    _patch_guard(monkeypatch, _OPUS_160, _WANT_OPUS)
+    assert guards.check_quality_target('/x/Song.opus', {}) is None
+
+
+def test_transcoded_mp3_accepted_when_profile_includes_mp3_320(monkeypatch):
+    """Re-encode to MP3 320 satisfies an MP3 320 target even if YouTube's
+    original stream was Opus — the guard checks the file on disk."""
+    _patch_guard(monkeypatch, _MP3_320, _WANT_FLAC_THEN_MP3)
+    assert guards.check_quality_target('/x/Song.mp3', {}) is None
+
+
+def test_transcoded_mp3_128_rejected_when_profile_wants_mp3_320(monkeypatch):
+    _patch_guard(monkeypatch, _MP3_128, _WANT_MP3_320)
+    reason = guards.check_quality_target('/x/Song.mp3', {})
+    assert reason is not None
+    assert 'MP3 128kbps' in reason
+
+
+def test_transcoded_aac_rejected_when_profile_asked_for_opus(monkeypatch):
+    _patch_guard(monkeypatch, _AAC_128, _WANT_OPUS)
+    reason = guards.check_quality_target('/x/Song.m4a', {})
+    assert reason is not None
+    assert 'AAC' in reason
+
+
+def test_transcoded_aac_accepted_when_profile_asked_for_aac(monkeypatch):
+    _patch_guard(monkeypatch, _AAC_128, _WANT_AAC)
+    assert guards.check_quality_target('/x/Song.m4a', {}) is None
+
+
+def test_transcode_output_unprobeable_is_not_rejected(monkeypatch):
+    """If mutagen can't read the re-encoded file, the quality gate fails open
+    (same as any other unreadable download) — it does not invent a mismatch."""
+    _patch_guard(monkeypatch, None, _WANT_OPUS)
+    assert guards.check_quality_target('/x/Song.mp3', {}) is None
+
+
+def test_integrity_check_does_not_take_a_quality_profile():
+    """Corruption/integrity is size + parse + duration. A successful re-encode
+    to a valid MP3 is not 'corrupt' just because the profile asked for Opus."""
+    import inspect
+    from core.imports.file_integrity import check_audio_integrity
+    params = inspect.signature(check_audio_integrity).parameters
+    assert 'targets' not in params
+    assert 'profile' not in params
+    assert 'ranked_targets' not in params
+
+
+def test_quality_mismatch_quarantine_is_not_an_integrity_trigger(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        guards, '_get_config_manager',
+        lambda: types.SimpleNamespace(get=lambda k, d=None: str(tmp_path) if 'download_path' in k else d),
+    )
+    src = tmp_path / 'Song.mp3'
+    src.write_bytes(b'ID3fake')
+    guards.move_to_quarantine(
+        str(src), {},
+        'Quality mismatch: file is MP3 320kbps, does not satisfy any configured target (best wanted: Opus)',
+        automation_engine=None, trigger='quality',
+    )
+    meta = json.loads(next((tmp_path / 'ss_quarantine').glob('*.json')).read_text(encoding='utf-8'))
+    assert meta['trigger'] == 'quality'
+    assert meta['trigger'] != 'integrity'
+    assert 'corrupt' not in meta['quarantine_reason'].lower()
+

--- a/tests/library/test_library_bitrate_estimate.py
+++ b/tests/library/test_library_bitrate_estimate.py
@@ -1,0 +1,55 @@
+"""Library bitrate: estimate when the container has no header field.
+
+Ogg Opus (YouTube remux) stores 0 because mutagen.oggopus only exposes
+length + channels. The enhanced album table then rendered a red dash
+while completed-download chips already showed the size/duration average.
+"""
+
+from __future__ import annotations
+
+import os
+
+from database.music_database import MusicDatabase
+from core.soulsync_client import _read_tags
+
+
+def test_read_tags_estimates_opus_bitrate_without_header(tmp_path, monkeypatch):
+    path = tmp_path / "Autumnal Embrace.opus"
+    path.write_bytes(b"x" * 40_000)
+
+    class _Info:
+        length = 2.0
+        channels = 2
+
+    class _Audio:
+        tags = None
+        info = _Info()
+
+    monkeypatch.setattr("mutagen.File", lambda *_a, **_k: _Audio())
+    assert _read_tags(str(path))["bitrate"] == 160
+
+
+def test_artist_full_detail_fills_opus_bitrate_from_size_and_duration(tmp_path):
+    """Already-imported Opus rows stay at bitrate=0 until a rescan. The
+    enhanced payload must still show the average so the table is not a dash."""
+    db = MusicDatabase(os.path.join(tmp_path, "t.db"))
+    conn = db._get_connection()
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO artists (id, name, server_source) VALUES ('1', 'Skyforest', 'soulsync')"
+    )
+    cur.execute("INSERT INTO albums (id, artist_id, title) VALUES ('a1', '1', 'Autumn')")
+    cur.execute(
+        """
+        INSERT INTO tracks (id, album_id, artist_id, title, duration, file_path, bitrate, file_size)
+        VALUES ('t1', 'a1', '1', 'Autumnal Embrace', 2000, 'Autumnal Embrace.opus', 0, 40000)
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    result = db.get_artist_full_detail("1")
+    assert result["success"] is True
+    track = result["albums"][0]["tracks"][0]
+    assert track["bitrate"] == 160
+    assert track["bitrate_vbr"] == 1

--- a/tests/quality/test_quality_meets_profile.py
+++ b/tests/quality/test_quality_meets_profile.py
@@ -58,3 +58,19 @@ def test_targets_from_profile_migrates_v2_qualities():
     profile = {'qualities': {'flac': {'enabled': True, 'priority': 1}}}
     targets, _ = targets_from_profile(profile)
     assert any(t.format == 'flac' for t in targets)
+
+
+def test_targets_from_profile_empty_or_missing_is_no_constraint():
+    for profile in ({}, {'ranked_targets': []}, {'ranked_targets': None}):
+        targets, fallback = targets_from_profile(profile)
+        assert targets == []
+        assert fallback is True
+        assert quality_meets_profile(MP3, targets) is True
+
+
+def test_targets_from_profile_missing_fallback_defaults_on():
+    targets, fallback = targets_from_profile({
+        'ranked_targets': [{'format': 'flac', 'bit_depth': 16}],
+    })
+    assert [t.format for t in targets] == ['flac']
+    assert fallback is True

--- a/tests/quality/test_source_map.py
+++ b/tests/quality/test_source_map.py
@@ -13,6 +13,7 @@ from core.quality.source_map import (
     quality_from_qobuz,
     quality_from_deezer,
     quality_from_amazon,
+    quality_from_youtube,
     format_from_extension,
     AUDIO_EXTENSIONS,
 )
@@ -146,3 +147,86 @@ def test_amazon_uhd_tier_fallback():
     assert aq.format == "flac"
     assert aq.bit_depth == 24
     assert aq.sample_rate == 96000
+
+
+@pytest.mark.parametrize("fmt,expected_format,expected_br", [
+    (None, "opus", 160),
+    ({}, "opus", 160),
+    ({"acodec": "opus", "abr": 50, "ext": "webm", "format_id": "249"}, "opus", 50),
+    ({"acodec": "opus", "abr": 70, "ext": "webm", "format_id": "250"}, "opus", 70),
+    ({"acodec": "opus", "abr": 160, "ext": "webm", "format_id": "251"}, "opus", 160),
+    ({"acodec": "opus", "abr": 256, "ext": "webm", "format_id": "774"}, "opus", 256),
+    ({"acodec": "mp4a.40.2", "abr": 48, "ext": "m4a", "format_id": "139"}, "aac", 48),
+    ({"acodec": "mp4a.40.2", "abr": 128, "ext": "m4a", "format_id": "140"}, "aac", 128),
+    ({"acodec": "mp4a.40.2", "abr": 256, "ext": "m4a", "format_id": "141"}, "aac", 256),
+    ({"acodec": "mp4a.40.5", "abr": 48, "ext": "m4a"}, "aac", 48),  # HE-AAC
+    ({"acodec": "aac", "ext": "m4a"}, "aac", 128),  # typical when abr missing
+    ({"acodec": "opus", "ext": "webm"}, "opus", 160),
+    ({"ext": "webm", "tbr": 160}, "opus", 160),
+    ({"ext": "m4a", "tbr": 128}, "aac", 128),
+    ({"ext": "opus", "abr": 160}, "opus", 160),
+    ({"ext": "aac"}, "aac", 128),
+    ({"acodec": "vorbis", "abr": 128}, "ogg", 128),  # legacy itag 171/172
+    ({"acodec": "mp3", "abr": 128, "ext": "mp3"}, "opus", 128),  # not a YouTube itag
+    ({"acodec": "unknown", "abr": 96}, "opus", 96),  # don't invent mp3
+    ({"acodec": "none"}, "opus", 160),
+    ({"abr": "not-a-number", "ext": "webm"}, "opus", 160),
+    ({"abr": 0, "tbr": 160, "acodec": "opus"}, "opus", 160),  # abr 0 → tbr
+    ({"abr": None, "tbr": 70, "acodec": "opus"}, "opus", 70),
+    ({"abr": 160.7, "acodec": "opus", "ext": "webm"}, "opus", 160),
+])
+def test_youtube_format_matrix(fmt, expected_format, expected_br):
+    aq = quality_from_youtube(fmt)
+    assert aq.format == expected_format
+    assert aq.bitrate == expected_br
+    assert aq.bit_depth is None  # YouTube is always lossy
+
+
+def test_youtube_abr_wins_over_tbr():
+    aq = quality_from_youtube({"acodec": "opus", "abr": 160, "tbr": 999, "ext": "webm"})
+    assert aq.bitrate == 160
+
+
+def test_youtube_missing_format_claims_opus_160():
+    aq = quality_from_youtube(None)
+    assert aq.format == "opus"
+    assert aq.bitrate == 160
+
+
+def test_youtube_never_invents_mp3_320():
+    for fmt in (None, {}, {"acodec": "opus"}, {"ext": "webm"}, {"acodec": "mystery"}):
+        aq = quality_from_youtube(fmt)
+        assert not (aq.format == "mp3" and aq.bitrate == 320)
+
+
+def test_youtube_string_abr_parses_int():
+    aq = quality_from_youtube({"acodec": "opus", "abr": "160", "ext": "webm"})
+    assert aq.bitrate == 160
+
+
+def test_youtube_string_float_abr_falls_back_to_typical():
+    """yt-dlp usually gives numeric abr; a '160.7' string is not int()-able."""
+    aq = quality_from_youtube({"acodec": "opus", "abr": "160.7", "ext": "webm"})
+    assert aq.format == "opus"
+    assert aq.bitrate == 160
+
+
+def test_youtube_empty_acodec_uses_ext():
+    assert quality_from_youtube({"acodec": "", "ext": "m4a", "abr": 128}).format == "aac"
+    assert quality_from_youtube({"acodec": None, "ext": "webm", "abr": 70}).format == "opus"
+
+
+def test_youtube_whitespace_acodec():
+    aq = quality_from_youtube({"acodec": "  OPUS  ", "abr": 160, "ext": "WEBM"})
+    assert aq.format == "opus"
+    assert aq.bitrate == 160
+
+
+def test_youtube_mapper_has_no_premium_or_cookies_knob():
+    import inspect
+    sig = inspect.signature(quality_from_youtube)
+    assert list(sig.parameters) == ["audio_format"]
+    with pytest.raises(TypeError):
+        quality_from_youtube(None, premium=True)
+    with pytest.raises(TypeError):
+        quality_from_youtube(None, cookies=True)

--- a/tests/quality/test_source_tier.py
+++ b/tests/quality/test_source_tier.py
@@ -43,6 +43,7 @@ def test_no_targets_requests_max(monkeypatch):
     _patch_targets(monkeypatch, [])
     assert sm.quality_tier_for_source('tidal') == 'hires'
     assert sm.quality_tier_for_source('deezer') == 'flac'
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
 
 
 def test_deezer_flac_and_mp3(monkeypatch):
@@ -57,6 +58,56 @@ def test_qobuz_hires_max(monkeypatch):
     assert sm.quality_tier_for_source('qobuz') == 'hires_max'
 
 
+T_OPUS = [QualityTarget(label='', format='opus')]
+T_OPUS_192 = [QualityTarget(label='', format='opus', min_bitrate=192)]
+T_AAC_128 = [QualityTarget(label='', format='aac', min_bitrate=128)]
+T_AAC_192 = [QualityTarget(label='', format='aac', min_bitrate=192)]
+
+
+def test_youtube_opus_without_floor_requests_160(monkeypatch):
+    _patch_targets(monkeypatch, T_OPUS)
+    assert sm.quality_tier_for_source('youtube') == 'opus_160'
+
+
+def test_youtube_opus_192_requests_256(monkeypatch):
+    _patch_targets(monkeypatch, T_OPUS_192)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+
+
+def test_youtube_aac_128_does_not_fetch_256(monkeypatch):
+    _patch_targets(monkeypatch, T_AAC_128)
+    assert sm.quality_tier_for_source('youtube') == 'aac_128'
+
+
+def test_youtube_aac_192_requests_256(monkeypatch):
+    _patch_targets(monkeypatch, T_AAC_192)
+    assert sm.quality_tier_for_source('youtube') == 'aac_256'
+
+
+def test_youtube_flac_or_mp3_is_best_effort_max(monkeypatch):
+    _patch_targets(monkeypatch, T_FLAC16)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+    _patch_targets(monkeypatch, T_MP3_320)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+
+
 def test_unknown_source_returns_default(monkeypatch):
     _patch_targets(monkeypatch, T_FLAC16)
     assert sm.quality_tier_for_source('nope', default='x') == 'x'
+
+
+def test_youtube_aac_without_floor_requests_128(monkeypatch):
+    _patch_targets(monkeypatch, [QualityTarget(label='', format='aac')])
+    assert sm.quality_tier_for_source('youtube') == 'aac_128'
+
+
+def test_youtube_opus_160_floor_stays_160_but_161_jumps(monkeypatch):
+    _patch_targets(monkeypatch, [QualityTarget(label='', format='opus', min_bitrate=160)])
+    assert sm.quality_tier_for_source('youtube') == 'opus_160'
+    _patch_targets(monkeypatch, [QualityTarget(label='', format='opus', min_bitrate=161)])
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+
+
+def test_youtube_ignores_second_target_when_top_is_unsatisfiable(monkeypatch):
+    _patch_targets(monkeypatch, T_FLAC16 + T_OPUS)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'

--- a/tests/quality/test_youtube_tier.py
+++ b/tests/quality/test_youtube_tier.py
@@ -226,7 +226,7 @@ def _patch_get_defaults(monkeypatch, values=None):
             return stored[key]
         return default
 
-    monkeypatch.setattr('config.settings.config_manager.get', _get)
+    monkeypatch.setattr('core.settings.config_manager.get', _get)
 
 
 def test_real_transcode_settings_missing_keys_are_mp3_320(monkeypatch):
@@ -264,7 +264,7 @@ def test_real_transcode_settings_never_raise(monkeypatch):
     def _boom(*_a, **_k):
         raise RuntimeError('settings locked')
 
-    monkeypatch.setattr('config.settings.config_manager.get', _boom)
+    monkeypatch.setattr('core.settings.config_manager.get', _boom)
     assert _real_youtube_transcode_settings() == (True, 'mp3', '320')
 
 

--- a/tests/quality/test_youtube_tier.py
+++ b/tests/quality/test_youtube_tier.py
@@ -1,0 +1,527 @@
+"""YouTube download tier — profile → requested rung → picked itag.
+
+Pins the same lowest-satisfying-rung rule as Tidal/Deezer, plus the
+client wrappers that must not break download when no quality profile
+exists (empty targets, missing DB, malformed rows).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import core.quality.source_map as sm
+from core.quality.model import QualityTarget
+from core.quality.selection import targets_from_profile
+from core.youtube_client import (
+    _YOUTUBE_QUALITY_CHAIN,
+    _YOUTUBE_QUALITY_MAP,
+    _YOUTUBE_TIER_SELECTORS,
+    _youtube_transcode_settings as _real_youtube_transcode_settings,
+    pick_youtube_audio_format,
+    youtube_audio_format_selector,
+    youtube_claimed_quality,
+    youtube_requested_tier,
+    youtube_transcode_output_quality,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reencode_off(monkeypatch):
+    """Profile-ladder tests assume remux (re-encode off)."""
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (False, 'mp3', '320'),
+    )
+
+
+def _patch_targets(monkeypatch, targets, fallback=True):
+    monkeypatch.setattr(sm, 'load_profile_targets', lambda: (targets, fallback))
+
+
+T_FLAC = [QualityTarget(label='', format='flac', bit_depth=16)]
+T_MP3 = [QualityTarget(label='', format='mp3', min_bitrate=320)]
+T_OPUS = [QualityTarget(label='', format='opus')]
+T_OPUS_THEN_FLAC = [
+    QualityTarget(label='', format='opus'),
+    QualityTarget(label='', format='flac', bit_depth=16),
+]
+T_FLAC_THEN_OPUS = [
+    QualityTarget(label='', format='flac', bit_depth=16),
+    QualityTarget(label='', format='opus'),
+]
+T_AAC = [QualityTarget(label='', format='aac')]
+T_AAC_THEN_OPUS = [
+    QualityTarget(label='', format='aac', min_bitrate=128),
+    QualityTarget(label='', format='opus', min_bitrate=192),
+]
+
+
+# ── ladder keys must not drift between source_map and the YouTube client ───
+
+
+def test_youtube_client_chain_matches_source_map_ladder():
+    ladder_keys = [key for key, _ in sm._SOURCE_TIER_LADDERS['youtube']]
+    assert ladder_keys == _YOUTUBE_QUALITY_CHAIN
+    assert list(_YOUTUBE_QUALITY_MAP) == _YOUTUBE_QUALITY_CHAIN
+    assert set(_YOUTUBE_TIER_SELECTORS) == set(ladder_keys)
+
+
+def test_youtube_quality_map_bitrates_match_ladder_claims():
+    for key, claimed in sm._SOURCE_TIER_LADDERS['youtube']:
+        assert _YOUTUBE_QUALITY_MAP[key].format == claimed.format
+        assert _YOUTUBE_QUALITY_MAP[key].bitrate == claimed.bitrate
+
+
+# ── quality_tier_for_source: missing / empty / only-top-target ─────────────
+
+
+def test_no_quality_profile_targets_requests_max_opus_256(monkeypatch):
+    _patch_targets(monkeypatch, [])
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+
+
+def test_empty_profile_dict_is_treated_as_no_targets():
+    targets, fallback = targets_from_profile({})
+    assert targets == []
+    assert fallback is True  # missing toggle defaults on
+
+
+def test_missing_ranked_targets_and_null_list():
+    assert targets_from_profile({'fallback_enabled': False})[0] == []
+    assert targets_from_profile({'ranked_targets': None})[0] == []
+    assert targets_from_profile({'ranked_targets': []})[0] == []
+
+
+def test_blank_target_row_has_no_format_constraint():
+    """A saved empty row is not 'no profile' — it matches every YouTube rung,
+    so the lowest rung (aac_128) wins. Distinct from ranked_targets=[]."""
+    targets, _ = targets_from_profile({'ranked_targets': [{}]})
+    assert len(targets) == 1
+    assert targets[0].format is None
+
+
+def test_blank_target_row_requests_lowest_youtube_rung(monkeypatch):
+    targets, _ = targets_from_profile({'ranked_targets': [{}]})
+    _patch_targets(monkeypatch, targets)
+    assert sm.quality_tier_for_source('youtube') == 'aac_128'
+
+
+def test_only_top_target_drives_youtube_request(monkeypatch):
+    """Second-row Opus must not pull the request down when the top target is FLAC."""
+    _patch_targets(monkeypatch, T_FLAC_THEN_OPUS)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+    _patch_targets(monkeypatch, T_OPUS_THEN_FLAC)
+    assert sm.quality_tier_for_source('youtube') == 'opus_160'
+
+
+def test_aac_with_no_min_bitrate_requests_128_not_256(monkeypatch):
+    _patch_targets(monkeypatch, T_AAC)
+    assert sm.quality_tier_for_source('youtube') == 'aac_128'
+
+
+def test_aac_then_opus_192_still_requests_aac_128(monkeypatch):
+    _patch_targets(monkeypatch, T_AAC_THEN_OPUS)
+    assert sm.quality_tier_for_source('youtube') == 'aac_128'
+
+
+@pytest.mark.parametrize("min_bitrate,want", [
+    (None, 'opus_160'),
+    (96, 'opus_160'),
+    (160, 'opus_160'),
+    (161, 'opus_256'),
+    (192, 'opus_256'),
+    (256, 'opus_256'),
+])
+def test_opus_bitrate_floor_boundary(monkeypatch, min_bitrate, want):
+    _patch_targets(monkeypatch, [QualityTarget(label='', format='opus', min_bitrate=min_bitrate)])
+    assert sm.quality_tier_for_source('youtube') == want
+
+
+@pytest.mark.parametrize("min_bitrate,want", [
+    (None, 'aac_128'),
+    (96, 'aac_128'),
+    (128, 'aac_128'),
+    (129, 'aac_256'),
+    (192, 'aac_256'),
+    (256, 'aac_256'),
+])
+def test_aac_bitrate_floor_boundary(monkeypatch, min_bitrate, want):
+    _patch_targets(monkeypatch, [QualityTarget(label='', format='aac', min_bitrate=min_bitrate)])
+    assert sm.quality_tier_for_source('youtube') == want
+
+
+def test_flac_and_mp3_profiles_are_best_effort_max(monkeypatch):
+    _patch_targets(monkeypatch, T_FLAC)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+    _patch_targets(monkeypatch, T_MP3)
+    assert sm.quality_tier_for_source('youtube') == 'opus_256'
+
+
+def test_mp3_only_profile_still_fetches_opus_not_mp3(monkeypatch):
+    """Without re-encode, an MP3 profile still requests best-effort Opus.
+    YouTube does not serve MP3."""
+    _patch_targets(monkeypatch, T_MP3)
+    assert youtube_requested_tier() == 'opus_256'
+    selector = youtube_audio_format_selector(youtube_requested_tier())
+    assert 'opus' in selector
+    assert 'mp3' not in selector.lower()
+
+
+def test_reencode_on_always_requests_best_original_stream(monkeypatch):
+    """Re-encode converts after download — always fetch the best source,
+    even if the profile is AAC 128 or MP3 320."""
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    _patch_targets(monkeypatch, T_AAC)
+    assert youtube_requested_tier() == 'opus_256'
+    _patch_targets(monkeypatch, T_MP3)
+    assert youtube_requested_tier() == 'opus_256'
+    _patch_targets(monkeypatch, T_OPUS)
+    assert youtube_requested_tier() == 'opus_256'
+    _patch_targets(monkeypatch, T_FLAC)
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_transcode_output_quality_is_none_when_reencode_off():
+    assert youtube_transcode_output_quality() is None
+
+
+@pytest.mark.parametrize("bitrate,want_br", [
+    ('0', 320),
+    ('', 320),
+    (None, 320),
+    ('nope', 320),
+    ('-5', 320),
+    (0, 320),
+    (-1, 320),
+    ('320.9', 320),  # int() rejects the float string
+])
+def test_transcode_output_invalid_bitrate_falls_back_to_320(monkeypatch, bitrate, want_br):
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, 'mp3', bitrate),
+    )
+    aq = youtube_transcode_output_quality()
+    assert aq.format == 'mp3'
+    assert aq.bitrate == want_br
+
+
+def test_transcode_output_codec_is_case_insensitive(monkeypatch):
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, 'M4A', '256'),
+    )
+    aq = youtube_transcode_output_quality()
+    assert aq.format == 'aac'
+    assert aq.bitrate == 256
+
+
+def _patch_get_defaults(monkeypatch, values=None):
+    stored = values or {}
+
+    def _get(key, default=None):
+        if key in stored:
+            return stored[key]
+        return default
+
+    monkeypatch.setattr('config.settings.config_manager.get', _get)
+
+
+def test_real_transcode_settings_missing_keys_are_mp3_320(monkeypatch):
+    _patch_get_defaults(monkeypatch)
+    assert _real_youtube_transcode_settings() == (True, 'mp3', '320')
+
+
+def test_real_transcode_settings_honour_explicit_off(monkeypatch):
+    _patch_get_defaults(monkeypatch, {'youtube.transcode': False})
+    transcode, codec, bitrate = _real_youtube_transcode_settings()
+    assert transcode is False
+    assert codec == 'mp3'
+    assert bitrate == '320'
+
+
+def test_real_transcode_settings_honour_explicit_on_aac(monkeypatch):
+    _patch_get_defaults(monkeypatch, {
+        'youtube.transcode': True,
+        'youtube.transcode_codec': 'aac',
+        'youtube.transcode_bitrate': '192',
+    })
+    assert _real_youtube_transcode_settings() == (True, 'aac', '192')
+
+
+def test_real_transcode_settings_empty_codec_bitrate_use_mp3_320(monkeypatch):
+    _patch_get_defaults(monkeypatch, {
+        'youtube.transcode': True,
+        'youtube.transcode_codec': '',
+        'youtube.transcode_bitrate': '',
+    })
+    assert _real_youtube_transcode_settings() == (True, 'mp3', '320')
+
+
+def test_real_transcode_settings_never_raise(monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError('settings locked')
+
+    monkeypatch.setattr('config.settings.config_manager.get', _boom)
+    assert _real_youtube_transcode_settings() == (True, 'mp3', '320')
+
+
+def test_product_default_claimed_quality_is_mp3_320(monkeypatch):
+    """Missing youtube.transcode* keys: rank as MP3 320, fetch best original."""
+    _patch_get_defaults(monkeypatch)
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        _real_youtube_transcode_settings,
+    )
+    aq = youtube_claimed_quality({'acodec': 'opus', 'abr': 160, 'ext': 'webm'})
+    assert aq.format == 'mp3'
+    assert aq.bitrate == 320
+    assert youtube_requested_tier() == 'opus_256'
+
+
+@pytest.mark.parametrize("codec,bitrate,want_fmt,want_br", [
+    ('mp3', '320', 'mp3', 320),
+    ('mp3', '128', 'mp3', 128),
+    ('aac', '192', 'aac', 192),
+    ('m4a', '256', 'aac', 256),
+    ('opus', '160', 'opus', 160),
+    ('ogg', '192', 'ogg', 192),
+    ('flac', '320', 'mp3', 320),
+    ('', '320', 'mp3', 320),
+])
+def test_transcode_output_quality_maps_codec_bitrate(monkeypatch, codec, bitrate, want_fmt, want_br):
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, codec, bitrate),
+    )
+    aq = youtube_transcode_output_quality()
+    assert aq is not None
+    assert aq.format == want_fmt
+    assert aq.bitrate == want_br
+
+
+def test_claimed_quality_uses_transcode_output_not_original_stream(monkeypatch):
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    aq = youtube_claimed_quality({'acodec': 'opus', 'abr': 160, 'ext': 'webm'})
+    assert aq.format == 'mp3'
+    assert aq.bitrate == 320
+
+
+def test_claimed_quality_uses_original_stream_when_reencode_off(monkeypatch):
+    aq = youtube_claimed_quality({'acodec': 'opus', 'abr': 160, 'ext': 'webm'})
+    assert aq.format == 'opus'
+    assert aq.bitrate == 160
+
+
+def test_claimed_quality_none_is_typical_opus_when_reencode_off():
+    aq = youtube_claimed_quality(None)
+    assert aq.format == 'opus'
+    assert aq.bitrate == 160
+
+
+def test_claimed_quality_none_is_mp3_320_when_reencode_on(monkeypatch):
+    monkeypatch.setattr(
+        'core.youtube_client._youtube_transcode_settings',
+        lambda: (True, 'mp3', '320'),
+    )
+    aq = youtube_claimed_quality(None)
+    assert aq.format == 'mp3'
+    assert aq.bitrate == 320
+
+
+# ── youtube_requested_tier must never raise ────────────────────────────────
+
+
+def test_requested_tier_empty_profile_is_opus_256(monkeypatch):
+    _patch_targets(monkeypatch, [])
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_requested_tier_follows_profile(monkeypatch):
+    _patch_targets(monkeypatch, T_OPUS)
+    assert youtube_requested_tier() == 'opus_160'
+    _patch_targets(monkeypatch, T_AAC)
+    assert youtube_requested_tier() == 'aac_128'
+
+
+def test_requested_tier_when_load_profile_targets_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError('database is locked')
+
+    monkeypatch.setattr(sm, 'load_profile_targets', _boom)
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_requested_tier_when_get_quality_profile_raises(monkeypatch):
+    class _BoomDb:
+        def get_quality_profile(self):
+            raise RuntimeError('no such table: quality_profiles')
+
+    monkeypatch.setattr('database.music_database.MusicDatabase', lambda: _BoomDb())
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_requested_tier_when_tier_helper_returns_none(monkeypatch):
+    monkeypatch.setattr(sm, 'quality_tier_for_source', lambda *a, **k: None)
+    monkeypatch.setattr('core.youtube_client.quality_tier_for_source', lambda *a, **k: None)
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_requested_tier_when_tier_helper_raises(monkeypatch):
+    def _boom(*_a, **_k):
+        raise ValueError('malformed ranked_targets')
+
+    monkeypatch.setattr('core.youtube_client.quality_tier_for_source', _boom)
+    assert youtube_requested_tier() == 'opus_256'
+
+
+def test_requested_tier_malformed_ranked_targets_do_not_break_download(monkeypatch):
+    class _Db:
+        def get_quality_profile(self):
+            return {'ranked_targets': ['not-a-dict'], 'fallback_enabled': True}
+
+    monkeypatch.setattr('database.music_database.MusicDatabase', lambda: _Db())
+    assert youtube_requested_tier() == 'opus_256'
+
+
+# ── format selector ────────────────────────────────────────────────────────
+
+
+def test_selector_none_uses_requested_tier(monkeypatch):
+    monkeypatch.setattr('core.youtube_client.youtube_requested_tier', lambda: 'aac_128')
+    assert youtube_audio_format_selector(None) == _YOUTUBE_TIER_SELECTORS['aac_128']
+
+
+def test_selector_unknown_and_blank_are_bestaudio():
+    assert youtube_audio_format_selector('nope') == 'bestaudio/best'
+    assert youtube_audio_format_selector('') == 'bestaudio/best'
+    assert youtube_audio_format_selector('  ') == 'bestaudio/best'
+
+
+def test_selector_is_case_insensitive():
+    assert youtube_audio_format_selector('OPUS_160') == _YOUTUBE_TIER_SELECTORS['opus_160']
+    assert youtube_audio_format_selector(' Aac_128 ') == _YOUTUBE_TIER_SELECTORS['aac_128']
+
+
+@pytest.mark.parametrize("tier", ['opus_256', 'aac_256', 'opus_160', 'aac_128'])
+def test_each_rung_has_a_selector(tier):
+    sel = youtube_audio_format_selector(tier)
+    assert sel.startswith('bestaudio')
+    assert sel.endswith('bestaudio/best') or '/best' in sel
+
+
+def test_high_rungs_prefer_abr_192_plus():
+    assert 'abr>=192' in youtube_audio_format_selector('opus_256')
+    assert 'abr>=192' in youtube_audio_format_selector('aac_256')
+    assert 'abr>=192' not in youtube_audio_format_selector('opus_160')
+    assert 'abr>=192' not in youtube_audio_format_selector('aac_128')
+
+
+# ── pick_youtube_audio_format ──────────────────────────────────────────────
+
+_OPUS_50 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 50, 'ext': 'webm', 'format_id': '249'}
+_OPUS_70 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 70, 'ext': 'webm', 'format_id': '250'}
+_OPUS_160 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 160, 'ext': 'webm', 'format_id': '251'}
+_OPUS_191 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 191, 'ext': 'webm', 'format_id': 'x191'}
+_OPUS_192 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 192, 'ext': 'webm', 'format_id': 'x192'}
+_OPUS_256 = {'vcodec': 'none', 'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': '774'}
+_AAC_48 = {'vcodec': 'none', 'acodec': 'mp4a.40.5', 'abr': 48, 'ext': 'm4a', 'format_id': '139'}
+_AAC_95 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 95, 'ext': 'm4a', 'format_id': 'x95'}
+_AAC_96 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 96, 'ext': 'm4a', 'format_id': 'x96'}
+_AAC_128 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 128, 'ext': 'm4a', 'format_id': '140'}
+_AAC_191 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 191, 'ext': 'm4a', 'format_id': 'x191a'}
+_AAC_192 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 192, 'ext': 'm4a', 'format_id': 'x192a'}
+_AAC_256 = {'vcodec': 'none', 'acodec': 'mp4a.40.2', 'abr': 256, 'ext': 'm4a', 'format_id': '141'}
+_MUXED = {'vcodec': 'avc1', 'acodec': 'mp4a.40.2', 'abr': 96, 'ext': 'mp4', 'format_id': '18'}
+_VIDEO = {'vcodec': 'avc1', 'acodec': 'none', 'ext': 'mp4', 'format_id': '137'}
+_STORY = {'vcodec': 'none', 'acodec': 'none', 'ext': 'mhtml', 'format_id': 'sb0'}
+
+
+@pytest.mark.parametrize("formats", [None, [], [_MUXED, _VIDEO, _STORY]])
+def test_pick_returns_none_without_audio_only(formats):
+    assert pick_youtube_audio_format(formats, tier='opus_256') is None
+
+
+def test_pick_unknown_tier_starts_at_top_rung():
+    formats = [_OPUS_160, _OPUS_256, _AAC_128]
+    assert pick_youtube_audio_format(formats, tier='nope')['format_id'] == '774'
+    assert pick_youtube_audio_format(formats, tier='')['format_id'] == '774'
+
+
+def test_pick_none_tier_uses_requested_tier(monkeypatch):
+    monkeypatch.setattr('core.youtube_client.youtube_requested_tier', lambda: 'aac_128')
+    picked = pick_youtube_audio_format([_OPUS_256, _AAC_128], tier=None)
+    assert picked['format_id'] == '140'
+
+
+@pytest.mark.parametrize("abr,want_id", [
+    (191, 'x191'),
+    (192, 'x192'),
+])
+def test_pick_opus_abr_192_is_the_256_rung_boundary(abr, want_id):
+    fmt = {'vcodec': 'none', 'acodec': 'opus', 'abr': abr, 'ext': 'webm', 'format_id': want_id}
+    # 191 belongs on the 160 rung; 192 on the 256 rung.
+    if abr < 192:
+        assert pick_youtube_audio_format([fmt], tier='opus_160')['format_id'] == want_id
+        # Asking for 256 walks down to 160 when 192+ is missing.
+        assert pick_youtube_audio_format([fmt], tier='opus_256')['format_id'] == want_id
+    else:
+        assert pick_youtube_audio_format([fmt], tier='opus_256')['format_id'] == want_id
+        # opus_160 must not upgrade to a 192+ stream.
+        assert pick_youtube_audio_format([fmt, _OPUS_160], tier='opus_160')['format_id'] == '251'
+
+
+def test_pick_aac_96_is_128_rung_and_95_is_not():
+    assert pick_youtube_audio_format([_AAC_96], tier='aac_128')['format_id'] == 'x96'
+    # 95 kbps is below the 128 rung; last-resort still returns it so ranking
+    # can stamp an honest claim instead of pretending nothing exists.
+    assert pick_youtube_audio_format([_AAC_95], tier='aac_128')['format_id'] == 'x95'
+
+
+def test_pick_aac_191_stays_on_128_rung_192_is_256():
+    assert pick_youtube_audio_format([_AAC_191], tier='aac_128')['format_id'] == 'x191a'
+    assert pick_youtube_audio_format([_AAC_192, _AAC_128], tier='aac_128')['format_id'] == '140'
+    assert pick_youtube_audio_format([_AAC_192], tier='aac_256')['format_id'] == 'x192a'
+
+
+def test_pick_uses_tbr_when_abr_missing_at_192_boundary():
+    fmt = {'vcodec': 'none', 'acodec': 'opus', 'tbr': 192, 'ext': 'webm', 'format_id': 'tbr192'}
+    assert pick_youtube_audio_format([fmt], tier='opus_256')['format_id'] == 'tbr192'
+    low = {'vcodec': 'none', 'acodec': 'opus', 'tbr': 160, 'ext': 'webm', 'format_id': 'tbr160'}
+    assert pick_youtube_audio_format([fmt, low], tier='opus_160')['format_id'] == 'tbr160'
+
+
+def test_pick_only_ultra_low_itags_is_last_resort_not_a_requested_rung():
+    picked = pick_youtube_audio_format([_AAC_48, _OPUS_50, _OPUS_70], tier='opus_256')
+    assert picked['format_id'] == '250'  # highest abr among leftovers
+    # None of these satisfy a 160/128 rung, so we did not pretend they were 160.
+    from core.quality.source_map import quality_from_youtube
+    assert quality_from_youtube(picked).bitrate == 70
+
+
+def test_pick_skips_missing_vcodec_and_muxed():
+    formats = [
+        {'acodec': 'opus', 'abr': 256, 'ext': 'webm', 'format_id': 'no-vcodec'},
+        _MUXED,
+        _OPUS_160,
+    ]
+    assert pick_youtube_audio_format(formats, tier='opus_160')['format_id'] == '251'
+
+
+def test_pick_walks_down_premium_to_free():
+    assert pick_youtube_audio_format([_OPUS_160, _AAC_128], tier='opus_256')['format_id'] == '251'
+    assert pick_youtube_audio_format([_AAC_128], tier='aac_256')['format_id'] == '140'
+
+
+def test_pick_does_not_cross_codec_to_satisfy_a_higher_rung():
+    # Asking for AAC 256 must not grab Opus 256 when AAC 128 is present.
+    picked = pick_youtube_audio_format([_OPUS_256, _AAC_128], tier='aac_256')
+    assert picked['format_id'] == '140'
+    # Asking for Opus 160 must not grab AAC 256.
+    picked = pick_youtube_audio_format([_AAC_256, _OPUS_160], tier='opus_160')
+    assert picked['format_id'] == '251'

--- a/tests/repair_jobs/test_quality_upgrade.py
+++ b/tests/repair_jobs/test_quality_upgrade.py
@@ -232,6 +232,17 @@ def _stub_engine(monkeypatch):
     )
 
 
+def test_scan_does_not_import_missing_reencode_module(monkeypatch):
+    """Quality Upgrade must not depend on core.quality.reencode."""
+    db = _FakeDB([_row(bitrate=128)], BALANCED)
+    _stub_engine(monkeypatch)
+    monkeypatch.setattr(qu, '_read_file_ids', lambda fp, **kw: {})
+    monkeypatch.setattr(qu, '_match_via_track_id', lambda *a, **k: (None, None))
+    monkeypatch.setattr(qu, '_match_via_album', lambda *a, **k: (None, None))
+    monkeypatch.setattr(qu, '_find_best_match', lambda *a, **k: (None, None, None, False))
+    qu.QualityUpgradeJob().scan(_ctx(db, []))
+
+
 def test_scan_creates_finding_for_low_quality_track(monkeypatch):
     db = _FakeDB([_row(bitrate=128)], BALANCED)
     _stub_engine(monkeypatch)

--- a/tests/test_youtube_cookies.py
+++ b/tests/test_youtube_cookies.py
@@ -220,3 +220,39 @@ def test_auth_from_real_file_round_trips(tmp_path):
     headers = ytmusic_auth_from_cookiefile(str(path))
     assert headers is not None
     assert "SAPISIDHASH" in headers["Authorization"]
+
+
+def test_auth_from_config_anonymous_when_not_paste_mode(monkeypatch):
+    monkeypatch.setattr(
+        "config.settings.config_manager.get",
+        lambda key, default="": "firefox" if key == "youtube.cookies_browser" else default,
+    )
+    from core.youtube_cookies import ytmusic_auth_from_config
+    assert ytmusic_auth_from_config() is None
+
+
+def test_auth_from_config_paste_mode_reads_cookiefile(monkeypatch, tmp_path):
+    path = tmp_path / "cookies.txt"
+    path.write_text(_JAR, encoding="utf-8")
+
+    def _get(key, default=""):
+        if key == "youtube.cookies_browser":
+            return PASTE_MODE
+        if key == "youtube.cookies_file":
+            return str(path)
+        return default
+
+    monkeypatch.setattr("config.settings.config_manager.get", _get)
+    from core.youtube_cookies import ytmusic_auth_from_config
+    headers = ytmusic_auth_from_config()
+    assert headers is not None
+    assert "SAPISIDHASH" in headers["Authorization"]
+
+
+def test_auth_from_config_exception_is_anonymous(monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("config down")
+
+    monkeypatch.setattr("config.settings.config_manager.get", _boom)
+    from core.youtube_cookies import ytmusic_auth_from_config
+    assert ytmusic_auth_from_config() is None

--- a/tests/test_youtube_cookies.py
+++ b/tests/test_youtube_cookies.py
@@ -224,7 +224,7 @@ def test_auth_from_real_file_round_trips(tmp_path):
 
 def test_auth_from_config_anonymous_when_not_paste_mode(monkeypatch):
     monkeypatch.setattr(
-        "config.settings.config_manager.get",
+        "core.settings.config_manager.get",
         lambda key, default="": "firefox" if key == "youtube.cookies_browser" else default,
     )
     from core.youtube_cookies import ytmusic_auth_from_config
@@ -242,7 +242,7 @@ def test_auth_from_config_paste_mode_reads_cookiefile(monkeypatch, tmp_path):
             return str(path)
         return default
 
-    monkeypatch.setattr("config.settings.config_manager.get", _get)
+    monkeypatch.setattr("core.settings.config_manager.get", _get)
     from core.youtube_cookies import ytmusic_auth_from_config
     headers = ytmusic_auth_from_config()
     assert headers is not None
@@ -253,6 +253,6 @@ def test_auth_from_config_exception_is_anonymous(monkeypatch):
     def _boom(*_a, **_k):
         raise RuntimeError("config down")
 
-    monkeypatch.setattr("config.settings.config_manager.get", _boom)
+    monkeypatch.setattr("core.settings.config_manager.get", _boom)
     from core.youtube_cookies import ytmusic_auth_from_config
     assert ytmusic_auth_from_config() is None

--- a/tests/test_youtube_music_meta.py
+++ b/tests/test_youtube_music_meta.py
@@ -12,9 +12,14 @@ Fixtures are trimmed copies of real ytmusicapi `get_playlist` responses.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+import sys
+
 from core.youtube_music_meta import (
     playlist_id_from_url,
+    search_ytmusic_songs,
     ytmusic_playlist_to_payload,
+    ytmusic_search_hit_to_track,
 )
 
 URL = "https://music.youtube.com/playlist?list=PLExamplePlaylistId00000000000000"
@@ -183,3 +188,111 @@ def test_missing_video_type_is_empty_not_none():
     payload = ytmusic_playlist_to_payload(
         _raw({**ATV_TRACK, "videoType": None}), URL)
     assert payload["tracks"][0]["video_type"] == ""
+
+
+# ── song search projection ────────────────────────────────────────────────
+
+SONG_HIT = {
+    "videoId": "exampleVid1",
+    "title": "Example Track",
+    "artists": [{"name": "Example Artist", "id": "UCExampleChannelId000000"}],
+    "album": {"name": "Example Album", "id": "MPREb_ExampleAlbumId"},
+    "duration": "3:45",
+    "duration_seconds": 225,
+    "videoType": "MUSIC_VIDEO_TYPE_ATV",
+    "thumbnails": [{"url": "https://i.ytimg.com/vi/exampleVid1/low.jpg"},
+                   {"url": "https://i.ytimg.com/vi/exampleVid1/high.jpg"}],
+}
+
+
+def test_search_hit_projects_artist_album_duration_and_watch_url():
+    track = ytmusic_search_hit_to_track(SONG_HIT)
+    assert track["id"] == "exampleVid1"
+    assert track["name"] == "Example Track"
+    assert track["artists"] == ["Example Artist"]
+    assert track["album"] == "Example Album"
+    assert track["duration_ms"] == 225_000
+    assert track["video_type"] == "MUSIC_VIDEO_TYPE_ATV"
+    assert track["url"] == "https://www.youtube.com/watch?v=exampleVid1"
+    assert track["thumbnail"] == "https://i.ytimg.com/vi/exampleVid1/high.jpg"
+
+
+def test_search_hit_without_video_id_is_dropped():
+    assert ytmusic_search_hit_to_track({**SONG_HIT, "videoId": ""}) is None
+    assert ytmusic_search_hit_to_track({**SONG_HIT, "videoId": None}) is None
+    assert ytmusic_search_hit_to_track("junk") is None
+
+
+def test_search_hit_without_title_is_dropped():
+    assert ytmusic_search_hit_to_track({**SONG_HIT, "title": ""}) is None
+    assert ytmusic_search_hit_to_track({**SONG_HIT, "title": None}) is None
+
+
+def test_search_hit_topic_suffix_stripped():
+    track = ytmusic_search_hit_to_track(
+        {**SONG_HIT, "artists": [{"name": "Example Band - Topic"}]})
+    assert track["artists"] == ["Example Band"]
+
+
+def test_search_hit_parses_duration_string_when_seconds_missing():
+    track = ytmusic_search_hit_to_track(
+        {**SONG_HIT, "duration_seconds": None, "duration": "3:45"})
+    assert track["duration_ms"] == 225_000
+
+
+def test_search_hit_parses_hour_duration_string():
+    track = ytmusic_search_hit_to_track(
+        {**SONG_HIT, "duration_seconds": None, "duration": "1:02:03"})
+    assert track["duration_ms"] == 3_723_000
+
+
+def test_search_ytmusic_songs_empty_query_returns_none():
+    assert search_ytmusic_songs("") is None
+    assert search_ytmusic_songs("   ") is None
+    assert search_ytmusic_songs(None) is None  # type: ignore[arg-type]
+
+
+def _install_fake_ytmusic(monkeypatch, search_impl):
+    class _FakeYTMusic:
+        def __init__(self, *_a, **_k):
+            pass
+
+        def search(self, query, filter="songs", limit=50):
+            return search_impl(query, filter, limit)
+
+    monkeypatch.setitem(sys.modules, "ytmusicapi", SimpleNamespace(YTMusic=_FakeYTMusic))
+
+
+def test_search_ytmusic_songs_missing_library_returns_none(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ytmusicapi", None)
+    assert search_ytmusic_songs("Artist - Title") is None
+
+
+def test_search_ytmusic_songs_exception_returns_none(monkeypatch):
+    class _Boom:
+        def __init__(self, *_a, **_k):
+            raise RuntimeError("inner-tube down")
+
+    monkeypatch.setitem(sys.modules, "ytmusicapi", SimpleNamespace(YTMusic=_Boom))
+    assert search_ytmusic_songs("Artist - Title") is None
+
+
+def test_search_ytmusic_songs_empty_or_unusable_returns_none(monkeypatch):
+    _install_fake_ytmusic(monkeypatch, lambda *_a: [])
+    assert search_ytmusic_songs("Artist - Title") is None
+
+    _install_fake_ytmusic(monkeypatch, lambda *_a: [{"title": "No Id"}])
+    assert search_ytmusic_songs("Artist - Title") is None
+
+
+def test_search_ytmusic_songs_sorts_atv_first(monkeypatch):
+    _install_fake_ytmusic(monkeypatch, lambda *_a: [
+        {**SONG_HIT, "videoId": "omv", "title": "Official Video",
+         "videoType": "MUSIC_VIDEO_TYPE_OMV"},
+        {**SONG_HIT, "videoId": "atv", "title": "Official Audio",
+         "videoType": "MUSIC_VIDEO_TYPE_ATV"},
+        {**SONG_HIT, "videoId": "ugc", "title": "Cover",
+         "videoType": "MUSIC_VIDEO_TYPE_UGC"},
+    ])
+    hits = search_ytmusic_songs("Example Artist - Example Track")
+    assert [h["id"] for h in hits] == ["atv", "omv", "ugc"]

--- a/tests/test_youtube_search_dash_query.py
+++ b/tests/test_youtube_search_dash_query.py
@@ -137,6 +137,7 @@ def test_search_catalog_hits_skip_yt_dlp_and_set_album(monkeypatch):
     assert track.duration == 225_000
     assert track.quality == "opus"
     assert track.bitrate == 160
+    assert track._source_metadata == {"source": "youtube", "catalog": True}
 
 
 def test_search_catalog_with_cookies_still_claims_opus_160(monkeypatch):
@@ -225,4 +226,39 @@ def test_search_catalog_none_falls_through_to_ytsearch(monkeypatch):
     tracks, albums = asyncio.run(client.search("Artist - Title"))
     assert captured == ["ytsearch50:Artist - Title"]
     assert len(tracks) == 1
+    assert albums == []
+
+
+def test_search_use_catalog_false_ignores_catalog_hits(monkeypatch):
+    captured = []
+
+    class _FakeYoutubeDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, search_query, download=False):
+            captured.append(search_query)
+            return {"entries": [{"id": "yt1", "title": "Remix Video"}]}
+
+    _stub_catalog(monkeypatch, [_CATALOG_HIT])
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _FakeYoutubeDL)
+    client = YouTubeClient.__new__(YouTubeClient)
+    monkeypatch.setattr(client, "_get_best_audio_format", lambda formats: None)
+    monkeypatch.setattr(
+        client,
+        "_youtube_to_track_result",
+        lambda entry, best_audio: SimpleNamespace(filename=entry["title"]),
+    )
+
+    tracks, albums = asyncio.run(
+        client.search("Artist - Remix", use_catalog=False),
+    )
+    assert captured == ["ytsearch50:Artist - Remix"]
+    assert [t.filename for t in tracks] == ["Remix Video"]
     assert albums == []

--- a/tests/test_youtube_search_dash_query.py
+++ b/tests/test_youtube_search_dash_query.py
@@ -13,6 +13,23 @@ from types import SimpleNamespace
 from core import youtube_client
 from core.youtube_client import YouTubeClient
 
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reencode_off(monkeypatch):
+    monkeypatch.setattr(
+        youtube_client, "_youtube_transcode_settings",
+        lambda: (False, "mp3", "320"),
+    )
+
+
+def _stub_catalog(monkeypatch, hits=None):
+    monkeypatch.setattr(
+        "core.youtube_music_meta.search_ytmusic_songs",
+        lambda *a, **k: hits,
+    )
+
 
 def test_escape_ytsearch_query_handles_leading_dash():
     assert YouTubeClient._escape_ytsearch_query("-4WUHJRhvrM") == r"\-4WUHJRhvrM"
@@ -46,6 +63,7 @@ def test_search_escapes_leading_dash_before_yt_dlp(monkeypatch):
         "_youtube_to_track_result",
         lambda entry, best_audio: SimpleNamespace(filename=entry["title"]),
     )
+    _stub_catalog(monkeypatch)
 
     tracks, albums = asyncio.run(client.search("-4WUHJRhvrM"))
 
@@ -85,3 +103,126 @@ def test_search_videos_escapes_leading_dash_before_yt_dlp(monkeypatch):
 
     assert captured == [r"ytsearch8:\-4WUHJRhvrM"]
     assert [r.video_id for r in results] == ["-4WUHJRhvrM"]
+
+
+_CATALOG_HIT = {
+    "id": "vid1",
+    "name": "Example Track",
+    "artists": ["Example Artist"],
+    "album": "Example Album",
+    "duration_ms": 225_000,
+    "video_type": "MUSIC_VIDEO_TYPE_ATV",
+    "thumbnail": "https://i.ytimg.com/vi/vid1/high.jpg",
+    "url": "https://www.youtube.com/watch?v=vid1",
+}
+
+
+def test_search_catalog_hits_skip_yt_dlp_and_set_album(monkeypatch):
+    _stub_catalog(monkeypatch, [_CATALOG_HIT])
+
+    def _boom(*_a, **_k):
+        raise AssertionError("yt-dlp must not run when catalog search returns hits")
+
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _boom)
+    client = YouTubeClient.__new__(YouTubeClient)
+    tracks, albums = asyncio.run(client.search("Example Artist - Example Track"))
+
+    assert albums == []
+    assert len(tracks) == 1
+    track = tracks[0]
+    assert track.album == "Example Album"
+    assert track.artist == "Example Artist"
+    assert track.title == "Example Track"
+    assert track.filename == "vid1||Example Track"
+    assert track.duration == 225_000
+    assert track.quality == "opus"
+    assert track.bitrate == 160
+
+
+def test_search_catalog_with_cookies_still_claims_opus_160(monkeypatch):
+    _stub_catalog(monkeypatch, [_CATALOG_HIT])
+    monkeypatch.setattr(
+        youtube_client, "_resolve_cookie_opts",
+        lambda: {"cookiefile": "/tmp/youtube_cookies.txt"},
+    )
+
+    def _boom(*_a, **_k):
+        raise AssertionError("yt-dlp must not run when catalog search returns hits")
+
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _boom)
+    client = YouTubeClient.__new__(YouTubeClient)
+    tracks, _ = asyncio.run(client.search("Example Artist - Example Track"))
+    assert tracks[0].quality == "opus"
+    assert tracks[0].bitrate == 160
+
+
+def test_search_catalog_cookies_plus_reencode_claim_mp3_not_premium_opus(monkeypatch):
+    _stub_catalog(monkeypatch, [_CATALOG_HIT])
+    monkeypatch.setattr(
+        youtube_client, "_resolve_cookie_opts",
+        lambda: {"cookiefile": "/tmp/youtube_cookies.txt"},
+    )
+    monkeypatch.setattr(
+        youtube_client, "_youtube_transcode_settings",
+        lambda: (True, "mp3", "320"),
+    )
+
+    def _boom(*_a, **_k):
+        raise AssertionError("yt-dlp must not run when catalog search returns hits")
+
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _boom)
+    client = YouTubeClient.__new__(YouTubeClient)
+    tracks, _ = asyncio.run(client.search("Example Artist - Example Track"))
+    assert tracks[0].quality == "mp3"
+    assert tracks[0].bitrate == 320
+
+
+def test_search_catalog_reencode_claims_converted_mp3(monkeypatch):
+    _stub_catalog(monkeypatch, [_CATALOG_HIT])
+    monkeypatch.setattr(
+        youtube_client, "_youtube_transcode_settings",
+        lambda: (True, "mp3", "320"),
+    )
+
+    def _boom(*_a, **_k):
+        raise AssertionError("yt-dlp must not run when catalog search returns hits")
+
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _boom)
+    client = YouTubeClient.__new__(YouTubeClient)
+    tracks, _ = asyncio.run(client.search("Example Artist - Example Track"))
+    assert tracks[0].quality == "mp3"
+    assert tracks[0].bitrate == 320
+    assert tracks[0].filename == "vid1||Example Track"
+
+
+def test_search_catalog_none_falls_through_to_ytsearch(monkeypatch):
+    captured = []
+
+    class _FakeYoutubeDL:
+        def __init__(self, opts):
+            self.opts = opts
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, search_query, download=False):
+            captured.append(search_query)
+            return {"entries": [{"id": "yt1", "title": "Fallback Title"}]}
+
+    _stub_catalog(monkeypatch)
+    monkeypatch.setattr(youtube_client.yt_dlp, "YoutubeDL", _FakeYoutubeDL)
+    client = YouTubeClient.__new__(YouTubeClient)
+    monkeypatch.setattr(client, "_get_best_audio_format", lambda formats: None)
+    monkeypatch.setattr(
+        client,
+        "_youtube_to_track_result",
+        lambda entry, best_audio: SimpleNamespace(filename=entry["title"]),
+    )
+
+    tracks, albums = asyncio.run(client.search("Artist - Title"))
+    assert captured == ["ytsearch50:Artist - Title"]
+    assert len(tracks) == 1
+    assert albums == []

--- a/web_server.py
+++ b/web_server.py
@@ -17298,48 +17298,9 @@ def _probe_audio_quality(file_path):
 
 
 def _get_audio_quality_string(file_path):
-    """
-    Read audio file and return a quality descriptor string.
-
-    Returns strings like 'FLAC 16bit', 'MP3-320', 'M4A-256', 'OGG-192'.
-    Returns empty string on any error.
-    """
-    try:
-        ext = os.path.splitext(file_path)[1].lower()
-
-        if ext == '.flac':
-            audio = FLAC(file_path)
-            bits = audio.info.bits_per_sample
-            return f"FLAC {bits}bit"
-
-        elif ext == '.mp3':
-            from mutagen.mp3 import MP3, BitrateMode
-            audio = MP3(file_path)
-            bitrate_kbps = audio.info.bitrate // 1000
-            if audio.info.bitrate_mode == BitrateMode.VBR:
-                return "MP3-VBR"
-            return f"MP3-{bitrate_kbps}"
-
-        elif ext in ('.m4a', '.aac', '.mp4'):
-            audio = MP4(file_path)
-            bitrate_kbps = audio.info.bitrate // 1000
-            return f"M4A-{bitrate_kbps}"
-
-        elif ext == '.ogg':
-            audio = OggVorbis(file_path)
-            bitrate_kbps = audio.info.bitrate // 1000
-            return f"OGG-{bitrate_kbps}"
-
-        elif ext == '.opus':
-            from mutagen.oggopus import OggOpus
-            audio = OggOpus(file_path)
-            bitrate_kbps = audio.info.bitrate // 1000
-            return f"OPUS-{bitrate_kbps}"
-
-        return ''
-    except Exception as e:
-        logger.debug(f"Could not determine audio quality for {file_path}: {e}")
-        return ''
+    """Read audio file and return a quality descriptor string."""
+    from core.imports.file_ops import get_audio_quality_string
+    return get_audio_quality_string(file_path)
 
 
 def _get_album_type_display(raw_type, track_count) -> str:

--- a/webui/index.html
+++ b/webui/index.html
@@ -4215,10 +4215,12 @@
                                         <textarea id="youtube-cookies-paste" class="form-input" rows="6"
                                                   placeholder="# Netscape HTTP Cookie File&#10;.youtube.com&#9;TRUE&#9;/&#9;TRUE&#9;...&#9;NAME&#9;VALUE"></textarea>
                                         <div class="setting-help-text">
-                                            For server/Docker installs with no local browser. Export your YouTube cookies
-                                            with a "Get cookies.txt LOCALLY" browser extension and paste the whole file.
-                                            Required for private playlists like your <strong>Liked Music</strong>.
-                                            Stored on the server and they expire periodically &mdash; re-paste if YouTube stops working.
+                                            For server/Docker installs with no local browser. Paste a Netscape/Mozilla
+                                            <code>cookies.txt</code>. Export with a
+                                            "Get cookies.txt LOCALLY" extension and paste the whole file &mdash; the
+                                            <code># Netscape HTTP Cookie File</code> header alone is not enough.
+                                            Required for private playlists like your <strong>Liked Music</strong>, and for
+                                            Premium audio itags. Cookies expire periodically &mdash; re-paste if YouTube stops working.
                                         </div>
                                     </div>
                                     <div class="form-group">

--- a/webui/index.html
+++ b/webui/index.html
@@ -4204,9 +4204,10 @@
                                         </select>
                                         <div class="setting-help-text">
                                             If YouTube shows "Sign in to confirm you're not a bot", select your browser here.
-                                            SoulSync will use your browser's YouTube cookies to authenticate. Reading a browser
-                                            only works when that browser is on the same machine as SoulSync &mdash; on a
-                                            server/Docker box, choose <strong>Paste cookies.txt</strong> instead.
+                                            SoulSync will use your browser's YouTube cookies to authenticate. Cookies are also
+                                            used for Premium audio qualities. Reading a browser only works when that browser is
+                                            on the same machine as SoulSync &mdash; on a server/Docker box, choose
+                                            <strong>Paste cookies.txt</strong> instead.
                                         </div>
                                     </div>
                                     <div class="form-group" id="youtube-cookies-paste-group" style="display:none;">
@@ -4226,6 +4227,42 @@
                                             value="3" placeholder="3">
                                         <div class="setting-help-text">
                                             Seconds between YouTube downloads to avoid bot detection. Default: 3
+                                        </div>
+                                    </div>
+                                    <div class="form-group">
+                                        <div class="setting-row">
+                                            <label class="checkbox-label">
+                                                <input type="checkbox" id="youtube-transcode" checked
+                                                    onchange="document.getElementById('youtube-transcode-options').style.display = this.checked ? 'block' : 'none'">
+                                                Re-encode YouTube audio
+                                            </label>
+                                            <span class="info-icon" role="button" tabindex="0" title="What's this?"
+                                                onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
+                                        </div>
+                                        <div class="setting-help-body" hidden>
+                                            YouTube serves Opus or AAC, not FLAC or MP3.
+                                            With this on, the quality list must include the converted format
+                                            (default MP3 320). With it off, add Opus or AAC to the list,
+                                            or turn Fallback on.
+                                        </div>
+                                    </div>
+                                    <div id="youtube-transcode-options">
+                                        <div class="form-group">
+                                            <label>Codec:</label>
+                                            <select id="youtube-transcode-codec" onchange="updateYoutubeTranscodeBitrateOptions()">
+                                                <option value="mp3">MP3</option>
+                                                <option value="opus">Opus</option>
+                                                <option value="aac">AAC (M4A)</option>
+                                            </select>
+                                        </div>
+                                        <div class="form-group">
+                                            <label>Bitrate:</label>
+                                            <select id="youtube-transcode-bitrate">
+                                                <option value="320">320 kbps</option>
+                                                <option value="256">256 kbps</option>
+                                                <option value="192">192 kbps</option>
+                                                <option value="128">128 kbps</option>
+                                            </select>
                                         </div>
                                     </div>
                                 </div>

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
+  bitrateClass,
+  formatTrackBitrate,
   albumEnrichServices,
   sortedTrackRows,
   inlineEditDisplay,
@@ -642,5 +644,43 @@ describe('sortedTrackRows', () => {
     const rows = [owned(1, 'B'), owned(2, 'A')];
     sortedTrackRows(rows, { field: 'title', ascending: true });
     expect(rows.map((r) => r.title)).toEqual(['B', 'A']);
+  });
+});
+
+describe('formatTrackBitrate', () => {
+  it('is a dash when the library row has no bitrate', () => {
+    expect(formatTrackBitrate({ file_path: 'a.opus' })).toBe('-');
+    expect(formatTrackBitrate({ bitrate: 0, file_path: 'a.mp3' })).toBe('-');
+  });
+
+  it('shows a CBR mp3 as an exact kbps figure', () => {
+    expect(formatTrackBitrate({ bitrate: 320, file_path: 'a.mp3' })).toBe('320 kbps');
+  });
+
+  it('marks opus and ogg as a VBR average', () => {
+    expect(formatTrackBitrate({ bitrate: 160, file_path: 'a.opus' })).toBe('~160 kbps');
+    expect(formatTrackBitrate({ bitrate: 192, file_path: 'a.ogg' })).toBe('~192 kbps');
+  });
+
+  it('marks aac and wma the same way — stored kbps is an average', () => {
+    expect(formatTrackBitrate({ bitrate: 256, file_path: 'a.m4a' })).toBe('~256 kbps');
+    expect(formatTrackBitrate({ bitrate: 256, file_path: 'a.aac' })).toBe('~256 kbps');
+    expect(formatTrackBitrate({ bitrate: 192, file_path: 'a.wma' })).toBe('~192 kbps');
+  });
+
+  it('marks an mp3 as VBR only when the row says so', () => {
+    expect(formatTrackBitrate({ bitrate: 192, file_path: 'a.mp3' })).toBe('192 kbps');
+    expect(formatTrackBitrate({ bitrate: 192, file_path: 'a.mp3', bitrate_vbr: 1 })).toBe(
+      '~192 kbps',
+    );
+  });
+});
+
+describe('bitrateClass', () => {
+  it('bands 320+ high, 192+ medium, else low', () => {
+    expect(bitrateClass(1000)).toBe('high');
+    expect(bitrateClass(192)).toBe('medium');
+    expect(bitrateClass(160)).toBe('low');
+    expect(bitrateClass(0)).toBe('low');
   });
 });

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -691,6 +691,35 @@ export function bitrateClass(bitrate: unknown): string {
   return value >= 320 ? 'high' : value >= 192 ? 'medium' : 'low';
 }
 
+const VBR_FORMATS = new Set(['OPUS', 'OGG', 'AAC', 'WMA']);
+
+type BitrateTrack = {
+  bitrate?: unknown;
+  file_path?: unknown;
+  bitrate_vbr?: unknown;
+};
+
+/** Opus/Vorbis are always VBR; AAC/WMA store an average; MP3 only when flagged. */
+export function trackIsVbr(track: BitrateTrack): boolean {
+  if (track.bitrate_vbr === true || track.bitrate_vbr === 1) return true;
+  return VBR_FORMATS.has(extractFormat(track.file_path));
+}
+
+/** Library bitrate cell. VBR rows show a size/header average, not a CBR constant. */
+export function formatTrackBitrate(track: BitrateTrack): string {
+  const value = Number(track.bitrate) || 0;
+  if (value <= 0) return '-';
+  if (trackIsVbr(track)) return `~${value} kbps`;
+  return `${value} kbps`;
+}
+
+export function trackBitrateTitle(track: BitrateTrack): string | undefined {
+  const value = Number(track.bitrate) || 0;
+  if (value <= 0) return undefined;
+  if (trackIsVbr(track)) return 'Average bitrate (VBR)';
+  return undefined;
+}
+
 /** The base name of the file, or a "missing" note for an unowned row. */
 export function trackFileName(track: EnhancedTrack): string {
   const path = track.file_path || '-';

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -252,6 +252,42 @@ describe('an owned row', () => {
     expect(rows()[1].querySelector('.enhanced-bitrate')?.className).toContain('medium');
   });
 
+  it('shows an opus average with a VBR tilde', () => {
+    renderTable({
+      id: 7,
+      tracks: [
+        {
+          id: 3,
+          track_number: 3,
+          title: 'Autumnal Embrace',
+          bitrate: 160,
+          file_path: '/music/Skyforest/Autumnal Embrace.opus',
+        },
+      ],
+    });
+    const cell = rows()[0].querySelector('.enhanced-bitrate');
+    expect(cell?.textContent).toBe('~160 kbps');
+    expect(cell?.getAttribute('title')).toBe('Average bitrate (VBR)');
+  });
+
+  it('shows an aac average with a VBR tilde', () => {
+    renderTable({
+      id: 7,
+      tracks: [
+        {
+          id: 4,
+          track_number: 4,
+          title: 'Voice of the Sea',
+          bitrate: 256,
+          file_path: '/music/Skyforest/Voice of the Sea.m4a',
+        },
+      ],
+    });
+    const cell = rows()[0].querySelector('.enhanced-bitrate');
+    expect(cell?.textContent).toBe('~256 kbps');
+    expect(cell?.getAttribute('title')).toBe('Average bitrate (VBR)');
+  });
+
   it('chips every match service, matched or not', () => {
     renderTable();
     const chips = [...rows()[0].querySelectorAll('.enhanced-track-match-chip')];

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -7,7 +7,9 @@ import type { EnhancedAlbum, EnhancedTrack } from '../-artist-detail.enhanced';
 import { extractFormat, formatDurationMs } from '../-artist-detail.enhanced';
 import {
   bitrateClass,
+  formatTrackBitrate,
   getAlbumTrackRows,
+  trackBitrateTitle,
   queueTrackPayload,
   sortedTrackRows,
   sortIndicator,
@@ -436,8 +438,11 @@ function TrackRow({
       </td>
 
       <td className="col-bitrate">
-        <span className={`enhanced-bitrate ${bitrateClass(track.bitrate)}`}>
-          {track.bitrate ? `${track.bitrate} kbps` : '-'}
+        <span
+          className={`enhanced-bitrate ${bitrateClass(track.bitrate)}`}
+          title={trackBitrateTitle(track)}
+        >
+          {formatTrackBitrate(track)}
         </span>
       </td>
 

--- a/webui/static/docs.js
+++ b/webui/static/docs.js
@@ -77,7 +77,7 @@ const DOCS_SECTIONS = [
                         <tr><td><strong>Spotify</strong></td><td>Primary metadata source (artists, albums, tracks, cover art, genres)</td><td>OAuth &mdash; Client ID + Secret</td></tr>
                         <tr><td><strong>iTunes / Apple Music</strong></td><td>Fallback metadata source, always free, no auth needed</td><td>None</td></tr>
                         <tr><td><strong>Soulseek (slskd)</strong></td><td>Download source &mdash; P2P network, best for lossless and rare music</td><td>URL + API key</td></tr>
-                        <tr><td><strong>YouTube</strong></td><td>Download source &mdash; audio extraction via yt-dlp</td><td>None (optional cookies browser)</td></tr>
+                        <tr><td><strong>YouTube</strong></td><td>Download source &mdash; audio extraction via yt-dlp</td><td>Optional: local cookies browser, or Netscape cookies.txt paste (Docker)</td></tr>
                         <tr><td><strong>Tidal</strong></td><td>Download source + playlist import + enrichment</td><td>OAuth &mdash; Client ID + Secret</td></tr>
                         <tr><td><strong>Qobuz</strong></td><td>Download source + enrichment</td><td>Username + Password, or Auth Token (from browser DevTools)</td></tr>
                         <tr><td><strong>HiFi</strong></td><td>Download source &mdash; free lossless via community API</td><td>None</td></tr>
@@ -814,7 +814,7 @@ const DOCS_SECTIONS = [
                     </tbody>
                 </table>
                 <div class="docs-callout tip"><span class="docs-callout-icon">&#x1F4A1;</span><div><strong>Hybrid mode</strong> is recommended for most users. It tries your primary source first, then falls back through your configured priority order. All six sources (Soulseek, YouTube, Tidal, Qobuz, HiFi, Deezer) can be ordered via drag-and-drop in Settings.</div></div>
-                <p class="docs-text"><strong>YouTube settings</strong> include cookies (bot detection bypass, and Premium audio if your account has it), download delay (seconds between requests), and <em>Re-encode YouTube audio</em> (MP3 320 by default).</p>
+                <p class="docs-text"><strong>YouTube settings</strong> include cookies (bot detection bypass, and Premium audio if your account has it), download delay (seconds between requests), and <em>Re-encode YouTube audio</em> (MP3 320 by default). On Docker, use <strong>Paste cookies.txt</strong>: Netscape/Mozilla format only (tab-separated rows). Paste the whole file from a "Get cookies.txt LOCALLY" extension &mdash; the header line alone is not enough.</p>
             </div>
             <div class="docs-subsection" id="search-downloading">
                 <h3 class="docs-subsection-title">Downloading Music</h3>
@@ -1455,7 +1455,7 @@ const DOCS_SECTIONS = [
             <div class="docs-subsection" id="set-other">
                 <h3 class="docs-subsection-title">Other Settings</h3>
                 <ul class="docs-list">
-                    <li><strong>YouTube Configuration</strong> &mdash; Select cookies browser (Chrome, Firefox, Edge) for bot detection bypass and Premium audio qualities if your account has them, set download delay (seconds between requests). <em>Re-encode YouTube audio</em> is on by default (MP3 320).</li>
+                    <li><strong>YouTube Configuration</strong> &mdash; Cookies for bot detection bypass and Premium audio if your account has it: pick a local browser, or on Docker/server use <strong>Paste cookies.txt</strong> (Netscape/Mozilla tab-separated file only &mdash; not JSON, not a <code>Cookie:</code> header). Set download delay (seconds between requests). <em>Re-encode YouTube audio</em> is on by default (MP3 320).</li>
                     <li><strong>UI Appearance</strong> &mdash; Custom accent colors with persistent preference. Changes apply immediately across the entire interface. Choose from different <strong>sidebar visualizer types</strong> for the media player audio visualization.</li>
                     <li><strong>API Keys</strong> &mdash; Generate and manage API keys for the REST API. Keys use a <code>sk_</code> prefix and are shown once at creation &mdash; only a SHA-256 hash is stored for security.</li>
                     <li><strong>Path Templates</strong> &mdash; Configure how files are organized in your library. The default template is <code>Artist/Album/TrackNum - Title.ext</code></li>

--- a/webui/static/docs.js
+++ b/webui/static/docs.js
@@ -814,7 +814,7 @@ const DOCS_SECTIONS = [
                     </tbody>
                 </table>
                 <div class="docs-callout tip"><span class="docs-callout-icon">&#x1F4A1;</span><div><strong>Hybrid mode</strong> is recommended for most users. It tries your primary source first, then falls back through your configured priority order. All six sources (Soulseek, YouTube, Tidal, Qobuz, HiFi, Deezer) can be ordered via drag-and-drop in Settings.</div></div>
-                <p class="docs-text"><strong>YouTube settings</strong> include cookies browser selection (for bot detection bypass), download delay (seconds between requests), and minimum confidence threshold for title matching.</p>
+                <p class="docs-text"><strong>YouTube settings</strong> include cookies (bot detection bypass, and Premium audio if your account has it), download delay (seconds between requests), and <em>Re-encode YouTube audio</em> (MP3 320 by default).</p>
             </div>
             <div class="docs-subsection" id="search-downloading">
                 <h3 class="docs-subsection-title">Downloading Music</h3>
@@ -1455,7 +1455,7 @@ const DOCS_SECTIONS = [
             <div class="docs-subsection" id="set-other">
                 <h3 class="docs-subsection-title">Other Settings</h3>
                 <ul class="docs-list">
-                    <li><strong>YouTube Configuration</strong> &mdash; Select cookies browser (Chrome, Firefox, Edge) for bot detection bypass, set download delay (seconds between requests), and minimum confidence threshold for title matching</li>
+                    <li><strong>YouTube Configuration</strong> &mdash; Select cookies browser (Chrome, Firefox, Edge) for bot detection bypass and Premium audio qualities if your account has them, set download delay (seconds between requests). <em>Re-encode YouTube audio</em> is on by default (MP3 320).</li>
                     <li><strong>UI Appearance</strong> &mdash; Custom accent colors with persistent preference. Changes apply immediately across the entire interface. Choose from different <strong>sidebar visualizer types</strong> for the media player audio visualization.</li>
                     <li><strong>API Keys</strong> &mdash; Generate and manage API keys for the REST API. Keys use a <code>sk_</code> prefix and are shown once at creation &mdash; only a SHA-256 hash is stored for security.</li>
                     <li><strong>Path Templates</strong> &mdash; Configure how files are organized in your library. The default template is <code>Artist/Album/TrackNum - Title.ext</code></li>

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -1804,17 +1804,18 @@ const HELPER_CONTENT = {
     },
     '#youtube-settings-container': {
         title: 'YouTube Settings',
-        description: 'Browser cookies selection for bot detection bypass and download delay between requests.',
+        description: 'Browser cookies selection for bot detection bypass and Premium audio qualities, plus download delay between requests. Re-encode to MP3 320 is on by default.',
     },
 
     // Quality Profile
     '#quality-profile-section': {
         title: 'Quality Profile',
-        description: 'Configure which audio formats and bitrates are preferred for Soulseek downloads. Quick presets or custom per-format settings with bitrate ranges.',
+        description: 'Configure which audio formats and bitrates are preferred for downloads, including YouTube. Quick presets or custom per-format settings with bitrate ranges.',
         tips: [
             'Audiophile: FLAC only, strict — fails if no lossless found',
             'Balanced: FLAC preferred, MP3 320 fallback (default)',
             'Space Saver: MP3 preferred, smallest files',
+            'YouTube is Opus or AAC unless you re-encode (default MP3 320)',
             'FLAC bit depth: choose 16-bit, 24-bit, or any',
             'Fallback toggle: when off, only downloads at preferred quality'
         ],

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -1804,7 +1804,7 @@ const HELPER_CONTENT = {
     },
     '#youtube-settings-container': {
         title: 'YouTube Settings',
-        description: 'Browser cookies selection for bot detection bypass and Premium audio qualities, plus download delay between requests. Re-encode to MP3 320 is on by default.',
+        description: 'Cookies for bot detection bypass and Premium audio: a local browser, or on Docker a pasted Netscape cookies.txt. Download delay and Re-encode to MP3 320 (on by default).',
     },
 
     // Quality Profile

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1308,6 +1308,19 @@ function updateLossyBitrateOptions() {
     }
 }
 
+function updateYoutubeTranscodeBitrateOptions() {
+    const codec = document.getElementById('youtube-transcode-codec')?.value || 'mp3';
+    const bitrateSelect = document.getElementById('youtube-transcode-bitrate');
+    if (!bitrateSelect) return;
+    const opt320 = bitrateSelect.querySelector('option[value="320"]');
+    if (codec === 'opus') {
+        if (opt320) opt320.disabled = true;
+        if (bitrateSelect.value === '320') bitrateSelect.value = '256';
+    } else {
+        if (opt320) opt320.disabled = false;
+    }
+}
+
 function updatePlexConfigurationButtons() {
     const plexUrl = document.getElementById('plex-url');
     const plexToken = document.getElementById('plex-token');
@@ -1609,6 +1622,21 @@ async function loadSettingsData() {
         // Populate YouTube settings
         document.getElementById('youtube-cookies-browser').value = settings.youtube?.cookies_browser || '';
         document.getElementById('youtube-download-delay').value = settings.youtube?.download_delay ?? 3;
+        const _ytTranscode = document.getElementById('youtube-transcode');
+        const _ytTranscodeOpts = document.getElementById('youtube-transcode-options');
+        if (_ytTranscode) {
+            _ytTranscode.checked = settings.youtube?.transcode !== false;
+            if (_ytTranscodeOpts) {
+                _ytTranscodeOpts.style.display = _ytTranscode.checked ? 'block' : 'none';
+            }
+        }
+        const _ytCodec = document.getElementById('youtube-transcode-codec');
+        if (_ytCodec) _ytCodec.value = settings.youtube?.transcode_codec || 'mp3';
+        const _ytBitrate = document.getElementById('youtube-transcode-bitrate');
+        if (_ytBitrate) _ytBitrate.value = settings.youtube?.transcode_bitrate || '320';
+        if (typeof updateYoutubeTranscodeBitrateOptions === 'function') {
+            updateYoutubeTranscodeBitrateOptions();
+        }
         // Show the cookies.txt paste box only in "custom" mode. We never echo the
         // stored cookie back to the UI (it's secret + lives in a file, not config);
         // if one is already saved, say so via placeholder so a blank save won't wipe it.
@@ -4702,6 +4730,9 @@ async function saveSettings(quiet = false) {
         youtube: {
             cookies_browser: document.getElementById('youtube-cookies-browser').value,
             download_delay: parseInt(document.getElementById('youtube-download-delay').value) || 3,
+            transcode: document.getElementById('youtube-transcode')?.checked || false,
+            transcode_codec: document.getElementById('youtube-transcode-codec')?.value || 'mp3',
+            transcode_bitrate: document.getElementById('youtube-transcode-bitrate')?.value || '320',
             // Raw cookies.txt blob — backend validates, writes it to a file, and stores
             // only the path (never echoed back). Blank = keep any already-saved file.
             cookies_paste: document.getElementById('youtube-cookies-paste')?.value || '',

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -49731,7 +49731,7 @@ textarea.enhanced-meta-field-input {
 .enhanced-track-table .col-title { width: auto; }
 .enhanced-track-table .col-duration { width: 70px; text-align: right; }
 .enhanced-track-table .col-format { width: 80px; }
-.enhanced-track-table .col-bitrate { width: 75px; text-align: right; }
+.enhanced-track-table .col-bitrate { width: 100px; text-align: right; }
 .enhanced-track-table .col-path { width: 25%; }
 .enhanced-track-table .col-bpm { width: 60px; text-align: right; }
 .enhanced-track-table .col-actions { width: 50px; text-align: center; }


### PR DESCRIPTION
## Summary

- **YouTube search was a pile of video titles.** Hits had no reliable artist/album, so matching was weaker than Tidal/Qobuz. Search now uses the YouTube Music catalog (structured artist/title/album). A pasted Netscape `cookies.txt` is enough in Docker; the browser dropdown does nothing there.

- **Re-encode is now optional.** Default is unchanged: convert to MP3 320 after download. Turn it off in Settings to keep the original Opus/AAC (FFmpeg remux / stream copy). Leftover DASH `.webm` next to the audio is discarded so import does not see the container.

- **SoulSync pretended YouTube was MP3 320.** YouTube does not serve MP3. Streams are Opus/AAC. Missing formats now claim typical Opus 160. Cookies are not Premium — itag 774 (Opus ~256) and 141 (AAC 256) are stamped only when the player actually returns them. With re-encode on, ranking uses the converted file on disk, not a fake YouTube MP3.

- **Best-quality search mixed sources into one matcher.** A Soulseek peer first forced YouTube/Tidal through the P2P path; a closer YouTube hit could drop a Tidal FLAC via the itag confidence band. Each source family now uses its own checker. YouTube is probed and ranked on its own rows; other sources stay in the pool. A rejected YouTube profile no longer wipes everyone else.

- **YouTube lost to Soulseek even when itag 774 was the top target.** Best-quality walks used Soulseek’s old `quality_score` (FLAC 1.0 vs Opus 0.3). Ranking now follows the profile list: Opus ≥192 beats later FLAC/MP3. Hybrid order only breaks ties on the same rung.

- **Premium itags showed up in the probe, then the download 403’d.** Ranking used `skip_download` URLs that YouTube then refused. Download always extracts fresh. A 403 retry used to strip cookies, which made 774/141 disappear; retries now keep cookies, try `web_music` only, and skip dead itag URLs.

- **Completed YouTube rows showed no quality (or fake MP3-320).** Mutagen cannot read Opus bitrate, so the chip was blank. The label now uses the itag probe bitrate when the file is still Opus/AAC. A transcoded MP3 still shows as MP3, not the Opus claim. Already-completed rows keep their old chips; only new imports get the new labels.

- **Library Enhanced view showed a dash for Opus bitrate.** Ogg Opus has no header bitrate, so import stored `0` while completed-download chips already estimated from size/duration. The album table now fills that average on import, scan, and artist-detail load, and prefixes Opus/AAC/WMA with `~` (VBR average). MP3 CBR stays an exact figure.

## Testing

I'm running a custom built image in my NAS for the last few days, Everything seems to be working fine. I am able to download Premium Youtube Music files at the original high quality. All tests also pass locally.

<img width="1090" height="304" alt="image" src="https://github.com/user-attachments/assets/8c40cd7c-f680-43e2-8f78-ea78c2950fb4" />

<img width="1614" height="441" alt="image" src="https://github.com/user-attachments/assets/32a14d54-a0f6-4de4-8d0b-bae3b9e99517" />
