### PR TITLE
fix/dev findings

### DIFF
--- a/core/amazon_worker.py
+++ b/core/amazon_worker.py
@@ -8,7 +8,7 @@ from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.amazon_client import AmazonClient
 from core.worker_utils import idle_backoff_seconds, interruptible_sleep, set_album_api_track_count
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 from core.amazon_outage import is_source_outage, next_poll_delay_seconds
 
 logger = get_logger("amazon_worker")
@@ -390,14 +390,22 @@ class AmazonWorker:
         self._update_track(track_id, api_data, stored_id)
 
     def _process_album(self, album_id: int, album_name: str, artist_name: str, item: Dict[str, Any]):
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='amazon_id',
             client_fetch_fn=lambda asin: self.client.get_album(asin, include_tracks=False),
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='amazon_match_status',
             log_prefix='Amazon',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         # honor_stored_match also returns False when the stored id failed to
         # re-fetch (transient error / rate limit). Don't fall through to a
@@ -438,14 +446,22 @@ class AmazonWorker:
             logger.debug(f"No match for album '{album_name}'")
 
     def _process_track(self, track_id: int, track_name: str, artist_name: str, item: Dict[str, Any]):
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='amazon_id',
             client_fetch_fn=self.client.get_track_details,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='amazon_match_status',
             log_prefix='Amazon',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         # honor_stored_match also returns False when the stored id failed to
         # re-fetch (transient error / rate limit). Don't fall through to a

--- a/core/bandcamp_worker.py
+++ b/core/bandcamp_worker.py
@@ -8,7 +8,7 @@ from utils.logging_config import get_logger
 from database.music_database import MusicDatabase
 from core.bandcamp_client import BandcampClient
 from core.worker_utils import interruptible_sleep, set_album_api_track_count
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("bandcamp_worker")
 
@@ -345,14 +345,22 @@ class BandcampWorker:
         # never overwriting a manual match. Bandcamp's canonical id IS the
         # release URL (no id->page lookup exists), so it stands in for the
         # numeric id other workers pass here.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='bandcamp_url',
             client_fetch_fn=self.client.get_release_metadata,
             on_match_fn=self._refresh_album_via_stored_url,
+            mark_status_fn=self._mark_status,
+            status_column='bandcamp_match_status',
             log_prefix='Bandcamp',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         # honor_stored_match also returns False when the stored URL failed to
         # re-fetch (transient error / rate limit). In that case DON'T fall
@@ -374,14 +382,22 @@ class BandcampWorker:
 
     def _process_track(self, track_id: int, track_name: str, artist_name: str):
         """Process a track: honor a stored match by id-refresh, else search."""
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='bandcamp_url',
             client_fetch_fn=self.client.get_release_metadata,
             on_match_fn=self._refresh_track_via_stored_url,
+            mark_status_fn=self._mark_status,
+            status_column='bandcamp_match_status',
             log_prefix='Bandcamp',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         if self._get_existing_url('track', track_id):
             logger.debug(f"Preserving Bandcamp match for track '{track_name}' despite a refresh miss")

--- a/core/deezer_worker.py
+++ b/core/deezer_worker.py
@@ -19,7 +19,7 @@ from core.worker_utils import (
     release_titles,
     set_album_api_track_count,
 )
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("deezer_worker")
 
@@ -500,14 +500,22 @@ class DeezerWorker:
         # never refreshed metadata). Now it goes through the full
         # refresh path via the stored ID, picking up label / genres /
         # explicit updates without ever overwriting the manual match.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='deezer_id',
             client_fetch_fn=self.client.get_album_raw,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='deezer_match_status',
             log_prefix='Deezer',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_album(artist_name, album_name)
@@ -552,14 +560,22 @@ class DeezerWorker:
     def _process_track(self, track_id: int, track_name: str, artist_name: str, item: Dict[str, Any]):
         """Process a track: search Deezer, verify, fetch full details for BPM, store metadata"""
         # Issue #501: honor manual matches (see _process_album).
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='deezer_id',
             client_fetch_fn=self.client.get_track_raw,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='deezer_match_status',
             log_prefix='Deezer',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_track(artist_name, track_name)

