### PR TITLE
fix(discovery): canonicalize YouTube titles before matching, not only after

### DIFF
--- a/core/discovery/canonical.py
+++ b/core/discovery/canonical.py
@@ -1,0 +1,40 @@
+"""Canonical-form scoring shared by the discovery workers.
+
+A source's track title is rarely the title a provider indexes. The decoration
+varies by source — a file/CSV playlist keeps a raw ``"Arctic Monkeys - Do I
+Wanna Know?"``; YouTube Music restates a localized title in Latin next to the
+original (``"晴る - Sunny"``); plain YouTube prepends the channel. Scored
+verbatim, none of those reach the provider's plain form.
+
+``core.text.source_title.canonical_source_track`` undecorates a title/artist
+pair conservatively — it returns the input unchanged unless the decoration is
+demonstrable. ``canonical_best_score`` uses that to score a result set BOTH
+ways and keep the better confidence, so canonicalization can only ever add a
+candidate, never weaken an existing match.
+
+This lives here rather than in one worker because every discovery worker has
+the same problem; ``core.discovery.playlist`` had the first copy (#785).
+"""
+
+from __future__ import annotations
+
+
+def canonical_best_score(deps, title, artist, duration_ms, results):
+    """Score `results` against the source pair and, when canonicalization
+    changes it, against the canonical pair too — keeping whichever scores
+    higher.
+
+    `deps` need only supply `discovery_score_candidates(title, artist,
+    duration_ms, results) -> (match, confidence, index)`.
+    Returns (match, confidence)."""
+    match, confidence, _ = deps.discovery_score_candidates(title, artist, duration_ms, results)
+    try:
+        from core.text.source_title import canonical_source_track
+        canon_title, canon_artist = canonical_source_track(title or '', artist or '')
+    except Exception:
+        return match, confidence
+    if (canon_title, canon_artist) != (title, artist):
+        alt_match, alt_conf, _ = deps.discovery_score_candidates(canon_title, canon_artist, duration_ms, results)
+        if alt_match and alt_conf > confidence:
+            return alt_match, alt_conf
+    return match, confidence

--- a/core/discovery/playlist.py
+++ b/core/discovery/playlist.py
@@ -37,6 +37,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from core.discovery.canonical import canonical_best_score
 from core.discovery.manual_match import should_rediscover
 
 logger = logging.getLogger(__name__)
@@ -55,28 +56,10 @@ def _matched_primary_artist(matched_data) -> str:
         return ''
 
 
-def _canonical_best_score(deps, title, artist, duration_ms, results):
-    """Score search results against the source track, trying the canonicalized
-    title/artist too and keeping the better confidence (#785).
-
-    YouTube playlists have their "Artist - Title" / channel decoration stripped
-    at ingest, but file/CSV-imported playlists keep raw titles — so a track
-    titled "Arctic Monkeys - Do I Wanna Know?" scored verbatim against the
-    library's "Do I Wanna Know?" never matched. canonical_source_track is
-    conservative (only strips an "<artist> - " prefix when it equals the
-    artist), so this can only ADD a better candidate, never weaken a match.
-    Returns (match, confidence)."""
-    match, confidence, _ = deps.discovery_score_candidates(title, artist, duration_ms, results)
-    try:
-        from core.text.source_title import canonical_source_track
-        canon_title, canon_artist = canonical_source_track(title or '', artist or '')
-    except Exception:
-        return match, confidence
-    if (canon_title, canon_artist) != (title, artist):
-        alt_match, alt_conf, _ = deps.discovery_score_candidates(canon_title, canon_artist, duration_ms, results)
-        if alt_match and alt_conf > confidence:
-            return alt_match, alt_conf
-    return match, confidence
+# Moved to core.discovery.canonical so the YouTube worker can share it rather
+# than grow a second copy (#785 introduced it here). Kept under the old private
+# name because this module's callers and tests reference it.
+_canonical_best_score = canonical_best_score
 
 
 @dataclass

--- a/core/discovery/youtube.py
+++ b/core/discovery/youtube.py
@@ -30,6 +30,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable
 
+from core.discovery.canonical import canonical_best_score
+
 logger = logging.getLogger(__name__)
 
 _UNKNOWN_ARTIST = 'Unknown Artist'
@@ -179,6 +181,33 @@ def run_youtube_discovery_worker(url_hash, deps: YoutubeDiscoveryDeps):
                 min_confidence = 0.9
                 source_duration = track.get('duration_ms', 0) or 0
 
