### PR TITLE
fix(wing-it): a stale flag is not an unresolved guess

### DIFF
--- a/database/music_database.py
+++ b/database/music_database.py
@@ -16520,13 +16520,41 @@ class MusicDatabase:
     # Wing It Pool: two states on a mirrored track's extra_data. Both key off wing_it_fallback,
     # which is set by the wing-it stub and SURVIVES a manual fix (update_mirrored_track_extra_data
     # merges rather than replaces), so the only difference is the manual_match flag:
-    #   needs attention : wing_it_fallback=true AND NOT manual_match  (unverified guess)
+    #   needs attention : still a stub AND NOT manual_match  (unverified guess)
     #   resolved        : wing_it_fallback=true AND manual_match=true (user fixed it — incl. fixes
     #                     made before this feature existed, since the flag was never wiped)
-    _WING_IT_ATTENTION = ("mpt.extra_data LIKE '%\"wing_it_fallback\": true%' "
-                          "AND mpt.extra_data NOT LIKE '%\"manual_match\": true%'")
-    _WING_IT_RESOLVED = ("mpt.extra_data LIKE '%\"wing_it_fallback\": true%' "
-                         "AND mpt.extra_data LIKE '%\"manual_match\": true%'")
+    #
+    # That the flag survives is what makes "resolved" work, but it also means the
+    # flag alone cannot answer "is this STILL a guess?". Discovery re-runs every
+    # sync, and a track that wing-it'd once and matched at 0.99 on a later pass
+    # keeps the flag — the writer only ever sets it, and the merge preserves what
+    # it omits. So "needs attention" tests the thing that actually regenerates
+    # each pass: whether matched_data is still a stub. Stub ids carry the
+    # ``wing_it_`` prefix (see core.discovery.wing_it.stub_track_id); a real
+    # match overwrites matched_data wholesale, prefix and all.
+    #
+    # json_extract, not a raw substring LIKE. Scoping to $.matched_data.id —
+    # rather than matching `"id": "wing_it_..."` anywhere in the blob — is what
+    # rules out a same-shaped key elsewhere in the document ever being mistaken
+    # for the stub id. json_extract yields SQL NULL for a missing path/row,
+    # which the comparisons below treat as "not a match" rather than erroring —
+    # but for a MALFORMED value (not just an absent key) it raises instead,
+    # and SQLite evaluates that error for the whole statement, not just the
+    # offending row: one corrupt extra_data would blank the entire pool through
+    # the try/except below, where the LIKE version it replaced would have just
+    # silently not matched that row's garbage text. json_valid() as the first
+    # AND-clause is what keeps a single bad row's failure scoped to that row.
+    _WING_IT_ATTENTION = (
+        "json_valid(mpt.extra_data) "
+        "AND json_extract(mpt.extra_data, '$.wing_it_fallback') = 1 "
+        "AND json_extract(mpt.extra_data, '$.matched_data.id') LIKE 'wing\\_it\\_%' ESCAPE '\\' "
+        "AND IFNULL(json_extract(mpt.extra_data, '$.manual_match'), 0) != 1"
+    )
+    _WING_IT_RESOLVED = (
+        "json_valid(mpt.extra_data) "
+        "AND json_extract(mpt.extra_data, '$.wing_it_fallback') = 1 "
+        "AND json_extract(mpt.extra_data, '$.manual_match') = 1"
+    )
 
     def get_wing_it_pool(self, profile_id: int = None, playlist_id: int = None,
                          resolved: bool = False) -> list:

--- a/tests/test_wing_it_pool.py
+++ b/tests/test_wing_it_pool.py
@@ -32,7 +32,21 @@ def _track(db, playlist_id, pos, name, artist, extra):
         conn.commit()
 
 
