### PR TITLE
fix(matching): give the download query ladder a version-stripped last resort

### DIFF
--- a/core/matching_engine.py
+++ b/core/matching_engine.py
@@ -487,7 +487,13 @@ class MusicMatchingEngine:
             # - Is reasonable length (4-30 chars)
             # - Doesn't look like a feature/remix indicator
             exclude_patterns = [
-                r'\b(remix|mix|edit|version|live|acoustic|instrumental|demo|feat|ft|featuring)\b'
+                r'\b(remix|mix|edit|version|live|acoustic|instrumental|demo|feat|ft|featuring)\b',
+                # Edition/master decoration ("Song - Deluxe", "Song - Mono")
+                # is not an album name either — without this, this heuristic
+                # strips it here before generate_download_queries' Priority 5
+                # last-resort ever gets a chance to, so the faithful
+                # "artist song deluxe" query is never tried at all.
+                r'\b(' + '|'.join(re.escape(tok) for tok in self._VERSION_TOKENS) + r')\b',
             ]
             
             is_likely_album = True
@@ -527,6 +533,119 @@ class MusicMatchingEngine:
         cleaned = " ".join(str(title or "").split())
         return len(cleaned) >= cls._TITLE_ONLY_MIN_CHARS
 
+    # EDITION decoration only: markers that distinguish two masters/releases of
+    # THE SAME RECORDING. Stripping these can only change which pressing you get.
+    #
+    # Performance markers — live, remix, acoustic, instrumental, radio/club/
+    # extended edits, demos, slowed/sped-up edits — are deliberately NOT here.
+    # They name a different take, and the version gate in
+    # calculate_slskd_match_confidence only rejects on the CANDIDATE's version:
+    # a plain studio file classifies as 'original' and is never rejected, so a
+    # query stripped down to "Song" would happily return the studio cut for a
+    # source that asked for "Song (Live)" — silently substituting a different
+    # performance. An edition strip has no such failure mode.
+    _VERSION_TOKENS = (
+        'remaster', 'remastered', 'mono', 'stereo', 'anniversary',
+        'deluxe', 'expanded', 'reissue', 'tv size', 'tv-size', 'edition',
+    )
+    # Performance markers that keep a decoration from being edition-only even
+    # when an edition token also appears in it — "(Live at the Deluxe
+    # Anniversary Tour)" contains "deluxe" and "anniversary", but it also
+    # names a different TAKE, and stripping the whole bracket would lose that
+    # along with the edition note. See the safety note below _VERSION_TOKENS'
+    # own docstring: this is the same failure mode, reached through a mixed
+    # label instead of a bare performance one.
+    _PERFORMANCE_TOKENS = (
+        'live', 'remix', 'mix', 'edit', 'acoustic', 'instrumental', 'radio',
+        'extended', 'club', 'demo', 'slowed', 'sped up', 'spedup', 'mashup',
+        'bootleg', 'version', 'ver',
+    )
+    # Connector words/numbers allowed alongside an edition token without
+    # disqualifying the decoration — "30th Anniversary Remaster" is still
+    # edition-only even though "30th" isn't itself a token.
+    _EDITION_STOPWORDS = frozenset({'the', 'a', 'an', 'of', 'and'})
+    _EDITION_NUMBER = re.compile(r"\d{1,4}(st|nd|rd|th)?")
+    _BRACKETED_GROUP = re.compile(r'\s*[\(\[]([^)\]]*)[)\]]')
+    _DASH_CHAR = re.compile(r'[-–—]')
+
+    def _is_edition_only_text(self, text: str) -> bool:
+        """Is `text` composed ENTIRELY of edition decoration (tokens, numbers/
+        ordinals, light connector words) with no performance marker and no
+        unrelated content? Used to decide whether a bracket/dash-tail is safe
+        to drop outright."""
+        low = text.lower()
+        if not any(tok in low for tok in self._VERSION_TOKENS):
+            return False
+        if any(re.search(r'\b' + re.escape(tok) + r'\b', low)
+               for tok in self._PERFORMANCE_TOKENS):
+            return False
+        # Whole-content check: every remaining word must be a number/ordinal,
+        # a stopword, or part of a recognized edition token — otherwise the
+        # text carries unrelated content ("Stereo Hearts" is a real title,
+        # not a mono/stereo mix note) and stripping it would drop more than
+        # the edition note.
+        residual = low
+        # Longest first: 'remaster' is a prefix of 'remastered', so removing
+        # it first would leave a stray "ed" that isn't a stopword/number and
+        # wrongly fail this check.
+        for tok in sorted(self._VERSION_TOKENS, key=len, reverse=True):
+            residual = residual.replace(tok, ' ')
+        for word in re.findall(r"[a-z0-9']+", residual):
+            if word in self._EDITION_STOPWORDS:
+                continue
+            if self._EDITION_NUMBER.fullmatch(word):
+                continue
+            return False
+        return True
+
+    def _dash_tail_edition_split(self, title: str) -> Optional[str]:
+        """`title` with a trailing "-<edition>" segment removed, or None if
+        none qualifies.
+
+        Tries every -/–/— position, RIGHT TO LEFT, and takes the first whose
+        trailing segment is edition-only. Whitespace around the separator is
+        optional (`"Nevermind–30th Anniversary Remaster"` must strip same as
+        the spaced form), which makes a naive "split on any dash" ambiguous
+        for a tail with its own internal hyphen — "the WORLD - TV-Size" has a
+        candidate split inside "TV-Size" itself. Right-to-left resolves it for
+        free: that inner candidate's tail is just "Size", which isn't
+        edition-only, so it's rejected and the search continues left to the
+        real separator, whose tail "TV-Size" IS a recognized token.
+        """
+        positions = [m.start() for m in self._DASH_CHAR.finditer(title)]
+        for pos in reversed(positions):
+            prefix = title[:pos].rstrip(' -–—')
+            tail = title[pos + 1:].strip()
+            if not prefix or not tail:
+                continue
+            if self._is_edition_only_text(tail):
+                return prefix
+        return None
+
+    def _strip_version_decoration(self, title: str) -> str:
+        """`title` with version-bearing decoration removed.
+
+        Drops bracketed groups and a trailing "-<edition>" segment ONLY when
+        their COMPLETE content is edition-only, so "Africa" is untouched, "Old
+        Town Road (feat. Billy Ray Cyrus)" keeps its credit (no edition
+        token), "Sweet Dreams (Are Made of This) [2005 Remaster]" loses just
+        the remaster note, and "(Live at the Deluxe Anniversary Tour)" is left
+        alone entirely — an edition token sharing a bracket with a performance
+        marker does not make it safe to drop the performance marker too.
+        Returns '' if stripping would leave nothing.
+        """
+        if not title:
+            return ''
+
+        stripped = self._BRACKETED_GROUP.sub(
+            lambda m: '' if self._is_edition_only_text(m.group(1)) else m.group(0), title)
+
+        dash_stripped = self._dash_tail_edition_split(stripped)
+        if dash_stripped is not None:
+            stripped = dash_stripped
+
+        return ' '.join(stripped.split()).strip(' -–—')
+
     def generate_download_queries(self, spotify_track: SpotifyTrack) -> List[str]:
         """
         Generate multiple search query variations for better matching.
@@ -537,6 +656,15 @@ class MusicMatchingEngine:
         if not spotify_track.artists:
             # No artist info - just use track name variations
             queries.append(self.clean_title(spotify_track.name))
+            # Deliberately NOT extended with a Priority 5 stripped-title query:
+            # calculate_slskd_match_confidence's minimum artist gate rejects
+            # any non-YouTube candidate with artist_score < 0.25, and with no
+            # source artist at all the loop that computes artist_score never
+            # runs, so it is unconditionally 0.0 — every candidate a search
+            # here could return is mathematically rejected before scoring
+            # finishes. Firing an extra broadcast-guarded query for a result
+            # that can never be accepted is pure network cost for zero
+            # possible benefit — worse than doing nothing.
             return queries
 
         # If artist or title contains non-ASCII (e.g. Japanese, Chinese, Korean),
@@ -592,10 +720,10 @@ class MusicMatchingEngine:
             # Define version keywords that should be preserved
             preserve_keywords = [
                 'slowed', 'reverb', 'sped up', 'speed up', 'spedup', 'slowdown',
-                'remix', 'mix', 'edit', 'version', 'remaster', 'acoustic', 
+                'remix', 'mix', 'edit', 'version', 'remaster', 'acoustic',
                 'live', 'demo', 'instrumental', 'radio', 'extended', 'club',
                 'original', 'clean', 'explicit', 'mashup', 'bootleg'
-            ]
+            ] + list(self._VERSION_TOKENS)
             
             # Check if the dash content contains version keywords
             should_preserve = any(keyword in dash_content for keyword in preserve_keywords)
@@ -660,6 +788,46 @@ class MusicMatchingEngine:
                 logger.debug(
                     f"PRIORITY 4: skipping title-only query for short title "
                     f"'{original_track_clean}' — too broad to search without an artist")
+
+        # PRIORITY 5: LAST RESORT — drop EDITION decoration ("[2005 Remaster]",
+        # "(Deluxe)", "(Mono)").
+        #
+        # Priorities 1-2 deliberately PRESERVE version info so a search for a
+        # specific cut doesn't return a different one. That is right, but it is
+        # also absolute: every rung of the ladder above carries the suffix, so
+        # when no peer happens to share that exact pressing the track never
+        # resolves at all. On a live library that is what a wishlist entry stuck
+        # at retry 6 looks like — "Sweet Dreams (Are Made of This) [2005
+        # Remaster]", "KAZENO LONELY WAY (2022 Remaster)" — tracks that are
+        # trivially available in some other edition of the same recording.
+        #
+        # Two things keep this safe. _VERSION_TOKENS covers editions only, never
+        # a different take (see its comment). And ordering: this query runs only
+        # after every version-faithful one has come up empty, so a wrong-edition
+        # result can never displace a right-edition one.
+        version_stripped = self._strip_version_decoration(original_title)
+        if version_stripped and version_stripped.lower() != original_title.strip().lower():
+            stripped_clean = self.clean_title(version_stripped)
+            if stripped_clean:
+                candidates = []
+                # A punctuation-only source artist ("...", "- - -") cleans to
+                # '', and f"{artist} {x}".strip() would then silently BECOME
+                # the unqualified broadcast form — skipping the distinctiveness
+                # gate below entirely. Only add the artist-qualified candidate
+                # when there is actually an artist to qualify it with.
+                if artist:
+                    candidates.append(f"{artist} {stripped_clean}".strip())
+                # The unqualified variant is still a broadcast, and stripping
+                # decoration only makes the title SHORTER — "Kid A (2009
+                # Remaster)" strips to "kid a". So it has to clear the same
+                # distinctiveness bar as PRIORITY 4 (#1102); the artist-qualified
+                # query above is unaffected either way.
+                if self._title_is_distinctive_enough_to_broadcast(stripped_clean):
+                    candidates.append(stripped_clean)
+                for candidate in candidates:
+                    if candidate.lower() not in [q.lower() for q in queries]:
+                        queries.append(candidate)
+                        logger.debug(f"PRIORITY 5: Version-stripped last resort: '{candidate}'")
 
         # Remove duplicates while preserving order
         unique_queries = []

--- a/tests/matching/test_version_stripped_query.py
+++ b/tests/matching/test_version_stripped_query.py
@@ -1,0 +1,163 @@
+"""Last-resort, version-stripped download query.
+
+`generate_download_queries` preserves version decoration on purpose so a search
+for a specific cut doesn't return a different one. That left no rung of the
+ladder without the suffix, so a track whose exact edition no peer shares never
+resolved at all. Priority 5 adds the broad query at the END, where it can only
+be reached once every version-faithful variant has already failed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.matching_engine import MusicMatchingEngine
+
+
+class _Track:
+    def __init__(self, name, artists, album=None):
+        self.name = name
+        self.artists = artists
+        self.album = album
+
+
+@pytest.fixture
+def me():
+    return MusicMatchingEngine()
+
+
+@pytest.mark.parametrize("title,expected", [
+    ("Sweet Dreams (Are Made of This) [2005 Remaster]", "Sweet Dreams (Are Made of This)"),
+    ("KAZENO LONELY WAY (2022 Remaster)", "KAZENO LONELY WAY"),
+    ("Rumours (Deluxe Edition)", "Rumours"),
+    ("Kind of Blue (Mono)", "Kind of Blue"),
+    ("the WORLD (TV Size)", "the WORLD"),
+    ("Nevermind - 30th Anniversary Remaster", "Nevermind"),
+    # CodeRabbit round 1 on #16: the dash-tail parser only recognized an
+    # ASCII hyphen and couldn't capture a tail with an internal hyphen.
+    ("the WORLD - TV-Size", "the WORLD"),
+    ("Nevermind – 30th Anniversary Remaster", "Nevermind"),   # en dash
+    ("Nevermind — 30th Anniversary Remaster", "Nevermind"),   # em dash
+    # CodeRabbit round 2 on #16: 'remaster' is a prefix of 'remastered', and
+    # removing it first left a stray "ed" the whole-content check didn't
+    # recognize, wrongly leaving "Remastered" titles untouched.
+    ("Song [2005 Remastered]", "Song"),
+    # CodeRabbit round 3 on #16: the separator needs no surrounding
+    # whitespace either — "Nevermind–30th..." (no spaces) must strip too.
+    ("Nevermind–30th Anniversary Remaster", "Nevermind"),      # unspaced en dash
+    ("the WORLD-TV-Size", "the WORLD"),                        # fully unspaced, two hyphens
+])
+def test_strips_version_decoration(me, title, expected):
+    assert me._strip_version_decoration(title) == expected
+
+
+@pytest.mark.parametrize("title", [
+    "Africa",
+    "Semi-Charmed Life",
+    "Old Town Road (feat. Billy Ray Cyrus)",   # a credit is not a version
+    "(No) Reason to Believe",                  # brackets are part of the title
+    # A different PERFORMANCE is never stripped — see _VERSION_TOKENS. Doing so
+    # would search for the studio cut, which the version gate lets through as
+    # 'original', silently swapping the take the user asked for.
+    "Wish You Were Here (Live)",
+    "Around the World (Radio Edit)",
+    "Layla (Acoustic)",
+    "One More Time (Club Mix)",
+    "Song 2 (Instrumental)",
+    "Blinding Lights (Extended Mix)",
+    # CodeRabbit round 1 on #16: an edition token sharing a bracket/tail with
+    # a performance marker must not strip the performance marker along with
+    # it — the whole decoration has to be edition-only, not just CONTAIN an
+    # edition word.
+    "Song (Live at the Deluxe Anniversary Tour)",
+    "Song - Deluxe Live",
+    # A generic dictionary word ("stereo") appearing inside unrelated bracket
+    # text is not an edition note either — the full content must reduce to
+    # edition tokens/numbers/stopwords, not just contain one match.
+    "Song (Stereo Hearts)",
+])
+def test_leaves_non_version_titles_alone(me, title):
+    assert me._strip_version_decoration(title) == title
+
+
+def test_stripped_query_is_appended_not_promoted(me):
+    """The broad query must come last — a version-faithful query outranks it."""
+    queries = me.generate_download_queries(
+        _Track("Sweet Dreams (Are Made of This) [2005 Remaster]", ["Eurythmics"]))
+
+    faithful = [i for i, q in enumerate(queries) if 'remaster' in q.lower()]
+    broad = [i for i, q in enumerate(queries)
+             if q.lower() == 'eurythmics sweet dreams are made of this']
+    assert faithful and broad, queries
+    assert min(broad) > max(faithful), queries
+
+
+def test_dash_edition_tag_is_tried_faithfully_before_stripping(me):
+    """CodeRabbit round 4 on #16: `detect_album_in_title`'s heuristic and
+    Priority 2's own separate preserve_keywords list both predate this PR and
+    neither recognized edition words — a DASH-based tag ("Song - Deluxe", no
+    parens) was misclassified as an album name and stripped immediately, so
+    the faithful "artist song deluxe" query was never tried at all and
+    Priority 5's own artist-qualified candidate just duplicated the
+    already-stripped Priority 1 output. The bracket form ("Song (Deluxe)")
+    already worked; the dash form now has to match it."""
+    for title in ("Song - Deluxe", "Song - Mono", "Song - Anniversary"):
+        queries = me.generate_download_queries(_Track(title, ["Artist"]))
+        faithful = [i for i, q in enumerate(queries) if q == "artist " + title.lower().replace(" - ", " ")]
+        stripped = [i for i, q in enumerate(queries) if q == "artist song"]
+        assert faithful, (title, queries)
+        assert not stripped or min(faithful) < min(stripped), (title, queries)
+
+
+def test_dash_performance_tag_is_never_stripped(me):
+    """The fix above must not blur back into the performance-marker safety
+    boundary — a dash tag naming a different TAKE still gets no stripped
+    fallback at all, mixed with an edition word or not."""
+    for title in ("Song - Live", "Song - Deluxe Live"):
+        queries = me.generate_download_queries(_Track(title, ["Artist"]))
+        assert "artist song" not in [q.lower() for q in queries], (title, queries)
+        assert "song" not in [q.lower() for q in queries], (title, queries)
+
+
+def test_punctuation_only_artist_does_not_bypass_the_broadcast_guard(me):
+    """CodeRabbit round 2 on #16: `clean_artist('...')` returns '', and
+    f"{artist} {title}".strip() with an empty artist silently BECOMES the
+    unqualified broadcast form — skipping _title_is_distinctive_enough_to_
+    broadcast entirely. A short title with a punctuation-only artist must
+    not reach the network as a bare 5-character query (#1102)."""
+    queries = me.generate_download_queries(_Track("Kid A (2009 Remaster)", ["..."]))
+    assert "kid a" not in [q.lower() for q in queries], queries
+
+
+def test_punctuation_only_artist_still_allows_a_distinctive_broadcast(me):
+    """The guard above must not overcorrect: a genuinely distinctive title
+    still gets its unqualified Priority 5 query even with no usable artist."""
+    queries = me.generate_download_queries(
+        _Track("Bohemian Rhapsody (2011 Remaster)", ["..."]))
+    assert "bohemian rhapsody" in [q.lower() for q in queries], queries
+
+
+def test_priority5_does_not_fire_with_no_artist_at_all(me):
+    """CodeRabbit round 3 on #16 flagged that `artists=[]` skips Priority 5 —
+    correct as an observation, but "fixing" it turned out to be actively
+    wrong: calculate_slskd_match_confidence's minimum artist gate rejects
+    every non-YouTube candidate with artist_score < 0.25, and with no source
+    artist the loop that computes it never runs, so it is unconditionally
+    0.0. A search here can NEVER produce an accepted result — only network
+    cost for a guaranteed-rejected outcome. The early return is correct;
+    Priority 5 must stay unreached for an artist-less track."""
+    queries = me.generate_download_queries(_Track("Bohemian Rhapsody (2011 Remaster)", []))
+    assert queries == ["bohemian rhapsody 2011 remaster"], queries
+
+
+def test_no_extra_query_when_there_is_no_version_to_strip(me):
+    """A plain title must not gain a duplicate rung."""
+    queries = me.generate_download_queries(_Track("Africa", ["TOTO"]))
+    assert len(queries) == len(set(q.lower() for q in queries))
+    assert all('africa' in q.lower() for q in queries)
+
+
+def test_empty_result_is_not_queried(me):
+    """Stripping everything must not produce a bare-artist query."""
+    queries = me.generate_download_queries(_Track("(Remastered)", ["Some Artist"]))
+    assert 'some artist' not in [q.lower() for q in queries]


