### PR TITLE
feat(discovery): resolve artist aliases before giving up on a track

### DIFF
--- a/core/discovery/playlist.py
+++ b/core/discovery/playlist.py
@@ -98,6 +98,10 @@ class PlaylistDiscoveryDeps:
     discovery_score_candidates: Callable
     get_metadata_cache: Callable[[], Any]
     build_discovery_wing_it_stub: Callable
+    # Resolve alternate spellings of an artist name (see
+    # MusicBrainzService.lookup_artist_aliases). Optional — discovery works
+    # without it, it just can't rescue an aliased artist.
+    lookup_artist_aliases: Callable[[str], list] = None
 
 
 def run_playlist_discovery_worker(playlists, automation_id=None, deps: PlaylistDiscoveryDeps = None):
@@ -297,6 +301,68 @@ def run_playlist_discovery_worker(playlists, automation_id=None, deps: PlaylistD
                                 best_match = match
                     except Exception as e:
                         logger.debug("extended discovery search failed: %s", e)
+
+                # Alias fallback: the source's artist name and the provider's
+                # can be different names for the same person, not variations of
+                # one string — "mgk" vs "Machine Gun Kelly", "Yorushika" vs
+                # "ヨルシカ". No amount of cleaning bridges those, and
+                # _discovery_score_candidates enforces a 0.5 artist floor
+                # BEFORE it looks at the title, so a perfect title match is
+                # discarded and the track becomes a Wing It stub.
+                #
+                # Runs only after everything else missed, so the common path
+                # pays nothing. lookup_artist_aliases is itself cached
+                # (library row → musicbrainz_cache → live MB) and caches its
+                # misses, so a given artist costs one MB call ever.
+                if (not best_match or best_confidence < min_confidence) and deps.lookup_artist_aliases:
+                    # File/CSV-imported titles can still carry a raw "Artist -
+                    # Title" prefix (see the canonical search-query block
+                    # above, #785) — canonicalize once, against the ORIGINAL
+                    # artist_name, so an alias query for "mgk - sun to me"
+                    # becomes "Machine Gun Kelly sun to me", not
+                    # "Machine Gun Kelly mgk - sun to me".
+                    alias_track_name = track_name
+                    try:
+                        from core.text.source_title import canonical_source_track
+                        alias_track_name, _ = canonical_source_track(track_name, artist_name)
+                    except Exception as e:
+                        logger.debug("alias-query canonicalization failed for %r: %s", track_name, e)
+                    try:
+                        aliases = deps.lookup_artist_aliases(artist_name) or []
+                    except Exception as e:
+                        logger.debug("artist alias lookup failed for %r: %s", artist_name, e)
+                        aliases = []
+                    seen_alias = {(artist_name or '').casefold()}
+                    for alias in aliases:
+                        alias = (alias or '').strip()
+                        if not alias or alias.casefold() in seen_alias:
+                            continue
+                        seen_alias.add(alias.casefold())
+                        try:
+                            alias_query = f"{alias} {alias_track_name}"
+                            if use_spotify:
+                                alias_results = deps.spotify_client.search_tracks(alias_query, limit=10)
+                            else:
+                                alias_results = itunes_client_instance.search_tracks(alias_query, limit=10)
+                            if not alias_results:
+                                continue
+                            # Score with the ALIAS as the source artist — scoring
+                            # against the original would re-fail the same floor
+                            # that sent us here.
+                            match, confidence, _ = deps.discovery_score_candidates(
+                                alias_track_name, alias, duration_ms, alias_results
+                            )
+                            if match and confidence > best_confidence:
+                                best_confidence = confidence
+                                best_match = match
+                                logger.info(
+                                    "Alias match: %r resolved via %r (confidence %.2f)",
+                                    artist_name, alias, confidence,
+                                )
+                            if best_confidence >= 0.9:
+                                break
+                        except Exception as e:
+                            logger.debug("alias search failed for %r: %s", alias, e)
 
                 # Step 4: Store results
                 if best_match and best_confidence >= min_confidence:

--- a/core/musicbrainz_service.py
+++ b/core/musicbrainz_service.py
@@ -1,6 +1,7 @@
 from typing import Optional, Dict, Any
 import json
 import re
+import threading
 from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 from utils.logging_config import get_logger
@@ -804,3 +805,26 @@ class MusicBrainzService:
             if conn:
                 conn.close()
 
+
+
+# ── Shared instance ─────────────────────────────────────────────────────────
+# The service is stateless apart from its HTTP session and the rate limiter,
+# and the rate limiter is what makes sharing matter: MusicBrainz allows one
+# request per second per client, so every extra instance is another way to
+# exceed it. Callers that only need a lookup should use this rather than
+# constructing their own (core.acoustid_verification and
+# core.exports.export_sources each grew a private singleton before this
+# existed).
+_shared_service = None
+_shared_service_lock = threading.Lock()
+
+
+def get_musicbrainz_service():
+    """The process-wide MusicBrainzService, created on first use."""
+    global _shared_service
+    if _shared_service is None:
+        with _shared_service_lock:
+            if _shared_service is None:
+                from database.music_database import get_database
+                _shared_service = MusicBrainzService(get_database())
+    return _shared_service

--- a/tests/discovery/test_discovery_playlist.py
+++ b/tests/discovery/test_discovery_playlist.py
@@ -108,6 +108,7 @@ def _build_deps(
     score_result=(None, 0.0, 0),
     auto_progress_log=None,
     activity_log=None,
+    lookup_artist_aliases=None,
 ):
     auto_progress_log = auto_progress_log if auto_progress_log is not None else []
     db = _FakeDB(tracks_by_playlist=tracks_by_playlist or {}, cache_match=cache_match)
@@ -134,6 +135,7 @@ def _build_deps(
         build_discovery_wing_it_stub=lambda title, artist, dur: {
             'name': title, 'artists': [artist], 'duration_ms': dur, 'wing_it': True
         },
+        lookup_artist_aliases=lookup_artist_aliases,
     )
     deps._db = db
     deps._spotify = spotify
@@ -542,3 +544,213 @@ def test_canonical_best_score_keeps_original_when_better():
     match, conf = dp._canonical_best_score(
         deps, 'Arctic Monkeys - Do I Wanna Know?', 'Arctic Monkeys', 0, ['r'])
     assert (match, conf) == ('ORIG', 0.9)
+
+
+# ---------------------------------------------------------------------------
+# Artist alias fallback
+# ---------------------------------------------------------------------------
+
+def _alias_deps(*, aliases, results_for, score_for, calls=None):
+    """Deps whose provider only answers for certain queries and whose scorer
+    only pays out for certain source artists — so a test can prove WHICH
+    artist name did the work."""
+    calls = calls if calls is not None else []
+
+    class _Client:
+        def __init__(self):
+            self.search_calls = []
+
+        def is_spotify_authenticated(self):
+            return True
+
+        def search_tracks(self, query, limit=10):
+            self.search_calls.append(query)
+            return results_for(query)
+
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1, name='sun to me', artist='mgk')]},
+        lookup_artist_aliases=lambda name: (calls.append(name) or aliases),
+    )
+    client = _Client()
+    deps.spotify_client = client
+    deps._spotify = client
+    deps.discovery_score_candidates = score_for
+    deps._alias_calls = calls
+    return deps
+
+
+_MGK = _FakeMatch(name='sun to me', artists=['Machine Gun Kelly'])
+
+
+def _only_alias_query(query):
+    return [_MGK] if 'Machine Gun Kelly' in query else []
+
+
+def _score_only_for(expected_artist, conf=0.99):
+    def _score(title, artist, duration_ms, results):
+        if artist == expected_artist and results:
+            return (_MGK, conf, 0)
+        return (None, 0.0, 0)
+    return _score
+
+
+def test_alias_rescues_a_track_the_source_artist_name_cannot_find():
+    """"mgk" and "Machine Gun Kelly" are different names for one artist, so the
+    0.5 artist floor discards a perfect title match. The alias must recover it."""
+    deps = _alias_deps(
+        aliases=['mgk', 'Machine Gun Kelly'],
+        results_for=_only_alias_query,
+        score_for=_score_only_for('Machine Gun Kelly'),
+    )
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    assert len(deps._db.extra_data_writes) == 1
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra.get('discovered') is True
+    assert not extra.get('wing_it_fallback')
+    assert extra['matched_data']['name'] == 'sun to me'
+
+
+def test_alias_lookup_is_skipped_when_the_track_already_matched():
+    """The lookup is a network call — the common path must not pay for it."""
+    match = _FakeMatch()
+    calls = []
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1)]},
+        spotify_results=[match],
+        score_result=(match, 0.95, 0),
+        lookup_artist_aliases=lambda name: calls.append(name) or ['Whoever'],
+    )
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    assert calls == []
+
+
+def test_alias_equal_to_the_source_artist_is_not_re_searched():
+    """MB returns the artist's own name in its alias list; searching it again
+    would just repeat the query that already failed."""
+    deps = _alias_deps(
+        aliases=['mgk', 'MGK', 'Machine Gun Kelly'],
+        results_for=_only_alias_query,
+        score_for=_score_only_for('Machine Gun Kelly'),
+    )
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    # 'mgk' and 'MGK' are the same name case-folded — only one extra query.
+    alias_queries = [q for q in deps._spotify.search_calls if 'Machine Gun Kelly' in q]
+    assert len(alias_queries) == 1
+    assert not any(q.startswith('MGK ') for q in deps._spotify.search_calls)
+
+
+def test_alias_does_not_override_a_better_existing_match():
+    """Additive only: a weaker alias hit must not displace a stronger one."""
+    strong = _FakeMatch(name='strong', artists=['mgk'])
+    weak = _FakeMatch(name='weak', artists=['Machine Gun Kelly'])
+
+    def _score(title, artist, duration_ms, results):
+        if artist == 'mgk':
+            return (strong, 0.80, 0)
+        return (weak, 0.75, 0)
+
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1, name='sun to me', artist='mgk')]},
+        spotify_results=[strong, weak],
+        lookup_artist_aliases=lambda name: ['Machine Gun Kelly'],
+    )
+    deps.discovery_score_candidates = _score
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra['matched_data']['name'] == 'strong'
+
+
+def test_alias_lookup_failure_degrades_to_wing_it():
+    """A raising lookup (MB down) must not break discovery."""
+    def _boom(name):
+        raise RuntimeError('musicbrainz unreachable')
+
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1)]},
+        spotify_results=[],
+        lookup_artist_aliases=_boom,
+    )
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra.get('wing_it_fallback') is True
+
+
+def test_alias_query_uses_the_canonicalized_title():
+    """A file/CSV import can keep a raw "Artist - Title" source title (#785).
+    Without canonicalizing first, the alias query becomes "Machine Gun Kelly
+    mgk - sun to me" — which the provider has nothing to match — instead of
+    "Machine Gun Kelly sun to me"."""
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1, name='mgk - sun to me', artist='mgk')]},
+        lookup_artist_aliases=lambda name: ['Machine Gun Kelly'],
+    )
+    client = deps.spotify_client
+
+    def _search(query, limit=10):
+        client.search_calls.append(query)
+        return [_MGK] if query == 'Machine Gun Kelly sun to me' else []
+    client.search_tracks = _search
+    deps.discovery_score_candidates = _score_only_for('Machine Gun Kelly')
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra.get('discovered') is True
+    assert extra['matched_data']['name'] == 'sun to me'
+
+
+def test_alias_rescues_a_track_via_itunes_when_spotify_is_not_active():
+    """The alias fallback also has to work on the non-Spotify path — it queries
+    `itunes_client_instance`, a name resolved fresh from
+    `get_metadata_fallback_client()` inside the worker, not `deps.spotify_client`."""
+    calls = []
+
+    class _ITunesClient:
+        def __init__(self):
+            self.search_calls = []
+
+        def search_tracks(self, query, limit=10):
+            self.search_calls.append(query)
+            return [_MGK] if 'Machine Gun Kelly' in query else []
+
+    itunes = _ITunesClient()
+    deps = _build_deps(
+        discovery_source='itunes',
+        tracks_by_playlist={'p1': [_track(track_id=1, name='sun to me', artist='mgk')]},
+        lookup_artist_aliases=lambda name: (calls.append(name) or ['Machine Gun Kelly']),
+    )
+    deps.get_metadata_fallback_client = lambda: itunes
+    deps.discovery_score_candidates = _score_only_for('Machine Gun Kelly')
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    assert calls == ['mgk']
+    assert any('Machine Gun Kelly' in q for q in itunes.search_calls)
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra.get('discovered') is True
+    assert not extra.get('wing_it_fallback')
+    assert extra['matched_data']['name'] == 'sun to me'
+
+
+def test_no_alias_dep_wired_is_not_an_error():
+    """The dep is optional — older wiring must keep working."""
+    deps = _build_deps(
+        tracks_by_playlist={'p1': [_track(track_id=1)]},
+        spotify_results=[],
+    )
+    assert deps.lookup_artist_aliases is None
+
+    dp.run_playlist_discovery_worker([_playlist('p1')], deps=deps)
+
+    extra = deps._db.extra_data_writes[0][1]
+    assert extra.get('wing_it_fallback') is True