--- a/core/downloads/atomic_album_publish.py
+++ b/core/downloads/atomic_album_publish.py
@@ -162,37 +162,73 @@ def publish_album_batch(
         db_path_update_fn: optional ``fn(staging_path, final_path)`` to repoint a
             track's DB ``file_path`` from staging to final. Injected.
 
-    Returns ``{published: [(staging, final)], failed: [(staging, err)]}``. A
-    per-file failure leaves THAT file staged (never partially in the library) and
-    is reported — the caller keeps the staging tree for retry/quarantine.
+    Returns ``{success, published: [(staging, final)], failed: [(staging, err)],
+    rollback_failed: [(final, err)]}``.
+
+    All or nothing (L2-002). "The whole album appears at once" is the entire
+    point of atomic publishing, so a per-file failure is not survivable by
+    leaving the rest live: the caller would report Complete for an album that is
+    half in the library and half in staging, with no retryable task for the
+    missing half. Any failure — a move, a mapping, or the DB repoint that tells
+    the library where the file now is — rolls every already-moved file back into
+    staging and reports ``success=False``, leaving the batch exactly as it was
+    so a retry can publish the whole thing.
+
+    ``db_path_update_fn`` may return the number of rows it repointed. Zero rows
+    for an AUDIO file means the library still points at a staging path that is
+    about to stop existing, which is a failed publish, not a warning.
     """
     published: List[Tuple[str, str]] = []
     failed: List[Tuple[str, str]] = []
+
+    def _roll_back() -> List[Tuple[str, str]]:
+        """Put every published file back in staging. Returns what would not go."""
+        stuck: List[Tuple[str, str]] = []
+        for staged_path, final_path in reversed(published):
+            try:
+                move_fn(final_path, staged_path)
+            except Exception as e:  # noqa: BLE001
+                logger.error("[Atomic Publish] rollback failed %s -> %s: %s",
+                             final_path, staged_path, e)
+                stuck.append((final_path, str(e)))
+        return stuck
 
     for staged in iter_staged_files(staging_root):
         final = to_final_path(staged, staging_root, transfer_dir)
         if not final:
             failed.append((staged, "could not map staged path back to a library path"))
-            continue
+            break
         try:
             move_fn(staged, final)
         except Exception as e:  # noqa: BLE001 — report + keep staged, never lose the file
             logger.error("[Atomic Publish] move failed %s -> %s: %s", staged, final, e)
             failed.append((staged, str(e)))
-            continue
+            break
         published.append((staged, final))
         if db_path_update_fn is not None:
             try:
-                db_path_update_fn(staged, final)
-            except Exception as e:  # noqa: BLE001 — file is published; DB fix is best-effort
+                rows = db_path_update_fn(staged, final)
+            except Exception as e:  # noqa: BLE001
                 logger.error("[Atomic Publish] DB path update failed %s -> %s: %s",
                              staged, final, e)
+                failed.append((staged, f"DB path update failed: {e}"))
+                break
+            is_audio = os.path.splitext(staged)[1].lower() in _AUDIO_EXTS
+            if is_audio and isinstance(rows, int) and rows < 1:
+                logger.error("[Atomic Publish] DB path update matched no row for %s", staged)
+                failed.append((staged, "DB path update matched no library row"))
+                break
 
-    # Remove the staging tree only when everything published (no orphan left behind).
-    if not failed:
+    rollback_failed: List[Tuple[str, str]] = []
+    if failed:
+        rollback_failed = _roll_back()
+        published = []
+    else:
+        # Remove the staging tree only when everything published.
         _prune_empty_tree(staging_root)
 
-    return {"published": published, "failed": failed}
+    return {"success": not failed, "published": published, "failed": failed,
+            "rollback_failed": rollback_failed}
 
 
 def discard_staging_root(staging_root: Optional[str]) -> bool:

--- a/core/downloads/lifecycle.py
+++ b/core/downloads/lifecycle.py
@@ -74,7 +74,7 @@ def _safe_batch_dirname(batch_id: str) -> str:
 _ALBUM_BUNDLE_CLEANED_SOURCES = ('soulseek', 'torrent', 'usenet')
 
 
-def _publish_atomic_album(batch_id: str, batch: dict, deps=None) -> None:
+def _publish_atomic_album(batch_id: str, batch: dict, deps=None) -> bool:
     """#999 atomic album publishing (opt-in): if this batch staged its tracks
     (private mirror, so Plex never saw a partial album), move them into the live
     library NOW — before the batch_complete/scan emit below — then repoint each
@@ -85,11 +85,11 @@ def _publish_atomic_album(batch_id: str, batch: dict, deps=None) -> None:
     AND it's a fresh whole-album batch. Any failure leaves the staged files where
     they are (quarantine) and is logged — never a partial library publish."""
     if not batch.get('_atomic_active'):
-        return
+        return True
     staging_root = batch.get('_atomic_staging_root')
     transfer_dir = batch.get('_atomic_transfer_dir')
     if not staging_root or not transfer_dir or not os.path.isdir(staging_root):
-        return
+        return True
     try:
         from core.downloads.atomic_album_publish import publish_album_batch
         from core.imports.file_ops import safe_move_file
@@ -97,13 +97,22 @@ def _publish_atomic_album(batch_id: str, batch: dict, deps=None) -> None:
 
         db = MusicDatabase()
 
-        def _db_update(staged_path: str, final_path: str) -> None:
+        def _db_update(staged_path: str, final_path: str):
+            """Repoint one file, returning how many library rows moved with it.
+
+            The count is the publish's proof that the library knows where the
+            file went; an audio file that repoints nothing leaves the library
+            pointing at a staging path this publish is about to remove. None
+            means the driver could not tell us, which is "unknown", not "zero" —
+            an unknown must not fail a publish that may well have worked."""
             conn = db._get_connection()
             try:
                 cur = conn.cursor()
                 cur.execute("UPDATE tracks SET file_path = ? WHERE file_path = ?",
                             (final_path, staged_path))
                 conn.commit()
+                rowcount = getattr(cur, 'rowcount', None)
+                return int(rowcount) if isinstance(rowcount, int) else None
             finally:
                 conn.close()
 
@@ -129,13 +138,22 @@ def _publish_atomic_album(batch_id: str, batch: dict, deps=None) -> None:
                     logger.debug("[Atomic Publish] repair re-register failed for %s: %s",
                                  _folder, _reg_err)
 
-        n_fail = len(result.get('failed', []))
-        logger.info("[Atomic Publish] Batch %s: published %d file(s)%s",
-                    batch_id, len(pubmap),
-                    (f"; {n_fail} kept in staging for retry" if n_fail else ""))
+        failures = result.get('failed', [])
+        if failures:
+            stuck = result.get('rollback_failed', [])
+            logger.error(
+                "[Atomic Publish] Batch %s NOT published: %d file(s) failed (%s); "
+                "everything rolled back to staging for retry%s",
+                batch_id, len(failures), failures[0][1] if failures else "unknown",
+                f"; {len(stuck)} could not be rolled back" if stuck else "")
+            return False
+        logger.info("[Atomic Publish] Batch %s: published %d file(s)",
+                    batch_id, len(pubmap))
+        return True
     except Exception as e:
         logger.error("[Atomic Publish] Batch %s publish failed (staged files kept): %s",
                      batch_id, e, exc_info=True)
+        return False
 
 
 def _cleanup_private_album_bundle_staging(batch_id: str, batch: dict) -> None:
@@ -675,14 +693,25 @@ def _on_download_completed(batch_id: str, task_id: str, success: bool, deps: Lif
 
             # FIXED: Ensure batch is not already marked as complete to prevent duplicate processing
             if batch.get('phase') != 'complete':
+                # #999 atomic album publish (opt-in, no-op unless staged): move
+                # the staged album into the live library BEFORE anything is
+                # marked complete, so Plex sees the whole album at once.
+                #
+                # L2-002: the publish decides whether this batch IS complete. It
+                # used to run after the phase flip and its result was only
+                # logged, so a failed publish still produced a Complete batch
+                # with history, scan and completion events for an album that was
+                # never published. A failure leaves the phase alone; the batch
+                # stays in monitoring and the next completion check retries.
+                if not _publish_atomic_album(batch_id, batch, deps):
+                    logger.error(
+                        "[Batch Manager] Batch %s: atomic album publish failed — "
+                        "not marking complete, staged files kept for retry", batch_id)
+                    return
+
                 # Mark batch as complete and set completion timestamp for auto-cleanup
                 batch['phase'] = 'complete'
                 batch['completion_time'] = time.time()  # Track when batch completed
-
-                # #999 atomic album publish (opt-in, no-op unless staged): move
-                # the staged album into the live library BEFORE the scan/emit
-                # below, so Plex sees the whole album at once.
-                _publish_atomic_album(batch_id, batch, deps)
 
                 # Record sync history completion
                 from database.music_database import MusicDatabase
@@ -914,14 +943,20 @@ def check_batch_completion_v2(batch_id: str, deps: LifecycleDeps) -> Optional[bo
                     # Check if this is an auto-initiated batch
                     is_auto_batch = batch.get('auto_initiated', False)
 
+                    # #999 atomic album publish (opt-in, no-op unless staged):
+                    # publish the staged album into the live library before the
+                    # batch is marked complete. L2-002: a failed publish must not
+                    # produce a Complete batch for an album that is still staged.
+                    if not _publish_atomic_album(batch_id, batch, deps):
+                        logger.error(
+                            "[Completion Check V2] Batch %s: atomic album publish "
+                            "failed — not marking complete, staged files kept for "
+                            "retry", batch_id)
+                        return False
+
                     # Mark batch as complete and set completion timestamp for auto-cleanup
                     batch['phase'] = 'complete'
                     batch['completion_time'] = time.time()  # Track when batch completed
-
-                    # #999 atomic album publish (opt-in, no-op unless staged):
-                    # publish the staged album into the live library before the
-                    # scan/emit below.
-                    _publish_atomic_album(batch_id, batch, deps)
 
                     # Add activity for batch completion
                     playlist_name = batch.get('playlist_name', 'Unknown Playlist')

--- a/core/enrichment/manual_match_honoring.py
+++ b/core/enrichment/manual_match_honoring.py
@@ -53,6 +53,11 @@ def _read_id_column(db, entity_table: str, entity_id, id_column: str) -> Optiona
     return str(value).strip() if value else None
 
 
+MATCHED = 'matched'
+UNAVAILABLE = 'error'
+NO_STORED_ID = ''
+
+
 def honor_stored_match(
     *,
     db,
@@ -61,8 +66,10 @@ def honor_stored_match(
     id_column: str,
     client_fetch_fn: Callable[[str], Any],
     on_match_fn: Callable[[Any, str, Any], None],
+    mark_status_fn: Optional[Callable[[str, Any, str], None]] = None,
+    status_column: Optional[str] = None,
     log_prefix: str = '',
-) -> bool:
+) -> str:
     """Fast-path enrichment via a stored source ID — preserves manual
     matches.
 
@@ -84,45 +91,78 @@ def honor_stored_match(
         log_prefix: Display name for log lines (``'Spotify'`` /
             ``'iTunes'`` / etc).
 
-    Returns:
-        True if a stored ID was found AND the fetch returned data AND
-        the on-match callback ran. Caller skips its search-by-name
-        flow and counts a match.
+        mark_status_fn: Optional ``fn(entity_kind, entity_id, status)``
+            — the worker's own ``_mark_status``. Used to persist an
+            ``error`` (with its ``*_last_attempted`` retry timestamp)
+            when a stored ID exists but the source could not confirm
+            it. Without it the failure leaves no trace and the entity
+            is picked again on the very next cycle, with no backoff.
+        status_column: The worker's ``<service>_match_status`` column.
+            An entity that already reads ``matched`` is NOT downgraded
+            to ``error`` by a transient failure — its chip would turn
+            red for a match that is still perfectly good, and it is
+            not the row a retry loop would pick anyway.
 
-        False if no stored ID is set, the fetch failed, or the fetch
-        returned empty. Caller falls through to its existing search-
-        by-name flow (the legacy behavior for un-matched entities).
+    Returns one of three states (L2-005):
+        ``MATCHED``     — the stored ID was refreshed. Caller counts a
+            match and skips search-by-name.
+        ``UNAVAILABLE`` — a stored ID IS set but the source could not
+            confirm it right now (fetch raised, or returned nothing).
+            Caller must NOT search by name: a transient provider
+            failure is not evidence that the stored ID is wrong, and
+            searching would overwrite a deliberately chosen ID with
+            whatever a fuzzy name match happens to return. The ID is
+            released only by an explicit re-match, never by a timeout.
+        ``NO_STORED_ID`` (falsy) — nothing is stored, so the caller
+            falls through to its existing search-by-name flow.
 
     Notes:
-        - Exceptions in ``client_fetch_fn`` are caught and logged at
-          warning level — caller falls through to search.
+        - Exceptions in ``client_fetch_fn`` are caught and logged.
         - Exceptions in ``on_match_fn`` propagate (those are real
           DB errors the worker should know about).
     """
     stored_id = _read_id_column(db, entity_table, entity_id, id_column)
     if not stored_id:
-        return False
+        return NO_STORED_ID
+
+    entity_kind = entity_table[:-1]
+
+    def _unavailable(reason: str) -> str:
+        already_matched = False
+        if status_column is not None:
+            try:
+                already_matched = _read_id_column(
+                    db, entity_table, entity_id, status_column) == 'matched'
+            except Exception as read_exc:  # noqa: BLE001 - older schema, no column
+                logger.debug(
+                    f"[{log_prefix}] could not read {status_column}: {read_exc}"
+                )
+        if mark_status_fn is not None and not already_matched:
+            try:
+                mark_status_fn(entity_kind, entity_id, 'error')
+            except Exception as mark_exc:  # noqa: BLE001 - bookkeeping only
+                logger.debug(
+                    f"[{log_prefix}] could not record the failed stored-ID "
+                    f"refresh for {entity_kind} #{entity_id}: {mark_exc}"
+                )
+        logger.warning(
+            f"[{log_prefix}] Stored ID {stored_id} for {entity_kind} "
+            f"#{entity_id} could not be confirmed ({reason}) — keeping it "
+            f"rather than searching by name"
+        )
+        return UNAVAILABLE
 
     try:
         api_data = client_fetch_fn(stored_id)
     except Exception as exc:
-        logger.warning(
-            f"[{log_prefix}] Stored-ID fetch failed for "
-            f"{entity_table[:-1]} #{entity_id} (id={stored_id}): {exc}"
-        )
-        return False
+        return _unavailable(str(exc))
 
     if not api_data:
-        logger.debug(
-            f"[{log_prefix}] Stored ID {stored_id} for "
-            f"{entity_table[:-1]} #{entity_id} returned empty data — "
-            f"falling through to search-by-name"
-        )
-        return False
+        return _unavailable("the source returned no data")
 
     on_match_fn(entity_id, stored_id, api_data)
     logger.info(
         f"[{log_prefix}] Honored manual match: "
-        f"{entity_table[:-1]} #{entity_id} → {id_column}={stored_id}"
+        f"{entity_kind} #{entity_id} → {id_column}={stored_id}"
     )
-    return True
+    return MATCHED

--- a/core/itunes_worker.py
+++ b/core/itunes_worker.py
@@ -19,7 +19,7 @@ from core.worker_utils import (
     release_titles,
     set_album_api_track_count,
 )
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("itunes_worker")
 
@@ -605,14 +605,22 @@ class iTunesWorker:
 
         # Issue #501: honor manual matches (see SpotifyWorker for full
         # explanation — same pattern across every per-source worker).
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='itunes_album_id',
             client_fetch_fn=self.client.get_album,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='itunes_match_status',
             log_prefix='iTunes',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         query = f"{artist_name} {album_name}" if artist_name else album_name
@@ -646,14 +654,22 @@ class iTunesWorker:
         artist_name = item.get('artist', '')
 
         # Issue #501: honor manual matches.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='itunes_track_id',
             client_fetch_fn=self.client.get_track_details,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='itunes_match_status',
             log_prefix='iTunes',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         query = f"{artist_name} {track_name}" if artist_name else track_name
@@ -760,7 +776,7 @@ class iTunesWorker:
                 year = album_obj.release_date[:4] if len(album_obj.release_date) >= 4 else None
                 if year and year.isdigit():
                     cursor.execute("""
-                        UPDATE albums SET year = ?
+                        UPDATE albums SET year = ?, updated_at = CURRENT_TIMESTAMP
                         WHERE id = ? AND (year IS NULL OR year = '' OR year = '0')
                     """, (year, album_id))
                 # #824: also store the FULL release date when iTunes has one

--- a/core/jiosaavn_worker.py
+++ b/core/jiosaavn_worker.py
@@ -13,7 +13,7 @@ from core.worker_utils import (
     interruptible_sleep,
     set_album_api_track_count,
 )
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("jiosaavn_worker")
 
@@ -381,14 +381,22 @@ class JioSaavnWorker:
         self._update_track(track_id, full_track_dict)
 
     def _process_album(self, album_id: int, album_name: str, artist_name: str):
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='jiosaavn_id',
             client_fetch_fn=self.client.get_album,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='jiosaavn_match_status',
             log_prefix='JioSaavn',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         # honor_stored_match also returns False when the stored id failed to
         # re-fetch (transient error / rate limit). Don't fall through to a
@@ -433,14 +441,22 @@ class JioSaavnWorker:
             logger.debug("No match for album '%s'", album_name)
 
     def _process_track(self, track_id: int, track_name: str, artist_name: str):
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='jiosaavn_id',
             client_fetch_fn=self.client.get_track_details,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='jiosaavn_match_status',
             log_prefix='JioSaavn',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
         # honor_stored_match also returns False when the stored id failed to
         # re-fetch (transient error / rate limit). Don't fall through to a

--- a/core/library/curation_sync.py
+++ b/core/library/curation_sync.py
@@ -40,6 +40,18 @@ def _accepts_users(reader) -> bool:
         return False
 
 
+def _accepts_status(marker) -> bool:
+    """Whether the database adapter takes the structured sweep record."""
+    if not callable(marker):
+        return False
+    try:
+        import inspect
+
+        return bool(inspect.signature(marker).parameters)
+    except (TypeError, ValueError):
+        return False
+
+
 def normalize_signals(raw: Dict[str, List[Dict[str, Any]]]) -> Dict[str, List[Dict[str, Any]]]:
     """Turn a client's raw ``{user: [{path, ...}]}`` into storage rows keyed by
     ``track_key``. Rows with no usable path are dropped; a user whose rows all
@@ -173,21 +185,34 @@ def sync_curation_signals(db, clients: Dict[str, Any],
     """Read every configured server's curation signals and store them.
 
     ``clients`` maps server name → client (or None). Returns a summary dict:
-    ``{servers, users, rows, stamped}``.
+    ``{servers, users, rows, stamped, complete, failed}``.
 
-    The stamp is what unblocks deletion in the cleaner, so it is only written
-    when at least one user was genuinely read. Everything else — a server that
-    is down, a client without the method, an exception mid-sweep — leaves the
-    previous stamp in place, which ages out and blocks deletion by itself.
+    The stamp is what unblocks deletion in the cleaner, so it records whether
+    the sweep was COMPLETE — every server that supports curation read, and every
+    one of its users stored. A partial sweep used to stamp itself fresh anyway
+    (L2-001): Bob's write failing while Alice's succeeded produced a snapshot
+    that said "Bob likes nothing", and the cleaner deleted on it. Everything that
+    goes wrong now lands in ``failed`` and marks the record incomplete, which
+    makes the cleaner keep everything until a clean sweep replaces it.
     """
-    summary = {'servers': [], 'users': 0, 'rows': 0, 'stamped': False}
+    summary = {'servers': [], 'users': 0, 'rows': 0, 'stamped': False,
+               'complete': True, 'failed': []}
+    expected_servers = []
 
     for server, client in (clients or {}).items():
         if client is None:
+            # The caller named this server as active, so it IS expected to
+            # contribute; we simply could not reach it. Skipping silently would
+            # record a "complete" sweep that quietly omits everyone on it.
+            expected_servers.append(server)
+            summary['failed'].append(server)
+            summary['complete'] = False
             continue
         reader = getattr(client, 'get_curation_signals', None)
         if not callable(reader):
-            continue  # server doesn't support it — contributes nothing
+            # This server genuinely cannot report curation signals. Nothing is
+            # missing from the snapshot because of it.
+            continue
         # Servers whose per-user data needs per-user credentials (Subsonic)
         # take them here. Passed per CALL, never assigned onto the client:
         # mutating a shared singleton's identity is how one user's view leaks
@@ -198,16 +223,24 @@ def sync_curation_signals(db, clients: Dict[str, Any],
         # take credentials" and silently retried without them, hiding a real
         # bug and reading the wrong user's data.
         wants_users = accounts and _accepts_users(reader)
+        expected_servers.append(server)
         try:
             raw = (reader(users=accounts) if wants_users else reader()) or {}
         except Exception as e:
             logger.warning("curation sync: %s failed, leaving its stored signals "
                            "untouched: %s", server, e)
+            summary['failed'].append(server)
+            summary['complete'] = False
             continue
 
         normalized = normalize_signals(raw)
         if not normalized:
-            logger.info("curation sync: %s returned no readable users", server)
+            # A server that supports curation and returned no readable user is
+            # not a server that told us nobody curates anything — it is a server
+            # we failed to read.
+            logger.warning("curation sync: %s returned no readable users", server)
+            summary['failed'].append(server)
+            summary['complete'] = False
             continue
 
         wrote_any = False
@@ -216,6 +249,8 @@ def sync_curation_signals(db, clients: Dict[str, Any],
                 stored = db.replace_curation_signals(server, user, rows)
             except Exception as e:
                 logger.warning("curation sync: storing %s/%s failed: %s", server, user, e)
+                summary['failed'].append(f"{server}/{user}")
+                summary['complete'] = False
                 continue
             summary['rows'] += stored
             summary['users'] += 1
@@ -223,16 +258,43 @@ def sync_curation_signals(db, clients: Dict[str, Any],
         if wrote_any:
             summary['servers'].append(server)
 
-    if summary['servers']:
-        try:
+    if not expected_servers:
+        # No configured server can report curation signals, so there is nothing
+        # for this feature to protect here and nothing to be incomplete about.
+        # Recording that explicitly is what lets the cleaner tell "curation
+        # cannot work on this install" from "curation has never run yet".
+        logger.info("curation sync: no configured server supports curation signals")
+
+    status = {
+        'complete': bool(summary['complete']),
+        'expected_servers': sorted(expected_servers),
+        'servers': sorted(summary['servers']),
+        'failed': sorted(summary['failed']),
+        'users': summary['users'],
+        'rows': summary['rows'],
+    }
+    # Ask by SIGNATURE, same reasoning as _accepts_users above: a TypeError
+    # from inside the adapter must not be mistaken for "this adapter is the old
+    # one", which would silently stamp an incomplete sweep as a good one.
+    structured = _accepts_status(getattr(db, 'mark_curation_sync', None))
+    try:
+        if structured:
+            # The record is written even for a failed sweep: "we tried and it
+            # did not work" is exactly what the cleaner has to know, and only
+            # a complete sweep counts as stamped.
+            db.mark_curation_sync(status)
+            summary['stamped'] = bool(status['complete'])
+        elif status['complete'] and summary['servers']:
+            # An adapter predating the structured record cannot carry the
+            # caveat, so only a clean sweep may stamp at all.
             db.mark_curation_sync()
             summary['stamped'] = True
-        except Exception as e:
-            logger.warning("curation sync: could not stamp completion: %s", e)
-    else:
-        logger.warning("curation sync: nothing was read from any server — the "
-                       "previous stamp stands and will age out, which keeps "
-                       "everything rather than deleting it")
+    except Exception as e:
+        logger.warning("curation sync: could not stamp completion: %s", e)
+    if not summary['complete']:
+        logger.warning("curation sync: incomplete (%s) — the cleaner keeps "
+                       "everything until a clean sweep replaces this",
+                       ", ".join(status['failed']) or "unknown")
 
     logger.info("curation sync: %d server(s), %d user(s), %d signal rows",
                 len(summary['servers']), summary['users'], summary['rows'])

--- a/core/qobuz_worker.py
+++ b/core/qobuz_worker.py
@@ -10,7 +10,7 @@ from database.music_database import MusicDatabase
 from core.qobuz_client import _qobuz_is_rate_limited
 from core.worker_utils import (accept_artist_match, _names_equivalent,
                                idle_backoff_seconds, interruptible_sleep)
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("qobuz_worker")
 
@@ -502,14 +502,22 @@ class QobuzWorker:
         """Process an album: search Qobuz, verify, fetch full details, store metadata"""
         # Issue #501: honor manual matches. Pre-fix this just marked
         # status='matched' without refreshing metadata.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='qobuz_id',
             client_fetch_fn=self.client.get_album,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='qobuz_match_status',
             log_prefix='Qobuz',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_album(artist_name, album_name)
@@ -564,14 +572,22 @@ class QobuzWorker:
     def _process_track(self, track_id: int, track_name: str, artist_name: str, item: Dict[str, Any]):
         """Process a track: search Qobuz, verify, fetch full details, store metadata"""
         # Issue #501: honor manual matches.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='qobuz_id',
             client_fetch_fn=self.client.get_track,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='qobuz_match_status',
             log_prefix='Qobuz',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_track(artist_name, track_name)

--- a/core/repair_jobs/expired_download_cleaner.py
+++ b/core/repair_jobs/expired_download_cleaner.py
@@ -163,16 +163,22 @@ class ExpiredDownloadCleanerJob(RepairJob):
     def _curation_lookup(self, context: JobContext, settings: dict):
         """``(curated_track_keys, stale)`` from the stored media-server signals.
 
-        Returns ``(None, False)`` when curation is switched off — the job then
-        behaves exactly as it did before the feature existed.
+        Three outcomes, and the difference between them is the whole safety
+        contract (L2-001):
 
-        ``stale`` is the safety valve. If the signal sweep has never run, or
-        last succeeded longer ago than ``curation_max_age_hours``, we have no
-        current picture of what anyone favourited, and a sweep that quietly
-        broke (server down, credentials rotated, worker crashed) would
-        otherwise look identical to "nobody likes any of these". Deleting on
-        that basis is the failure this whole job has to avoid, so a stale
-        sweep keeps everything.
+        * ``(None, False)`` — curation cannot apply here: the user switched it
+          off, the database predates it, or no configured server can report it.
+          The job behaves exactly as it did before the feature existed.
+        * ``(set(), True)`` — curation applies but we do not have a trustworthy
+          picture: never swept, swept incompletely, swept too long ago, or the
+          signals could not be read. Nothing is deleted.
+        * ``(keys, False)`` — a complete, fresh snapshot. These keys are
+          protected; everything else is judged on retention and play count.
+
+        The middle case is the one that matters. A sweep that quietly broke —
+        server down, credentials rotated, a failed write for one user — used to
+        be indistinguishable from "nobody likes any of these", and deleting on
+        that basis is the exact failure this job exists to avoid.
         """
         if not bool(settings.get('use_curation_signals', True)):
             return None, False
@@ -181,28 +187,50 @@ class ExpiredDownloadCleanerJob(RepairJob):
         except (TypeError, ValueError):
             max_age = 48.0
 
-        synced_at = None
         reader = getattr(context.db, 'get_curation_sync_at', None)
         if not callable(reader):
             # Database predates the feature — no signals to consult, and no
             # claim to make about staleness.
             return None, False
+
+        status, synced_at = None, None
         try:
+            status_reader = getattr(context.db, 'get_curation_status', None)
+            if callable(status_reader):
+                status = status_reader()
             synced_at = parse_ts(reader())
         except Exception as e:
-            logger.warning("expired cleanup: curation sync stamp unreadable (%s) "
+            logger.warning("expired cleanup: curation sync state unreadable (%s) "
                            "— keeping everything this run", e)
             return set(), True
 
+        if status is not None:
+            if not status.get('expected_servers') and status.get('complete'):
+                # The sweep ran and found no server that can report curation.
+                # Nothing to protect, so the job runs on retention + play count
+                # exactly as it did before the feature existed.
+                return None, False
+            if not status.get('complete'):
+                logger.warning(
+                    "[Expired Cleaner] the last curation sweep was incomplete (%s) "
+                    "— keeping everything this run",
+                    ", ".join(status.get('failed') or []) or "reason unrecorded")
+                return set(), True
+            synced_at = parse_ts(status.get('at')) or synced_at
+
         if synced_at is None:
-            # NEVER synced is different from "went stale". A sweep that has
-            # never run means curation simply isn't in use on this install, so
-            # the job behaves as it always did (retention + play count). Only a
-            # sweep that WAS working and then stopped is evidence that
-            # something broke, and that is what must block deletion — treating
-            # "not set up" as "broken" would silently make the job useless for
-            # everyone who never turns curation on.
-            return None, False
+            # Curation is switched on and no sweep has ever completed, so we
+            # have no idea what anyone favourited. That is not the same as
+            # "nobody favourited anything", and this job deletes files. The
+            # sweep is scheduled by the same settings that enabled this job, so
+            # this state resolves itself on the next media-server poll; an
+            # install with no media server should switch use_curation_signals
+            # off, which restores the pre-feature behaviour immediately.
+            logger.warning(
+                "[Expired Cleaner] curation signals are enabled but no sweep has "
+                "completed yet — keeping everything this run. Switch off "
+                "'use_curation_signals' if this install has no media server.")
+            return set(), True
         age_hours = (datetime.now(timezone.utc) - synced_at).total_seconds() / 3600.0
         if age_hours > max_age:
             logger.warning("[Expired Cleaner] curation signals are %.1fh old (max %.1fh) "

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -3409,11 +3409,20 @@ class RepairWorker:
                                    (corrected_track_number, track_id))
                 album_id = details.get('album_id')
                 if album_id:
+                    # Every one of these columns is exported by MetaSync, so
+                    # each write moves updated_at (L2-011) — otherwise the full
+                    # export changes and no incremental ever mentions the row.
                     if corrected_album:
-                        cursor.execute("UPDATE albums SET title = ? WHERE id = ?", (corrected_album, album_id))
+                        cursor.execute("UPDATE albums SET title = ?, "
+                                       "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                                       (corrected_album, album_id))
                     if corrected_year and corrected_year.isdigit():
-                        cursor.execute("UPDATE albums SET year = ? WHERE id = ?", (int(corrected_year), album_id))
-                    cursor.execute("UPDATE albums SET artist_id = ? WHERE id = ?", (new_artist_id, album_id))
+                        cursor.execute("UPDATE albums SET year = ?, "
+                                       "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                                       (int(corrected_year), album_id))
+                    cursor.execute("UPDATE albums SET artist_id = ?, "
+                                   "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                                   (new_artist_id, album_id))
                 conn.commit()
             finally:
                 conn.close()

--- a/core/soulid_worker.py
+++ b/core/soulid_worker.py
@@ -178,6 +178,7 @@ class SoulIDWorker:
 
         # One-time migration: reset artist soul IDs when algorithm changes
         self._migrate_artist_soul_ids()
+        self._migrate_artist_soul_id_paths()
 
         while not self.should_stop:
             try:
@@ -273,7 +274,9 @@ class SoulIDWorker:
                 soul_id_path = None
 
             cursor.execute(
-                "UPDATE artists SET soul_id = ?, soul_id_path = ? WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
+                "UPDATE artists SET soul_id = ?, soul_id_path = ?, "
+                "updated_at = CURRENT_TIMESTAMP "
+                "WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
                 (soul_id, soul_id_path, artist_id)
             )
             conn.commit()
@@ -529,7 +532,8 @@ class SoulIDWorker:
                 if not soul_id:
                     soul_id = f'soul_unnamed_{album_id}'
                 cursor.execute(
-                    "UPDATE albums SET soul_id = ? WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
+                    "UPDATE albums SET soul_id = ?, updated_at = CURRENT_TIMESTAMP "
+                    "WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
                     (soul_id, album_id)
                 )
                 count += 1
@@ -583,7 +587,12 @@ class SoulIDWorker:
                 # Song soul ID: artist + track (links singles to album versions)
                 song_soul_id = generate_soul_id(artist_name, title)
 
-                # Album track soul ID: artist + album + track (specific to this release)
+                # updated_at moves with every soul_id write (L2-011): a row with no
+        # soul_id is filtered OUT of the MetaSync export entirely, so minting
+        # one is the moment that row starts existing for consumers. Without the
+        # touch, a full walk that ran before this worker meant the row never
+        # appeared in any later incremental either.
+        # Album track soul ID: artist + album + track (specific to this release)
                 album_soul_id = ''
                 if album_title:
                     album_soul_id = generate_soul_id(artist_name, album_title, title)
@@ -591,7 +600,9 @@ class SoulIDWorker:
                 if not song_soul_id:
                     song_soul_id = f'soul_unnamed_{track_id}'
                 cursor.execute(
-                    "UPDATE tracks SET soul_id = ?, album_soul_id = ? WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
+                    "UPDATE tracks SET soul_id = ?, album_soul_id = ?, "
+                    "updated_at = CURRENT_TIMESTAMP "
+                    "WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
                     (song_soul_id, album_soul_id or None, track_id)
                 )
                 count += 1
@@ -617,6 +628,97 @@ class SoulIDWorker:
 
     # ── Migrations ──
 
+    # How a stored id was derived, when the row predates the column. Kept
+    # separate from the id-algorithm marker so an install that is already on the
+    # current algorithm still gets its paths (L2-014).
+    PATH_MIGRATION_KEY = 'soulid_artist_path_version'
+    PATH_MIGRATION_VERSION = 'v1'
+
+    def _migrate_artist_soul_id_paths(self):
+        """Fill ``soul_id_path`` for artists whose id predates the column.
+
+        The column is additive, so existing rows start NULL — and nothing ever
+        fills them: the worker only looks at artists with NO soul_id, and the
+        id-algorithm migration returns early on an install that is already on
+        the current version. MetaSync/Hydrabase could therefore never tell a
+        provider-canonical, reproducible artist key from a library-dependent
+        album/name fallback (L2-014).
+
+        Regenerating the ids to find out is not on the table: a soul_id is the
+        shared content key peers have already traded claims about. Instead each
+        path is PROVEN locally by recomputing it — a name-only or album-derived
+        id reproduces exactly, and anything that reproduces neither cannot be
+        proven from here. That last group is recorded as ``unknown`` rather than
+        assumed canonical: an album deleted since the id was minted looks
+        identical from here, and guessing would upgrade its trustworthiness on
+        no evidence.
+        """
+        conn = None
+        try:
+            conn = self.db._get_connection()
+            cursor = conn.cursor()
+            columns = {r[1] for r in cursor.execute("PRAGMA table_info(artists)")}
+            if 'soul_id_path' not in columns:
+                return
+
+            cursor.execute("SELECT value FROM metadata WHERE key = ? LIMIT 1",
+                           (self.PATH_MIGRATION_KEY,))
+            row = cursor.fetchone()
+            if row and row[0] == self.PATH_MIGRATION_VERSION:
+                return
+
+            cursor.execute(r"""
+                SELECT id, soul_id, name FROM artists
+                 WHERE soul_id IS NOT NULL AND soul_id != ''
+                   AND soul_id NOT LIKE 'soul\_unnamed\_%' ESCAPE '\'
+                   AND soul_id_path IS NULL
+                   AND name IS NOT NULL AND name != ''
+            """)
+            pending = cursor.fetchall()
+
+            resolved = {'name': 0, 'album': 0, 'unknown': 0}
+            for artist_id, stored, name in pending:
+                path = 'unknown'
+                if stored and stored == generate_soul_id(name):
+                    path = 'name'
+                else:
+                    cursor.execute("""
+                        SELECT title FROM albums
+                         WHERE artist_id = ? AND title IS NOT NULL AND title != ''
+                    """, (artist_id,))
+                    # Every album, not just today's alphabetically-first one:
+                    # the library may have gained or lost releases since the id
+                    # was minted, and only an exact reproduction proves the path.
+                    for (title,) in cursor.fetchall():
+                        if stored == generate_soul_id(name, title):
+                            path = 'album'
+                            break
+                resolved[path] += 1
+                cursor.execute(
+                    "UPDATE artists SET soul_id_path = ?, "
+                    "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (path, artist_id))
+
+            cursor.execute(
+                "INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)",
+                (self.PATH_MIGRATION_KEY, self.PATH_MIGRATION_VERSION))
+            conn.commit()
+            if pending:
+                logger.info(
+                    "SoulID path migration: %d artist(s) — %d name, %d album, "
+                    "%d unproven", len(pending), resolved['name'],
+                    resolved['album'], resolved['unknown'])
+        except Exception as e:
+            logger.error(f"SoulID path migration failed: {e}")
+            if conn:
+                try:
+                    conn.rollback()
+                except Exception as _e:
+                    logger.debug("rollback failed: %s", _e)
+        finally:
+            if conn:
+                conn.close()
+
     def _migrate_artist_soul_ids(self):
         """One-time reset: clear all artist soul IDs when algorithm changes.
         Uses a versioned metadata flag to run only once per algorithm version."""
@@ -631,7 +733,9 @@ class SoulIDWorker:
                 return  # Already on latest version
 
             # Reset all artist soul IDs for regeneration
-            cursor.execute("UPDATE artists SET soul_id = NULL WHERE soul_id IS NOT NULL")
+            cursor.execute("UPDATE artists SET soul_id = NULL, "
+                           "updated_at = CURRENT_TIMESTAMP "
+                           "WHERE soul_id IS NOT NULL")
             reset_count = cursor.rowcount
 
             # Mark current version

--- a/core/spotify_worker.py
+++ b/core/spotify_worker.py
@@ -18,7 +18,7 @@ from core.worker_utils import (
     set_album_api_track_count,
     source_id_conflict,
 )
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("spotify_worker")
 
@@ -800,14 +800,22 @@ class SpotifyWorker:
         # refresh metadata via that ID and skip search-by-name — which
         # would otherwise overwrite the manual match with whatever
         # name-search returned.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='spotify_album_id',
             client_fetch_fn=self.client.get_album,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='spotify_match_status',
             log_prefix='Spotify',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         query = f"{artist_name} {album_name}" if artist_name else album_name
@@ -851,14 +859,22 @@ class SpotifyWorker:
         artist_name = item.get('artist', '')
 
         # Issue #501: honor manual matches (see _process_album_individual).
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='spotify_track_id',
             client_fetch_fn=self.client.get_track_details,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='spotify_match_status',
             log_prefix='Spotify',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         query = f"{artist_name} {track_name}" if artist_name else track_name
@@ -972,7 +988,7 @@ class SpotifyWorker:
                 year = album_obj.release_date[:4] if len(album_obj.release_date) >= 4 else None
                 if year and year.isdigit():
                     cursor.execute("""
-                        UPDATE albums SET year = ?
+                        UPDATE albums SET year = ?, updated_at = CURRENT_TIMESTAMP
                         WHERE id = ? AND (year IS NULL OR year = '' OR year = '0')
                     """, (year, album_id))
                 # #824: also store the FULL release date when Spotify has one

--- a/core/tidal_worker.py
+++ b/core/tidal_worker.py
@@ -9,7 +9,7 @@ from database.music_database import MusicDatabase
 from core.tidal_client import TidalClient
 from core.worker_utils import (accept_artist_match, _names_equivalent,
                                idle_backoff_seconds, interruptible_sleep)
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import MATCHED, honor_stored_match
 
 logger = get_logger("tidal_worker")
 
@@ -518,14 +518,22 @@ class TidalWorker:
         # Issue #501: honor manual matches. Pre-fix this just marked
         # status='matched' without refreshing metadata. Now goes
         # through the full refresh path via the stored ID.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='albums', entity_id=album_id,
             id_column='tidal_id',
             client_fetch_fn=self.client.get_album,
             on_match_fn=self._refresh_album_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='tidal_match_status',
             log_prefix='Tidal',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_album(artist_name, album_name)
@@ -573,14 +581,22 @@ class TidalWorker:
     def _process_track(self, track_id: int, track_name: str, artist_name: str, item: Dict[str, Any]):
         """Process a track: search Tidal, verify, fetch full details, store metadata"""
         # Issue #501: honor manual matches.
-        if honor_stored_match(
+        _stored = honor_stored_match(
             db=self.db, entity_table='tracks', entity_id=track_id,
             id_column='tidal_id',
             client_fetch_fn=self.client.get_track,
             on_match_fn=self._refresh_track_via_stored_id,
+            mark_status_fn=self._mark_status,
+            status_column='tidal_match_status',
             log_prefix='Tidal',
-        ):
-            self.stats['matched'] += 1
+        )
+        if _stored:
+            # L2-005: a stored ID the source could not confirm right now is
+            # NOT released to a fuzzy name search below — a transient provider
+            # failure is not evidence that the ID is wrong, and searching
+            # overwrote deliberately chosen matches with whatever came back.
+            if _stored == MATCHED:
+                self.stats['matched'] += 1
             return
 
         result = self.client.search_track(artist_name, track_name)

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -8,7 +8,7 @@ import os
 import re
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Dict, Any, Tuple
 from dataclasses import dataclass
 from pathlib import Path
@@ -1753,9 +1753,14 @@ class MusicDatabase:
             # Auto writes can't clobber a manual lock; manual writes always apply.
             guard = "" if locked else " AND (canonical_locked IS NULL OR canonical_locked = 0)"
             cursor.execute(
+                # updated_at moves with the canonical claim (L2-011): these
+                # columns are part of the MetaSync payload, so a claim that did
+                # not touch the timestamp changed what a full export says while
+                # every incremental export kept omitting the row.
                 "UPDATE albums SET canonical_source = ?, canonical_album_id = ?, "
                 "canonical_score = ?, canonical_locked = ?, "
-                "canonical_resolved_at = CURRENT_TIMESTAMP "
+                "canonical_resolved_at = CURRENT_TIMESTAMP, "
+                "updated_at = CURRENT_TIMESTAMP "
                 f"WHERE id = ?{guard}",
                 (source, str(canonical_album_id), float(score), 1 if locked else 0, album_id),
             )
@@ -17325,6 +17330,11 @@ class MusicDatabase:
     # ── Curation signals (media-server favourites / ratings / playlists) ──
 
     CURATION_SYNC_KEY = 'curation_signals_synced_at'
+    # The structured outcome of the last sweep. The bare timestamp above cannot
+    # express "half of it failed", and a fresh stamp over a half-written
+    # snapshot is indistinguishable from "nobody curated anything" — which is
+    # the state that deletes a library (L2-001).
+    CURATION_STATUS_KEY = 'curation_signals_sync_status'
 
     def replace_curation_signals(self, server: str, user_key: str, signals) -> int:
         """Replace one user's curation signals for one server, atomically.
@@ -17336,66 +17346,98 @@ class MusicDatabase:
 
         ``signals`` items need ``track_key``; ``favorite``, ``rating``,
         ``in_playlist`` and ``source_path`` are optional.
+
+        Raises on any storage failure. This is a safety API: swallowing the
+        error and returning 0 made a failed write indistinguishable from "this
+        user curated nothing", and the caller then stamped the sweep as a
+        success (L2-001). The caller decides what a failure means; it must never
+        have to guess whether one happened.
         """
         rows = [s for s in (signals or []) if isinstance(s, dict) and s.get('track_key')]
-        try:
-            with self._get_connection() as conn:
-                cursor = conn.cursor()
-                cursor.execute(
-                    "DELETE FROM curation_signals WHERE server = ? AND user_key = ?",
-                    (str(server), str(user_key)))
-                cursor.executemany(
-                    "INSERT OR REPLACE INTO curation_signals "
-                    "(server, user_key, track_key, favorite, rating, in_playlist, "
-                    " source_path, updated_at) "
-                    "VALUES (?,?,?,?,?,?,?,CURRENT_TIMESTAMP)",
-                    [(str(server), str(user_key), s['track_key'],
-                      1 if s.get('favorite') else 0,
-                      s.get('rating'),
-                      1 if s.get('in_playlist') else 0,
-                      s.get('source_path'))
-                     for s in rows])
-                conn.commit()
-            return len(rows)
-        except Exception as e:
-            logger.error(f"Error storing curation signals for {server}/{user_key}: {e}")
-            return 0
-
-    def get_curation_signals_by_track_key(self) -> Dict[str, List[Dict[str, Any]]]:
-        """Every stored signal, grouped by track_key, for the cleanup decision."""
-        grouped: Dict[str, List[Dict[str, Any]]] = {}
-        try:
-            conn = self._get_connection()
+        with self._get_connection() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT track_key, server, user_key, favorite, rating, in_playlist "
-                "FROM curation_signals")
-            for track_key, server, user_key, favorite, rating, in_playlist in cursor.fetchall():
-                grouped.setdefault(track_key, []).append({
-                    'server': server,
-                    'user': user_key,
-                    'favorite': bool(favorite),
-                    'rating': rating,
-                    'in_playlist': bool(in_playlist),
-                })
-        except Exception as e:
-            logger.debug(f"Error reading curation signals: {e}")
+                "DELETE FROM curation_signals WHERE server = ? AND user_key = ?",
+                (str(server), str(user_key)))
+            cursor.executemany(
+                "INSERT OR REPLACE INTO curation_signals "
+                "(server, user_key, track_key, favorite, rating, in_playlist, "
+                " source_path, updated_at) "
+                "VALUES (?,?,?,?,?,?,?,CURRENT_TIMESTAMP)",
+                [(str(server), str(user_key), s['track_key'],
+                  1 if s.get('favorite') else 0,
+                  s.get('rating'),
+                  1 if s.get('in_playlist') else 0,
+                  s.get('source_path'))
+                 for s in rows])
+            conn.commit()
+        return len(rows)
+
+    def get_curation_signals_by_track_key(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Every stored signal, grouped by track_key, for the cleanup decision.
+
+        Raises on a read failure (L2-001). An empty dict has to mean "nobody
+        curated anything"; returning it for a schema or I/O error handed the
+        cleaner that exact conclusion and let it delete favourited files.
+        """
+        grouped: Dict[str, List[Dict[str, Any]]] = {}
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT track_key, server, user_key, favorite, rating, in_playlist "
+            "FROM curation_signals")
+        for track_key, server, user_key, favorite, rating, in_playlist in cursor.fetchall():
+            grouped.setdefault(track_key, []).append({
+                'server': server,
+                'user': user_key,
+                'favorite': bool(favorite),
+                'rating': rating,
+                'in_playlist': bool(in_playlist),
+            })
         return grouped
 
-    def mark_curation_sync(self) -> None:
-        """Record that a curation sweep completed successfully."""
-        try:
-            self.set_preference(self.CURATION_SYNC_KEY, datetime.now().isoformat())
-        except Exception as e:
-            logger.debug(f"Error stamping curation sync: {e}")
+    def mark_curation_sync(self, status: Optional[Dict[str, Any]] = None) -> None:
+        """Record the outcome of a curation sweep.
+
+        ``status`` is the structured record the cleaner reads; it must carry a
+        ``complete`` flag saying whether EVERY expected server and user was
+        stored. The plain timestamp is kept alongside it for older readers.
+        Raises on failure — a stamp that silently did not land is a stamp the
+        cleaner will read as older than it is, and eventually as absent.
+        """
+        now = datetime.now().isoformat()
+        if status is None:
+            # A caller that has nothing structured to say is asserting a plain
+            # successful sweep. Clear any older record rather than leaving one
+            # behind that would keep describing a sweep this one replaced.
+            self.set_preference(self.CURATION_STATUS_KEY, '')
+        else:
+            payload = dict(status)
+            payload.setdefault('complete', True)
+            payload['at'] = now
+            self.set_preference(self.CURATION_STATUS_KEY,
+                                json.dumps(payload, ensure_ascii=False))
+        self.set_preference(self.CURATION_SYNC_KEY, now)
 
     def get_curation_sync_at(self):
-        """When the last successful curation sweep finished, or None."""
-        try:
-            return self.get_preference(self.CURATION_SYNC_KEY)
-        except Exception as e:
-            logger.debug(f"Error reading curation sync stamp: {e}")
+        """When the last curation sweep finished, or None. Raises on failure."""
+        return self.get_preference(self.CURATION_SYNC_KEY)
+
+    def get_curation_status(self) -> Optional[Dict[str, Any]]:
+        """The last sweep's structured outcome, or None if none was recorded.
+
+        Raises on a read failure, for the same reason as the signals above: the
+        caller must be able to tell "never swept" from "cannot tell".
+        """
+        raw = self.get_preference(self.CURATION_STATUS_KEY)
+        if not raw:
             return None
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            # A corrupted record is not evidence of a good sweep.
+            return {'complete': False, 'at': None, 'corrupt': True}
+        return parsed if isinstance(parsed, dict) else {'complete': False, 'at': None}
 
     def get_origin_cleanup_candidates(self):
         """Origin-tracked downloads (watchlist/playlist) annotated with the
@@ -18205,6 +18247,27 @@ class MusicDatabase:
 
     # ── MetaSync export ──────────────────────────────────────────────────
 
+    @staticmethod
+    def _normalize_since(value: Any) -> str:
+        """One aware-UTC ``'YYYY-MM-DD HH:MM:SS'`` string for the export filter.
+
+        A naive input is read as UTC because that is what SQLite's
+        CURRENT_TIMESTAMP writes; anything with an offset is converted, so two
+        callers naming the same instant in different zones get the same slice.
+        """
+        text = str(value or "").strip()
+        if not text:
+            return text
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            raise ValueError(
+                "since must be an ISO-8601 timestamp "
+                f"(e.g. 2026-08-19T00:00:00), got {value!r}")
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
     def api_export_entities(self, entity: str, cursor: str = "",
                             since: str = "", limit: int = 500) -> List[Dict[str, Any]]:
         """Page through artists/albums/tracks for the MetaSync export.
@@ -18228,6 +18291,26 @@ class MusicDatabase:
 
         Read-only.
         """
+        # The instant a row's EXPORTED payload last changed — its own timestamp
+        # or a parent's (L2-011). An album carries its artist's name and a track
+        # carries the artist name plus the album title and year, so renaming an
+        # artist rewrites what the export says about every one of its albums and
+        # tracks while touching none of their timestamps. A consumer that had
+        # already walked them would never be told.
+        # julianday() on every side, never a text MAX: the timestamps in these
+        # columns are a mix of 'YYYY-MM-DD HH:MM:SS' and ISO-with-a-'T', and
+        # 'T' > ' ' — a lexicographic MAX would pick the older one whenever the
+        # two rows were written in different formats. COALESCE to 0 so an
+        # unparseable or absent parent timestamp cannot NULL out the whole
+        # comparison and drop the row from every incremental export.
+        _day = "COALESCE(julianday({0}), 0)"
+        effective = {
+            'artist': _day.format("t.updated_at"),
+            'album': f"MAX({_day.format('t.updated_at')}, {_day.format('ar.updated_at')})",
+            'track': (f"MAX({_day.format('t.updated_at')}, "
+                      f"{_day.format('ar.updated_at')}, "
+                      f"{_day.format('al.updated_at')})"),
+        }
         specs = {
             'artist': (_EXPORT_ARTIST_COLUMNS, "FROM artists t", ""),
             'album': (
@@ -18278,8 +18361,15 @@ class MusicDatabase:
             where.append("t.id > ?")
             params.append(str(cursor))
         if since:
-            where.append("t.updated_at >= ?")
-            params.append(str(since))
+            # Compared as INSTANTS, not as text (L2-010). SQLite writes
+            # CURRENT_TIMESTAMP as 'YYYY-MM-DD HH:MM:SS' while the API accepts
+            # ISO-8601 with a 'T' and an offset, and 'T' > ' ' in ASCII — so a
+            # caller asking for everything since midnight got nothing at all
+            # from that same day, and an offset was ranked by its own text
+            # rather than by the moment it denotes. julianday() parses both
+            # sides, and the input is normalised to UTC once, here.
+            where.append(f"{effective[entity]} >= julianday(?)")
+            params.append(self._normalize_since(since))
 
         try:
             conn = self._get_connection()

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -11216,33 +11216,55 @@ class MusicDatabase:
             logger.error(f"Failed to save quality profile: {e}")
             return False
 
+    # The columns `_write_default_quality_profile_row` writes unconditionally
+    # (the ranked-target ladder and its flags), and the ones it writes only
+    # when the caller actually named them. See that method for why the split
+    # exists.
+    _QUALITY_LADDER_COLUMNS = (
+        "ranked_targets", "fallback_enabled", "search_mode",
+        "rank_candidates_by_quality", "upgrade_policy", "upgrade_cutoff_index",
+    )
+    _QUALITY_BUNDLE_COLUMNS = (
+        "acoustid_required", "downsample_enabled", "deep_audio_verify",
+        "replace_lower_quality", "lossy_copy_enabled", "lossy_copy_codec",
+        "lossy_copy_bitrate", "lossy_copy_delete_original",
+    )
+
     def _write_default_quality_profile_row(self, profile: dict) -> None:
         """Write-through helper for `set_quality_profile`: updates the
-        ``is_default=1`` row in `quality_profiles` to match."""
-        import json
-        try:
-            cutoff_index = max(0, int(profile.get("upgrade_cutoff_index") or 0))
-        except (TypeError, ValueError):
-            cutoff_index = 0
-        upgrade_policy = profile.get("upgrade_policy")
-        if upgrade_policy not in ("acceptable", "until_cutoff", "until_top"):
-            upgrade_policy = "acceptable"
+        ``is_default=1`` row in `quality_profiles` to match.
+
+        Writes the ladder columns always and a bundle column only when
+        ``profile`` actually carries that key. The asymmetry is the point:
+        ``GET /api/quality-profile`` returns all fourteen fields, but the
+        Settings page posts back only the six ladder ones
+        (``settings.js::collectQualityProfileFromUI``) and a Quick Set preset
+        carries even fewer. The other eight belong to the global config and
+        reach this row through
+        :meth:`sync_default_quality_profile_from_config` after a settings
+        save, so a POST that never mentioned them must leave them alone —
+        writing a coerced default for an absent key would silently reset
+        lossy-copy, AcoustID strictness and replace-lower-quality every time
+        somebody reordered the target ladder.
+
+        Naming a key still works, including turning one off: presence decides,
+        not truthiness. That is what makes a full round-trip of the GET
+        payload behave the way a caller expects, which it previously did not
+        (PR #1103 reported exactly that, but fixed it by writing all fourteen
+        unconditionally, which is the reset described above).
+        """
+        params = self._quality_profile_bundle_params(profile)
+        columns = list(self._QUALITY_LADDER_COLUMNS)
+        columns += [c for c in self._QUALITY_BUNDLE_COLUMNS if c in profile]
+        # Interpolated, but only ever from the two class-level tuples above —
+        # `profile` decides which of those names are used, never what they are.
+        assignments = ", ".join(f"{c}=:{c}" for c in columns)
         conn = self._get_connection()
         try:
             conn.execute(
-                """UPDATE quality_profiles
-                      SET ranked_targets=?, fallback_enabled=?, search_mode=?,
-                          rank_candidates_by_quality=?, upgrade_policy=?,
-                          upgrade_cutoff_index=?, updated_at=CURRENT_TIMESTAMP
-                    WHERE is_default=1""",
-                (
-                    json.dumps(profile.get("ranked_targets") or []),
-                    1 if profile.get("fallback_enabled", True) else 0,
-                    profile.get("search_mode") if profile.get("search_mode") in ("priority", "best_quality") else "priority",
-                    1 if profile.get("rank_candidates_by_quality") else 0,
-                    upgrade_policy,
-                    cutoff_index,
-                ),
+                f"UPDATE quality_profiles SET {assignments}, "
+                "updated_at=CURRENT_TIMESTAMP WHERE is_default=1",
+                {c: params[c] for c in columns},
             )
             conn.commit()
         finally:

--- a/tests/downloads/test_atomic_album_publish.py
+++ b/tests/downloads/test_atomic_album_publish.py
@@ -143,7 +143,11 @@ def test_publish_moves_all_files_updates_db_and_prunes(tmp_path):
         assert s.startswith(staging) and f.startswith(transfer)
 
 
-def test_publish_keeps_file_staged_on_move_failure(tmp_path):
+def test_a_failed_move_rolls_the_whole_album_back(tmp_path):
+    """L2-002: "the album appears at once" is the point of atomic publishing.
+    Leaving the files that did move live produced an album half in the library
+    and half in staging, which the batch then reported as Complete with no
+    retryable task for the missing half."""
     transfer = str(tmp_path / "music")
     staging = ap.staging_root_for_batch(transfer, "b2")
     good = _mk(Path(staging) / "A" / "Al" / "01.flac")
@@ -156,13 +160,76 @@ def test_publish_keeps_file_staged_on_move_failure(tmp_path):
 
     res = ap.publish_album_batch(staging, transfer, _move_one_fails)
 
-    assert len(res["published"]) == 1
+    assert res["success"] is False
+    assert res["published"] == []
     assert len(res["failed"]) == 1 and res["failed"][0][0].endswith("02.flac")
-    # The good one published; the failed one is STILL in staging (never lost,
-    # never a partial-library orphan), and the tree is NOT pruned.
-    assert os.path.isfile(os.path.join(transfer, "A", "Al", "01.flac"))
+    assert res["rollback_failed"] == []
+    # Nothing is live, both files are back in staging, the tree is NOT pruned.
+    assert not os.path.isfile(os.path.join(transfer, "A", "Al", "01.flac"))
+    assert os.path.isfile(good)
     assert os.path.isfile(bad)
     assert os.path.isdir(staging)
+
+
+def test_a_db_repoint_exception_fails_the_publish(tmp_path):
+    transfer = str(tmp_path / "music")
+    staging = ap.staging_root_for_batch(transfer, "b3")
+    track = _mk(Path(staging) / "A" / "Al" / "01.flac")
+
+    def _boom(_staged, _final):
+        raise RuntimeError("database is locked")
+
+    res = ap.publish_album_batch(staging, transfer, _move, _boom)
+
+    assert res["success"] is False
+    assert os.path.isfile(track), "the file must go back where a retry can find it"
+    assert not os.path.isfile(os.path.join(transfer, "A", "Al", "01.flac"))
+
+
+def test_a_db_repoint_that_matches_no_row_fails_the_publish(tmp_path):
+    """The move worked, but the library still points at a staging path this
+    publish is about to remove — the track would read as missing."""
+    transfer = str(tmp_path / "music")
+    staging = ap.staging_root_for_batch(transfer, "b4")
+    track = _mk(Path(staging) / "A" / "Al" / "01.flac")
+
+    res = ap.publish_album_batch(staging, transfer, _move,
+                                 lambda _s, _f: 0)
+
+    assert res["success"] is False
+    assert os.path.isfile(track)
+
+
+def test_a_sidecar_that_matches_no_row_is_fine(tmp_path):
+    """Cover art and lyrics have no track row by design, so a zero rowcount for
+    them says nothing about the publish."""
+    transfer = str(tmp_path / "music")
+    staging = ap.staging_root_for_batch(transfer, "b5")
+    _mk(Path(staging) / "A" / "Al" / "01.flac")
+    _mk(Path(staging) / "A" / "Al" / "folder.jpg")
+
+    seen = []
+
+    def _update(staged, _final):
+        seen.append(staged)
+        return 0 if staged.endswith(".jpg") else 1
+
+    res = ap.publish_album_batch(staging, transfer, _move, _update)
+
+    assert res["success"] is True
+    assert len(seen) == 2
+    assert os.path.isfile(os.path.join(transfer, "A", "Al", "folder.jpg"))
+
+
+def test_an_unknown_rowcount_does_not_fail_the_publish(tmp_path):
+    """A driver that cannot report a rowcount gives "unknown", not "zero"."""
+    transfer = str(tmp_path / "music")
+    staging = ap.staging_root_for_batch(transfer, "b6")
+    _mk(Path(staging) / "A" / "Al" / "01.flac")
+
+    res = ap.publish_album_batch(staging, transfer, _move, lambda _s, _f: None)
+
+    assert res["success"] is True
 
 
 def test_discard_removes_genuine_staging_root(tmp_path):

--- a/tests/downloads/test_atomic_publish_wiring.py
+++ b/tests/downloads/test_atomic_publish_wiring.py
@@ -207,3 +207,71 @@ def test_publish_reregisters_final_folder_with_repair(monkeypatch, tmp_path):
     # The PUBLISHED album folder (not the emptied staging one) is registered so
     # the post-batch track-number repair scans real files.
     assert registered == [("B", os.path.join(transfer, "Artist", "Album"))]
+
+
+# --- L2-002: a failed publish must not produce a Complete batch -------------
+
+
+def _staged_batch(monkeypatch, tmp_path, name="F"):
+    """A batch with one staged track, ready to publish."""
+    from pathlib import Path
+
+    batch = {"is_album_download": True}
+    transfer = _wire(monkeypatch, tmp_path, flag=True, batch=batch)
+    final = os.path.join(transfer, "Artist", "Album", "01 - Song.flac")
+    staged = pl._maybe_stage_album_track({"batch_id": "B"}, final)
+    Path(staged).parent.mkdir(parents=True, exist_ok=True)
+    Path(staged).write_bytes(b"AUDIO")
+    return batch, staged, final
+
+
+def test_publish_hook_reports_success(monkeypatch, tmp_path):
+    batch, staged, final = _staged_batch(monkeypatch, tmp_path)
+
+    class _FakeConn:
+        rowcount = 1
+
+        def cursor(self): return self
+        def execute(self, q, params): pass
+        def commit(self): pass
+        def close(self): pass
+
+    class _FakeDB:
+        def _get_connection(self): return _FakeConn()
+
+    monkeypatch.setattr("database.music_database.MusicDatabase", _FakeDB)
+
+    assert lc._publish_atomic_album("B", batch) is True
+    assert os.path.isfile(final)
+
+
+def test_publish_hook_reports_failure_and_leaves_the_album_staged(monkeypatch, tmp_path):
+    """The result used to be logged and discarded, so the caller marked the
+    batch complete and emitted history/scan/completion events for an album that
+    never reached the library."""
+    batch, staged, final = _staged_batch(monkeypatch, tmp_path)
+
+    def _no_move(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("core.imports.file_ops.safe_move_file", _no_move)
+
+    class _FakeDB:
+        def _get_connection(self):  # never reached
+            raise AssertionError("no move, no repoint")
+
+    monkeypatch.setattr("database.music_database.MusicDatabase", _FakeDB)
+
+    assert lc._publish_atomic_album("B", batch) is False
+    assert os.path.isfile(staged)
+    assert not os.path.isfile(final)
+
+
+def test_a_noop_publish_still_reports_success(monkeypatch, tmp_path):
+    """A batch that never staged anything is not a failed publish."""
+    assert lc._publish_atomic_album("B", {"is_album_download": True}) is True
+    assert lc._publish_atomic_album("B", {
+        "_atomic_active": True,
+        "_atomic_staging_root": str(tmp_path / "gone"),
+        "_atomic_transfer_dir": str(tmp_path / "music"),
+    }) is True

--- a/tests/downloads/test_downloads_lifecycle.py
+++ b/tests/downloads/test_downloads_lifecycle.py
@@ -852,3 +852,51 @@ class TestGlobalGateDoesNotStampede:
 
         started = [c for c in rec.calls if c[0] == 'submit_dl']
         assert len(started) == 3, f'3 slots free, expected 3 starts, got {len(started)}'
+
+
+# ---------------------------------------------------------------------------
+# L2-002: a failed atomic publish must not produce a Complete batch
+# ---------------------------------------------------------------------------
+
+def _one_task_batch():
+    download_tasks['t1'] = {'status': 'completed', 'track_info': {'name': 'X'}}
+    download_batches['b1'] = {
+        'queue': ['t1'], 'queue_index': 1, 'active_count': 1,
+        'max_concurrent': 1, 'permanently_failed_tracks': [],
+        'cancelled_tracks': set(), 'playlist_name': 'P',
+    }
+
+
+def test_a_failed_publish_leaves_the_batch_incomplete(monkeypatch):
+    """The batch used to be stamped complete BEFORE the publish ran, and the
+    publish's result was only logged — so history, scan and completion events
+    all fired for an album that never reached the library."""
+    _one_task_batch()
+    monkeypatch.setattr(lc, '_publish_atomic_album', lambda *a, **kw: False)
+    deps, _ = _build_deps()
+
+    lc.on_download_completed('b1', 't1', True, deps)
+
+    assert download_batches['b1'].get('phase') != 'complete'
+    assert 'completion_time' not in download_batches['b1']
+
+
+def test_a_successful_publish_completes_the_batch_as_before(monkeypatch):
+    _one_task_batch()
+    monkeypatch.setattr(lc, '_publish_atomic_album', lambda *a, **kw: True)
+    deps, _ = _build_deps()
+
+    lc.on_download_completed('b1', 't1', True, deps)
+
+    assert download_batches['b1'].get('phase') == 'complete'
+
+
+def test_completion_check_v2_also_refuses_a_failed_publish(monkeypatch):
+    _one_task_batch()
+    monkeypatch.setattr(lc, '_publish_atomic_album', lambda *a, **kw: False)
+    deps, _ = _build_deps()
+
+    result = lc.check_batch_completion_v2('b1', deps)
+
+    assert result is False
+    assert download_batches['b1'].get('phase') != 'complete'

--- a/tests/enrichment/test_manual_match_honoring.py
+++ b/tests/enrichment/test_manual_match_honoring.py
@@ -19,7 +19,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from core.enrichment.manual_match_honoring import honor_stored_match
+from core.enrichment.manual_match_honoring import (
+    MATCHED, NO_STORED_ID, UNAVAILABLE, honor_stored_match,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -55,7 +57,8 @@ class _FakeDB:
                 id INTEGER PRIMARY KEY,
                 spotify_album_id TEXT,
                 deezer_id TEXT,
-                itunes_album_id TEXT
+                itunes_album_id TEXT,
+                spotify_match_status TEXT
             )
         """)
         cur.execute("""
@@ -116,12 +119,12 @@ def test_honors_stored_id_when_present(db):
         log_prefix='Spotify',
     )
 
-    assert result is True
+    assert result == MATCHED
     fetch.assert_called_once_with('SP-ABC')
     on_match.assert_called_once_with(42, 'SP-ABC', api_payload)
 
 
-def test_returns_false_when_no_stored_id(db):
+def test_returns_no_stored_id_when_no_stored_id(db):
     """Pin: no stored ID → returns False, no fetch attempted, no
     callback. Caller proceeds with its search-by-name fallback."""
     db.insert_album(42, spotify_album_id=None)
@@ -135,12 +138,12 @@ def test_returns_false_when_no_stored_id(db):
         log_prefix='Spotify',
     )
 
-    assert result is False
+    assert result == NO_STORED_ID
     fetch.assert_not_called()
     on_match.assert_not_called()
 
 
-def test_returns_false_when_stored_id_empty_string(db):
+def test_returns_no_stored_id_when_stored_id_empty_string(db):
     """Pin: empty string treated same as NULL — no fetch, return False."""
     db.insert_album(42, spotify_album_id='')
     fetch = MagicMock()
@@ -152,11 +155,11 @@ def test_returns_false_when_stored_id_empty_string(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is False
+    assert result == NO_STORED_ID
     fetch.assert_not_called()
 
 
-def test_returns_false_when_entity_not_in_db(db):
+def test_returns_no_stored_id_when_entity_not_in_db(db):
     """Pin: missing row → returns False, no fetch, no callback."""
     fetch = MagicMock()
     on_match = MagicMock()
@@ -167,7 +170,7 @@ def test_returns_false_when_entity_not_in_db(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is False
+    assert result == NO_STORED_ID
     fetch.assert_not_called()
 
 
@@ -176,28 +179,51 @@ def test_returns_false_when_entity_not_in_db(db):
 # ---------------------------------------------------------------------------
 
 
-def test_returns_false_when_fetch_raises(db):
-    """Pin: client.get_X(stored_id) raises → caught, logged at warning,
-    returns False so caller falls through to search. Worker must not
-    crash on a transient API failure."""
+def test_a_fetch_failure_keeps_the_stored_id_instead_of_searching(db):
+    """L2-005: a transient API failure is not evidence that the stored ID is
+    wrong. Returning "no stored id" sent the worker into a fuzzy name search,
+    which then overwrote a deliberately chosen match with whatever came back.
+
+    The failure is recorded as ``error`` (with its retry timestamp) so the
+    entity is not re-picked on the very next cycle with no backoff."""
     db.insert_album(42, spotify_album_id='SP-ABC')
     fetch = MagicMock(side_effect=RuntimeError("API down"))
     on_match = MagicMock()
+    marked = []
 
     result = honor_stored_match(
         db=db, entity_table='albums', entity_id=42,
         id_column='spotify_album_id',
         client_fetch_fn=fetch, on_match_fn=on_match,
+        mark_status_fn=lambda kind, eid, status: marked.append((kind, eid, status)),
     )
 
-    assert result is False
+    assert result == UNAVAILABLE
+    assert result, "must be truthy so the caller skips search-by-name"
+    assert marked == [('album', 42, 'error')]
     on_match.assert_not_called()
 
 
-def test_returns_false_when_fetch_returns_none(db):
-    """Pin: stored ID points at a removed/invalid catalog entry →
-    fetch returns None → falls through to search instead of writing
-    junk to DB."""
+def test_a_broken_status_writer_does_not_break_the_refresh(db):
+    db.insert_album(42, spotify_album_id='SP-ABC')
+
+    def _boom(*_a):
+        raise RuntimeError("db locked")
+
+    result = honor_stored_match(
+        db=db, entity_table='albums', entity_id=42,
+        id_column='spotify_album_id',
+        client_fetch_fn=MagicMock(side_effect=RuntimeError("API down")),
+        on_match_fn=MagicMock(), mark_status_fn=_boom,
+    )
+
+    assert result == UNAVAILABLE
+
+
+def test_an_empty_fetch_also_keeps_the_stored_id(db):
+    """A source that answers "I have nothing for this id" is indistinguishable
+    from one that is having a bad day, and both cases used to release the id to
+    a name search. Releasing it takes an explicit re-match."""
     db.insert_album(42, spotify_album_id='SP-DEAD')
     fetch = MagicMock(return_value=None)
     on_match = MagicMock()
@@ -208,11 +234,11 @@ def test_returns_false_when_fetch_returns_none(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is False
+    assert result == UNAVAILABLE
     on_match.assert_not_called()
 
 
-def test_returns_false_when_fetch_returns_empty_dict(db):
+def test_an_empty_dict_response_also_keeps_the_stored_id(db):
     """Pin: empty dict treated same as None — falsy result skips
     callback."""
     db.insert_album(42, spotify_album_id='SP-EMPTY')
@@ -225,7 +251,7 @@ def test_returns_false_when_fetch_returns_empty_dict(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is False
+    assert result == UNAVAILABLE
     on_match.assert_not_called()
 
 
@@ -263,7 +289,7 @@ def test_works_with_tracks_table(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is True
+    assert result == MATCHED
     fetch.assert_called_once_with('SP-T-1')
 
 
@@ -281,7 +307,7 @@ def test_works_with_alternate_columns(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is True
+    assert result == MATCHED
     fetch.assert_called_once_with('12345')
 
 
@@ -298,5 +324,46 @@ def test_rejects_invalid_table_name(db):
         client_fetch_fn=fetch, on_match_fn=on_match,
     )
 
-    assert result is False
+    assert result == NO_STORED_ID
     fetch.assert_not_called()
+
+
+def test_an_already_matched_entity_is_not_downgraded_by_a_hiccup(db):
+    """Backoff must not cost the user their chip: an album that reads
+    ``matched`` is not the row a retry loop keeps re-picking, and turning it
+    red for a provider outage misreports a match that is still good."""
+    db.insert_album(42, spotify_album_id='SP-ABC',
+                    spotify_match_status='matched')
+    marked = []
+
+    result = honor_stored_match(
+        db=db, entity_table='albums', entity_id=42,
+        id_column='spotify_album_id',
+        client_fetch_fn=MagicMock(side_effect=RuntimeError("API down")),
+        on_match_fn=MagicMock(),
+        mark_status_fn=lambda kind, eid, status: marked.append((kind, eid, status)),
+        status_column='spotify_match_status',
+    )
+
+    assert result == UNAVAILABLE
+    assert marked == []
+
+
+def test_an_unsettled_entity_still_gets_its_backoff(db):
+    """The row a retry loop WOULD keep re-picking: an id is stored but no
+    status was ever written, so nothing stops the next cycle choosing it again
+    immediately."""
+    db.insert_album(43, spotify_album_id='SP-XYZ')
+    marked = []
+
+    result = honor_stored_match(
+        db=db, entity_table='albums', entity_id=43,
+        id_column='spotify_album_id',
+        client_fetch_fn=MagicMock(side_effect=RuntimeError("API down")),
+        on_match_fn=MagicMock(),
+        mark_status_fn=lambda kind, eid, status: marked.append((kind, eid, status)),
+        status_column='spotify_match_status',
+    )
+
+    assert result == UNAVAILABLE
+    assert marked == [('album', 43, 'error')]

--- a/tests/library/test_curation_sync.py
+++ b/tests/library/test_curation_sync.py
@@ -17,6 +17,7 @@ class _DB:
     def __init__(self, fail_on=None):
         self.stored = {}
         self.stamped = 0
+        self.status = None
         self._fail_on = fail_on
 
     def replace_curation_signals(self, server, user, rows):
@@ -25,8 +26,9 @@ class _DB:
         self.stored[(server, user)] = rows
         return len(rows)
 
-    def mark_curation_sync(self):
+    def mark_curation_sync(self, status=None):
         self.stamped += 1
+        self.status = status
 
 
 class _Client:
@@ -107,7 +109,7 @@ def test_a_server_that_raises_does_not_stamp_or_clear():
     summary = sync_curation_signals(db, {"navidrome": _Client(raises=True)})
     assert db.stored == {}, "a failed read wrote over stored signals"
     assert summary["stamped"] is False
-    assert db.stamped == 0
+    assert db.status["complete"] is False
 
 
 def test_a_server_returning_nothing_does_not_stamp():
@@ -116,7 +118,7 @@ def test_a_server_returning_nothing_does_not_stamp():
     db = _DB()
     summary = sync_curation_signals(db, {"navidrome": _Client({})})
     assert summary["stamped"] is False
-    assert db.stamped == 0
+    assert db.status["complete"] is False
 
 
 def test_a_client_without_the_method_is_skipped_not_fatal():
@@ -129,13 +131,21 @@ def test_a_client_without_the_method_is_skipped_not_fatal():
     assert summary["stamped"] is True
 
 
-def test_a_none_client_is_skipped():
+def test_a_none_client_is_an_unreachable_expected_server():
+    """The caller named plex as active, so it is expected to contribute. A
+    "complete" sweep that quietly omits everyone on it is the deletion path."""
     db = _DB()
     summary = sync_curation_signals(db, {"plex": None})
     assert summary["stamped"] is False
+    assert db.status["complete"] is False
+    assert db.status["expected_servers"] == ["plex"]
 
 
 def test_one_users_write_failing_does_not_lose_the_others():
+    """Alice's rows are kept — but the snapshot is INCOMPLETE (L2-001). Bob's
+    stored signals are now whatever they were before, and the fresh half claims
+    to be the whole picture. Stamping that as a good sweep is what let the
+    cleaner delete tracks Bob had favourited."""
     db = _DB(fail_on=("navidrome", "bob"))
     summary = sync_curation_signals(db, {
         "navidrome": _Client({"alice": [_sig(favorite=True)],
@@ -144,17 +154,70 @@ def test_one_users_write_failing_does_not_lose_the_others():
     assert ("navidrome", "alice") in db.stored
     assert ("navidrome", "bob") not in db.stored
     assert summary["users"] == 1
-    assert summary["stamped"] is True, "alice was read fine — that is real progress"
+    assert summary["complete"] is False
+    assert summary["failed"] == ["navidrome/bob"]
+    assert db.status["complete"] is False
 
 
-def test_every_server_failing_leaves_the_stamp_alone():
+def test_a_complete_sweep_is_recorded_as_complete():
+    db = _DB()
+    summary = sync_curation_signals(db, {
+        "navidrome": _Client({"alice": [_sig(favorite=True)]}),
+    })
+    assert summary["complete"] is True
+    assert db.status == {"complete": True, "expected_servers": ["navidrome"],
+                         "servers": ["navidrome"], "failed": [], "users": 1,
+                         "rows": 1}
+
+
+def test_a_server_with_no_readable_users_is_a_failure_not_an_empty_answer():
+    """A curation-capable server that returns nothing was not read. Treating it
+    as "these people curate nothing" is the deletion path."""
+    db = _DB()
+    summary = sync_curation_signals(db, {"navidrome": _Client({})})
+    assert summary["complete"] is False
+    assert db.status["complete"] is False
+
+
+def test_no_capable_server_is_recorded_as_a_complete_empty_sweep():
+    """So the cleaner can tell "curation cannot work here" (run normally) from
+    "curation has never run yet" (keep everything)."""
+    db = _DB()
+    summary = sync_curation_signals(db, {"plex": _ClientWithoutSupport()})
+    assert summary["complete"] is True
+    assert db.status["expected_servers"] == []
+
+
+def test_a_legacy_adapter_is_only_stamped_on_a_clean_sweep():
+    """An adapter whose mark_curation_sync takes no argument cannot carry the
+    incomplete caveat, so a partial sweep must not stamp it at all."""
+
+    class _LegacyDB(_DB):
+        def mark_curation_sync(self):  # no status parameter
+            self.stamped += 1
+
+    db = _LegacyDB(fail_on=("navidrome", "bob"))
+    summary = sync_curation_signals(db, {
+        "navidrome": _Client({"alice": [_sig(favorite=True)],
+                              "bob": [_sig(favorite=True)]}),
+    })
+    assert summary["stamped"] is False
+    assert db.stamped == 0
+
+
+def test_every_server_failing_is_recorded_as_an_incomplete_sweep():
+    """The failure is written down rather than left implicit: an absent record
+    and a failed sweep both have to keep the cleaner's hands off, and only one
+    of them can say why."""
     db = _DB()
     summary = sync_curation_signals(db, {
         "navidrome": _Client(raises=True),
         "jellyfin": _Client(raises=True),
     })
     assert summary["servers"] == []
-    assert db.stamped == 0
+    assert summary["stamped"] is False
+    assert db.status["complete"] is False
+    assert db.status["failed"] == ["jellyfin", "navidrome"]
 
 
 # ── multi-user credentials (phase 3) ──────────────────────────────────────

--- a/tests/quality/test_quality_profiles_crud.py
+++ b/tests/quality/test_quality_profiles_crud.py
@@ -354,3 +354,139 @@ def test_apply_quality_profile_to_settings_pushes_into_config_manager(db, monkey
 
 def test_apply_quality_profile_to_settings_returns_none_for_unknown_id(db):
     assert db.apply_quality_profile_to_settings(999999) is None
+
+
+# ---------------------------------------------------------------------------
+# The write-through only touches what the caller actually sent (#1103)
+# ---------------------------------------------------------------------------
+
+_BUNDLE_ON = {
+    "acoustid_required": 1,
+    "downsample_enabled": 1,
+    "deep_audio_verify": 1,
+    "replace_lower_quality": 1,
+    "lossy_copy_enabled": 1,
+    "lossy_copy_codec": "opus",
+    "lossy_copy_bitrate": "256",
+    "lossy_copy_delete_original": 1,
+}
+
+# Exactly what settings.js::collectQualityProfileFromUI() posts to
+# POST /api/quality-profile — the ladder and nothing else.
+_LADDER_ONLY = {
+    "version": 3,
+    "preset": "custom",
+    "fallback_enabled": True,
+    "search_mode": "priority",
+    "rank_candidates_by_quality": False,
+    "upgrade_policy": "acceptable",
+    "upgrade_cutoff_index": 0,
+    "ranked_targets": [{"format": "flac"}],
+}
+
+
+def _arm_bundle(db):
+    """Turn every non-ladder setting on, the way the profile CRUD would."""
+    conn = db._get_connection()
+    try:
+        conn.execute(
+            "UPDATE quality_profiles SET "
+            + ", ".join(f"{c}=?" for c in _BUNDLE_ON)
+            + " WHERE is_default=1",
+            tuple(_BUNDLE_ON.values()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _bundle_row(db):
+    conn = db._get_connection()
+    try:
+        row = conn.execute(
+            "SELECT * FROM quality_profiles WHERE is_default=1").fetchone()
+        return {c: row[c] for c in _BUNDLE_ON}
+    finally:
+        conn.close()
+
+
+def test_a_ladder_only_save_does_not_reset_the_other_settings(db):
+    """The Settings page posts six fields; the row holds fourteen.
+
+    Coercing the eight it never mentions would turn lossy-copy, AcoustID
+    strictness and replace-lower-quality off every time somebody reordered the
+    target ladder — and those eight are owned by the config, which reaches this
+    row through sync_default_quality_profile_from_config().
+    """
+    _arm_bundle(db)
+
+    assert db.set_quality_profile(dict(_LADDER_ONLY)) is True
+
+    assert _bundle_row(db) == _BUNDLE_ON
+
+
+def test_a_preset_apply_does_not_reset_them_either(db):
+    """A Quick Set preset carries fewer keys still (ranked_targets, preset,
+    version, fallback_enabled, qualities) — same rule applies."""
+    _arm_bundle(db)
+
+    assert db.set_quality_profile(db.get_quality_preset("lossless")) is True
+
+    assert _bundle_row(db) == _BUNDLE_ON
+
+
+def test_naming_a_field_writes_it_including_switching_it_off(db):
+    """Presence decides, not truthiness — otherwise a caller could turn these
+    on but never off, which is the half-working state #1103 reported."""
+    _arm_bundle(db)
+
+    assert db.set_quality_profile({
+        **_LADDER_ONLY,
+        "replace_lower_quality": False,
+        "lossy_copy_enabled": False,
+        "lossy_copy_codec": "aac",
+    }) is True
+
+    row = _bundle_row(db)
+    assert row["replace_lower_quality"] == 0
+    assert row["lossy_copy_enabled"] == 0
+    assert row["lossy_copy_codec"] == "aac"
+    # Untouched keys keep their value.
+    assert row["acoustid_required"] == 1
+    assert row["lossy_copy_bitrate"] == "256"
+    assert row["lossy_copy_delete_original"] == 1
+
+
+def test_a_full_get_payload_round_trips(db):
+    """GET returns all fourteen; posting that back must be a no-op rather than
+    dropping the eight the endpoint used to ignore."""
+    _arm_bundle(db)
+    before = db.get_quality_profile()
+
+    assert db.set_quality_profile(before) is True
+
+    after = db.get_quality_profile()
+    for field in _BUNDLE_ON:
+        assert after[field] == before[field], field
+
+
+def test_the_ladder_is_still_written_unconditionally(db):
+    """Guard for the sparse UPDATE: the six ladder columns must never fall out
+    of the statement just because the bundle ones did."""
+    assert db.set_quality_profile({
+        **_LADDER_ONLY,
+        "fallback_enabled": False,
+        "search_mode": "best_quality",
+        "rank_candidates_by_quality": True,
+        "upgrade_policy": "until_cutoff",
+        "upgrade_cutoff_index": 2,
+        "ranked_targets": [{"label": "Only FLAC", "format": "flac"}],
+    }) is True
+
+    reloaded = db.get_quality_profile()
+    assert reloaded["fallback_enabled"] is False
+    assert reloaded["search_mode"] == "best_quality"
+    assert reloaded["rank_candidates_by_quality"] is True
+    assert reloaded["upgrade_policy"] == "until_cutoff"
+    assert reloaded["upgrade_cutoff_index"] == 2
+    assert reloaded["ranked_targets"] == [{"label": "Only FLAC", "format": "flac"}]

--- a/tests/test_curation_signals_storage.py
+++ b/tests/test_curation_signals_storage.py
@@ -148,16 +148,61 @@ def test_a_signal_matches_across_a_docker_style_path_difference(db):
 
 # ── the stale guard ───────────────────────────────────────────────────────
 
-def test_never_synced_falls_back_to_the_old_behaviour(db):
-    """Curation was never set up on this install, so the job works exactly as
-    it did before the feature existed — retention plus play count.
+def test_never_synced_keeps_everything(db):
+    """L2-001: curation is ON (the default) and no sweep has ever completed, so
+    we do not know what anyone favourited. That is not the same as "nobody
+    favourited anything", and this job deletes files.
 
-    This is deliberately NOT treated as "unknown, keep everything": that would
-    silently make the job do nothing for every user who never turns curation
-    on, which is a functional regression dressed up as safety."""
+    The sweep is scheduled by the same settings that enable this job, so the
+    state resolves itself on the next media-server poll. An install with no
+    media server turns ``use_curation_signals`` off — see the test below — and
+    gets the pre-feature behaviour back immediately."""
     _download(db)
     _track(db)
+    assert _scan(db) == []
+
+
+def test_a_sweep_that_found_no_capable_server_is_not_a_blocker(db):
+    """The other half of L2-001's "pending" rule. Once the sweep has actually
+    run and reported that no configured server can produce curation signals,
+    there is nothing for the feature to protect and the job must work normally
+    — otherwise it would be permanently disabled on those installs."""
+    _download(db)
+    _track(db)
+    db.mark_curation_sync({'complete': True, 'expected_servers': [],
+                           'servers': [], 'failed': []})
     assert len(_scan(db)) == 1
+
+
+def test_an_incomplete_sweep_keeps_everything(db):
+    """A sweep where one server or one user failed produced a snapshot that
+    says those people like nothing. Stamping it fresh anyway is what deleted
+    favourited files."""
+    _download(db)
+    _track(db)
+    db.mark_curation_sync({'complete': False, 'expected_servers': ['plex'],
+                           'servers': [], 'failed': ['plex/bob']})
+    assert _scan(db) == []
+
+
+def test_a_corrupt_status_record_keeps_everything(db):
+    _download(db)
+    _track(db)
+    db.set_preference(db.CURATION_STATUS_KEY, 'not json')
+    assert _scan(db) == []
+
+
+def test_unreadable_signals_keep_everything(db, monkeypatch):
+    """The read used to swallow its error and return {}, which the cleaner read
+    as "nobody curated anything"."""
+    _download(db)
+    _track(db)
+    db.mark_curation_sync({'complete': True, 'expected_servers': ['plex'],
+                           'servers': ['plex'], 'failed': []})
+    monkeypatch.setattr(
+        type(db), 'get_curation_signals_by_track_key',
+        lambda self: (_ for _ in ()).throw(RuntimeError("no such table")))
+    assert _scan(db) == []
 
 
 def test_a_stale_sweep_keeps_everything(db):
@@ -172,7 +217,17 @@ def test_a_stale_sweep_keeps_everything(db):
     assert _scan(db, curation_max_age_hours=48) == []
 
 
-def test_a_fresh_sweep_allows_deletion(db):
+def test_a_fresh_complete_sweep_allows_deletion(db):
+    _download(db)
+    _track(db)
+    db.mark_curation_sync({'complete': True, 'expected_servers': ['plex'],
+                           'servers': ['plex'], 'failed': []})
+    assert len(_scan(db)) == 1
+
+
+def test_a_bare_legacy_stamp_still_allows_deletion(db):
+    """An adapter/caller that only writes the timestamp keeps working: a stamp
+    with no structured record is still a completed sweep."""
     _download(db)
     _track(db)
     db.mark_curation_sync()

--- a/tests/test_expired_cleanup_rebuild_safety.py
+++ b/tests/test_expired_cleanup_rebuild_safety.py
@@ -137,8 +137,12 @@ class _Ctx:
 def _scan(db, settings=None):
     job = ExpiredDownloadCleanerJob()
     ctx = _Ctx(db)
+    # These tests are about the rebuild stamp and play_count, not curation.
+    # Curation defaults ON and blocks every deletion until a sweep has
+    # completed (L2-001), which would make every case here trivially pass.
     merged = {"watchlist_retention": "1w", "playlist_retention": "1w",
-              "keep_if_played_at_least": 2, "dry_run": True}
+              "keep_if_played_at_least": 2, "dry_run": True,
+              "use_curation_signals": False}
     merged.update(settings or {})
     job._get_settings = lambda _c: merged
     job.scan(ctx)

--- a/tests/test_metasync_export.py
+++ b/tests/test_metasync_export.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import sqlite3
+from urllib.parse import urlencode
 
 import pytest
 from flask import Flask
@@ -116,7 +117,10 @@ def client(db, monkeypatch):
 
 
 def _get(client, **params):
-    qs = "&".join(f"{k}={v}" for k, v in params.items() if v not in (None, ""))
+    # urlencode, not string concatenation: a '+' in a raw query string is a
+    # SPACE, which silently mangles both an offset like +02:00 and a base64
+    # cursor before the route ever sees them.
+    qs = urlencode({k: v for k, v in params.items() if v not in (None, "")})
     return client.get(f"/api/v1/metasync/export?{qs}",
                       headers={"Authorization": f"Bearer {RAW_KEY}"})
 
@@ -174,6 +178,133 @@ def test_since_filters_to_changed_rows(db, client):
 
     everything = _get(client, entity="artist").get_json()["data"]["items"]
     assert len(everything) == 2
+
+
+def test_a_same_day_change_is_not_lost_to_a_text_comparison(db, client):
+    """L2-010: SQLite writes CURRENT_TIMESTAMP as 'YYYY-MM-DD HH:MM:SS' while
+    the API takes ISO-8601 with a 'T'. Compared as text, 'T' > ' ', so asking
+    for everything since midnight silently returned nothing from that same
+    day — a permanent hole in every consumer's incremental feed."""
+    _seed(db, artists=1, albums_per_artist=0, tracks_per_album=0)
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET updated_at = ? WHERE id = ?",
+                 ("2026-08-21 12:00:00", "ar000"))
+    conn.commit()
+
+    for since in ("2026-08-21T00:00:00", "2026-08-21 00:00:00",
+                  "2026-08-21T00:00:00Z"):
+        items = _get(client, entity="artist", since=since).get_json()["data"]["items"]
+        assert [i["soul_id"] for i in items] == ["soul_artist_0"], since
+
+
+def test_offsets_are_compared_as_instants_not_as_text(db, client):
+    """13:00+02:00 is 11:00 UTC, so a row stamped 11:30 UTC is after it — but
+    ranked as text the offset string decided the answer instead."""
+    _seed(db, artists=1, albums_per_artist=0, tracks_per_album=0)
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET updated_at = ? WHERE id = ?",
+                 ("2026-08-21 11:30:00", "ar000"))
+    conn.commit()
+
+    included = _get(client, entity="artist",
+                    since="2026-08-21T13:00:00+02:00").get_json()["data"]["items"]
+    assert [i["soul_id"] for i in included] == ["soul_artist_0"]
+
+    excluded = _get(client, entity="artist",
+                    since="2026-08-21T14:00:00+02:00").get_json()["data"]["items"]
+    assert excluded == []
+
+
+def test_the_boundary_itself_is_included(db, client):
+    _seed(db, artists=1, albums_per_artist=0, tracks_per_album=0)
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET updated_at = ? WHERE id = ?",
+                 ("2026-08-21 12:00:00", "ar000"))
+    conn.commit()
+
+    items = _get(client, entity="artist",
+                 since="2026-08-21T12:00:00").get_json()["data"]["items"]
+    assert [i["soul_id"] for i in items] == ["soul_artist_0"]
+
+
+# ── L2-011: the change feed has to cover the whole payload ────────────────
+
+def _touch(db, table, row_id, when):
+    conn = db._get_connection()
+    conn.execute(f"UPDATE {table} SET updated_at = ? WHERE id = ?", (when, row_id))
+    conn.commit()
+
+
+def _incremental(client, entity, since):
+    return [i["soul_id"] for i in
+            _get(client, entity=entity, since=since).get_json()["data"]["items"]]
+
+
+def test_an_artist_rename_invalidates_its_albums_and_tracks(db, client):
+    """The album payload carries the artist's NAME and the track payload carries
+    the artist name plus the album title. Renaming an artist rewrites what the
+    export says about every one of its children while touching none of their
+    timestamps, so a consumer that had already walked them was never told."""
+    _seed(db, artists=1, albums_per_artist=1, tracks_per_album=1)
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET name = 'Renamed', updated_at = ? WHERE id = 'ar000'",
+                 ("2026-08-21 12:00:00",))
+    conn.commit()
+
+    since = "2026-08-21T00:00:00"
+    assert _incremental(client, "album", since) == ["soul_album_0_0"]
+    assert _incremental(client, "track", since) == ["soul_track_0_0_0"]
+
+
+def test_an_album_retitle_invalidates_its_tracks(db, client):
+    """A track's payload carries its album's title and year."""
+    _seed(db, artists=1, albums_per_artist=1, tracks_per_album=1)
+    _touch(db, "albums", "al000000", "2026-08-21 12:00:00")
+
+    assert _incremental(client, "track", "2026-08-21T00:00:00") == ["soul_track_0_0_0"]
+
+
+def test_an_untouched_child_is_still_left_out(db, client):
+    """The widened predicate must not turn the incremental export into a full
+    one: nothing changed anywhere, so nothing comes back."""
+    _seed(db, artists=1, albums_per_artist=1, tracks_per_album=1)
+
+    assert _incremental(client, "album", "2026-08-21T00:00:00") == []
+    assert _incremental(client, "track", "2026-08-21T00:00:00") == []
+
+
+def test_minting_a_soul_id_makes_the_row_appear_in_the_incremental(db, client):
+    """A row with no soul_id is filtered OUT of the export entirely, so minting
+    one is the moment it starts existing for consumers. The SoulID worker used
+    to write it without touching updated_at, so a full walk that ran before the
+    worker meant the row never appeared in any later incremental either."""
+    from core.soulid_worker import SoulIDWorker  # noqa: F401  (import guard only)
+
+    _seed(db, artists=1, albums_per_artist=0, tracks_per_album=0)
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET soul_id = NULL WHERE id = 'ar000'")
+    conn.commit()
+    assert _incremental(client, "artist", "2026-08-01T00:00:00") == []
+
+    # What the worker's write now does, verbatim.
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET soul_id = ?, soul_id_path = ?, "
+                 "updated_at = CURRENT_TIMESTAMP "
+                 "WHERE id = ? AND (soul_id IS NULL OR soul_id = '')",
+                 ("soul_artist_0", "canonical", "ar000"))
+    conn.commit()
+
+    assert _incremental(client, "artist", "2026-08-01T00:00:00") == ["soul_artist_0"]
+
+
+def test_a_canonical_claim_shows_up_in_the_incremental(db, client):
+    """canonical_source/canonical_album_id are exported fields."""
+    _seed(db, artists=1, albums_per_artist=1, tracks_per_album=0)
+    assert _incremental(client, "album", "2026-08-21T00:00:00") == []
+
+    assert db.set_album_canonical("al000000", "musicbrainz", "mb-1", 0.9) is True
+
+    assert _incremental(client, "album", "2026-08-21T00:00:00") == ["soul_album_0_0"]
 
 
 # ── unpublishable rows are never served ───────────────────────────────────

--- a/tests/test_quality_profile_preview_nudge.py
+++ b/tests/test_quality_profile_preview_nudge.py
@@ -1,0 +1,124 @@
+"""Editing a profile-captured toggle while previewing somebody else's profile
+must say so.
+
+The Settings -> Quality page owns two kinds of control. The ranked-target
+ladder saves through `debouncedSaveQualityProfile`, which already refuses to
+write while a non-default profile is previewed and shows the editing banner
+instead. The other eight (AcoustID strictness, downsample, deep verify,
+replace-lower-quality and the lossy-copy group) are ordinary config keys saved
+by the whole-page `saveSettings`, and that one substitutes the real default's
+stored values back in for exactly those keys before sending — so the edit is
+correctly NOT written anywhere.
+
+Correct, but silent: the user toggled something, no banner appeared, and the
+value read Off again after switching profiles and back. These assertions pin
+the nudge that closes the gap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def settings_js() -> str:
+    return (ROOT / "webui" / "static" / "settings.js").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def index_html() -> str:
+    return (ROOT / "webui" / "index.html").read_text(
+        encoding="utf-8", errors="replace")
+
+
+# The eight controls a profile captures beyond the ladder. Same list as
+# settings.js::collectFullQualityBundleFromUI reads.
+BUNDLE_CONTROL_IDS = (
+    "acoustid-require-verified",
+    "downsample-hires",
+    "audio-completeness-check",
+    "import-replace-lower-quality",
+    "lossy-copy-enabled",
+    "lossy-copy-codec",
+    "lossy-copy-bitrate",
+    "lossy-copy-delete-original",
+)
+
+
+@pytest.mark.parametrize("control_id", BUNDLE_CONTROL_IDS)
+def test_every_profile_captured_control_is_in_the_nudge_set(settings_js, control_id):
+    """A control missing here edits silently again — the exact bug."""
+    start = settings_js.index("_QP_BUNDLE_CONTROL_IDS = new Set([")
+    end = settings_js.index("]);", start)
+    assert f"'{control_id}'" in settings_js[start:end]
+
+
+@pytest.mark.parametrize("control_id", BUNDLE_CONTROL_IDS)
+def test_the_nudge_set_matches_what_the_profile_actually_captures(settings_js,
+                                                                  control_id):
+    """Guard against the two lists drifting: every id in the nudge set must
+    really be read by collectFullQualityBundleFromUI."""
+    start = settings_js.index("function collectFullQualityBundleFromUI()")
+    end = settings_js.index("\n}", start)
+    assert f"'{control_id}'" in settings_js[start:end]
+
+
+def test_the_settings_autosave_runs_the_nudge(settings_js):
+    """It has to hang off the whole-page autosave, not the quality one — those
+    eight controls never reach debouncedSaveQualityProfile."""
+    start = settings_js.index("function debouncedAutoSaveSettings(event)")
+    end = settings_js.index("\n}", start)
+    body = settings_js[start:end]
+    assert "_qpNudgeIfEditingForeignProfile(event)" in body
+    # The event is what identifies the control; a no-arg signature cannot tell
+    # a lossy-copy toggle from a Plex URL.
+    assert "debouncedAutoSaveSettings(event)" in settings_js
+
+
+def test_the_nudge_only_fires_for_a_foreign_profile(settings_js):
+    """Editing the live default is the normal case and must stay quiet."""
+    start = settings_js.index("function _qpNudgeIfEditingForeignProfile(event)")
+    end = settings_js.index("\n}", start)
+    body = settings_js[start:end]
+    assert "_qpEditingProfileId === null" in body
+    assert "_qpEditingProfileId === _qpDefaultProfileId()" in body
+    assert "qpShowEditingBanner()" in body
+
+
+def test_the_nudge_does_not_block_the_save(settings_js):
+    """saveSettings already substitutes the default's values back in for these
+    keys, so the save is a no-op for them — skipping it outright would drop
+    whatever unrelated edit was debounced alongside."""
+    start = settings_js.index("function _qpNudgeIfEditingForeignProfile(event)")
+    end = settings_js.index("\n}", start)
+    body = settings_js[start:end]
+    # It may return early (nothing to say), but it must never report back.
+    assert "return true" not in body and "return false" not in body
+
+
+def test_the_substitution_block_that_makes_the_nudge_honest_is_still_there(
+        settings_js):
+    """If this ever goes away the nudge becomes a lie: the edit WOULD then be
+    written, straight into the wrong profile."""
+    for line in (
+        "settings.acoustid.require_verified = !!def.acoustid_required",
+        "settings.import.replace_lower_quality = !!def.replace_lower_quality",
+        "settings.post_processing.audio_completeness_check = !!def.deep_audio_verify",
+        "settings.lossy_copy.enabled = !!def.lossy_copy_enabled",
+    ):
+        assert line in settings_js
+
+
+def test_the_banner_tells_the_user_what_to_do(index_html):
+    """It used to say 'changes on the left', which is the ladder tiles — but
+    six of the eight controls this now fires for live in completely different
+    sections of the page."""
+    start = index_html.index('id="qp-editing-banner"')
+    end = index_html.index("</div>", start)
+    banner = index_html[start:end]
+    assert "on this page" in banner
+    assert "✎" in banner

--- a/tests/test_soulid_path_migration.py
+++ b/tests/test_soulid_path_migration.py
@@ -1,0 +1,167 @@
+"""Backfilling ``artists.soul_id_path`` (L2-014).
+
+The column is additive, so every artist that already had a soul_id when it
+landed starts NULL — and nothing ever fills it: the worker only looks at
+artists with NO soul_id, and the id-algorithm migration returns early on an
+install that is already on the current version. MetaSync/Hydrabase then cannot
+tell a provider-canonical, reproducible artist key from a library-dependent
+album/name fallback.
+
+Regenerating the ids to find out is not an option: a soul_id is the shared
+content key peers have already traded claims about. Each path is PROVEN locally
+instead, and anything that cannot be proven is recorded as ``unknown`` rather
+than assumed canonical.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from core.soulid_worker import SoulIDWorker, generate_soul_id
+
+
+class _DB:
+    def __init__(self, path):
+        self.path = path
+
+    def _get_connection(self):
+        conn = sqlite3.connect(self.path)
+        return conn
+
+
+@pytest.fixture
+def db(tmp_path):
+    path = str(tmp_path / "soulid.db")
+    conn = sqlite3.connect(path)
+    conn.executescript("""
+        CREATE TABLE artists(id TEXT PRIMARY KEY, name TEXT, soul_id TEXT,
+                             soul_id_path TEXT, updated_at TIMESTAMP);
+        CREATE TABLE albums(id TEXT PRIMARY KEY, artist_id TEXT, title TEXT);
+        CREATE TABLE metadata(key TEXT PRIMARY KEY, value TEXT);
+    """)
+    conn.commit()
+    conn.close()
+    return _DB(path)
+
+
+def _worker(db):
+    worker = SoulIDWorker.__new__(SoulIDWorker)
+    worker.db = db
+    return worker
+
+
+def _artist(db, artist_id, name, soul_id, albums=()):
+    conn = db._get_connection()
+    conn.execute("INSERT INTO artists(id, name, soul_id) VALUES(?,?,?)",
+                 (artist_id, name, soul_id))
+    for i, title in enumerate(albums):
+        conn.execute("INSERT INTO albums(id, artist_id, title) VALUES(?,?,?)",
+                     (f"{artist_id}-al{i}", artist_id, title))
+    conn.commit()
+    conn.close()
+
+
+def _paths(db):
+    conn = db._get_connection()
+    try:
+        return dict(conn.execute("SELECT id, soul_id_path FROM artists").fetchall())
+    finally:
+        conn.close()
+
+
+def test_a_name_only_id_is_proven_and_labelled(db):
+    _artist(db, "a1", "Rone", generate_soul_id("Rone"))
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": "name"}
+
+
+def test_an_album_derived_id_is_proven_and_labelled(db):
+    _artist(db, "a1", "Rone", generate_soul_id("Rone", "Tohu Bohu"),
+            albums=("Tohu Bohu",))
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": "album"}
+
+
+def test_an_album_derived_id_survives_the_library_gaining_releases(db):
+    """The id was minted from the alphabetically-first album at the time. A
+    release added since would be first today, so only checking today's first
+    album would misread this as canonical and quietly upgrade its trust."""
+    _artist(db, "a1", "Rone", generate_soul_id("Rone", "Tohu Bohu"),
+            albums=("Aleph", "Tohu Bohu"))
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": "album"}
+
+
+def test_an_id_that_reproduces_neither_is_recorded_as_unproven(db):
+    """A canonical (provider-id derived) key looks exactly like an id whose
+    source album has since been deleted, so this is where the migration stops
+    guessing."""
+    _artist(db, "a1", "Rone", generate_soul_id("Rone", "1234567"),
+            albums=("Tohu Bohu",))
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": "unknown"}
+
+
+def test_an_existing_path_is_never_overwritten(db):
+    _artist(db, "a1", "Rone", generate_soul_id("Rone"))
+    conn = db._get_connection()
+    conn.execute("UPDATE artists SET soul_id_path='canonical'")
+    conn.commit()
+    conn.close()
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": "canonical"}
+
+
+def test_unnamed_placeholder_ids_are_left_alone(db):
+    _artist(db, "a1", "Rone", "soul_unnamed_a1")
+
+    _worker(db)._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": None}
+
+
+def test_it_runs_once_and_stamps_its_own_version(db):
+    _artist(db, "a1", "Rone", generate_soul_id("Rone"))
+    worker = _worker(db)
+
+    worker._migrate_artist_soul_id_paths()
+
+    conn = db._get_connection()
+    try:
+        assert conn.execute(
+            "SELECT value FROM metadata WHERE key=?",
+            (SoulIDWorker.PATH_MIGRATION_KEY,)).fetchone()[0] == \
+            SoulIDWorker.PATH_MIGRATION_VERSION
+        # A row that turns up NULL afterwards is not re-scanned.
+        conn.execute("UPDATE artists SET soul_id_path=NULL")
+        conn.commit()
+    finally:
+        conn.close()
+
+    worker._migrate_artist_soul_id_paths()
+
+    assert _paths(db) == {"a1": None}
+
+
+def test_a_database_without_the_column_is_a_no_op(db):
+    conn = db._get_connection()
+    conn.executescript("""
+        DROP TABLE artists;
+        CREATE TABLE artists(id TEXT PRIMARY KEY, name TEXT, soul_id TEXT);
+    """)
+    conn.commit()
+    conn.close()
+
+    _worker(db)._migrate_artist_soul_id_paths()  # must not raise

--- a/webui/index.html
+++ b/webui/index.html
@@ -4680,7 +4680,7 @@
                                 </div>
                                 <p class="qp-side-panel-hint">Click a profile's name to view/edit its settings on the left (this alone never activates it). Per row: ● set as the active default, ✏ rename, ✎ save the settings shown on the left into this profile, ⇩ use for Auto-Import instead of the default, × delete. "Manage" above shows what's active for what.</p>
                                 <div class="qp-editing-banner" id="qp-editing-banner" style="display:none">
-                                    Viewing <strong class="qp-editing-banner-name">this profile</strong> — not the active default. Changes on the left only save here once you click its ✎.
+                                    Viewing <strong class="qp-editing-banner-name">this profile</strong> — not the active default. Any quality setting you change on this page only saves into it once you click its ✎.
                                 </div>
                                 <div class="qp-profile-list" id="qp-profile-list">
                                     <!-- rows injected by renderCustomQualityProfiles() -->

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -78,11 +78,36 @@ function syncRetryConditionalRows() {
 }
 window.syncRetryConditionalRows = syncRetryConditionalRows;
 
-function debouncedAutoSaveSettings() {
+// The Settings -> Quality controls that a PROFILE captures but the whole-page
+// save sends as ordinary config keys. Editing one of these while previewing a
+// non-default profile is deliberately not persisted by the page save (see the
+// substitution block in saveSettings), so the edit only reaches the profile
+// once the user clicks that row's Update (v) button. Without a nudge that
+// looked like a silent failure: toggle it, switch profiles, come back, and it
+// reads Off again with nothing having told you why.
+const _QP_BUNDLE_CONTROL_IDS = new Set([
+    'acoustid-require-verified', 'downsample-hires', 'audio-completeness-check',
+    'import-replace-lower-quality', 'lossy-copy-enabled', 'lossy-copy-codec',
+    'lossy-copy-bitrate', 'lossy-copy-delete-original',
+]);
+
+// Show the "you are editing <profile>" banner when a profile-captured control
+// is edited while previewing somebody else's profile. Only a notice — the save
+// itself is left alone, because saveSettings already substitutes the real
+// default's values back in for exactly these keys.
+function _qpNudgeIfEditingForeignProfile(event) {
+    const id = event && event.target && event.target.id;
+    if (!id || !_QP_BUNDLE_CONTROL_IDS.has(id)) return;
+    if (_qpEditingProfileId === null || _qpEditingProfileId === _qpDefaultProfileId()) return;
+    qpShowEditingBanner();
+}
+
+function debouncedAutoSaveSettings(event) {
     // Ignore changes made while the page is programmatically populating its
     // fields on load — those aren't user edits and must not trigger a full
     // save (which re-initializes every backend service client).
     if (window._suppressSettingsAutoSave) return;
+    _qpNudgeIfEditingForeignProfile(event);
     // ISOLATION: the video side reuses this shared settings page, so editing a
     // VIDEO field (TMDB key, region, autoplay…) would otherwise fire this MUSIC
     // auto-save — which reads the server toggle from the DOM and would persist


### PR DESCRIPTION
@Nezreka, was reviewing my library v2 branch against dev and found 16 things.. ten of those are the overhaul's own fault and stay in my branch. the other six are already sitting on dev and have nothing to do with library v2, so i pulled them out here.. this branch is straight off dev, doesn't touch a single lib2 file and depends on nothing else of mine.

all six have tests, full suite passes (14515).

## expired download cleaner can delete files people favourited (L2-001)

this is the one i'd take first.. it's supposed to spare anything someone favourited, rated or put in a playlist, but every db call it uses for that was fail open. write errors returned 0, read errors returned {}, and if one user failed halfway through a sweep it still stamped itself as a clean run..

all three look identical to the cleaner: nobody likes any of this.. and that's exactly when it starts deleting. so a db hiccup or a plex that's briefly down is enough to lose files.

storage calls raise now, the sweep records whether every expected server and user really got stored, and the cleaner won't delete without a complete fresh snapshot.. installs without a media server still work normally, that case gets recorded explicitly so it doesn't block forever.

## atomic album publish reports half albums as done (L2-002)

if file 3 of 10 fails, the first two stayed live and the batch was still marked Complete.. album half in the library, half in staging, and no retryable task left for the rest.

failed db repoints were only logged too, so the db kept pointing at a staging path the same publish deleted right after.. it's all or nothing now, any failure rolls everything back and the batch doesn't complete.

## a rate limit overwrites your manual matches (L2-005)

`honor_stored_match` returned False when the fetch failed.. and False means "no stored id, go search by name" to the worker. so one hiccup and the id you picked by hand gets replaced with whatever the fuzzy search came back with.

three states now, and an id only gets released by an explicit re match.. the failure goes in as `error` with a timestamp so backoff actually works.

## metasync `since` is compared as text (L2-010)

sqlite writes `updated_at` with a space, the api takes ISO with a T, and T sorts after space.. so "give me everything since midnight" returns nothing from today. with a cheerful 200 and an empty list, so it just looks like there were no changes.

normalised to UTC and compared through `julianday()` now.

## metasync incremental has holes (L2-011)

soul ids, canonical claims and album year updates all change the exported payload without touching `updated_at`.. and an album carries its artist's name while a track carries the album title, so renaming an artist rewrites payloads that then never get re exported.

those writers touch the timestamp now, and the filter looks at the parent rows too.

## soul_id_path never gets filled (L2-014)

additive column, so old rows are NULL and nothing ever fills them.. checked the history, the algorithm marker landed in march and the column in august, so basically every existing install has empty paths.

didn't want to regenerate the ids since peers already traded claims on them.. so there's a migration that recomputes each path to prove it, and writes `unknown` where it can't.

## unrelated

`pytest -n 8` is currently useless.. the xdist workers race in `video_database._ensure_columns` and you get hundreds of fake errors in suites that have nothing to do with any of this. serial runs are fine.