### PR DESCRIPTION
`generate_download_queries` preserves version decoration on purpose — priorities 1 and 2 both check the dash content and the parenthesized content against a keyword list and keep the query faithful when it looks like a version rather than an album name. That's the right default: a search for a specific cut shouldn't quietly return a different one.

But the preservation is absolute. Every rung of the ladder carries the suffix, so when no peer happens to share that exact edition, the search has nowhere left to go and the track never resolves at all. In a live wishlist that's what entries pinned at high retry counts look like — `"Sweet Dreams (Are Made of This) [2005 Remaster]"`, `"KAZENO LONELY WAY (2022 Remaster)"` — tracks that are trivially available in some other edition.

## The fix

**Priority 5** adds one broad, version-stripped query at the END of the ladder. Ordering is what keeps it safe: it's only reached once every version-faithful variant has already come up empty, so a wrong-edition result can never displace a right-edition one.

`_VERSION_TOKENS` is scoped to **edition/master decoration only** — `remaster`, `mono`, `stereo`, `anniversary`, `deluxe`, `expanded`, `reissue`, `tv size` — never a performance marker (`live`, `remix`, `acoustic`, `radio edit`, `extended`...). That distinction matters: the matcher's own version gate (`calculate_slskd_match_confidence`) rejects a candidate on the *candidate's* version, and a plain studio file classifies as `'original'`, which is never rejected. So stripping `(Live)` would happily search for, find, and download the **studio cut** for a source that asked for the live one — a silent performance substitution. An edition strip has no such failure mode; it can only change which *pressing* you get.