+                # YouTube Music restates a localized title in Latin next to the
+                # original ("晴る - Sunny"), and plain YouTube prepends the channel
+                # ("Nicholas Shaw - Castaway"). Providers index only the plain
+                # form. The canonical pair is needed here (not just inside
+                # canonical_best_score) because Strategy 5 SEARCHES with it.
+                try:
+                    from core.text.source_title import canonical_source_track
+                    canon_title, canon_artist = canonical_source_track(cleaned_title, cleaned_artist)
+                except Exception as e:
+                    logger.debug(f"Canonicalization failed for '{cleaned_title}': {e}")
+                    canon_title, canon_artist = cleaned_title, cleaned_artist
+                has_canon = (canon_title, canon_artist) != (cleaned_title, cleaned_artist)
+
+                def _score_best(
+                    results,
+                    title=cleaned_title,
+                    artist=cleaned_artist,
+                    duration_ms=source_duration,
+                ):
+                    """Score `results` both ways, keeping the better confidence.
+
+                    title/artist/duration_ms are bound as defaults, not read from
+                    the enclosing scope — this closure is (re)defined on every
+                    loop iteration and a late-binding read would see whichever
+                    track happened to be current when it was finally called."""
+                    return canonical_best_score(deps, title, artist, duration_ms, results)
+
                 # Strategy 1: Use matching_engine search queries
                 try:
                     temp_track = type('TempTrack', (), {
@@ -207,9 +236,7 @@ def run_youtube_discovery_worker(url_hash, deps: YoutubeDiscoveryDeps):
                             continue
 
                         # Score all results using the matching engine
-                        match, confidence, match_idx = deps.discovery_score_candidates(
-                            cleaned_title, cleaned_artist, source_duration, search_results
-                        )
+                        match, confidence = _score_best(search_results)
 
                         if match and confidence > best_confidence and confidence >= min_confidence:
                             best_confidence = confidence
@@ -242,9 +269,7 @@ def run_youtube_discovery_worker(url_hash, deps: YoutubeDiscoveryDeps):
                         query = f"{cleaned_title} {cleaned_artist}"
                         fallback_results = itunes_client.search_tracks(query, limit=5)
                     if fallback_results:
-                        match, confidence, _ = deps.discovery_score_candidates(
-                            cleaned_title, cleaned_artist, source_duration, fallback_results
-                        )
+                        match, confidence = _score_best(fallback_results)
                         if match and confidence >= min_confidence:
                             matched_track = match
                             best_confidence = confidence
@@ -261,9 +286,7 @@ def run_youtube_discovery_worker(url_hash, deps: YoutubeDiscoveryDeps):
                     else:
                         fallback_results = itunes_client.search_tracks(query, limit=5)
                     if fallback_results:
-                        match, confidence, _ = deps.discovery_score_candidates(
-                            cleaned_title, cleaned_artist, source_duration, fallback_results
-                        )
+                        match, confidence = _score_best(fallback_results)
                         if match and confidence >= min_confidence:
                             matched_track = match
                             best_confidence = confidence
@@ -278,13 +301,32 @@ def run_youtube_discovery_worker(url_hash, deps: YoutubeDiscoveryDeps):
                     else:
                         extended_results = itunes_client.search_tracks(query, limit=50)
                     if extended_results:
-                        match, confidence, _ = deps.discovery_score_candidates(
-                            cleaned_title, cleaned_artist, source_duration, extended_results
-                        )
+                        match, confidence = _score_best(extended_results)
                         if match and confidence >= min_confidence:
                             matched_track = match
                             best_confidence = confidence
                             logger.info(f"Strategy 4 YouTube match (extended): {match.artists[0]} - {match.name} (confidence: {confidence:.3f})")
+
+                # Strategy 5: query with the canonical title/artist. Strategies 1-4
+                # all *search* with the raw pair — scoring the canonical form only
+                # helps when the provider already returned the right release, and
+                # "晴る - Sunny" as a query returns nothing to score. Asking for
+                # "Sunny" is what actually surfaces the track.
+                if not matched_track and has_canon:
+                    logger.info(f"YouTube Strategy 5: Canonical retry: '{canon_artist}' - '{canon_title}'")
+                    query = f"{canon_artist} {canon_title}"
+                    if use_spotify:
+                        canon_results = deps.spotify_client.search_tracks(query, limit=10)
+                    else:
+                        canon_results = itunes_client.search_tracks(query, limit=10)
+                    if canon_results:
+                        match, confidence = _score_best(canon_results)
+                        if match and confidence >= min_confidence:
+                            matched_track = match
+                            best_confidence = confidence
+                            if use_spotify and match.id:
+                                best_raw_track = deps.get_metadata_cache().get_entity('spotify', 'track', match.id)
+                            logger.info(f"Strategy 5 YouTube match (canonical): {match.artists[0]} - {match.name} (confidence: {confidence:.3f})")
 
                 # Create result entry. yt_artist falls back to the matched artist when
                 # YouTube/recovery left it "Unknown Artist" but we matched confidently (#909).

--- a/tests/discovery/test_discovery_youtube.py
+++ b/tests/discovery/test_discovery_youtube.py
@@ -434,3 +434,139 @@ def test_display_artist_stays_unknown_with_no_match():
 def test_display_artist_trims_whitespace():
     assert dy.resolve_display_artist('  ', 'Matched') == 'Matched'
     assert dy.resolve_display_artist('Real Artist  ', '') == 'Real Artist'
+
+
+# ---------------------------------------------------------------------------
+# Canonical title/artist (dual-title restatement, "Artist - Title" prefix)
+# ---------------------------------------------------------------------------
+
+def _scorer_keyed_on_title(expected_title, match, *, conf=0.95):
+    """A scorer that only pays out for `expected_title`, so a test can prove
+    WHICH title the worker scored with."""
+    def _score(title, artist, duration_ms, results):
+        if title == expected_title:
+            return (match, conf, 0)
+        return (None, 0.0, 0)
+    return _score
+
+
+def test_canonical_title_scored_when_raw_title_scores_nothing():
+    """"晴る - Sunny" must also be scored as "Sunny" — the provider indexes the
+    transliteration, so the raw restated string matches nothing."""
+    states = {}
+    match = _FakeMatch(name='Sunny', artists=['Yorushika'])
+    deps = _build_deps(states=states, spotify_results=[match])
+    deps.discovery_score_candidates = _scorer_keyed_on_title('Sunny', match)
+    _seed_state('h', states, tracks=[_track(name='晴る - Sunny', artist='Yorushika')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    result = states['h']['discovery_results'][0]
+    assert result['status'] == 'Found'
+    assert result['spotify_track'] == 'Sunny'
+    assert states['h']['spotify_matches'] == 1
+
+
+def test_canonical_artist_alone_is_propagated_to_strategy5():
+    """The title isn't always what changes — clean_source_artist strips
+    "- Topic" from an auto-generated YouTube channel name, so "Arctic Monkeys -
+    Topic" canonicalizes to "Arctic Monkeys" with the title untouched. Strategy
+    5 must query and score with THAT artist, proving the full (title, artist)
+    pair propagates, not just whichever half the other tests happen to cover."""
+    states = {}
+    match = _FakeMatch(name='Do I Wanna Know?', artists=['Arctic Monkeys'])
+
+    class _OnlyCanonicalArtistQuery(_FakeSpotifyClient):
+        def search_tracks(self, query, limit=10):
+            self.search_calls.append((query, limit))
+            return [match] if 'Arctic Monkeys' in query and 'Topic' not in query else []
+
+    deps = _build_deps(states=states)
+    deps.spotify_client = _OnlyCanonicalArtistQuery(results=[])
+
+    def _score(title, artist, duration_ms, results):
+        if artist == 'Arctic Monkeys' and results:
+            return (match, 0.95, 0)
+        return (None, 0.0, 0)
+    deps.discovery_score_candidates = _score
+    _seed_state('h', states, tracks=[
+        _track(name='Do I Wanna Know?', artist='Arctic Monkeys - Topic')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    assert states['h']['discovery_results'][0]['status'] == 'Found'
+    assert any('Topic' not in q for q, _ in deps.spotify_client.search_calls)
+
+
+def test_strategy5_queries_with_the_canonical_pair():
+    """Scoring the canonical form is not enough when the RAW query returns
+    nothing to score — strategy 5 has to ask the provider for "Sunny"."""
+    states = {}
+    match = _FakeMatch(name='Sunny', artists=['Yorushika'])
+
+    class _OnlyCanonicalQuery(_FakeSpotifyClient):
+        def search_tracks(self, query, limit=10):
+            self.search_calls.append((query, limit))
+            return [match] if 'Sunny' in query and '晴る' not in query else []
+
+    deps = _build_deps(states=states)
+    deps.spotify_client = _OnlyCanonicalQuery(results=[])
+    deps.discovery_score_candidates = _scorer_keyed_on_title('Sunny', match)
+    _seed_state('h', states, tracks=[_track(name='晴る - Sunny', artist='Yorushika')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    assert states['h']['discovery_results'][0]['status'] == 'Found'
+    assert any('晴る' not in q for q, _ in deps.spotify_client.search_calls)
+
+
+def test_raw_title_still_wins_when_it_scores_higher():
+    """Canonicalization is an ADDITIONAL candidate, never a replacement."""
+    states = {}
+    raw_match = _FakeMatch(id='raw', name='COLORS (Album Mix)')
+    canon_match = _FakeMatch(id='canon', name='Colors (Ailu Mix)')
+
+    def _score(title, artist, duration_ms, results):
+        if title == 'COLORS (Album Mix) - Colors (Ailu Mix)':
+            return (raw_match, 0.99, 0)
+        return (canon_match, 0.91, 0)
+
+    deps = _build_deps(states=states, spotify_results=[raw_match, canon_match])
+    deps.discovery_score_candidates = _score
+    _seed_state('h', states, tracks=[
+        _track(name='COLORS (Album Mix) - Colors (Ailu Mix)', artist='FLOW')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    assert states['h']['discovery_results'][0]['spotify_track'] == 'COLORS (Album Mix)'
+
+
+def test_plain_title_takes_no_canonical_detour():
+    """A title with no decoration must not trigger the extra strategy-5 search."""
+    states = {}
+    deps = _build_deps(states=states, spotify_results=[])
+    _seed_state('h', states, tracks=[_track(name='Semi-Charmed Life', artist='Third Eye Blind')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    assert states['h']['discovery_results'][0]['status'] == 'Wing It'
+    # strategies 1-4 only; no canonical retry was issued. Asserting the count,
+    # not just that every query contains the title — a redundant Strategy 5
+    # call would ALSO contain "Semi-Charmed Life" and pass the weaker check.
+    assert len(deps._spotify.search_calls) == 4
+
+
+def test_canonicalization_failure_does_not_break_discovery(monkeypatch):
+    """A raising canonicalizer must degrade to raw-only matching, not error out."""
+    import core.text.source_title as st
+    monkeypatch.setattr(st, 'canonical_source_track',
+                        lambda t, a: (_ for _ in ()).throw(RuntimeError('boom')))
+    states = {}
+    match = _FakeMatch()
+    deps = _build_deps(states=states, spotify_results=[match],
+                       score_candidates_result=(match, 0.95, 0))
+    _seed_state('h', states, tracks=[_track(name='晴る - Sunny', artist='Yorushika')])
+
+    dy.run_youtube_discovery_worker('h', deps)
+
+    assert states['h']['discovery_results'][0]['status'] == 'Found'


### PR DESCRIPTION
`canonical_source_track` recognizes a title stated twice (`晴る - Sunny`, `神様の神様 - Kamisamano Kamisama`) and a channel-prefixed one (`Nicholas Shaw - Castaway`). The sync, playlist and playlist-reconcile paths all call it. **The YouTube discovery worker is the one discovery worker that never did** — and it's the path that decides whether a mirrored playlist track resolves to a release at all, so it's the path that creates the Wing It stubs.

It scored and searched with `track['name']` verbatim through all four strategies. Providers index the transliteration, so the raw restated string scores against nothing and, worse, *searches* for nothing: strategies 1-4 all build their query from the raw pair, so the right release is never in the result set to be scored.

## Two behavioural changes, both additive

- Each result set is now scored against the raw pair **and**, when canonicalization changed something, the canonical pair too — keeping the higher confidence. An over-eager strip can only add a comparison, never remove one.
- **Strategy 5** re-queries the provider with the canonical pair when 1-4 came up empty. Scoring alone cannot help when the query returned no candidates.

## The refactor — the part worth reviewing

The best-of scoring is not new: `core/discovery/playlist.py` grew it as `_canonical_best_score` for #785, and this worker needs exactly the same thing. Rather than carry a second copy, it moves to a new `core/discovery/canonical.py` as `canonical_best_score`, with the rationale that was split across two call sites collected in the module docstring.

`playlist.py` keeps the old private name as an alias (`_canonical_best_score = canonical_best_score`), so **its callers and its existing tests are untouched** — they pass unmodified.

## Measured

Against the live mirror (2,063 tracks across 22 YouTube playlists): **29 of 69 unique Wing It stubs resolve at confidence 1.00**, including every `原題 - Romanization` entry and the `(acoustic)`-suffixed ones.

## Cost

`canonical_source_track` is unchanged and still conservative — it returns its input untouched unless the decoration is demonstrable — so a plain title takes no detour and issues no extra search. Strategy 5 only runs when 1-4 all missed.

## Tests

`tests/discovery/` + `tests/test_source_title.py` — 419 passed, including upstream's existing `_canonical_best_score` tests through the alias, and a case proving the canonical *artist* half of the pair propagates to Strategy 5 on its own (every other test here happened to change only the title — `clean_source_artist` stripping `"- Topic"` from a channel name with the title untouched exercises the other half).