--- a/web_server.py
+++ b/web_server.py
@@ -25571,6 +25571,23 @@ def _sync_discovery_results_to_mirrored(source_type, source_playlist_id, discove
 from core.discovery import playlist as _discovery_playlist
 
 
+def _lookup_artist_aliases(artist_name):
+    """Alternate spellings for an artist name, or [] if none can be resolved.
+
+    Thin wrapper over MusicBrainzService.lookup_artist_aliases, which already
+    does the caching (library row -> musicbrainz_cache -> live MB) and applies
+    the trust gate that keeps a fuzzy near-miss from renaming an artist.
+    Best-effort by contract: any failure returns [] so discovery falls back to
+    exactly its prior behaviour.
+    """
+    try:
+        from core.musicbrainz_service import get_musicbrainz_service
+        return get_musicbrainz_service().lookup_artist_aliases(artist_name) or []
+    except Exception as e:
+        logger.debug("artist alias lookup unavailable for %r: %s", artist_name, e)
+        return []
+
+
 def _build_playlist_discovery_deps():
     """Build the PlaylistDiscoveryDeps bundle from web_server.py globals on each call."""
     return _discovery_playlist.PlaylistDiscoveryDeps(
@@ -25590,6 +25607,7 @@ def _build_playlist_discovery_deps():
         discovery_score_candidates=_discovery_score_candidates,
         get_metadata_cache=get_metadata_cache,
         build_discovery_wing_it_stub=_build_discovery_wing_it_stub,
+        lookup_artist_aliases=_lookup_artist_aliases,
     )
 
 


### PR DESCRIPTION
`_discovery_score_candidates` enforces a 0.5 artist-similarity floor and rejects a candidate on it **before** looking at the title. That's the right guard, but it assumes the source's artist name and the provider's are variations of one string. Often they're two different names for the same artist:

| Source says | Provider indexes | Similarity |
|---|---|---|
| `mgk` | `Machine Gun Kelly` | ~0.30 |
| `Yorushika` | `ヨルシカ` | ~0.30 |

A title matching at 1.00 is discarded and the track is written off as a Wing It stub. No cleaning fixes this — the strings share no substring. It needs data about artist *identity*, and MusicBrainz already has it.

## Wiring, not new machinery

`lookup_artist_aliases` has existed since #442 (the AcoustID verifier's cross-script problem is this same problem), with the resolution chain, the caching, and the trust gate that stops a fuzzy near-miss from renaming an artist. It was simply never offered to discovery.

On a miss, this asks for the artist's aliases and retries the search and the scoring under each one, keeping the best result. Scoring uses the **alias** as the source artist — scoring under the original name would re-fail the floor that sent us here.

The alias query and scoring also canonicalize the source title first, the same way the file/CSV query-generation block earlier in this function already does (#785). Without it, a raw imported title like `"mgk - sun to me"` would build the alias query as `"Machine Gun Kelly mgk - sun to me"` — nothing a provider matches — instead of `"Machine Gun Kelly sun to me"`.

## Measured

Against Deezer with the real scorer: six sampled mgk tracks go **0.00 → 0.99**, while a control (`Machine Gun Kelly` + `Bohemian Rhapsody`) stays correctly rejected. On the library that motivated this, **25 of one playlist's 77 stubs are a single artist alias**.

## Cost is bounded by design

- Runs only after every existing strategy has missed, so the common path pays nothing.
- `lookup_artist_aliases` caches misses as well as hits (library row → `musicbrainz_cache` → live MB), so an artist costs **one MB request ever**.
- The dep is optional and the lookup is best-effort: unwired, raising, or empty all degrade to exactly the previous behaviour.

## Also in here

`get_musicbrainz_service()`. MusicBrainz allows one request per second per client and the rate limiter lives on the instance, so every extra instance is another way to exceed it — `core.acoustid_verification` and `core.exports.export_sources` had each already grown a private singleton. New callers now have one to share; **the existing two are left alone** to keep this diff to the point.

## Tests

`tests/discovery/` — 357 passed, including cases for alias hit, alias miss, lookup raising, the dep being unwired, the alias query using the canonicalized title, and the fallback working over the iTunes path (it resolves `itunes_client_instance` fresh inside the worker, a distinct path from `deps.spotify_client`).