-WING_IT = {'discovered': True, 'provider': 'wing_it_fallback', 'confidence': 0, 'wing_it_fallback': True}
+def _stub(name='Stub', artist='Stub Artist'):
+    """matched_data as the wing-it fallback actually writes it — the `wing_it_`
+    id prefix is what marks the row as still-a-guess."""
+    return {'id': 'wing_it_ab12cd34', 'name': name, 'artists': [{'name': artist}],
+            'album': {'name': ''}, 'source': 'wing_it_fallback'}
+
+
+WING_IT = {'discovered': True, 'provider': 'wing_it_fallback', 'confidence': 0,
+           'wing_it_fallback': True, 'matched_data': _stub()}
+# A track that wing-it'd on one pass and matched for real on a later one. The
+# writer only ever SETS wing_it_fallback and extra_data is merged, so the stale
+# flag survives — but matched_data was replaced wholesale, stub id and all.
+WING_IT_AUTO_RESOLVED = {'discovered': True, 'provider': 'spotify', 'confidence': 0.99,
+                         'wing_it_fallback': True,
+                         'matched_data': {'id': '2cb10pqT6p291kduzk3jvO', 'name': 'Real Match'}}
 # A resolved wing-it track: /fix MERGES extra_data, so wing_it_fallback survives alongside the
 # new manual_match flag — that pairing is what marks it resolved (no separate marker needed).
 WING_IT_RESOLVED = {'discovered': True, 'provider': 'spotify', 'confidence': 1.0,
@@ -79,5 +93,85 @@ def test_empty_when_no_wing_it(tmp_path):
     db = MusicDatabase(database_path=str(tmp_path / "w3.db"))
     pid = _playlist(db, 'Clean')
     _track(db, pid, 0, 'Matched', 'X', MATCHED)
+    assert db.get_wing_it_pool(profile_id=1) == []
+    assert db.get_wing_it_pool_stats(profile_id=1) == {'wing_it': 0, 'matched': 0}
+
+
+def test_stale_flag_on_a_real_match_is_not_attention(tmp_path):
+    """A track that wing-it'd once and later matched at 0.99 must leave the pool.
+
+    Discovery re-runs every sync and the flag is never cleared, so keying purely
+    on wing_it_fallback reports resolved tracks as unverified guesses forever —
+    on the live library that was 317 of 445 rows.
+    """
+    db = MusicDatabase(database_path=str(tmp_path / "stale.db"))
+    pid = _playlist(db, 'Liked Music')
+    _track(db, pid, 0, 'Still A Guess', 'Nobody', WING_IT)
+    _track(db, pid, 1, 'Semi-Charmed Life', 'Dance Gavin Dance', WING_IT_AUTO_RESOLVED)
+
+    attention = db.get_wing_it_pool(profile_id=1)
+    assert [t['track_name'] for t in attention] == ['Still A Guess']
+    # The auto-resolved track leaves the pool entirely — it must not count as
+    # 'matched' either. That label is earned only by a MANUAL fix
+    # (wing_it_fallback AND manual_match); an auto-resolve on a later
+    # discovery pass carries no manual_match key at all.
+    assert db.get_wing_it_pool_stats(profile_id=1) == {'wing_it': 1, 'matched': 0}
+
+
+def test_underscore_in_prefix_is_matched_literally(tmp_path):
+    """`_` is a single-char wildcard in SQL LIKE — without ESCAPE, `wing_it_`
+    would also match ids like `wingXitY`, letting non-stubs back into the pool."""
+    db = MusicDatabase(database_path=str(tmp_path / "esc.db"))
+    pid = _playlist(db, 'Edge Cases')
+    _track(db, pid, 0, 'Impostor', 'Nobody', {
+        'discovered': True, 'wing_it_fallback': True,
+        'matched_data': {'id': 'wingXitY0001', 'name': 'Impostor'}})
+
+    assert db.get_wing_it_pool(profile_id=1) == []
+
+
+def test_stub_id_outside_matched_data_does_not_count(tmp_path):
+    """The predicate is scoped to $.matched_data.id specifically, not "any 'id'
+    key anywhere in the document" — a wing_it_-prefixed id sitting elsewhere in
+    extra_data must not make an otherwise-real match look like a stub."""
+    db = MusicDatabase(database_path=str(tmp_path / "scope.db"))
+    pid = _playlist(db, 'Edge Cases')
+    _track(db, pid, 0, 'Not A Stub', 'Nobody', {
+        'discovered': True, 'wing_it_fallback': True,
+        'id': 'wing_it_ab12cd34',  # stray top-level key, not matched_data.id
+        'matched_data': {'name': 'no id here'}})
+
+    assert db.get_wing_it_pool(profile_id=1) == []
+
+
+def test_malformed_extra_data_on_one_row_does_not_blank_the_pool(tmp_path):
+    """SQLite's json_extract raises on a malformed value, and that error is
+    for the whole statement, not just the offending row — so a naive
+    json_extract-only predicate would let one corrupt row hide every other
+    track behind the outer try/except's empty-list fallback. json_valid() as
+    the leading clause is what keeps the failure scoped to that one row,
+    matching what the substring-LIKE predicate this replaced did for free."""
+    db = MusicDatabase(database_path=str(tmp_path / "corrupt.db"))
+    pid = _playlist(db, 'Edge Cases')
+    _track(db, pid, 0, 'Still Fine', 'Nobody', WING_IT)
+    with db._get_connection() as conn:
+        conn.execute(
+            "INSERT INTO mirrored_playlist_tracks (playlist_id, position, track_name, artist_name, extra_data) "
+            "VALUES (?,?,?,?,?)",
+            (pid, 1, 'Corrupted Row', 'Nobody', 'not valid json {{{'))
+        conn.commit()
+
+    attention = db.get_wing_it_pool(profile_id=1)
+    assert [t['track_name'] for t in attention] == ['Still Fine']
+    assert db.get_wing_it_pool_stats(profile_id=1) == {'wing_it': 1, 'matched': 0}
+
+
+def test_null_extra_data_is_excluded_not_an_error(tmp_path):
+    """json_extract on a NULL/absent extra_data must not raise — the row is
+    simply not a wing-it track."""
+    db = MusicDatabase(database_path=str(tmp_path / "null.db"))
+    pid = _playlist(db, 'Edge Cases')
+    _track(db, pid, 0, 'No Data', 'Nobody', None)
+
     assert db.get_wing_it_pool(profile_id=1) == []
     assert db.get_wing_it_pool_stats(profile_id=1) == {'wing_it': 0, 'matched': 0}


### PR DESCRIPTION
The Wing It Pool's "needs attention" list keys on `wing_it_fallback: true` alone. That flag is only ever SET — no writer clears it — and `update_mirrored_track_extra_data` merges rather than replaces, so a key the writer omits keeps its previous value. Discovery re-runs on every sync, so a track that wing-it'd once and matched for real on a later pass carries the flag forever and is reported as an unverified guess at confidence 1.00.

On a live library that was **317 of 445 listed rows** — 71% of the pool was tracks that had already resolved, enough noise to make the surface unusable for the 128 that genuinely needed a hand.

## Why not just clear the flag on success

That's the obvious fix and the wrong one. The "resolved" state (`wing_it_fallback` AND `manual_match`) deliberately relies on the flag surviving, so clearing it would empty that list instead.

Both meanings can coexist: the flag stays the historical marker ("was ever a guess"), and "needs attention" tests the thing that actually regenerates each pass — whether `matched_data` is still a stub. Stub ids carry the `wing_it_` prefix under both id schemes; a real match replaces `matched_data` wholesale, prefix included.

## Implementation

Both predicates use `json_extract`, scoped to `$.matched_data.id` — not a substring match for `"id": "wing_it_..."` anywhere in the JSON blob, which would also fire on a same-shaped key sitting elsewhere in the document. `json_valid(mpt.extra_data)` guards both as the leading clause: `json_extract` raises on a malformed value rather than returning NULL, and SQLite evaluates that for the whole statement, not just the offending row — without the guard, one corrupted row would blank the entire pool through the surrounding `try/except`, which is worse than the substring-LIKE approach it replaces (that just silently didn't match a malformed row's garbage text).

- **Retroactive by construction.** It reclassifies existing rows on read, so there's no migration and libraries with years of stale flags are fixed on the next page load.

## Tests

`tests/test_wing_it_pool.py` — 8 cases, including: a stale flag on a real match (excluded from attention, and correctly *not* counted as `matched` either — that label is earned only by a manual fix), a stub id appearing outside `matched_data` (must not count), NULL `extra_data`, and a malformed row that must not blank the rest of the pool (verified to fail without the `json_valid` guard, pass with it).