The unqualified (title-only) variant of the Priority 5 query also has to clear the same distinctiveness bar as the existing title-only-broadcast guard (`_title_is_distinctive_enough_to_broadcast`, #1102) — stripping decoration only makes a title *shorter*, so without this it would regenerate exactly the short-title broadcasts that guard exists to stop.

## Four review rounds, real findings every time

This went through CodeRabbit repeatedly on a fork PR before coming here. Every finding was independently verified by reproduction before being trusted or fixed — one round produced a suggestion that looked reasonable but turned out to be actively wrong on inspection, and that one was reverted rather than shipped (details below). Nothing here is unverified.

**Round 1 — the token-scoping mechanism itself had gaps:**
- An edition token sharing a bracket/tail with a performance marker didn't make the whole decoration safe to drop — `"(Live at the Deluxe Anniversary Tour)"` had "live" stripped right along with "deluxe"/"anniversary", reintroducing the exact wrong-performance risk the scoping exists to prevent. Fixed by requiring the *complete* decoration to reduce to edition tokens, numbers/ordinals, and light stopwords, and by explicitly rejecting anything containing a performance-marker word even alongside a genuine edition token. Also fixed a related false positive: `"(Stereo Hearts)"` is real title text, not a mono/stereo mix note, and no longer gets stripped just because "stereo" appears as a substring.
- The dash-tail parser only recognized an ASCII hyphen and rejected a tail containing its own hyphen, so `"the WORLD - TV-Size"` and an en/em-dash separator never reached the fallback at all.

**Round 2 — bugs in round 1's own fixes:**
- `'remaster'` is a prefix of `'remastered'`, and the whole-content check removed it first, leaving a stray `"ed"` that didn't match any stopword/number — so `"Song [2005 Remastered]"` was wrongly left untouched. Fixed: tokens now stripped longest-first.
- The artist-qualified candidate was built as `f"{artist} {stripped_clean}".strip()` unconditionally. A punctuation-only source artist (`"..."`, `"- - -"`) cleans to `''`, and the `.strip()` silently turned that "qualified" candidate into the *unqualified broadcast form* — bypassing the distinctiveness guard entirely. Reproduced end-to-end: `("Kid A (2009 Remaster)", ["..."])` generated the bare query `"kid a"`, exactly the #1102 NAT-exhaustion shape the guard exists to stop.

**Round 3 — two more, one legitimate, one I reverted:**
- The dash separator still required surrounding whitespace, so an unspaced en/em-dash (`"Nevermind–30th Anniversary Remaster"`) never stripped. Fixed with a right-to-left search over every dash position, taking the first candidate whose tail is edition-only — this also resolves the ambiguity a naive whitespace-optional regex would hit (`"the WORLD-TV-Size"` has a candidate split inside "TV-Size" itself; the inner candidate's tail "Size" fails the edition-only check and the search falls through to the real separator).
- CodeRabbit also flagged that `artists=[]` skips Priority 5 entirely, and suggested extending it there too. **I implemented that, then reverted it after checking whether it could ever actually help**: `calculate_slskd_match_confidence`'s minimum artist gate rejects any non-YouTube candidate with `artist_score < 0.25`, and with no source artist the loop that computes `artist_score` never runs — it's unconditionally `0.0`. A search fired from that branch can never produce an accepted result; it would be pure network cost for a mathematically guaranteed rejection. Reverted, with the reasoning documented in the code so it isn't re-flagged and re-"fixed" the same wrong way.

**Round 4 — a real gap in code this PR never touched:**
- A DASH-based edition tag (`"Song - Deluxe"`, no parens) never got a faithful query at all — traced it end-to-end and the claim held. Two *pre-existing* heuristics, both predating this PR, share the blind spot: `detect_album_in_title`'s exclude list and a separate `preserve_keywords` list in Priority 2's own dash-handling. Neither recognized edition words, so "Deluxe"/"Mono"/"Anniversary" got silently classified as an "album name" and stripped by Priority 1/2 — before Priority 5 ever got a chance to run, and Priority 5's own artist-qualified candidate then just duplicated the already-stripped output. The bracket form (`"Song (Deluxe)"`) was unaffected. Fixed by extending both existing heuristics to also recognize `self._VERSION_TOKENS` — safe in this direction, since being over-inclusive about what these two "preserve, don't strip yet" checks protect can only mean falling through to a later priority, never a wrong download. Verified the safety boundary still holds: `"Song - Live"` and `"Song - Deluxe Live"` still correctly get zero stripped fallback.

## Measured against a real, live backlog

Ran this against an actual production wishlist (660 tracks stuck at retry ≥ 2): **11 carry edition decoration** this fix targets. Tested live against the real Soulseek network with the production `calculate_slskd_match_confidence` scorer (search only, no downloads):

- **5 of 11 rescued outright** at ≥0.7 confidence (0.91–0.99) — e.g. Eurythmics' *Sweet Dreams (Are Made of This) (2005 Remaster)* → 0.97, Makoto Matsushita's *First Light (2018 Remaster)* → 0.91
- 1 borderline (0.60 — the right file is there, just under threshold)
- 5 had no supply on the network at all under any query — the fix can't invent availability, so those stay stuck regardless

Every rescued track's query was confirmed genuinely new (not reachable by the existing faithful-query ladder), so this is real incremental reach, not overlap.

## Tests

`tests/matching/test_version_stripped_query.py` — 33 cases, covering every safety boundary above (edition-vs-performance, artist-empty broadcast guard, dash-vs-bracket parity) and every round's regression. `tests/matching/` full run: 756 passed. `tests/discovery` + `tests/downloads` + `tests/imports` (dependents of the two pre-existing heuristics touched in round 4): 1923 passed, no regressions.
