### PR TITLE
fix(downloads,tests)

### DIFF
--- a/core/downloads/atomic_album_publish.py
+++ b/core/downloads/atomic_album_publish.py
@@ -26,6 +26,7 @@ Scope guardrails baked in here (defensive; the call sites also gate):
 from __future__ import annotations
 
 import os
+import re
 from typing import Callable, Dict, List, Optional, Tuple
 
 from utils.logging_config import get_logger
@@ -132,6 +133,31 @@ def album_folder_is_fresh(album_folder: str) -> bool:
         return False
 
 
+_DIGIT_RUN = re.compile(r"(\d+)")
+
+
+def _publish_order_key(path: str) -> tuple:
+    """Sort key that reads digit runs as NUMBERS, so 9 comes before 10 and 10
+    before 100.
+
+    Plain string order gets that wrong as soon as an album passes 99 tracks:
+    post-processing zero-pads track numbers to two digits, so a boxset's
+    "100 - Title.flac" sorts in among the ones, ahead of tracks 11-99. Rollback
+    stays correct either way -- it walks the files it actually moved, not this
+    list -- but the publish log of a partial failure is read by a human, and
+    "45 published, 100 failed" has to mean what it appears to say.
+
+    The raw path rides along as the final tiebreaker so two names differing only
+    in case or in leading zeros still get a stable order instead of falling back
+    on os.walk's.
+    """
+    chunks = tuple(
+        (1, int(chunk), "") if chunk.isdigit() else (0, 0, chunk.lower())
+        for chunk in _DIGIT_RUN.split(path)
+    )
+    return (chunks, path)
+
+
 def iter_staged_files(staging_root: str) -> List[str]:
     """Every real file under the staging root (audio + sidecars: art, .lrc, …),
     so publish moves the whole prepared album folder, not just the audio."""
@@ -152,7 +178,7 @@ def iter_staged_files(staging_root: str) -> List[str]:
     # 02 first, the failing track is the FIRST one, nothing has published yet,
     # and the rollback never runs. The guard for the db-pointer rollback passed
     # with the rollback deleted.
-    out.sort()
+    out.sort(key=_publish_order_key)
     return out
 
 

--- a/core/downloads/atomic_album_publish.py
+++ b/core/downloads/atomic_album_publish.py
@@ -141,6 +141,18 @@ def iter_staged_files(staging_root: str) -> List[str]:
     for root, _dirs, files in os.walk(staging_root):
         for name in files:
             out.append(os.path.join(root, name))
+    # SORTED, and it is load-bearing. os.walk hands back directory order, which
+    # is the filesystem's business and differs between machines: the same album
+    # publishes 01 then 02 on ext4 and 02 then 01 on btrfs. Publish order decides
+    # which files are already live when a later one fails, so it decides what the
+    # rollback has to undo — and an all-or-nothing publish whose behaviour under
+    # failure depends on the host filesystem cannot be reasoned about at all.
+    #
+    # It also silently disarmed the rollback tests below: on a box that walks
+    # 02 first, the failing track is the FIRST one, nothing has published yet,
+    # and the rollback never runs. The guard for the db-pointer rollback passed
+    # with the rollback deleted.
+    out.sort()
     return out
 
 

--- a/database/video_database.py
+++ b/database/video_database.py
@@ -489,11 +489,34 @@ class VideoDatabase:
 
     @staticmethod
     def _ensure_columns(conn) -> None:
-        """Add any new columns to an existing DB (idempotent ALTER TABLE)."""
+        """Add any new columns to an existing DB (idempotent ALTER TABLE).
+
+        The PRAGMA read is a hint, not the decision. It used to be the decision,
+        and that is a check-then-act: two processes opening the same video DB at
+        once both read "column absent", both ALTER, and the loser dies with
+        "duplicate column name" — which _initialize_database rolls back and
+        re-raises, so the whole database comes up unusable over a column that IS
+        now there. Reproduced by the test suite under `-n 8`, where every xdist
+        worker initialises the one shared temp DB; in production the same window
+        is a restart racing a still-running worker.
+
+        The error is swallowed ONLY for the duplicate, and only for the column
+        this iteration was adding: any other OperationalError (locked, no such
+        table, bad type) is still a real failure and still propagates. Losing
+        the race means somebody else did the work — which is exactly the
+        outcome asked for.
+        """
         for table, col, coltype in _COLUMN_MIGRATIONS:
             cols = {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
-            if col not in cols:
+            if col in cols:
+                continue
+            try:
                 conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {coltype}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
+                logger.debug(
+                    "video schema: %s.%s was added by another process mid-init", table, col)
 
     @staticmethod
     def _run_data_migrations(conn, prev_version: int) -> None:

--- a/tests/downloads/test_atomic_album_publish.py
+++ b/tests/downloads/test_atomic_album_publish.py
@@ -337,3 +337,27 @@ def test_iter_staged_files_finds_everything(tmp_path):
     _mk(Path(staging) / "cover.png")
     assert len(ap.iter_staged_files(staging)) == 3
     assert ap.iter_staged_files(str(tmp_path / "absent")) == []
+
+
+def test_publish_order_does_not_depend_on_the_filesystem(tmp_path):
+    """os.walk hands back DIRECTORY order, which differs between machines: the
+    tracks below come out 02-then-01 on btrfs and 01-then-02 on ext4.
+
+    Publish order decides which files are already live when a later one fails,
+    so it decides what the rollback has to undo — an all-or-nothing publish
+    whose behaviour under failure depends on the host filesystem cannot be
+    reasoned about. It also silently disarmed the two rollback tests above: on a
+    box that walks 02 first the failing track is the FIRST one, nothing has
+    published yet, and the rollback never runs, so
+    test_rollback_takes_the_db_pointer_back_with_the_file passed with the
+    rollback deleted.
+    """
+    staging = str(tmp_path / "stage")
+    for name in ("02.flac", "01.flac", "10.flac", "cover.png"):
+        _mk(Path(staging) / "A" / "Al" / name)
+
+    found = ap.iter_staged_files(staging)
+
+    assert found == sorted(found)
+    assert [os.path.basename(p) for p in found] == \
+        ["01.flac", "02.flac", "10.flac", "cover.png"]

--- a/tests/downloads/test_atomic_album_publish.py
+++ b/tests/downloads/test_atomic_album_publish.py
@@ -358,6 +358,40 @@ def test_publish_order_does_not_depend_on_the_filesystem(tmp_path):
 
     found = ap.iter_staged_files(staging)
 
-    assert found == sorted(found)
     assert [os.path.basename(p) for p in found] == \
         ["01.flac", "02.flac", "10.flac", "cover.png"]
+
+
+def test_publish_order_reads_track_numbers_as_numbers(tmp_path):
+    """Ordering is by track NUMBER, not by the spelling of the number.
+
+    post_processing zero-pads track numbers to a minimum of two digits, so an
+    album that runs past 99 gets "100 - Title.flac" alongside "09 - …", and a
+    plain string sort files 100 in among the ones. Rollback survives that (it
+    replays the files it really moved), but the publish log of a partial failure
+    is a human-readable record of what went live before what, and it has to
+    match the order the tracks are actually in.
+    """
+    staging = str(tmp_path / "stage")
+    for name in ("100 - c.flac", "09 - a.flac", "10 - b.flac", "99 - z.flac"):
+        _mk(Path(staging) / "A" / "Boxset" / name)
+
+    found = [os.path.basename(p) for p in ap.iter_staged_files(staging)]
+
+    assert found == ["09 - a.flac", "10 - b.flac", "99 - z.flac", "100 - c.flac"]
+    # ... which is exactly where a plain string sort disagrees.
+    assert found != sorted(found)
+
+
+def test_publish_order_is_total_even_for_names_that_only_differ_in_case(tmp_path):
+    """No pair of files may be left to os.walk to order. Folding case for the
+    numeric comparison introduces ties, so the raw path breaks them."""
+    staging = str(tmp_path / "stage")
+    for name in ("Track.flac", "track.flac"):
+        _mk(Path(staging) / "A" / "Al" / name)
+
+    first = ap.iter_staged_files(staging)
+    second = ap.iter_staged_files(staging)
+
+    assert first == second
+    assert len(first) == 2

--- a/tests/test_tidal_collection_tracks.py
+++ b/tests/test_tidal_collection_tracks.py
@@ -28,6 +28,7 @@ from unittest.mock import patch
 
 import pytest
 
+from core import tidal_client as tidal_client_mod
 from core.tidal_client import Track, Playlist, TidalClient
 
 
@@ -47,6 +48,20 @@ class _FakeResp:
 
     def json(self):
         return self._body
+
+
+class _RequestsShim:
+    """Stands in for `core.tidal_client`'s module-global ``requests`` for the
+    length of one call: ``.get`` is recorded, everything else (``.exceptions``,
+    ``.Session``, ...) falls through to the real module so any other tidal_client
+    code running in a background thread meanwhile is unaffected."""
+
+    def __init__(self, real, on_get):
+        self._real = real
+        self.get = on_get
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
 
 
 def _make_authed_client():
@@ -474,7 +489,25 @@ class TestGetPlaylistVirtualId:
 
         client.session = SimpleNamespace(get=_record, headers={})
 
-        with patch.object(client, 'get_collection_tracks', return_value=fake_collection), \
+        # Session traffic is not the only way out: six other HTTP call sites in
+        # core/tidal_client.py reach for the module-global `requests` directly,
+        # so a copy-paste of one of them into the virtual branch would leave
+        # `session_urls` empty and slip past. Rebind the NAME inside
+        # core.tidal_client rather than patching `requests.get` itself -- the
+        # shared requests module every background enrichment thread also calls
+        # through stays untouched, which is the whole reason this guard stopped
+        # being flaky, and the URL filter below keeps a concurrent Tidal worker
+        # from writing into the assertion.
+        module_urls: list[str] = []
+
+        def _record_module_get(url, *args, **kwargs):
+            module_urls.append(str(url))
+            return _FakeResp(404, text="not found")
+
+        shim = _RequestsShim(tidal_client_mod.requests, _record_module_get)
+
+        with patch.object(tidal_client_mod, 'requests', shim), \
+             patch.object(client, 'get_collection_tracks', return_value=fake_collection), \
              patch.object(client, '_ensure_valid_token') as mock_token:
             playlist = client.get_playlist("tidal-favorites")
 
@@ -488,6 +521,7 @@ class TestGetPlaylistVirtualId:
         # endpoint OR the auth precheck (get_collection_tracks
         # handles its own auth gate downstream).
         assert session_urls == []
+        assert [u for u in module_urls if "tidal-favorites" in u] == []
         assert not mock_token.called
 
     def test_real_playlist_id_falls_through_to_normal_path(self):

--- a/tests/test_tidal_collection_tracks.py
+++ b/tests/test_tidal_collection_tracks.py
@@ -457,9 +457,25 @@ class TestGetPlaylistVirtualId:
             Track(id='1002', name='Innerbloom', artists=['RÜFÜS DU SOL']),
         ]
 
+        # The real fallthrough issues `self.session.get(.../playlists/<id>)`,
+        # so THAT is what has to stay untouched. The guard used to patch
+        # `core.tidal_client.requests.get` instead — an object the code path
+        # under test cannot reach at all (get_collection_tracks, its only user
+        # here, is mocked out), while being the ONE shared requests module every
+        # background enrichment thread also calls through. It could not fail for
+        # the reason it claimed and could only fail for an unrelated one, which
+        # is exactly what happened: a live enrichment worker's request flipped
+        # `.called` and turned a Tidal playlist test red.
+        session_urls: list[str] = []
+
+        def _record(url, *args, **kwargs):
+            session_urls.append(str(url))
+            return _FakeResp(404, text="not found")
+
+        client.session = SimpleNamespace(get=_record, headers={})
+
         with patch.object(client, 'get_collection_tracks', return_value=fake_collection), \
-             patch.object(client, '_ensure_valid_token') as mock_token, \
-             patch('core.tidal_client.requests.get') as mock_get:
+             patch.object(client, '_ensure_valid_token') as mock_token:
             playlist = client.get_playlist("tidal-favorites")
 
         assert isinstance(playlist, Playlist)
@@ -471,7 +487,7 @@ class TestGetPlaylistVirtualId:
         # Virtual path should NOT touch the real /playlists/<id>
         # endpoint OR the auth precheck (get_collection_tracks
         # handles its own auth gate downstream).
-        assert not mock_get.called
+        assert session_urls == []
         assert not mock_token.called
 
     def test_real_playlist_id_falls_through_to_normal_path(self):

--- a/tests/test_vanilla_globals_resolve.py
+++ b/tests/test_vanilla_globals_resolve.py
@@ -40,6 +40,7 @@ now fails.
 from __future__ import annotations
 
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -122,7 +123,15 @@ def test_no_new_unresolved_globals(filename, tmp_path):
     }
     # oxlint resolves -c relative to its own cwd and cannot read a WSL /tmp path
     # from a Windows binary, so the config lands inside the project.
-    config_path = _WEBUI / ".oxlintrc.globalcheck.json"
+    #
+    # ONE FILE PER CASE. A single shared name was fine while this test ran alone
+    # and is not fine under `-n 8`: 43 parametrized cases spread over 8 xdist
+    # workers wrote DIFFERENT global sets to the same path and unlinked it under
+    # each other, so a case linted its neighbour's globals and reported no-undef
+    # for names that were legitimately excluded — 24 red files, every one of
+    # them fine. The script name is already unique per case; the pid keeps two
+    # concurrent runs apart as well.
+    config_path = _WEBUI / f".oxlintrc.globalcheck.{os.getpid()}.{filename}.json"
     config_path.write_text(json.dumps(config), encoding="utf-8")
     try:
         proc = subprocess.run(

--- a/tests/test_video_db_install_race.py
+++ b/tests/test_video_db_install_race.py
@@ -76,3 +76,63 @@ def test_install_survives_concurrent_lazy_create(monkeypatch):
     assert videoapi.get_video_db() is sentinel
     # The leaked thread still got a usable handle for its own dying breath.
     assert isinstance(lazy_result.get("db"), _SlowDB)
+
+
+# ── the schema half of the same problem ────────────────────────────────────
+
+
+def test_a_column_another_process_added_mid_init_is_not_fatal(tmp_path, monkeypatch):
+    """_ensure_columns was a check-then-act, and two processes opening the same
+    video DB is not hypothetical.
+
+    Reproduced by this suite under `-n 8`: every xdist worker initialises the
+    one shared temp DB, so several read "channel_id absent", several ALTER, and
+    the losers die with `duplicate column name: channel_id`. That error was not
+    contained — _initialize_database rolls back and re-raises it, so the whole
+    video database came up unusable over a column that IS now there, and 29
+    tests errored in setup. In production the same window is a restart racing a
+    still-running enrichment worker.
+
+    Deterministic, and with real sqlite: the other connection is made to win
+    between this one's PRAGMA and its ALTER, which is precisely the window.
+    """
+    import sqlite3
+
+    import database.video_database as vdb
+
+    path = str(tmp_path / "v.db")
+    mine = sqlite3.connect(path)
+    mine.execute("CREATE TABLE videos(id INTEGER PRIMARY KEY)")
+    mine.commit()
+    theirs = sqlite3.connect(path)
+
+    class _LosesTheRace:
+        def execute(self, sql, *args):
+            if " ADD COLUMN " in sql:
+                theirs.execute(sql)          # the other process gets there first
+                theirs.commit()
+            return mine.execute(sql, *args)
+
+    monkeypatch.setattr(vdb, "_COLUMN_MIGRATIONS", [("videos", "channel_id", "TEXT")])
+
+    vdb.VideoDatabase._ensure_columns(_LosesTheRace())  # must not raise
+
+    assert "channel_id" in {r[1] for r in mine.execute("PRAGMA table_info(videos)")}
+
+
+def test_any_other_alter_failure_still_propagates(tmp_path, monkeypatch):
+    """Only the duplicate is swallowed. A missing table, a locked database or a
+    bad type is a real migration failure and must still take the init down —
+    otherwise this becomes a blanket `except OperationalError: pass` and the
+    next genuine schema break ships as a silently half-migrated database."""
+    import sqlite3
+
+    import pytest as _pytest
+
+    import database.video_database as vdb
+
+    mine = sqlite3.connect(str(tmp_path / "v.db"))
+    monkeypatch.setattr(vdb, "_COLUMN_MIGRATIONS", [("gone", "channel_id", "TEXT")])
+
+    with _pytest.raises(sqlite3.OperationalError, match="no such table"):
+        vdb.VideoDatabase._ensure_columns(mine)

--- a/tests/test_watchlist_blind_source_fallthrough.py
+++ b/tests/test_watchlist_blind_source_fallthrough.py
@@ -63,6 +63,19 @@ def scan(monkeypatch):
         monkeypatch.setattr(ws, 'get_client_for_source', lambda s, **kw: clients.get(s))
 
         scanner = ws.WatchlistScanner.__new__(ws.WatchlistScanner)
+        # PIN THE CHAIN. Every assertion below is about the ORDER sources are
+        # asked in, and the un-preferred path derives that from
+        # get_primary_source() — which reads the shared, process-wide
+        # config_manager. Any earlier test in the same xdist worker that sets a
+        # different primary source silently reorders this one's chain, and the
+        # failure reads as a real regression ("walked on past a source that
+        # answered correctly", calls == ['itunes']) rather than as leakage.
+        # Caught under `-n 8`; the default this pins to is what the tests always
+        # meant. The `preferred` path deliberately keeps the real
+        # get_source_priority — that IS what test_per_artist_override_still_wins
+        # is checking.
+        scanner._watchlist_source_priority = lambda: list(
+            ws.get_source_priority('deezer'))
         scanner._get_lookback_period_setting = lambda: '30'
         scanner._get_rescan_cutoff = lambda: None
         scanner._rescan_cutoff_log_marker = None

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -2,3 +2,9 @@
 node_modules
 static/dist
 test-results
+
+# Per-case oxlint config written by tests/test_vanilla_globals_resolve.py. It
+# has to live here (oxlint resolves -c against its own cwd and a Windows binary
+# cannot read a WSL /tmp path) and is unlinked on the way out — but a killed run
+# leaves one behind, and 43 of them would otherwise show up as untracked.
+.oxlintrc.globalcheck.*.json

--- a/webui/src/platform/artwork-thumb.test.ts
+++ b/webui/src/platform/artwork-thumb.test.ts
@@ -23,7 +23,9 @@ describe('thumb', () => {
 
   it('leaves other local paths alone', () => {
     expect(thumb('/static/placeholder-album.png', 'grid')).toBe('/static/placeholder-album.png');
-    expect(thumb('/api/video/poster/movie/12?w=300', 'grid')).toBe('/api/video/poster/movie/12?w=300');
+    expect(thumb('/api/video/poster/movie/12?w=300', 'grid')).toBe(
+      '/api/video/poster/movie/12?w=300',
+    );
   });
 
   it('does not add a second query string', () => {

--- a/webui/src/platform/artwork-thumb.wiring.test.ts
+++ b/webui/src/platform/artwork-thumb.wiring.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
 /**

--- a/webui/src/routes/active-downloads/-adl.use-verification.test.tsx
+++ b/webui/src/routes/active-downloads/-adl.use-verification.test.tsx
@@ -305,7 +305,6 @@ describe('grouping alternative candidates', () => {
   });
 });
 
-
 /**
  * TheHomeGuy: "the number at the top didnt update till i happened to click into
  * the area to check for songs."

--- a/webui/src/routes/active-downloads/-ui/adl-row-detail.test.tsx
+++ b/webui/src/routes/active-downloads/-ui/adl-row-detail.test.tsx
@@ -128,7 +128,12 @@ describe('liveDetailLines', () => {
           source: 'Soulseek',
           username: 'slow_peer',
           filename: 'a.flac',
-          picked: { quality: 'flac', queue_length: 40, free_upload_slots: 0, upload_speed: 2097152 },
+          picked: {
+            quality: 'flac',
+            queue_length: 40,
+            free_upload_slots: 0,
+            upload_speed: 2097152,
+          },
           slskd_state: 'Queued, Remotely',
           queued_seconds: 45,
           tried_sources: 3,

--- a/webui/src/routes/artist-detail/-artist-detail.reassign.test.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.reassign.test.ts
@@ -10,20 +10,23 @@ import { albumBits, describeMapping, describeMatch } from './-artist-detail.reas
 
 describe('describeMapping', () => {
   it('says so plainly when everything lines up', () => {
-    expect(describeMapping({ success: true, mapped_count: 12, unmapped_count: 0 }))
-      .toBe('All 12 tracks line up');
+    expect(describeMapping({ success: true, mapped_count: 12, unmapped_count: 0 })).toBe(
+      'All 12 tracks line up',
+    );
   });
 
   it('names what would be LEFT BEHIND, not just what moves', () => {
     // The user is about to split their album if they proceed. Reporting only
     // "9 tracks line up" would read like success.
-    expect(describeMapping({ success: true, mapped_count: 9, unmapped_count: 3 }))
-      .toBe('9 of 12 tracks line up — 3 would stay with the current artist');
+    expect(describeMapping({ success: true, mapped_count: 9, unmapped_count: 3 })).toBe(
+      '9 of 12 tracks line up — 3 would stay with the current artist',
+    );
   });
 
   it('handles nothing at all without producing "0 of 0"', () => {
-    expect(describeMapping({ success: true, mapped_count: 0, unmapped_count: 0 }))
-      .toBe('Nothing to line up');
+    expect(describeMapping({ success: true, mapped_count: 0, unmapped_count: 0 })).toBe(
+      'Nothing to line up',
+    );
   });
 
   it('survives a payload with the counts missing', () => {
@@ -32,11 +35,18 @@ describe('describeMapping', () => {
 });
 
 describe('describeMatch', () => {
-  const base = { local_id: 1, local_title: 'x', local_track_number: 1, target_title: 'x',
-                 target_track_number: 1 };
+  const base = {
+    local_id: 1,
+    local_title: 'x',
+    local_track_number: 1,
+    target_title: 'x',
+    target_track_number: 1,
+  };
 
   it('explains WHY a pairing was proposed', () => {
-    expect(describeMatch({ ...base, mapped: true, matched_by: 'track_number' })).toBe('by track number');
+    expect(describeMatch({ ...base, mapped: true, matched_by: 'track_number' })).toBe(
+      'by track number',
+    );
     expect(describeMatch({ ...base, mapped: true, matched_by: 'title' })).toBe('by title');
   });
 
@@ -51,8 +61,9 @@ describe('describeMatch', () => {
 
 describe('albumBits', () => {
   it('reads as one line', () => {
-    expect(albumBits({ id: '1', name: 'X', year: '2019-03-04', album_type: 'album', total_tracks: 12 }))
-      .toBe('2019 · album · 12 tracks');
+    expect(
+      albumBits({ id: '1', name: 'X', year: '2019-03-04', album_type: 'album', total_tracks: 12 }),
+    ).toBe('2019 · album · 12 tracks');
   });
 
   it('skips blanks instead of leaving empty separators', () => {

--- a/webui/src/routes/artist-detail/-artist-detail.reassign.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.reassign.ts
@@ -67,16 +67,22 @@ async function getJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export async function searchReassignArtists(source: string, query: string): Promise<ReassignArtist[]> {
+export async function searchReassignArtists(
+  source: string,
+  query: string,
+): Promise<ReassignArtist[]> {
   const url = `/api/reassign/artists?source=${encodeURIComponent(source)}&q=${encodeURIComponent(query)}`;
   const data = await getJson<{ success: boolean; artists?: ReassignArtist[] }>(url);
-  return data.success ? data.artists ?? [] : [];
+  return data.success ? (data.artists ?? []) : [];
 }
 
-export async function fetchReassignAlbums(source: string, artistId: string): Promise<ReassignAlbum[]> {
+export async function fetchReassignAlbums(
+  source: string,
+  artistId: string,
+): Promise<ReassignAlbum[]> {
   const url = `/api/reassign/albums?source=${encodeURIComponent(source)}&artist_id=${encodeURIComponent(artistId)}`;
   const data = await getJson<{ success: boolean; albums?: ReassignAlbum[] }>(url);
-  return data.success ? data.albums ?? [] : [];
+  return data.success ? (data.albums ?? []) : [];
 }
 
 export async function previewReassign(body: {

--- a/webui/src/routes/artist-detail/-ui/album-meta-row.tsx
+++ b/webui/src/routes/artist-detail/-ui/album-meta-row.tsx
@@ -102,8 +102,6 @@ export function AlbumMetaRow({ album, isAdmin, onSaved }: Props) {
           </button>
         </div>
       ) : null}
-
-
     </div>
   );
 }

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -1,5 +1,6 @@
-import { thumb } from '@/platform/artwork-thumb';
 import { useEffect, useState } from 'react';
+
+import { thumb } from '@/platform/artwork-thumb';
 
 import type { EnhancedAlbum, EnhancedData } from '../-artist-detail.enhanced';
 

--- a/webui/src/routes/artist-detail/-ui/expanded-album-header.tsx
+++ b/webui/src/routes/artist-detail/-ui/expanded-album-header.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 
-import { ReassignModal } from './reassign-modal';
-
 import type { EnhancedAlbum, EnhancedTrack } from '../-artist-detail.enhanced';
 
 import {
@@ -21,6 +19,7 @@ import { analyzeAlbumReplayGainRequest } from '../-artist-detail.tags-rg';
 import { ArtPicker } from './art-picker';
 import { BatchTagPreviewModal } from './batch-tag-preview-modal';
 import { ManualMatchModal } from './manual-match-modal';
+import { ReassignModal } from './reassign-modal';
 import { ReorganizeModal } from './reorganize-modal';
 import { SmartDeleteDialog, ALBUM_DELETE_COPY } from './smart-delete-dialog';
 

--- a/webui/src/routes/artist-detail/-ui/reassign-modal.tsx
+++ b/webui/src/routes/artist-detail/-ui/reassign-modal.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useState } from 'react';
 
-import type {
-  ReassignAlbum,
-  ReassignArtist,
-  ReassignPreview,
-} from '../-artist-detail.reassign';
+import type { ReassignAlbum, ReassignArtist, ReassignPreview } from '../-artist-detail.reassign';
 
-import { fetchReidentifySources } from '../-artist-detail.reidentify';
 import {
   albumBits,
   applyReassign,
@@ -16,6 +11,7 @@ import {
   previewReassign,
   searchReassignArtists,
 } from '../-artist-detail.reassign';
+import { fetchReidentifySources } from '../-artist-detail.reidentify';
 
 /**
  * Reassign an album to a different artist.

--- a/webui/src/routes/automations/-automations.format.test.ts
+++ b/webui/src/routes/automations/-automations.format.test.ts
@@ -223,9 +223,9 @@ describe('automationMeta while the side is paused', () => {
   });
 
   it('says paused for both trigger kinds', () => {
-    expect(automationMeta({ ...base, trigger_type: 'schedule', enabled: 1 }, NOW, true).paused).toBe(
-      true,
-    );
+    expect(
+      automationMeta({ ...base, trigger_type: 'schedule', enabled: 1 }, NOW, true).paused,
+    ).toBe(true);
     expect(
       automationMeta({ ...base, trigger_type: 'app_started', enabled: 1 }, NOW, true).paused,
     ).toBe(true);
@@ -250,12 +250,11 @@ describe('automationMeta while the side is paused', () => {
   });
 
   it('defaults to not paused, so every existing caller keeps its behaviour', () => {
-    expect(automationMeta({ ...base, trigger_type: 'app_started', enabled: 1 }, NOW).listening).toBe(
-      true,
-    );
+    expect(
+      automationMeta({ ...base, trigger_type: 'app_started', enabled: 1 }, NOW).listening,
+    ).toBe(true);
   });
 });
-
 
 describe('automationOutcome — the handler stops speaking its own dialect', () => {
   it('says what a watchlist scan accomplished', () => {
@@ -337,9 +336,9 @@ describe('automationOutcome — the handler stops speaking its own dialect', () 
 
   it('does not claim a result for a run that handed off to a worker', () => {
     // discover_playlist returns status:'started' — the real outcome lands later.
-    expect(automationOutcome('discover_playlist', { status: 'started', playlist_count: '4' })).toEqual(
-      { text: 'Handed off — still working', kind: 'skipped' },
-    );
+    expect(
+      automationOutcome('discover_playlist', { status: 'started', playlist_count: '4' }),
+    ).toEqual({ text: 'Handed off — still working', kind: 'skipped' });
   });
 
   it('falls back to the generic facts for an action with no sentence', () => {

--- a/webui/src/routes/automations/-automations.format.ts
+++ b/webui/src/routes/automations/-automations.format.ts
@@ -135,7 +135,9 @@ const ACTION_SENTENCES: Record<string, Sentence> = {
     if (!found) return `Checked ${plural(scanned, 'file')}, no duplicates`;
     const freed = num(r.space_freed_mb);
     const tail = removed ? `removed ${plural(removed, 'file')}` : `${found} to review`;
-    return freed ? `Found ${found} duplicates, ${tail} (${freed} MB)` : `Found ${found} duplicates, ${tail}`;
+    return freed
+      ? `Found ${found} duplicates, ${tail} (${freed} MB)`
+      : `Found ${found} duplicates, ${tail}`;
   },
   // refreshed / errors
   refresh_mirrored: (r) => {
@@ -353,7 +355,9 @@ export function automationMeta(
     // `?? undefined` because lastResultFacts returns null for "nothing worth
     // showing", while every other field here uses undefined for absent.
     // Prefer a sentence over the handler's raw dict keys; falls back to them.
-    result: a.last_error ? undefined : (automationOutcome(a.action_type, a.last_result) ?? undefined),
+    result: a.last_error
+      ? undefined
+      : (automationOutcome(a.action_type, a.last_result) ?? undefined),
   };
 }
 

--- a/webui/src/routes/automations/-automations.helpers.test.ts
+++ b/webui/src/routes/automations/-automations.helpers.test.ts
@@ -170,7 +170,6 @@ describe('filterOptions', () => {
   });
 });
 
-
 describe('automationHealth — the verdict, not an inventory', () => {
   const a = (over: Record<string, unknown>) => ({ id: 1, name: 'a', ...over }) as never;
 
@@ -244,7 +243,6 @@ describe('filterAutomations with a health lens', () => {
     expect(out.map((r) => (r as { id: number }).id)).toEqual([1]);
   });
 });
-
 
 describe('sectionSummary — a collapsed family still says something', () => {
   const a = (over: Record<string, unknown>) => ({ id: 1, name: 'a', ...over }) as never;

--- a/webui/src/routes/automations/-ui/automation-card.test.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.test.tsx
@@ -208,14 +208,20 @@ describe('the schedule line answers the card‘s most-asked question', () => {
 
   it('stops an event automation claiming to Listen while paused', () => {
     render(
-      <AutomationCard paused automation={auto({ id: 1, enabled: 1, trigger_type: 'app_started' })} />,
+      <AutomationCard
+        paused
+        automation={auto({ id: 1, enabled: 1, trigger_type: 'app_started' })}
+      />,
     );
     expect(next().textContent).toBe('Paused');
   });
 
   it('says switched off rather than paused for an automation the user turned off', () => {
     render(
-      <AutomationCard paused automation={auto({ id: 1, enabled: 0, trigger_type: 'app_started' })} />,
+      <AutomationCard
+        paused
+        automation={auto({ id: 1, enabled: 0, trigger_type: 'app_started' })}
+      />,
     );
     expect(next().textContent).toBe('Switched off');
     expect(card().className).toContain('disabled');
@@ -223,7 +229,9 @@ describe('the schedule line answers the card‘s most-asked question', () => {
   });
 
   it('says Listening for an armed event automation', () => {
-    render(<AutomationCard automation={auto({ id: 1, enabled: 1, trigger_type: 'app_started' })} />);
+    render(
+      <AutomationCard automation={auto({ id: 1, enabled: 1, trigger_type: 'app_started' })} />,
+    );
     expect(next().textContent).toBe('Listening');
   });
 
@@ -366,7 +374,9 @@ describe('the cadence is editable on the card face', () => {
     );
     expect(editable()).toBeNull();
     unmount();
-    render(<AutomationCard automation={auto({ id: 2, enabled: 1, trigger_type: 'app_started' })} />);
+    render(
+      <AutomationCard automation={auto({ id: 2, enabled: 1, trigger_type: 'app_started' })} />,
+    );
     expect(editable()).toBeNull();
   });
 

--- a/webui/src/routes/automations/-ui/automation-card.tsx
+++ b/webui/src/routes/automations/-ui/automation-card.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import type { AutomationSchedule } from '../-automations.format';
 import type { Automation } from '../-automations.types';
 
-import type { AutomationSchedule } from '../-automations.format';
-
 import { updateAutomationTrigger } from '../-automations.api';
-import { automationMeta, automationSchedule, formatAction, formatTrigger } from '../-automations.format';
+import {
+  automationMeta,
+  automationSchedule,
+  formatAction,
+  formatTrigger,
+} from '../-automations.format';
 import { automationIcon, formatNotify } from '../-automations.icons';
 import {
   type AutomationRunState,
@@ -175,7 +179,11 @@ function TriggerCadence({
     if (editing) return;
     const raw = Number.parseInt(String(config.interval ?? 1), 10);
     setInterval(Number.isFinite(raw) && raw > 0 ? raw : 1);
-    setUnit((UNITS as readonly string[]).includes(String(config.unit)) ? (config.unit as IntervalUnit) : 'hours');
+    setUnit(
+      (UNITS as readonly string[]).includes(String(config.unit))
+        ? (config.unit as IntervalUnit)
+        : 'hours',
+    );
     setTime(typeof config.time === 'string' && config.time ? config.time : '00:00');
     // config is a fresh object identity each render; the values are the input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -189,7 +197,9 @@ function TriggerCadence({
         : { ...config, interval: Math.max(1, interval), unit };
       await updateAutomationTrigger(a.id, next);
       window.showToast?.(
-        daily ? `${a.name} now runs daily at ${time}` : `${a.name} now runs every ${interval} ${unit}`,
+        daily
+          ? `${a.name} now runs daily at ${time}`
+          : `${a.name} now runs every ${interval} ${unit}`,
         'success',
       );
       setEditing(false);
@@ -262,7 +272,12 @@ function TriggerCadence({
           </select>
         </>
       )}
-      <button type="button" className="auto-cadence-save" disabled={saving} onClick={() => void save()}>
+      <button
+        type="button"
+        className="auto-cadence-save"
+        disabled={saving}
+        onClick={() => void save()}
+      >
         {saving ? '…' : 'Save'}
       </button>
       <button type="button" className="auto-cadence-cancel" onClick={() => setEditing(false)}>

--- a/webui/src/routes/dashboard/-dash.automations.test.ts
+++ b/webui/src/routes/dashboard/-dash.automations.test.ts
@@ -2,8 +2,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { parseDbUtc } from './-dash.autosync';
 import { automationCardRows, triggerLabel } from './-dash.automations';
+import { parseDbUtc } from './-dash.autosync';
 
 const NOW = Date.parse('2026-08-11T12:00:00Z');
 
@@ -17,12 +17,44 @@ describe('parseDbUtc', () => {
 
 describe('triggerLabel', () => {
   it('covers the engine trigger map and falls back to events', () => {
-    expect(triggerLabel({ id: 1, trigger_type: 'schedule', trigger_config: { interval: 6, unit: 'hours' } })).toBe('Every 6 hours');
-    expect(triggerLabel({ id: 1, trigger_type: 'schedule', trigger_config: '{"interval": 2, "unit": "days"}' })).toBe('Every 2 days');
-    expect(triggerLabel({ id: 1, trigger_type: 'daily_time', trigger_config: { time: '04:30' } })).toBe('Daily @ 04:30');
-    expect(triggerLabel({ id: 1, trigger_type: 'weekly_time', trigger_config: { time: '09:00', days: ['mon'] } })).toBe('Mon @ 09:00');
-    expect(triggerLabel({ id: 1, trigger_type: 'monthly_time', trigger_config: { day: 15, time: '02:00' } })).toBe('Monthly · day 15 @ 02:00');
-    expect(triggerLabel({ id: 1, trigger_type: 'event', trigger_config: { event: 'watchlist.new_release' } })).toBe('On watchlist new release');
+    expect(
+      triggerLabel({
+        id: 1,
+        trigger_type: 'schedule',
+        trigger_config: { interval: 6, unit: 'hours' },
+      }),
+    ).toBe('Every 6 hours');
+    expect(
+      triggerLabel({
+        id: 1,
+        trigger_type: 'schedule',
+        trigger_config: '{"interval": 2, "unit": "days"}',
+      }),
+    ).toBe('Every 2 days');
+    expect(
+      triggerLabel({ id: 1, trigger_type: 'daily_time', trigger_config: { time: '04:30' } }),
+    ).toBe('Daily @ 04:30');
+    expect(
+      triggerLabel({
+        id: 1,
+        trigger_type: 'weekly_time',
+        trigger_config: { time: '09:00', days: ['mon'] },
+      }),
+    ).toBe('Mon @ 09:00');
+    expect(
+      triggerLabel({
+        id: 1,
+        trigger_type: 'monthly_time',
+        trigger_config: { day: 15, time: '02:00' },
+      }),
+    ).toBe('Monthly · day 15 @ 02:00');
+    expect(
+      triggerLabel({
+        id: 1,
+        trigger_type: 'event',
+        trigger_config: { event: 'watchlist.new_release' },
+      }),
+    ).toBe('On watchlist new release');
   });
 });
 

--- a/webui/src/routes/dashboard/-dash.automations.ts
+++ b/webui/src/routes/dashboard/-dash.automations.ts
@@ -79,7 +79,10 @@ export function triggerLabel(row: AutomationApiRow): string {
   }
   if (type === 'daily_time') return `Daily @ ${String(cfg.time || '00:00')}`;
   if (type === 'weekly_time') {
-    return weeklyLabel(String(cfg.time || '00:00'), Array.isArray(cfg.days) ? (cfg.days as string[]) : []);
+    return weeklyLabel(
+      String(cfg.time || '00:00'),
+      Array.isArray(cfg.days) ? (cfg.days as string[]) : [],
+    );
   }
   if (type === 'monthly_time') {
     return `Monthly · day ${String(cfg.day ?? 1)} @ ${String(cfg.time || '00:00')}`;

--- a/webui/src/routes/dashboard/-dash.autosync.test.ts
+++ b/webui/src/routes/dashboard/-dash.autosync.test.ts
@@ -34,9 +34,9 @@ describe('intervalLabel', () => {
 describe('weeklyLabel', () => {
   it('collapses full/empty weeks to Daily and orders days Mon–Sun', () => {
     expect(weeklyLabel('09:00', [])).toBe('Daily @ 09:00');
-    expect(
-      weeklyLabel('09:00', ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']),
-    ).toBe('Daily @ 09:00');
+    expect(weeklyLabel('09:00', ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'])).toBe(
+      'Daily @ 09:00',
+    );
     // Toggled on out of order — renders canonical.
     expect(weeklyLabel('04:30', ['fri', 'mon'])).toBe('Mon, Fri @ 04:30');
   });

--- a/webui/src/routes/dashboard/-dash.autosync.ts
+++ b/webui/src/routes/dashboard/-dash.autosync.ts
@@ -298,7 +298,14 @@ export function autoSyncCardRows(state: AutoSyncSeamState, nowMs: number): AutoS
     push(key, s.automation_id, s.automation_name, intervalLabel(s.hours), s.enabled, s.next_run);
   }
   for (const [key, s] of Object.entries(state.weeklySchedules || {})) {
-    push(key, s.automation_id, s.automation_name, weeklyLabel(s.time, s.days), s.enabled, s.next_run);
+    push(
+      key,
+      s.automation_id,
+      s.automation_name,
+      weeklyLabel(s.time, s.days),
+      s.enabled,
+      s.next_run,
+    );
   }
 
   const sortStamp = (r: AutoSyncCardRow) => {

--- a/webui/src/routes/dashboard/-dash.content.test.ts
+++ b/webui/src/routes/dashboard/-dash.content.test.ts
@@ -158,7 +158,12 @@ describe('fetchers', () => {
     window.openDownloadMissingModalForYouTube = modal;
     fetchMock
       .mockReturnValueOnce(
-        ok({ id: 'alb1', name: 'New One', image_url: 'cover.jpg', tracks: [{ id: 't1', name: 'Song A' }] }),
+        ok({
+          id: 'alb1',
+          name: 'New One',
+          image_url: 'cover.jpg',
+          tracks: [{ id: 't1', name: 'Song A' }],
+        }),
       )
       .mockReturnValueOnce(ok({ owned_tracks: { 'Song A': { owned: false } } }));
     await openFreshRelease({
@@ -238,16 +243,22 @@ describe('openArtistFromRail', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
     await openArtistFromRail({ name: 'Aphex Twin', libraryArtistId: 'art_1' });
-    expect(nav).toHaveBeenCalledWith('artist-detail', { artistId: 'art_1', artistName: 'Aphex Twin' });
+    expect(nav).toHaveBeenCalledWith('artist-detail', {
+      artistId: 'art_1',
+      artistName: 'Aphex Twin',
+    });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('resolves an exact library name match (case-insensitive)', async () => {
     const nav = vi.fn();
     window.navigateToPage = nav as never;
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      json: async () => ({ artists: [{ id: 7, name: 'Aphex Twin' }] }),
-    })));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        json: async () => ({ artists: [{ id: 7, name: 'Aphex Twin' }] }),
+      })),
+    );
     await openArtistFromRail({ name: 'aphex twin' });
     expect(nav).toHaveBeenCalledWith('artist-detail', { artistId: 7, artistName: 'Aphex Twin' });
   });
@@ -255,7 +266,10 @@ describe('openArtistFromRail', () => {
   it('falls to the provider id when the library misses', async () => {
     const nav = vi.fn();
     window.navigateToPage = nav as never;
-    vi.stubGlobal('fetch', vi.fn(async () => ({ json: async () => ({ artists: [] }) })));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ json: async () => ({ artists: [] }) })),
+    );
     await openArtistFromRail({ name: 'Fresh Face', spotifyArtistId: 'sp9' });
     expect(nav).toHaveBeenCalledWith('artist-detail', {
       artistId: 'sp9',

--- a/webui/src/routes/dashboard/-dash.content.ts
+++ b/webui/src/routes/dashboard/-dash.content.ts
@@ -75,12 +75,19 @@ export async function openArtistFromRail(input: {
   }
   if (name) {
     try {
-      const response = await fetch(`/api/library/artists?search=${encodeURIComponent(name)}&limit=5`);
-      const data = (await response.json()) as { artists?: Array<{ id?: number | string; name?: string }> };
+      const response = await fetch(
+        `/api/library/artists?search=${encodeURIComponent(name)}&limit=5`,
+      );
+      const data = (await response.json()) as {
+        artists?: Array<{ id?: number | string; name?: string }>;
+      };
       const lower = name.toLowerCase();
       const exact = (data.artists ?? []).find((a) => (a.name ?? '').toLowerCase() === lower);
       if (exact && exact.id != null) {
-        void window.navigateToPage?.('artist-detail', { artistId: exact.id, artistName: exact.name });
+        void window.navigateToPage?.('artist-detail', {
+          artistId: exact.id,
+          artistName: exact.name,
+        });
         return;
       }
     } catch {
@@ -215,8 +222,7 @@ function fromRow(row: WatchlistReleaseRow & DiscoverAlbumRow, fromDiscover: bool
     albumItunesId: row.album_itunes_id ?? '',
     albumDeezerId: row.album_deezer_id ?? '',
     sourceProvider:
-      row.source ??
-      (row.album_spotify_id ? 'spotify' : row.album_deezer_id ? 'deezer' : 'itunes'),
+      row.source ?? (row.album_spotify_id ? 'spotify' : row.album_deezer_id ? 'deezer' : 'itunes'),
     owned: Boolean((row as WatchlistReleaseRow).owned),
     fromDiscover,
   };
@@ -283,7 +289,10 @@ interface OwnedEntry {
  * Every track owned → owned. "Most" is not enough: playing an album the user
  * is missing half of, instead of offering to complete it, buries the gap.
  */
-export function albumIsOwned(ownedTracks: Record<string, OwnedEntry>, trackNames: string[]): OwnedEntry | null {
+export function albumIsOwned(
+  ownedTracks: Record<string, OwnedEntry>,
+  trackNames: string[],
+): OwnedEntry | null {
   if (trackNames.length === 0) return null;
   let first: OwnedEntry | null = null;
   for (const name of trackNames) {

--- a/webui/src/routes/dashboard/-dash.hello.ts
+++ b/webui/src/routes/dashboard/-dash.hello.ts
@@ -56,8 +56,6 @@ export function buildHelloStats(input: {
 
 /** How many enrichment workers are actually running right now. 'active' is
  *  the one stateClass -dash.core assigns for running-and-not-paused. */
-export function countBusyWorkers(
-  pills: Record<string, { stateClass: string | null }>,
-): number {
+export function countBusyWorkers(pills: Record<string, { stateClass: string | null }>): number {
   return Object.values(pills).filter((pill) => pill.stateClass === 'active').length;
 }

--- a/webui/src/routes/dashboard/-dash.library.test.ts
+++ b/webui/src/routes/dashboard/-dash.library.test.ts
@@ -119,7 +119,9 @@ describe('libraryCardView — the five states', () => {
   });
 
   it('healthy without last_update reads Never; invalid dates too', () => {
-    expect(libraryCardView(stats, connected, false, NOW).subtitle).toContain('Last refreshed Never');
+    expect(libraryCardView(stats, connected, false, NOW).subtitle).toContain(
+      'Last refreshed Never',
+    );
     expect(
       libraryCardView({ ...stats, last_update: 'garbage' }, connected, false, NOW).subtitle,
     ).toContain('Last refreshed Never');

--- a/webui/src/routes/dashboard/-dash.library.ts
+++ b/webui/src/routes/dashboard/-dash.library.ts
@@ -295,8 +295,9 @@ export function syncCardView(entry: SyncHistoryEntry, nowMs: number): SyncCardVi
   // label (the type says 'manual' for those; 'album' is what the row IS).
   const typeLabel = entry.is_album_download
     ? 'album'
-    : (entry.sync_type ? String(entry.sync_type).toLowerCase() : null);
-
+    : entry.sync_type
+      ? String(entry.sync_type).toLowerCase()
+      : null;
 
   return {
     id: entry.id,

--- a/webui/src/routes/dashboard/-dash.listening.test.ts
+++ b/webui/src/routes/dashboard/-dash.listening.test.ts
@@ -39,7 +39,14 @@ describe('toRecentPlays', () => {
 
   it('shapes rows, drops untitled ones, and respects the limit', () => {
     const rows = [
-      { title: 'Windowlicker', artist: 'Aphex Twin', album: 'Windowlicker EP', played_at: '2026-08-12 11:00:00', server_source: 'plex', image_url: '/art/1' },
+      {
+        title: 'Windowlicker',
+        artist: 'Aphex Twin',
+        album: 'Windowlicker EP',
+        played_at: '2026-08-12 11:00:00',
+        server_source: 'plex',
+        image_url: '/art/1',
+      },
       { title: '   ', artist: 'Nobody', played_at: '2026-08-12 10:00:00' },
       { title: 'Flim', artist: 'Aphex Twin', played_at: '2026-08-12 09:00:00', image_url: null },
       { title: 'Alberto Balsalm', artist: 'Aphex Twin', played_at: '2026-08-12 08:00:00' },

--- a/webui/src/routes/dashboard/-ui/automations-card.tsx
+++ b/webui/src/routes/dashboard/-ui/automations-card.tsx
@@ -153,9 +153,7 @@ function QuickSettings() {
   const [maxPerf, setMaxPerf] = useState(
     () => localStorage.getItem('soulsync-max-performance') === '1',
   );
-  const [accent, setAccent] = useState(
-    () => localStorage.getItem('soulsync-accent') || '#1db954',
-  );
+  const [accent, setAccent] = useState(() => localStorage.getItem('soulsync-accent') || '#1db954');
 
   /** Apply instantly via init.js's own applier, then persist to the server
    *  config (partial POST — the handler merges key-by-key). Without the
@@ -180,9 +178,7 @@ function QuickSettings() {
   const [particles, setParticles] = useState(
     () => localStorage.getItem('soulsync-particles') !== 'false',
   );
-  const [orbs, setOrbs] = useState(
-    () => localStorage.getItem('soulsync-worker-orbs') !== 'false',
-  );
+  const [orbs, setOrbs] = useState(() => localStorage.getItem('soulsync-worker-orbs') !== 'false');
 
   const toggleReduce = () => {
     const next = !reduce;

--- a/webui/src/routes/dashboard/-ui/content-rails.tsx
+++ b/webui/src/routes/dashboard/-ui/content-rails.tsx
@@ -19,11 +19,10 @@
 
 import { useCallback, useState } from 'react';
 
-import type { FreshRelease, RecentlyAddedAlbum } from '../-dash.content';
-import { useLiveRefresh } from '../-dash.live-refresh';
-
-import { getShellBridge } from '@/platform/shell/bridge';
 import { thumb } from '@/platform/artwork-thumb';
+import { getShellBridge } from '@/platform/shell/bridge';
+
+import type { FreshRelease, RecentlyAddedAlbum } from '../-dash.content';
 
 import {
   fetchFreshReleases,
@@ -33,6 +32,7 @@ import {
   openFreshRelease,
   relativeAge,
 } from '../-dash.content';
+import { useLiveRefresh } from '../-dash.live-refresh';
 
 interface RailCardProps {
   /** Small corner check — the library already has this (discover's badge). */
@@ -52,7 +52,18 @@ interface RailCardProps {
   onOpen: () => void;
 }
 
-function RailCard({ owned, cover, fallbackCover, name, sub, caption, badge, titleAttr, onOpen, onArtistClick }: RailCardProps) {
+function RailCard({
+  owned,
+  cover,
+  fallbackCover,
+  name,
+  sub,
+  caption,
+  badge,
+  titleAttr,
+  onOpen,
+  onArtistClick,
+}: RailCardProps) {
   // Fallback ladder, one rung per failure: cover -> the artist's art -> ♫.
   // History thumb URLs can be stale or media-server-authed and die in the
   // browser even when they exist, so the second image matters as much as the
@@ -61,9 +72,21 @@ function RailCard({ owned, cover, fallbackCover, name, sub, caption, badge, titl
   const [rung, setRung] = useState(0);
   const src = candidates[rung];
   return (
-    <div className="ya-card dash-rail-card" title={titleAttr ?? `${name} — ${sub}`} onClick={onOpen}>
+    <div
+      className="ya-card dash-rail-card"
+      title={titleAttr ?? `${name} — ${sub}`}
+      onClick={onOpen}
+    >
       <div className="ya-card-img">
-        {src && <img key={src} src={thumb(src, 'grid')} alt="" loading="lazy" onError={() => setRung(rung + 1)} />}
+        {src && (
+          <img
+            key={src}
+            src={thumb(src, 'grid')}
+            alt=""
+            loading="lazy"
+            onError={() => setRung(rung + 1)}
+          />
+        )}
         <div className="ya-card-placeholder" style={src ? { display: 'none' } : undefined}>
           ♫
         </div>
@@ -71,7 +94,9 @@ function RailCard({ owned, cover, fallbackCover, name, sub, caption, badge, titl
       <div className="ya-card-gradient" />
       {owned && (
         <div className="ya-card-badges">
-          <div className="discover-album-badge owned" title="In your library">✓</div>
+          <div className="discover-album-badge owned" title="In your library">
+            ✓
+          </div>
         </div>
       )}
       {caption && <div className="dash-rail-caption">{caption}</div>}
@@ -133,7 +158,8 @@ export function ContentBand() {
 
   // A tab you can't switch to is clutter; a selected tab whose feed is empty
   // (recent empty, fresh not) silently shows the one with rows.
-  const active: BandTab = tab === 'recent' && !hasRecent ? 'fresh' : tab === 'fresh' && !hasFresh ? 'recent' : tab;
+  const active: BandTab =
+    tab === 'recent' && !hasRecent ? 'fresh' : tab === 'fresh' && !hasFresh ? 'recent' : tab;
   const fromDiscover = hasFresh && releases[0].fromDiscover;
   const now = Date.now();
 

--- a/webui/src/routes/dashboard/-ui/dashboard-header.test.tsx
+++ b/webui/src/routes/dashboard/-ui/dashboard-header.test.tsx
@@ -10,9 +10,9 @@
  * fixture at P9, when the vanilla markup was deleted.
  */
 
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { vanillaDashboardHtml } from './dash-artefact';
@@ -128,7 +128,9 @@ describe('the hello strip', () => {
     window._currentProfileName = 'BoulderBadgeDad';
     const view = await mountHeader();
     const greeting = view.container.querySelector('.hello-greeting span')!;
-    expect(greeting.textContent).toMatch(/^(good (morning|afternoon|evening)|up late\?), BoulderBadgeDad$/);
+    expect(greeting.textContent).toMatch(
+      /^(good (morning|afternoon|evening)|up late\?), BoulderBadgeDad$/,
+    );
     view.unmount();
 
     delete window._currentProfileName;

--- a/webui/src/routes/dashboard/-ui/library-card.test.tsx
+++ b/webui/src/routes/dashboard/-ui/library-card.test.tsx
@@ -275,7 +275,6 @@ describe('the scan flow', () => {
   });
 });
 
-
 /**
  * TheHomeGuy asked for a way to know there is something to review without
  * going to the downloads page and clicking into the tab. Plus the strip picked

--- a/webui/src/routes/dashboard/-ui/library-card.tsx
+++ b/webui/src/routes/dashboard/-ui/library-card.tsx
@@ -301,10 +301,7 @@ function useReviewCount(): number | null {
 
 function SettingsLink() {
   return (
-    <span
-      className="link"
-      onClick={() => void window.navigateToPage?.('settings')}
-    >
+    <span className="link" onClick={() => void window.navigateToPage?.('settings')}>
       Settings
     </span>
   );
@@ -420,7 +417,14 @@ export function LibraryCard() {
                 id="library-status-browse-btn"
                 onClick={() => void window.navigateToPage?.('library')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M3 6h18M3 12h18M3 18h18" />
                 </svg>
                 Browse
@@ -431,7 +435,14 @@ export function LibraryCard() {
                 title="Open the enrichment manager's Verify Matches repair flow"
                 onClick={() => window.openEnrichmentManager?.()}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
                   <polyline points="22 4 12 14.01 9 11.01" />
                 </svg>
@@ -443,7 +454,14 @@ export function LibraryCard() {
                 title="Open the Tools maintenance center"
                 onClick={() => void window.navigateToPage?.('tools')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
                 </svg>
                 Repair
@@ -454,7 +472,14 @@ export function LibraryCard() {
                 title="Back up the SoulSync database now"
                 onClick={() => void backupNow()}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <ellipse cx="12" cy="5" rx="9" ry="3" />
                   <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
                   <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
@@ -479,11 +504,20 @@ export function LibraryCard() {
                 }
                 onClick={() => void window.navigateToPage?.('active-downloads')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
                 </svg>
                 Review
-                {reviewCount ? <span className="library-status-btn-badge">{reviewCount}</span> : null}
+                {reviewCount ? (
+                  <span className="library-status-btn-badge">{reviewCount}</span>
+                ) : null}
               </button>
               <button
                 className="library-status-btn library-status-btn-secondary"
@@ -491,7 +525,14 @@ export function LibraryCard() {
                 title="Tracks SoulSync is still trying to find"
                 onClick={() => void window.navigateToPage?.('wishlist')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M20.8 4.6a5.5 5.5 0 0 0-7.8 0L12 5.7l-1-1.1a5.5 5.5 0 0 0-7.8 7.8l1 1.1L12 21.2l7.8-7.7 1-1.1a5.5 5.5 0 0 0 0-7.8z" />
                 </svg>
                 Wishlist
@@ -502,7 +543,14 @@ export function LibraryCard() {
                 title="Active and queued downloads"
                 onClick={() => void window.navigateToPage?.('active-downloads')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
                   <polyline points="7 10 12 15 17 10" />
                   <line x1="12" y1="15" x2="12" y2="3" />
@@ -515,7 +563,14 @@ export function LibraryCard() {
                 title="Find music you don't have yet"
                 onClick={() => void window.navigateToPage?.('discover')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <circle cx="12" cy="12" r="10" />
                   <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
                 </svg>
@@ -527,7 +582,14 @@ export function LibraryCard() {
                 title="Playlists and their sync schedules"
                 onClick={() => void window.navigateToPage?.('sync')}
               >
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                >
                   <polyline points="23 4 23 10 17 10" />
                   <polyline points="1 20 1 14 7 14" />
                   <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />

--- a/webui/src/routes/dashboard/-ui/library-strip-layout.test.ts
+++ b/webui/src/routes/dashboard/-ui/library-strip-layout.test.ts
@@ -39,7 +39,6 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
 /** Comments stripped: they name the very properties being asserted. */

--- a/webui/src/routes/dashboard/-ui/listening-history-band.test.tsx
+++ b/webui/src/routes/dashboard/-ui/listening-history-band.test.tsx
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ListeningHistoryBand } from './listening-history-band';
 
-const playTrackByMetadata = vi.hoisted(() => vi.fn(async () => {}));
+// Typed with the real arity. `vi.fn(async () => {})` infers `calls: []` — an
+// empty tuple — so every `mock.calls[0][n]` below is a TS2493 type error, and
+// oxlint --type-check gates CI on those. Four red errors on dev, and they turn
+// every unrelated branch's `npm run check` red too.
+const playTrackByMetadata = vi.hoisted(() =>
+  vi.fn(async (_bridge: unknown, _title: string, _artist: string, _album?: string) => {}),
+);
 vi.mock('../../../features/playback/play-track', () => ({ playTrackByMetadata }));
 
 const openArtistFromRail = vi.hoisted(() => vi.fn(async () => {}));

--- a/webui/src/routes/dashboard/-ui/listening-history-band.tsx
+++ b/webui/src/routes/dashboard/-ui/listening-history-band.tsx
@@ -28,11 +28,11 @@ import { useCallback, useState } from 'react';
 
 import type { RecentPlay, RecentPlayRow } from '../-dash.listening';
 
-import { playTrackByMetadata } from '../../../features/playback/play-track';
-import { getShellBridge } from '../../../platform/shell/bridge';
 import { openArtistFromRail } from '../-dash.content';
 import { toRecentPlays } from '../-dash.listening';
 import { useLiveRefresh } from '../-dash.live-refresh';
+import { playTrackByMetadata } from '../../../features/playback/play-track';
+import { getShellBridge } from '../../../platform/shell/bridge';
 
 // 25, not 12: this is the dashboard's whole view of what you have been
 // listening to, and a dozen rows runs out inside one album.
@@ -81,11 +81,16 @@ export function ListeningHistoryBand() {
             key={play.key}
             className="ya-card dash-rail-card"
             title={`Play ${play.title} — ${play.artist}${play.source ? ` · ${play.source}` : ''}`}
-            onClick={() => void playTrackByMetadata(getShellBridge(), play.title, play.artist, play.album)}
+            onClick={() =>
+              void playTrackByMetadata(getShellBridge(), play.title, play.artist, play.album)
+            }
           >
             <div className="ya-card-img">
               {play.imageUrl && <img src={play.imageUrl} alt="" loading="lazy" />}
-              <div className="ya-card-placeholder" style={play.imageUrl ? { display: 'none' } : undefined}>
+              <div
+                className="ya-card-placeholder"
+                style={play.imageUrl ? { display: 'none' } : undefined}
+              >
                 ♫
               </div>
             </div>

--- a/webui/src/routes/dashboard/-ui/sync-band.tsx
+++ b/webui/src/routes/dashboard/-ui/sync-band.tsx
@@ -107,10 +107,7 @@ function useSyncBand() {
   }, [loadAll, loadHistory]);
 
   const scheduleRows = useMemo(() => (seam ? autoSyncCardRows(seam, nowMs) : []), [seam, nowMs]);
-  const rows = useMemo(
-    () => syncBandRows(scheduleRows, entries ?? []),
-    [scheduleRows, entries],
-  );
+  const rows = useMemo(() => syncBandRows(scheduleRows, entries ?? []), [scheduleRows, entries]);
 
   // While a pipeline runs its phase/progress must move — a short loop that
   // exists ONLY while a running row is present.
@@ -236,31 +233,28 @@ function useSyncBand() {
   }, []);
 
   /** Delete a manual run's history entry — the 200ms fade, state-driven. */
-  const removeEntry = useCallback(
-    async (id: number | string) => {
-      setFadingIds((prev) => new Set(prev).add(id));
-      const unfade = () =>
-        setFadingIds((prev) => {
-          const next = new Set(prev);
-          next.delete(id);
-          return next;
-        });
-      try {
-        const resp = await fetch(`/api/sync/history/${id}`, { method: 'DELETE' });
-        if (resp.ok) {
-          setTimeout(() => {
-            setEntries((prev) => (prev ? prev.filter((v) => v.id !== id) : prev));
-            unfade();
-          }, 200);
-        } else {
+  const removeEntry = useCallback(async (id: number | string) => {
+    setFadingIds((prev) => new Set(prev).add(id));
+    const unfade = () =>
+      setFadingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    try {
+      const resp = await fetch(`/api/sync/history/${id}`, { method: 'DELETE' });
+      if (resp.ok) {
+        setTimeout(() => {
+          setEntries((prev) => (prev ? prev.filter((v) => v.id !== id) : prev));
           unfade();
-        }
-      } catch {
+        }, 200);
+      } else {
         unfade();
       }
-    },
-    [],
-  );
+    } catch {
+      unfade();
+    }
+  }, []);
 
   return {
     seamPhase,
@@ -504,12 +498,16 @@ export function SyncBand() {
       <header className="dash-card__head">
         <h3 className="dash-card__title">
           Sync
-          {scheduled > 0 ? <span className="autosync-count-pill">{scheduled} scheduled</span> : null}
+          {scheduled > 0 ? (
+            <span className="autosync-count-pill">{scheduled} scheduled</span>
+          ) : null}
           {activeSyncs > 0 ? (
             <span className="dash-syncs-live">{activeSyncs} syncing now</span>
           ) : null}
         </h3>
-        <p className="dash-card__sub">Your playlists — what&apos;s scheduled, what ran, what you own.</p>
+        <p className="dash-card__sub">
+          Your playlists — what&apos;s scheduled, what ran, what you own.
+        </p>
         <button type="button" className="autosync-manage-btn" onClick={() => openBoard(loadAll)}>
           Manage
         </button>
@@ -523,7 +521,11 @@ export function SyncBand() {
                 Auto-Sync refreshes a playlist, hunts its missing tracks, and pushes it to your
                 server — on a schedule you set.
               </span>
-              <button type="button" className="autosync-empty-cta" onClick={() => openBoard(loadAll)}>
+              <button
+                type="button"
+                className="autosync-empty-cta"
+                onClick={() => openBoard(loadAll)}
+              >
                 Set one up
               </button>
             </div>

--- a/webui/src/routes/dashboard/-ui/system-stats.tsx
+++ b/webui/src/routes/dashboard/-ui/system-stats.tsx
@@ -102,7 +102,9 @@ function StatCard({ id, title, tile }: { id: string; title: string; tile: StatTi
     <div className="stat-tile" id={id} title={tile.subtitle}>
       <p className="stat-card-value">{tile.value}</p>
       <p className="stat-card-title">{title}</p>
-      <p className="stat-card-subtitle" style={{ display: 'none' }}>{tile.subtitle}</p>
+      <p className="stat-card-subtitle" style={{ display: 'none' }}>
+        {tile.subtitle}
+      </p>
     </div>
   );
 }

--- a/webui/src/routes/discover/-discover.cache-sections.ts
+++ b/webui/src/routes/discover/-discover.cache-sections.ts
@@ -104,7 +104,7 @@ export const CACHE_SECTIONS: CacheSectionDef[] = [
 export const GENRE_EXPLORER_SECTION = {
   id: 'cache-genre-explorer',
   title: 'Browse Your Sound',
-  subtitle: "Every genre in your collection, one tap deep",
+  subtitle: 'Every genre in your collection, one tap deep',
   endpoint: '/api/discover/genre-explorer',
   /** `_insertCacheSection(..., 'top', false)` — no `.discover-grid` wrapper. */
   position: 'top' as const,

--- a/webui/src/routes/discover/-discover.use-page.ts
+++ b/webui/src/routes/discover/-discover.use-page.ts
@@ -186,10 +186,14 @@ export function useDiscoverPage(): DiscoverPageController {
   // ── Tier 2: below the fold, gated on tier 1 ───────────────────────────
   // The four mix-registry feeders, the genre shelves and the caches all live
   // here now — they render well below the first viewport.
-  const genreExplorer = useQuery(shelfQuery('genre-explorer', fetchGenreExplorer, aboveFoldSettled));
+  const genreExplorer = useQuery(
+    shelfQuery('genre-explorer', fetchGenreExplorer, aboveFoldSettled),
+  );
   const popularPicks = useQuery(shelfQuery('popular-picks', fetchPopularPicks, aboveFoldSettled));
   const hiddenGems = useQuery(shelfQuery('hidden-gems', fetchHiddenGems, aboveFoldSettled));
-  const shuffle = useQuery(shelfQuery('discovery-shuffle', fetchDiscoveryShuffle, aboveFoldSettled));
+  const shuffle = useQuery(
+    shelfQuery('discovery-shuffle', fetchDiscoveryShuffle, aboveFoldSettled),
+  );
   const listeningMix = useQuery(shelfQuery('listening-mix', fetchListeningMix, aboveFoldSettled));
   const genreNewReleases = useQuery(
     shelfQuery('genre-new-releases', fetchGenreNewReleases, aboveFoldSettled),

--- a/webui/src/routes/discover/-ui/album-shelves.tsx
+++ b/webui/src/routes/discover/-ui/album-shelves.tsx
@@ -1,5 +1,6 @@
-import { thumb } from '@/platform/artwork-thumb';
 import { useState } from 'react';
+
+import { thumb } from '@/platform/artwork-thumb';
 
 import type { RecentAlbum } from '../-discover.recent-releases';
 import type { SeasonalAlbum, SeasonData } from '../-discover.seasonal';
@@ -45,7 +46,9 @@ export function DiscoverAlbumCard({
   return (
     <div className="ya-card discover-album-card" title={titleAttr} onClick={onOpen}>
       <div className="ya-card-img">
-        {!failed && <img src={thumb(cover, 'grid')} alt="" loading="lazy" onError={() => setFailed(true)} />}
+        {!failed && (
+          <img src={thumb(cover, 'grid')} alt="" loading="lazy" onError={() => setFailed(true)} />
+        )}
         <div className="ya-card-placeholder" style={failed ? undefined : { display: 'none' }}>
           ♫
         </div>

--- a/webui/src/routes/discover/-ui/cache-shelves.test.tsx
+++ b/webui/src/routes/discover/-ui/cache-shelves.test.tsx
@@ -129,6 +129,8 @@ describe('genre explorer', () => {
   it('titles itself Browse Your Sound with the tap hint', () => {
     render(<GenreExplorerSection genres={genres} onOpenGenre={vi.fn()} />);
     expect(screen.getByText('Browse Your Sound').tagName).toBe('H3');
-    expect(screen.getByText("Every genre in your collection, one tap deep")).toHaveClass('discover-section-subtitle');
+    expect(screen.getByText('Every genre in your collection, one tap deep')).toHaveClass(
+      'discover-section-subtitle',
+    );
   });
 });

--- a/webui/src/routes/library/-ui/library-artist-card.tsx
+++ b/webui/src/routes/library/-ui/library-artist-card.tsx
@@ -1,5 +1,6 @@
-import { thumb } from '@/platform/artwork-thumb';
 import { useState } from 'react';
+
+import { thumb } from '@/platform/artwork-thumb';
 
 import type { ArtistBadge, LibraryArtist } from '../-library.types';
 
@@ -105,7 +106,9 @@ function ArtistImage({ artist, hasImage }: { artist: LibraryArtist; hasImage: bo
   // `key` remounts rather than swapping src on the element that just errored,
   // so each stage gets a clean load cycle. Not test-observable: jsdom never
   // fetches images, so the error events above are synthetic either way.
-  return <img key={stage} src={thumb(src, 'grid')} alt={artist.name} loading="lazy" onError={onError} />;
+  return (
+    <img key={stage} src={thumb(src, 'grid')} alt={artist.name} loading="lazy" onError={onError} />
+  );
 }
 
 /** One artist tile. Markup mirrors buildLibraryArtistCardHTML so the CSS applies unchanged. */

--- a/webui/src/routes/search/-search.helpers.ts
+++ b/webui/src/routes/search/-search.helpers.ts
@@ -32,7 +32,9 @@ export function loadRecentSearches(): string[] {
   try {
     const raw: unknown = JSON.parse(window.localStorage.getItem(RECENT_KEY) || '[]');
     return Array.isArray(raw)
-      ? raw.filter((q): q is string => typeof q === 'string' && q.trim() !== '').slice(0, RECENT_MAX)
+      ? raw
+          .filter((q): q is string => typeof q === 'string' && q.trim() !== '')
+          .slice(0, RECENT_MAX)
       : [];
   } catch {
     return [];
@@ -43,10 +45,10 @@ export function loadRecentSearches(): string[] {
 export function saveRecentSearch(query: string): string[] {
   const q = query.trim();
   if (!q) return loadRecentSearches();
-  const next = [q, ...loadRecentSearches().filter((x) => x.toLowerCase() !== q.toLowerCase())].slice(
-    0,
-    RECENT_MAX,
-  );
+  const next = [
+    q,
+    ...loadRecentSearches().filter((x) => x.toLowerCase() !== q.toLowerCase()),
+  ].slice(0, RECENT_MAX);
   try {
     window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
   } catch {

--- a/webui/src/routes/search/-ui/search-page.tsx
+++ b/webui/src/routes/search/-ui/search-page.tsx
@@ -505,7 +505,9 @@ function JumpChips({
           type="button"
           className="enh-jump-chip"
           onClick={() =>
-            document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            document
+              .getElementById(sectionId)
+              ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
           }
         >
           {label}

--- a/webui/src/routes/search/-ui/search-results.test.tsx
+++ b/webui/src/routes/search/-ui/search-results.test.tsx
@@ -1,6 +1,6 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { SearchAlbum, SearchTrack } from '../-search.types';
@@ -488,4 +488,4 @@ describe('an album result shows its title', () => {
     expect(bare, 'the colliding rule vanished — re-check the opt-out').toBeTruthy();
     expect(bare![1]).toMatch(/aspect-ratio:\s*1/);
   });
-})
+});

--- a/webui/src/routes/search/-ui/search-results.tsx
+++ b/webui/src/routes/search/-ui/search-results.tsx
@@ -188,7 +188,7 @@ export function SearchResults({
   // The spotlight: the best match gets the big card. Artists outrank albums
   // outrank tracks — the same priority the section order implies.
   const topArtist = dbArtists[0] ?? artists[0];
-  const topAlbum = topArtist ? undefined : fullAlbums[0] ?? singlesAndEps[0];
+  const topAlbum = topArtist ? undefined : (fullAlbums[0] ?? singlesAndEps[0]);
   const topTrack = topArtist || topAlbum ? undefined : tracks[0];
   const spotlight = topArtist
     ? {
@@ -201,7 +201,10 @@ export function SearchResults({
       }
     : topAlbum
       ? {
-          kind: topAlbum.album_type === 'single' || topAlbum.album_type === 'ep' ? 'Single / EP' : 'Album',
+          kind:
+            topAlbum.album_type === 'single' || topAlbum.album_type === 'ep'
+              ? 'Single / EP'
+              : 'Album',
           name: topAlbum.name ?? '',
           image: albumImage(topAlbum),
           round: false,

--- a/webui/src/routes/stats/-route.test.tsx
+++ b/webui/src/routes/stats/-route.test.tsx
@@ -224,13 +224,27 @@ describe('stats route', () => {
       http.get('/api/stats/cached', () =>
         HttpResponse.json({
           success: true,
-          overview: { total_plays: 24, total_time_ms: 1, unique_artists: 1,
-                      unique_albums: 1, unique_tracks: 1 },
+          overview: {
+            total_plays: 24,
+            total_time_ms: 1,
+            unique_artists: 1,
+            unique_albums: 1,
+            unique_tracks: 1,
+          },
           // A previous window that should not exist for 'all'.
-          previous: { total_plays: 12, total_time_ms: 1, unique_artists: 1,
-                      unique_albums: 1, unique_tracks: 1 },
-          top_artists: [], top_albums: [], top_tracks: [],
-          timeline: [], genres: [], recent: [],
+          previous: {
+            total_plays: 12,
+            total_time_ms: 1,
+            unique_artists: 1,
+            unique_albums: 1,
+            unique_tracks: 1,
+          },
+          top_artists: [],
+          top_albums: [],
+          top_tracks: [],
+          timeline: [],
+          genres: [],
+          recent: [],
           health: { total_tracks: 12 },
         }),
       ),
@@ -308,12 +322,24 @@ describe('stats route', () => {
       http.get('/api/stats/cached', () =>
         HttpResponse.json({
           success: true,
-          overview: { total_plays: 3, total_time_ms: 1, unique_artists: 1,
-                      unique_albums: 1, unique_tracks: 1 },
-          clock: { grid: Array.from({ length: 7 }, () => Array(24).fill(0)),
-                   peak: { weekday: null, hour: null, plays: 0 }, total: 0 },
-          top_artists: [], top_albums: [], top_tracks: [],
-          timeline: [], genres: [], recent: [],
+          overview: {
+            total_plays: 3,
+            total_time_ms: 1,
+            unique_artists: 1,
+            unique_albums: 1,
+            unique_tracks: 1,
+          },
+          clock: {
+            grid: Array.from({ length: 7 }, () => Array(24).fill(0)),
+            peak: { weekday: null, hour: null, plays: 0 },
+            total: 0,
+          },
+          top_artists: [],
+          top_albums: [],
+          top_tracks: [],
+          timeline: [],
+          genres: [],
+          recent: [],
           health: { total_tracks: 1 },
         }),
       ),
@@ -346,11 +372,20 @@ describe('stats route', () => {
       http.get('/api/stats/cached', () =>
         HttpResponse.json({
           success: true,
-          overview: { total_plays: 3, total_time_ms: 1, unique_artists: 1,
-                      unique_albums: 1, unique_tracks: 1 },
+          overview: {
+            total_plays: 3,
+            total_time_ms: 1,
+            unique_artists: 1,
+            unique_albums: 1,
+            unique_tracks: 1,
+          },
           own_vs_play: [],
-          top_artists: [], top_albums: [], top_tracks: [],
-          timeline: [], genres: [], recent: [],
+          top_artists: [],
+          top_albums: [],
+          top_tracks: [],
+          timeline: [],
+          genres: [],
+          recent: [],
           health: { total_tracks: 1 },
         }),
       ),
@@ -366,11 +401,20 @@ describe('stats route', () => {
       http.get('/api/stats/cached', () =>
         HttpResponse.json({
           success: true,
-          overview: { total_plays: 24, total_time_ms: 1, unique_artists: 1,
-                      unique_albums: 1, unique_tracks: 1 },
+          overview: {
+            total_plays: 24,
+            total_time_ms: 1,
+            unique_artists: 1,
+            unique_albums: 1,
+            unique_tracks: 1,
+          },
           previous: null,
-          top_artists: [], top_albums: [], top_tracks: [],
-          timeline: [], genres: [], recent: [],
+          top_artists: [],
+          top_albums: [],
+          top_tracks: [],
+          timeline: [],
+          genres: [],
+          recent: [],
           health: { total_tracks: 12 },
         }),
       ),
@@ -379,7 +423,6 @@ describe('stats route', () => {
     expect(await screen.findByText('Total Plays')).toBeTruthy();
     expect(screen.queryByText(/vs previous/)).toBeNull();
   });
-
 });
 
 describe('stats route survives a backend outage', () => {

--- a/webui/src/routes/stats/-ui/stats-page.module.css
+++ b/webui/src/routes/stats/-ui/stats-page.module.css
@@ -902,7 +902,9 @@
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease;
+  transition:
+    background 120ms ease,
+    color 120ms ease;
 }
 
 .statsTab:hover {
@@ -999,7 +1001,11 @@
 }
 
 /* Own vs Play — library share against listening share. */
-.statsOwnPlay { display: flex; flex-direction: column; gap: 8px; }
+.statsOwnPlay {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 
 .statsOwnPlayRow {
   display: grid;
@@ -1016,7 +1022,11 @@
   text-overflow: ellipsis;
 }
 
-.statsOwnPlayBars { display: flex; flex-direction: column; gap: 3px; }
+.statsOwnPlayBars {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
 
 .statsOwnPlayOwned,
 .statsOwnPlayPlayed {
@@ -1025,12 +1035,24 @@
   min-width: 2px;
 }
 
-.statsOwnPlayOwned { background: rgba(255, 255, 255, 0.28); }
-.statsOwnPlayPlayed { background: rgb(var(--accent-rgb)); }
+.statsOwnPlayOwned {
+  background: rgba(255, 255, 255, 0.28);
+}
+.statsOwnPlayPlayed {
+  background: rgb(var(--accent-rgb));
+}
 
-.statsOwnPlayGap { font-size: 12px; font-weight: 700; text-align: right; }
-.statsOwnPlayGapUp { color: #4ade80; }
-.statsOwnPlayGapDown { color: #f87171; }
+.statsOwnPlayGap {
+  font-size: 12px;
+  font-weight: 700;
+  text-align: right;
+}
+.statsOwnPlayGapUp {
+  color: #4ade80;
+}
+.statsOwnPlayGapDown {
+  color: #f87171;
+}
 
 .statsOwnPlayLegend {
   display: flex;
@@ -1049,8 +1071,13 @@
   margin-left: 8px;
 }
 
-.statsOwnPlayKeyOwned { background: rgba(255, 255, 255, 0.28); margin-left: 0; }
-.statsOwnPlayKeyPlayed { background: rgb(var(--accent-rgb)); }
+.statsOwnPlayKeyOwned {
+  background: rgba(255, 255, 255, 0.28);
+  margin-left: 0;
+}
+.statsOwnPlayKeyPlayed {
+  background: rgb(var(--accent-rgb));
+}
 
 .statsNeglected {
   margin-top: 14px;
@@ -1073,9 +1100,19 @@
   font-size: 12px;
 }
 
-.statsNeglectedName { color: rgba(255, 255, 255, 0.8); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.statsNeglectedArtist { color: rgba(255, 255, 255, 0.4); }
-.statsNeglectedCount { color: rgba(255, 255, 255, 0.35); text-align: right; }
+.statsNeglectedName {
+  color: rgba(255, 255, 255, 0.8);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.statsNeglectedArtist {
+  color: rgba(255, 255, 255, 0.4);
+}
+.statsNeglectedCount {
+  color: rgba(255, 255, 255, 0.35);
+  text-align: right;
+}
 
 /* Entry point to the Year in Listening takeover. Styled as the page's one
    accented action — everything else in this header is a neutral control, and

--- a/webui/src/routes/stats/-ui/stats-page.tsx
+++ b/webui/src/routes/stats/-ui/stats-page.tsx
@@ -68,9 +68,8 @@ import {
 } from '../-stats.helpers';
 import { STATS_TAB_VALUES } from '../-stats.types';
 import { Route } from '../route';
-import { YearStory } from './year-story';
-
 import styles from './stats-page.module.css';
+import { YearStory } from './year-story';
 
 const STATS_TOOLTIP_STYLE = {
   background: 'rgba(12, 12, 12, 0.96)',
@@ -342,7 +341,6 @@ export function StatsPage() {
               </StatsSectionCard>
             </div>
           </div>
-
         </>
       ) : (
         <StatsEmptyState />
@@ -385,7 +383,11 @@ function OverviewCards({
       label: 'Listening Time',
       value: formatListeningTime(overview.total_time_ms),
     },
-    { key: 'unique_artists', label: 'Artists', value: formatCompactNumber(overview.unique_artists) },
+    {
+      key: 'unique_artists',
+      label: 'Artists',
+      value: formatCompactNumber(overview.unique_artists),
+    },
     { key: 'unique_albums', label: 'Albums', value: formatCompactNumber(overview.unique_albums) },
     { key: 'unique_tracks', label: 'Tracks', value: formatCompactNumber(overview.unique_tracks) },
   ] as const;
@@ -442,7 +444,6 @@ function StatsCardDelta({
     </div>
   );
 }
-
 
 /**
  * The shape of a listening week — plays by weekday x hour — plus the habit
@@ -530,7 +531,6 @@ function StatsListeningClock({
   );
 }
 
-
 /**
  * What share of the library a genre is, against what share of the listening.
  *
@@ -549,11 +549,7 @@ function StatsOwnVsPlayCard({
   rows: StatsOwnVsPlay[];
 }) {
   if (!rows.length) {
-    return (
-      <div className={styles.statsClockEmpty}>
-        Not enough tagged artists to compare yet.
-      </div>
-    );
+    return <div className={styles.statsClockEmpty}>Not enough tagged artists to compare yet.</div>;
   }
 
   return (
@@ -598,9 +594,7 @@ function StatsOwnVsPlayCard({
 
       {neglected.length ? (
         <div className={styles.statsNeglected}>
-          <div className={styles.statsNeglectedTitle}>
-            Never played ({neglected.length})
-          </div>
+          <div className={styles.statsNeglectedTitle}>Never played ({neglected.length})</div>
           {neglected.slice(0, 5).map((album) => (
             <div key={album.id} className={styles.statsNeglectedRow}>
               <span className={styles.statsNeglectedName}>{album.name}</span>

--- a/webui/src/routes/stats/-ui/year-story.module.css
+++ b/webui/src/routes/stats/-ui/year-story.module.css
@@ -318,7 +318,9 @@
   color: inherit;
   text-decoration: none;
   border-bottom: 2px solid transparent;
-  transition: border-color 0.2s ease, color 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .heroLink:hover,
@@ -690,7 +692,9 @@
   height: 3px;
   background: currentColor;
   opacity: 0.7;
-  box-shadow: 0 8px 0 currentColor, 0 16px 0 currentColor;
+  box-shadow:
+    0 8px 0 currentColor,
+    0 16px 0 currentColor;
 }
 
 .swatch {

--- a/webui/src/routes/stats/-ui/year-story.test.tsx
+++ b/webui/src/routes/stats/-ui/year-story.test.tsx
@@ -36,7 +36,13 @@ const FULL_YEAR: YearInListening = {
     },
   ],
   discoveries: [
-    { name: 'Brand New Act', first_played: '2026-02-01', plays: 34, id: '99', image_url: '/img/new.jpg' },
+    {
+      name: 'Brand New Act',
+      first_played: '2026-02-01',
+      plays: 34,
+      id: '99',
+      image_url: '/img/new.jpg',
+    },
   ],
   peak_day: { date: '2026-05-20', plays: 47 },
   top_hour: { hour: 22, plays: 300 },
@@ -91,7 +97,9 @@ describe('YearStory', () => {
   it('opens from the URL alone', async () => {
     renderStory();
 
-    expect(await screen.findByRole('dialog', { name: 'Your Year in Listening' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('dialog', { name: 'Your Year in Listening' }),
+    ).toBeInTheDocument();
   });
 
   it('stays shut when the param is absent', async () => {
@@ -99,7 +107,9 @@ describe('YearStory', () => {
 
     await screen.findByTestId('stats-page');
 
-    expect(screen.queryByRole('dialog', { name: 'Your Year in Listening' })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', { name: 'Your Year in Listening' }),
+    ).not.toBeInTheDocument();
   });
 
   it('opens on the period, so the reader knows what window this is', async () => {
@@ -141,7 +151,7 @@ describe('YearStory', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Next' }));
 
     const counter = await screen.findByLabelText('1,247');
-    expect(counter).not.toHaveTextContent('1,247');   // it starts from zero
+    expect(counter).not.toHaveTextContent('1,247'); // it starts from zero
 
     // countUpDuration scales with magnitude — ~1.45s for a number this size,
     // which is past waitFor's 1s default.
@@ -157,7 +167,10 @@ describe('YearStory', () => {
   });
 
   it('collapses to a single slide that says so when there is nothing to tell', async () => {
-    serveYear({ has_data: false, totals: { plays: 0, minutes: 0, artists: 0, albums: 0, tracks: 0, active_days: 0 } });
+    serveYear({
+      has_data: false,
+      totals: { plays: 0, minutes: 0, artists: 0, albums: 0, tracks: 0, active_days: 0 },
+    });
     renderStory();
 
     await screen.findByText('Your Year in Listening');
@@ -397,7 +410,8 @@ describe('YearStory', () => {
     }
 
     const pressed = ['Plays', 'Listening time', 'Artists', 'Days with music'].filter(
-      (label) => screen.getByRole('button', { name: label }).getAttribute('aria-pressed') === 'true',
+      (label) =>
+        screen.getByRole('button', { name: label }).getAttribute('aria-pressed') === 'true',
     );
     expect(pressed).toHaveLength(1);
   });

--- a/webui/src/routes/stats/-ui/year-story.tsx
+++ b/webui/src/routes/stats/-ui/year-story.tsx
@@ -1,14 +1,16 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { fetchAlbumPlayTracks, yearInListeningQueryOptions } from '../-year.api';
+import type { YearAlbum, YearInListening, YearSlideKind } from '../-year.types';
+
 import {
   countUpDuration,
   countUpValue,
   prefersReducedMotion,
   staggerDelay,
 } from '../-year.animation';
+import { fetchAlbumPlayTracks, yearInListeningQueryOptions } from '../-year.api';
 import {
   DEFAULT_YEAR_CARD_OPTIONS,
   MAX_YEAR_CARD_STATS,
@@ -35,8 +37,6 @@ import {
   monthBarHeight,
   peakMonthPlays,
 } from '../-year.helpers';
-import type { YearAlbum, YearInListening, YearSlideKind } from '../-year.types';
-
 import styles from './year-story.module.css';
 
 /**
@@ -243,15 +243,7 @@ function Reveal({
  * render as ragged holes. The fallback carries the first letter so a row is
  * still identifiable at a glance.
  */
-function Art({
-  src,
-  name,
-  className,
-}: {
-  src?: string | null;
-  name: string;
-  className: string;
-}) {
+function Art({ src, name, className }: { src?: string | null; name: string; className: string }) {
   const [failed, setFailed] = useState(false);
   if (!src || failed) {
     return (
@@ -446,11 +438,7 @@ function YearSlide({
           <p className={styles.kicker}>The albums you lived in</p>
           <div className={styles.albumGrid}>
             {year.top_albums.slice(0, 4).map((album, index) => (
-              <AlbumCard
-                key={`${album.name}-${album.artist ?? ''}`}
-                album={album}
-                index={index}
-              />
+              <AlbumCard key={`${album.name}-${album.artist ?? ''}`} album={album} index={index} />
             ))}
           </div>
           <p className={styles.footnote}>Click an album to play it.</p>
@@ -808,7 +796,10 @@ function YearCard({ year }: { year: YearInListening }) {
                   title={YEAR_CARD_LAYOUTS[key].blurb}
                   onClick={() => set('layout', key as YearCardLayout)}
                 >
-                  <span className={`${styles.layoutGlyph} ${styles[`glyph_${key}`] ?? ''}`} aria-hidden="true" />
+                  <span
+                    className={`${styles.layoutGlyph} ${styles[`glyph_${key}`] ?? ''}`}
+                    aria-hidden="true"
+                  />
                   {YEAR_CARD_LAYOUTS[key].label}
                 </button>
               ))}
@@ -859,7 +850,10 @@ function YearCard({ year }: { year: YearInListening }) {
 
           <fieldset className={styles.cardGroup}>
             <legend className={styles.cardControlLabel}>
-              Numbers <span className={styles.cardCount}>{statCount}/{MAX_YEAR_CARD_STATS}</span>
+              Numbers{' '}
+              <span className={styles.cardCount}>
+                {statCount}/{MAX_YEAR_CARD_STATS}
+              </span>
             </legend>
             <div className={styles.chipRow}>
               {YEAR_CARD_STAT_DEFS.map((def) => {

--- a/webui/src/routes/stats/-year.api.ts
+++ b/webui/src/routes/stats/-year.api.ts
@@ -2,8 +2,9 @@ import { queryOptions } from '@tanstack/react-query';
 
 import { apiClient, readJson } from '@/app/api-client';
 
-import { STATS_QUERY_KEY } from './-stats.api';
 import type { YearInListening, YearInListeningPayload } from './-year.types';
+
+import { STATS_QUERY_KEY } from './-stats.api';
 
 export async function fetchYearInListening(): Promise<YearInListening> {
   const payload = await readJson<YearInListeningPayload>(apiClient.get('stats/year'));

--- a/webui/src/routes/stats/-year.card.test.ts
+++ b/webui/src/routes/stats/-year.card.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { YearInListening } from './-year.types';
+
 import {
   DEFAULT_YEAR_CARD_OPTIONS,
   MAX_YEAR_CARD_STATS,
@@ -11,7 +13,6 @@ import {
   type YearCardOptions,
   type YearCardStatKey,
 } from './-year.card';
-import type { YearInListening } from './-year.types';
 
 function makeYear(overrides: Partial<YearInListening> = {}): YearInListening {
   return {
@@ -83,7 +84,14 @@ describe('buildYearCardModel — content', () => {
   });
 
   it('never renders more rows than fit on a card', () => {
-    const all: YearCardStatKey[] = ['plays', 'minutes', 'artists', 'albums', 'tracks', 'active_days'];
+    const all: YearCardStatKey[] = [
+      'plays',
+      'minutes',
+      'artists',
+      'albums',
+      'tracks',
+      'active_days',
+    ];
 
     expect(buildYearCardModel(makeYear(), opts({ stats: all })).stats).toHaveLength(
       MAX_YEAR_CARD_STATS,

--- a/webui/src/routes/stats/-year.card.ts
+++ b/webui/src/routes/stats/-year.card.ts
@@ -1,5 +1,6 @@
-import { describeListeningTime } from './-year.helpers';
 import type { YearInListening, YearTotals } from './-year.types';
+
+import { describeListeningTime } from './-year.helpers';
 
 /**
  * The card studio: a PURE MODEL and a draw pass.

--- a/webui/src/routes/stats/-year.helpers.test.ts
+++ b/webui/src/routes/stats/-year.helpers.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { YearInListening } from './-year.types';
+
 import {
   buildYearSlides,
   describeListeningTime,
@@ -9,7 +11,6 @@ import {
   monthBarHeight,
   peakMonthPlays,
 } from './-year.helpers';
-import type { YearInListening } from './-year.types';
 
 function makeYear(overrides: Partial<YearInListening> = {}): YearInListening {
   return {
@@ -19,7 +20,9 @@ function makeYear(overrides: Partial<YearInListening> = {}): YearInListening {
     months: [{ month: '2026-01', label: 'Jan 2026', plays: 100, minutes: 4000, top_artist: 'A' }],
     top_artists: [{ name: 'A', plays: 60, months_on_top: 3 }],
     top_albums: [{ name: 'The Album', artist: 'A', plays: 40 }],
-    top_tracks: [{ name: 'T', artist: 'A', album: 'Al', plays: 12, first_played: null, last_played: null }],
+    top_tracks: [
+      { name: 'T', artist: 'A', album: 'Al', plays: 12, first_played: null, last_played: null },
+    ],
     discoveries: [{ name: 'New', first_played: '2026-02-01', plays: 9 }],
     peak_day: { date: '2026-05-20', plays: 14 },
     top_hour: { hour: 22, plays: 30 },
@@ -136,10 +139,16 @@ describe('formatHour', () => {
 
 describe('buildYearSlides', () => {
   it('tells the whole story when the year is full', () => {
-    expect(buildYearSlides(makeYear({ top_artists: [
-      { name: 'A', plays: 60, months_on_top: 3 },
-      { name: 'B', plays: 20, months_on_top: 1 },
-    ] }))).toEqual([
+    expect(
+      buildYearSlides(
+        makeYear({
+          top_artists: [
+            { name: 'A', plays: 60, months_on_top: 3 },
+            { name: 'B', plays: 20, months_on_top: 1 },
+          ],
+        }),
+      ),
+    ).toEqual([
       'opening',
       'totals',
       'months',
@@ -158,7 +167,9 @@ describe('buildYearSlides', () => {
   });
 
   it('trusts the play count over the has_data flag', () => {
-    const empty = makeYear({ totals: { plays: 0, minutes: 0, artists: 0, albums: 0, tracks: 0, active_days: 0 } });
+    const empty = makeYear({
+      totals: { plays: 0, minutes: 0, artists: 0, albums: 0, tracks: 0, active_days: 0 },
+    });
 
     expect(buildYearSlides(empty)).toEqual(['opening']);
   });

--- a/webui/src/routes/sync/-sync.account-cache.ts
+++ b/webui/src/routes/sync/-sync.account-cache.ts
@@ -94,9 +94,7 @@ export function urlTabCacheKey(source: string): string {
 export function useRememberedPlaylists(
   cacheKey: string,
 ): [UrlTabPlaylist[], Dispatch<SetStateAction<UrlTabPlaylist[]>>] {
-  const [rows, setRows] = useState<UrlTabPlaylist[]>(
-    () => recallAccountPlaylists(cacheKey) ?? [],
-  );
+  const [rows, setRows] = useState<UrlTabPlaylist[]>(() => recallAccountPlaylists(cacheKey) ?? []);
   useEffect(() => {
     rememberAccountPlaylists(cacheKey, rows);
   }, [cacheKey, rows]);

--- a/webui/src/routes/sync/-sync.card-schedule.ts
+++ b/webui/src/routes/sync/-sync.card-schedule.ts
@@ -24,6 +24,13 @@ import { useCallback, useEffect, useState } from 'react';
 import type { AutoSyncHistoryEntry, MirroredRow } from './-sync.autosync';
 
 import {
+  createAutomation,
+  deleteAutomation,
+  fetchAutomations,
+  fetchPipelineHistory,
+  updateAutomation,
+} from './-sync.api';
+import {
   AUTO_SYNC_BUCKETS,
   autoSyncCanSchedulePlaylist,
   autoSyncIntervalLabel,
@@ -35,13 +42,6 @@ import {
   buildAutoSyncScheduleState,
   detectBrowserTimezone,
 } from './-sync.autosync';
-import {
-  createAutomation,
-  deleteAutomation,
-  fetchAutomations,
-  fetchPipelineHistory,
-  updateAutomation,
-} from './-sync.api';
 
 /** What a card knows about its own schedule. */
 export interface CardSchedule {
@@ -272,10 +272,9 @@ export function useCardSchedules(options: UseCardSchedulesOptions = {}): CardSch
         // An HOURLY row is a different trigger shape, so it is replaced rather
         // than updated into a weekly one — updating across shapes is how you
         // end up with a row that claims both.
-        const res =
-          existing?.weekly
-            ? await updateAutomation(existing.automationId, payload)
-            : await createAutomation(payload);
+        const res = existing?.weekly
+          ? await updateAutomation(existing.automationId, payload)
+          : await createAutomation(payload);
         const data = (await res.json()) as { error?: string };
         if (!res.ok || data.error) throw new Error(data.error || 'Failed to save schedule');
         if (existing && !existing.weekly) await deleteAutomation(existing.automationId);

--- a/webui/src/routes/sync/-sync.history.test.ts
+++ b/webui/src/routes/sync/-sync.history.test.ts
@@ -55,7 +55,7 @@ describe('the source tabs', () => {
     expect(tabs.map((t) => t.source)).toEqual([null, 'spotify', 'deezer', 'tidal']);
   });
 
-  it("All counts the STATS, not the filtered page total", () => {
+  it('All counts the STATS, not the filtered page total', () => {
     // The page total moves with the active filter, so a strip built from it
     // would report on itself as you clicked around.
     const tabs = syncHistorySourceTabs({ spotify: 10, tidal: 2 }, 'tidal');
@@ -261,8 +261,9 @@ describe('reading one poll of the sync status', () => {
   });
 
   it('does not leave a dangling dash when there is no current track', () => {
-    expect(syncHistoryProgress({ status: 'syncing', progress: { current_step: 'Matching' } }).step)
-      .toBe('Matching');
+    expect(
+      syncHistoryProgress({ status: 'syncing', progress: { current_step: 'Matching' } }).step,
+    ).toBe('Matching');
   });
 
   it('never divides by a zero total', () => {

--- a/webui/src/routes/sync/-sync.lb-tabs.test.ts
+++ b/webui/src/routes/sync/-sync.lb-tabs.test.ts
@@ -135,7 +135,12 @@ describe('the LB card numbers (_refreshOneLbSyncCard 253-283)', () => {
    */
   it('fresh hides; discovery counters carry the pct fallback', () => {
     expect(
-      lbCoverageCounts({ phase: 'fresh', spotifyTotal: 5, spotifyMatches: 1, discoveryProgress: 10 }),
+      lbCoverageCounts({
+        phase: 'fresh',
+        spotifyTotal: 5,
+        spotifyMatches: 1,
+        discoveryProgress: 10,
+      }),
     ).toBeNull();
     expect(
       lbCoverageCounts({
@@ -726,5 +731,4 @@ describe('lbCoverageCounts — the numbers behind the card bar', () => {
   it('fresh returns null so the card hides the element entirely', () => {
     expect(lbCoverageCounts(lbInput({ phase: 'fresh' }))).toBeNull();
   });
-
 });

--- a/webui/src/routes/sync/-sync.lb-tabs.ts
+++ b/webui/src/routes/sync/-sync.lb-tabs.ts
@@ -195,7 +195,12 @@ export function lbCoverageCounts(input: LbProgressInput): LbCoverageCounts | nul
     const matched = sp.matched_tracks || sp.spotify_matches || 0;
     const total = sp.total_tracks || sp.spotify_total || 0;
     const failed = sp.failed_tracks !== undefined ? sp.failed_tracks : Math.max(0, total - matched);
-    return { total, matched, failed, percentage: total > 0 ? Math.round((matched / total) * 100) : 0 };
+    return {
+      total,
+      matched,
+      failed,
+      percentage: total > 0 ? Math.round((matched / total) * 100) : 0,
+    };
   }
   const total = input.spotifyTotal || 0;
   const matched = input.spotifyMatches || 0;

--- a/webui/src/routes/sync/-sync.library.test.ts
+++ b/webui/src/routes/sync/-sync.library.test.ts
@@ -8,9 +8,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import type { MirroredPlaylistRow } from './-sync.mirrored';
-
 import type { LibraryFilter } from './-sync.library';
+import type { MirroredPlaylistRow } from './-sync.mirrored';
 
 import {
   LIBRARY_FILTERS,
@@ -177,7 +176,10 @@ describe('which tabs render', () => {
   });
 
   it('hides a state tab with nothing in it — a tab with no rows has no tab', () => {
-    expect(libraryVisibleFilters(counts({ all: 3, synced: 3 }), 'all').map((f) => f.id)).toEqual(['all', 'synced']);
+    expect(libraryVisibleFilters(counts({ all: 3, synced: 3 }), 'all').map((f) => f.id)).toEqual([
+      'all',
+      'synced',
+    ]);
   });
 
   it('always keeps All, so the strip never empties', () => {
@@ -187,17 +189,18 @@ describe('which tabs render', () => {
   it('keeps the ACTIVE tab even at zero', () => {
     // Removing the tab you are standing on would move the page out from
     // under you the moment its last row finished.
-    expect(libraryVisibleFilters(counts({ all: 3, synced: 3 }), 'attention').map((f) => f.id)).toEqual([
-      'all',
-      'attention',
-      'synced',
-    ]);
+    expect(
+      libraryVisibleFilters(counts({ all: 3, synced: 3 }), 'attention').map((f) => f.id),
+    ).toEqual(['all', 'attention', 'synced']);
   });
 
   it('renders them in the declared order, never the order they filled up', () => {
-    expect(libraryVisibleFilters(counts({ all: 9, attention: 1, running: 1, synced: 1, scheduled: 1, unscheduled: 1 }), 'all').map((f) => f.id)).toEqual(
-      LIBRARY_FILTERS.map((f) => f.id),
-    );
+    expect(
+      libraryVisibleFilters(
+        counts({ all: 9, attention: 1, running: 1, synced: 1, scheduled: 1, unscheduled: 1 }),
+        'all',
+      ).map((f) => f.id),
+    ).toEqual(LIBRARY_FILTERS.map((f) => f.id));
   });
 });
 
@@ -264,9 +267,9 @@ describe('the card state', () => {
 
   it('an error outranks a run still in flight', () => {
     // A failed run needs a human whether or not the poller has caught up.
-    expect(
-      libraryCardState(row({ pipeline_state: { status: 'running', error: 'boom' } })),
-    ).toBe('error');
+    expect(libraryCardState(row({ pipeline_state: { status: 'running', error: 'boom' } }))).toBe(
+      'error',
+    );
   });
 
   it('a never-touched playlist is ok, not short', () => {
@@ -304,7 +307,11 @@ describe('sorting', () => {
 
   it('keeps the incoming order within a state', () => {
     // The backend sends newest-updated first; that is a sensible second key.
-    expect(librarySortedRows(rows).slice(3).map((r) => r.id)).toEqual([1, 5]);
+    expect(
+      librarySortedRows(rows)
+        .slice(3)
+        .map((r) => r.id),
+    ).toEqual([1, 5]);
   });
 
   it('does not reorder the caller’s array', () => {
@@ -438,7 +445,10 @@ describe('ordering the library', () => {
     // Not the raw name: a renamed playlist shows its alias, so sorting on the
     // original would order the list by something invisible.
     expect(librarySortedRows(rows, 'name').map((r) => r.name)).toEqual(['apple', 'Mango', 'Zebra']);
-    const renamed = [row({ id: 1, name: 'Zebra', display_name: 'aardvark' }), row({ id: 2, name: 'apple' })];
+    const renamed = [
+      row({ id: 1, name: 'Zebra', display_name: 'aardvark' }),
+      row({ id: 2, name: 'apple' }),
+    ];
     expect(librarySortedRows(renamed, 'name')[0].id).toBe(1);
   });
 
@@ -472,7 +482,12 @@ describe('ordering the library', () => {
 
   it('every declared sort id is handled, none falls through to state silently', () => {
     const byId = Object.fromEntries(
-      LIBRARY_SORTS.map((s) => [s.id, librarySortedRows(rows, s.id).map((r) => r.id).join()]),
+      LIBRARY_SORTS.map((s) => [
+        s.id,
+        librarySortedRows(rows, s.id)
+          .map((r) => r.id)
+          .join(),
+      ]),
     );
     // name/tracks/recent must each differ from the default ordering.
     for (const id of ['name', 'tracks', 'recent']) {
@@ -509,10 +524,12 @@ describe('when the ownership figure may be stated', () => {
   const full = { total_count: 50, discovered_count: 50 };
 
   it('is known once every track has been checked', () => {
-    expect(libraryOwnedKnown(row({ ...full, in_library_count: 47, library_checked_count: 50 }))).toBe(
-      true,
+    expect(
+      libraryOwnedKnown(row({ ...full, in_library_count: 47, library_checked_count: 50 })),
+    ).toBe(true);
+    expect(libraryOwned(row({ ...full, in_library_count: 47, library_checked_count: 50 }))).toBe(
+      47,
     );
-    expect(libraryOwned(row({ ...full, in_library_count: 47, library_checked_count: 50 }))).toBe(47);
   });
 
   it('is UNKNOWN for a playlist the matcher has never checked', () => {
@@ -529,9 +546,9 @@ describe('when the ownership figure may be stated', () => {
     // The sync skips rows with no usable id or name, so a partial check would
     // let a small "not downloaded" number stand for a playlist where many more
     // were never examined.
-    expect(libraryOwnedKnown(row({ ...full, in_library_count: 12, library_checked_count: 20 }))).toBe(
-      false,
-    );
+    expect(
+      libraryOwnedKnown(row({ ...full, in_library_count: 12, library_checked_count: 20 })),
+    ).toBe(false);
   });
 
   it('is UNKNOWN for an empty playlist, which cannot be short of anything', () => {

--- a/webui/src/routes/sync/-sync.shell.ts
+++ b/webui/src/routes/sync/-sync.shell.ts
@@ -171,8 +171,7 @@ export const SYNC_HEADER_ACTIONS: readonly SyncHeaderAction[] = [
   {
     key: 'wing-it-pool',
     label: 'Wing It Pool',
-    title:
-      'Review tracks Wing It auto-matched on a best-effort guess — verify or re-match them',
+    title: 'Review tracks Wing It auto-matched on a best-effort guess — verify or re-match them',
   },
   {
     key: 'library-match',

--- a/webui/src/routes/sync/-sync.url-detect.test.ts
+++ b/webui/src/routes/sync/-sync.url-detect.test.ts
@@ -8,14 +8,9 @@
 
 import { describe, expect, it } from 'vitest';
 
-import {
-  extractDeezerPlaylistId,
-  extractITunesLinkId,
-  extractSpotifyPublicId,
-} from './-sync.urls';
-import { deezerInputResult, spotifyPublicUrlError } from './-sync.url-tabs';
 import type { DetectedSource } from './-sync.url-detect';
 
+import { SYNC_TABS } from './-sync.shell';
 import {
   DETECTED_SOURCE_SERVICE_LABELS,
   DETECTED_SOURCE_TAB_IDS,
@@ -24,7 +19,8 @@ import {
   isDetected,
   wrongTabError,
 } from './-sync.url-detect';
-import { SYNC_TABS } from './-sync.shell';
+import { deezerInputResult, spotifyPublicUrlError } from './-sync.url-tabs';
+import { extractDeezerPlaylistId, extractITunesLinkId, extractSpotifyPublicId } from './-sync.urls';
 import { SYNC_VERTICAL_IDS } from './-sync.verticals';
 
 describe('detectPlaylistUrl — the happy routes', () => {
@@ -84,10 +80,7 @@ describe('detectPlaylistUrl — the errors that used to be wrong', () => {
   it('names the fix for a Deezer SHARE link instead of calling it invalid', () => {
     // This is what Deezer's own Share button copies. Telling the user it is
     // invalid reads as the feature being broken.
-    for (const url of [
-      'https://link.deezer.com/s/30abcdef',
-      'https://deezer.page.link/xyz123',
-    ]) {
+    for (const url of ['https://link.deezer.com/s/30abcdef', 'https://deezer.page.link/xyz123']) {
       const d = detectPlaylistUrl(url);
       expect(d.source).toBeNull();
       expect(isDetected(d) ? '' : d.error).toContain('share link');

--- a/webui/src/routes/sync/-sync.url-tabs.ts
+++ b/webui/src/routes/sync/-sync.url-tabs.ts
@@ -9,7 +9,6 @@
 import type { UrlHistoryEntry } from './-sync.urls';
 
 import { wrongTabError } from './-sync.url-detect';
-
 import {
   extractDeezerPlaylistId,
   isDeezerShareUrl,
@@ -77,7 +76,9 @@ export function spotifyPublicUrlError(url: string): string | null {
     !url.startsWith('spotify:playlist:') &&
     !url.startsWith('spotify:album:')
   ) {
-    return wrongTabError(url, 'spotify_public') ?? 'Please enter a valid Spotify playlist or album URL';
+    return (
+      wrongTabError(url, 'spotify_public') ?? 'Please enter a valid Spotify playlist or album URL'
+    );
   }
   return null;
 }

--- a/webui/src/routes/sync/-sync.use-history.test.ts
+++ b/webui/src/routes/sync/-sync.use-history.test.ts
@@ -123,9 +123,7 @@ describe('re-syncing a row', () => {
       entry: { id: 7, source: 'discover' },
     });
     const start = vi.spyOn(api, 'startSync');
-    const { result } = renderHook(() =>
-      useSyncHistory({ active: true, openDownloadModal }),
-    );
+    const { result } = renderHook(() => useSyncHistory({ active: true, openDownloadModal }));
     await act(async () => {
       await result.current.resync(7);
     });
@@ -139,9 +137,7 @@ describe('re-syncing a row', () => {
       entry: { id: 7, playlist_name: 'Road Trip', source: 'spotify', tracks: [{ name: 'A' }] },
     });
     const start = vi.spyOn(api, 'startSync').mockResolvedValue({ success: true });
-    const { result } = renderHook(() =>
-      useSyncHistory({ active: true, now: () => 1_700_000 }),
-    );
+    const { result } = renderHook(() => useSyncHistory({ active: true, now: () => 1_700_000 }));
     await act(async () => {
       await result.current.resync(7);
     });
@@ -149,7 +145,14 @@ describe('re-syncing a row', () => {
       playlist_id: 'resync_7_1700000',
       playlist_name: 'Road Trip',
       tracks: [
-        { id: '', name: 'A', artists: ['Unknown Artist'], album: '', duration_ms: 0, popularity: 0 },
+        {
+          id: '',
+          name: 'A',
+          artists: ['Unknown Artist'],
+          album: '',
+          duration_ms: 0,
+          popularity: 0,
+        },
       ],
     });
     expect(result.current.resyncs[7]).toBeTruthy();
@@ -190,12 +193,10 @@ describe('the poll', () => {
       entry: { id: 7, source: 'spotify' },
     });
     vi.spyOn(api, 'startSync').mockResolvedValue({ success: true });
-    const status = vi
-      .spyOn(api, 'fetchAccountSyncStatus')
-      .mockResolvedValue({
-        status: 'syncing',
-        progress: { matched_tracks: 1, failed_tracks: 1, total_tracks: 4 },
-      } as never);
+    const status = vi.spyOn(api, 'fetchAccountSyncStatus').mockResolvedValue({
+      status: 'syncing',
+      progress: { matched_tracks: 1, failed_tracks: 1, total_tracks: 4 },
+    } as never);
 
     const { result } = renderHook(() => useSyncHistory({ active: true, toast }));
     await act(async () => {

--- a/webui/src/routes/sync/-sync.use-history.ts
+++ b/webui/src/routes/sync/-sync.use-history.ts
@@ -169,8 +169,7 @@ export function useSyncHistory(options: UseSyncHistoryOptions) {
             if (progress.phase === 'finished') {
               toast(`Re-sync complete: ${progress.matched}/${progress.total} matched`, 'success');
             }
-            const linger =
-              progress.phase === 'finished' ? FINISHED_LINGER_MS : ENDED_LINGER_MS;
+            const linger = progress.phase === 'finished' ? FINISHED_LINGER_MS : ENDED_LINGER_MS;
             setTimeout(() => {
               setResyncs((prev) => {
                 const next = { ...prev };

--- a/webui/src/routes/sync/-ui/activity-modal.tsx
+++ b/webui/src/routes/sync/-ui/activity-modal.tsx
@@ -88,7 +88,12 @@ export function ActivityModal({
       <div className="sync-activity-modal" role="dialog" aria-modal="true" aria-label="Activity">
         <div className="sync-activity-head">
           <h3>Activity</h3>
-          <button type="button" className="sync-activity-close" aria-label="Close" onClick={onClose}>
+          <button
+            type="button"
+            className="sync-activity-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
             &times;
           </button>
         </div>

--- a/webui/src/routes/sync/-ui/add-playlist-sheet.tsx
+++ b/webui/src/routes/sync/-ui/add-playlist-sheet.tsx
@@ -107,75 +107,73 @@ export function AddPlaylistSheet({ anchor, anchorEl, onRoute, onClose }: AddPlay
         </button>
       </div>
 
-        <div className="add-playlist-section">
-          <label className="add-playlist-label" htmlFor="add-playlist-url">
-            Paste a link
-          </label>
-          <div className="add-playlist-row">
-            <input
-              id="add-playlist-url"
-              type="text"
-              autoFocus
-              value={input}
-              placeholder="A playlist or album link from Spotify, Apple Music, Deezer or YouTube"
-              onChange={(e) => {
-                setInput(e.target.value);
-                setSubmitted(false);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') submit();
-              }}
-            />
-            <button
-              type="button"
-              className="add-playlist-submit"
-              // Never disabled: a disabled button explains nothing, and the
-              // whole point here is to SAY what is wrong with the link.
-              onClick={submit}
-            >
-              Add
-            </button>
-          </div>
-          {hint && (
-            <p className={`add-playlist-hint${recognised ? ' add-playlist-hint--ok' : ''}`}>
-              {hint}
-            </p>
-          )}
-        </div>
-
-        <div className="add-playlist-section">
-          <span className="add-playlist-label">Or from a connected account</span>
-          <div className="add-playlist-accounts">
-            {ADD_PLAYLIST_ACCOUNTS.map((account) => (
-              <button
-                key={account.tab}
-                type="button"
-                className="add-playlist-account"
-                onClick={() => {
-                  onRoute(account.tab);
-                  onClose();
-                }}
-              >
-                <span aria-hidden="true">{account.glyph}</span>
-                {account.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <div className="add-playlist-section">
-          <span className="add-playlist-label">Or from a file</span>
+      <div className="add-playlist-section">
+        <label className="add-playlist-label" htmlFor="add-playlist-url">
+          Paste a link
+        </label>
+        <div className="add-playlist-row">
+          <input
+            id="add-playlist-url"
+            type="text"
+            autoFocus
+            value={input}
+            placeholder="A playlist or album link from Spotify, Apple Music, Deezer or YouTube"
+            onChange={(e) => {
+              setInput(e.target.value);
+              setSubmitted(false);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submit();
+            }}
+          />
           <button
             type="button"
-            className="add-playlist-file"
-            onClick={() => {
-              onRoute('import-file');
-              onClose();
-            }}
+            className="add-playlist-submit"
+            // Never disabled: a disabled button explains nothing, and the
+            // whole point here is to SAY what is wrong with the link.
+            onClick={submit}
           >
-            📄 Import CSV, TSV, TXT or M3U
+            Add
           </button>
         </div>
+        {hint && (
+          <p className={`add-playlist-hint${recognised ? ' add-playlist-hint--ok' : ''}`}>{hint}</p>
+        )}
+      </div>
+
+      <div className="add-playlist-section">
+        <span className="add-playlist-label">Or from a connected account</span>
+        <div className="add-playlist-accounts">
+          {ADD_PLAYLIST_ACCOUNTS.map((account) => (
+            <button
+              key={account.tab}
+              type="button"
+              className="add-playlist-account"
+              onClick={() => {
+                onRoute(account.tab);
+                onClose();
+              }}
+            >
+              <span aria-hidden="true">{account.glyph}</span>
+              {account.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="add-playlist-section">
+        <span className="add-playlist-label">Or from a file</span>
+        <button
+          type="button"
+          className="add-playlist-file"
+          onClick={() => {
+            onRoute('import-file');
+            onClose();
+          }}
+        >
+          📄 Import CSV, TSV, TXT or M3U
+        </button>
+      </div>
     </div>
   );
 }

--- a/webui/src/routes/sync/-ui/autosync-modal.tsx
+++ b/webui/src/routes/sync/-ui/autosync-modal.tsx
@@ -313,10 +313,7 @@ export function AutoSyncModal({
         )}
       </div>
 
-      <AutoSyncMonitorPanel
-        playlists={state.playlists}
-        onDetails={onOpenDetails}
-      />
+      <AutoSyncMonitorPanel playlists={state.playlists} onDetails={onOpenDetails} />
 
       <div className="auto-sync-tabs">
         {(Object.keys(TAB_LABELS) as AutoSyncTab[]).map((key) => (

--- a/webui/src/routes/sync/-ui/autosync-panels.test.tsx
+++ b/webui/src/routes/sync/-ui/autosync-panels.test.tsx
@@ -35,9 +35,7 @@ describe('AutoSyncMonitorPanel (1131-1160)', () => {
     return {
       onDetails,
       onRefresh,
-      ...render(
-        <AutoSyncMonitorPanel playlists={playlists} onDetails={onDetails} />,
-      ),
+      ...render(<AutoSyncMonitorPanel playlists={playlists} onDetails={onDetails} />),
     };
   };
 

--- a/webui/src/routes/sync/-ui/autosync-shared.test.tsx
+++ b/webui/src/routes/sync/-ui/autosync-shared.test.tsx
@@ -348,10 +348,7 @@ describe('AutoSyncBoardIntro (826-834 / 950-960)', () => {
   it('renders the board-specific copy, and carries no Refresh of its own', () => {
     const onRefresh = vi.fn();
     const { container } = render(
-      <AutoSyncBoardIntro
-        heading="Drag playlists onto a day"
-        blurb="blurb"
-      />,
+      <AutoSyncBoardIntro heading="Drag playlists onto a day" blurb="blurb" />,
     );
     expect(container.querySelector('strong')?.textContent).toBe('Drag playlists onto a day');
     // This intro renders on BOTH boards, so its button was two of the four

--- a/webui/src/routes/sync/-ui/autosync-shared.tsx
+++ b/webui/src/routes/sync/-ui/autosync-shared.tsx
@@ -482,13 +482,7 @@ export function AutoSyncLane({
 }
 
 /** 826-834 / 950-960. The strip above both boards. */
-export function AutoSyncBoardIntro({
-  heading,
-  blurb,
-}: {
-  heading: string;
-  blurb: string;
-}) {
+export function AutoSyncBoardIntro({ heading, blurb }: { heading: string; blurb: string }) {
   return (
     <div className="auto-sync-board-intro">
       <div>

--- a/webui/src/routes/sync/-ui/autosync-weekly.tsx
+++ b/webui/src/routes/sync/-ui/autosync-weekly.tsx
@@ -249,11 +249,7 @@ export function AutoSyncWeeklyEditor({
               </small>
             </>
           ) : (
-            <button
-              type="button"
-              className="auto-sync-tz-summary"
-              onClick={() => setTzOpen(true)}
-            >
+            <button type="button" className="auto-sync-tz-summary" onClick={() => setTzOpen(true)}>
               Runs in <b>{draft.tz}</b> · change
             </button>
           )}

--- a/webui/src/routes/sync/-ui/card-progress.tsx
+++ b/webui/src/routes/sync/-ui/card-progress.tsx
@@ -23,7 +23,6 @@ import type { ReactNode } from 'react';
 
 import type { SourceVerticalConfig } from '../-sync.sources';
 import type { SourcePlaylistState } from '../-sync.state';
-
 import type { CardCoverageValue } from './card-coverage';
 
 import { checkNoteCounts, slashTextCounts } from '../-sync.url-tabs';

--- a/webui/src/routes/sync/-ui/mirrored-tab.test.tsx
+++ b/webui/src/routes/sync/-ui/mirrored-tab.test.tsx
@@ -89,7 +89,6 @@ function Harness(props: Partial<Parameters<typeof MirroredTab>[0]> = {}) {
   );
 }
 
-
 /**
  * Run one of a card's overflow actions.
  *
@@ -104,7 +103,6 @@ function runCardAction(label: string, cardIndex = 0): void {
   ) as HTMLElement;
   fireEvent.click(item);
 }
-
 
 describe('MirroredTab — load and card', () => {
   it('renders the card: cover, brand mark, name, one meta line, schedule', async () => {
@@ -1164,8 +1162,8 @@ describe('MirroredTab — the Scheduled tab keeps up with the menu', () => {
       />,
     );
 
-    return waitFor(() => expect(screen.getByText('Road Trip')).toBeInTheDocument())
-      .then(async () => {
+    return waitFor(() => expect(screen.getByText('Road Trip')).toBeInTheDocument()).then(
+      async () => {
         const scheduledTab = () =>
           [...document.querySelectorAll('.library-tab')].find((t) =>
             t.textContent?.startsWith('Scheduled'),
@@ -1180,7 +1178,8 @@ describe('MirroredTab — the Scheduled tab keeps up with the menu', () => {
 
         // The tab is gone because nothing is scheduled any more.
         await waitFor(() => expect(scheduledTab()).toBeFalsy());
-      });
+      },
+    );
   });
 });
 
@@ -1199,8 +1198,7 @@ describe('MirroredTab — the sort control', () => {
     await waitFor(() => expect(screen.getByText('Zebra')).toBeInTheDocument());
   }
 
-  const names = () =>
-    [...document.querySelectorAll('.pl-card-name b')].map((n) => n.textContent);
+  const names = () => [...document.querySelectorAll('.pl-card-name b')].map((n) => n.textContent);
 
   it('reorders the grid by the name a user sees', async () => {
     await renderMany();

--- a/webui/src/routes/sync/-ui/mirrored-tab.tsx
+++ b/webui/src/routes/sync/-ui/mirrored-tab.tsx
@@ -44,9 +44,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { MirroredPlaylistDetail } from '../-sync.api';
 import type { ExportMode } from '../-sync.export';
+import type { LibraryFilter, LibrarySort } from '../-sync.library';
 import type { MirroredPlaylistRow } from '../-sync.mirrored';
 import type { PipelineController } from '../-sync.use-pipeline';
 import type { SourceVertical } from '../-sync.use-vertical';
+import type { AutoSyncWeeklyDraft } from './autosync-weekly';
 
 import {
   clearMirroredDiscovery,
@@ -58,21 +60,12 @@ import {
   patchMirroredCustomName,
 } from '../-sync.api';
 import { patchMirroredSourceRef } from '../-sync.api';
+import { patchMirroredPreferences } from '../-sync.api';
 import { getMirroredSourceRef } from '../-sync.autosync';
+import { autoSyncCanSchedulePlaylist } from '../-sync.autosync';
+import { autoSyncPlaylistHealth, detectBrowserTimezone } from '../-sync.autosync';
+import { cardScheduleLabel, useCardSchedules } from '../-sync.card-schedule';
 import { exportNotConnectedStatus } from '../-sync.export';
-import {
-  mirroredHash,
-  mirroredPhaseLine,
-  mirroredDiscoveryTracks,
-  pipelinePhaseFor,
-  timeAgo,
-} from '../-sync.mirrored';
-import { SOURCE_REF_FAILED, sourceRefUpdatedToast } from '../-sync.pipeline';
-import { SYNC_SOURCES } from '../-sync.sources';
-import { asString } from '../-sync.url-tabs';
-import { useExportJobs } from '../-sync.use-export';
-import type { LibraryFilter, LibrarySort } from '../-sync.library';
-
 import {
   libraryCardState,
   librarySortedRows,
@@ -84,22 +77,27 @@ import {
   libraryVisibleFilters,
   libraryVisibleRows,
 } from '../-sync.library';
-import { autoSyncCanSchedulePlaylist } from '../-sync.autosync';
-import { cardScheduleLabel, useCardSchedules } from '../-sync.card-schedule';
-import { autoSyncPlaylistHealth, detectBrowserTimezone } from '../-sync.autosync';
-import { patchMirroredPreferences } from '../-sync.api';
-import type { AutoSyncWeeklyDraft } from './autosync-weekly';
-
+import {
+  mirroredHash,
+  mirroredPhaseLine,
+  mirroredDiscoveryTracks,
+  pipelinePhaseFor,
+  timeAgo,
+} from '../-sync.mirrored';
+import { SOURCE_REF_FAILED, sourceRefUpdatedToast } from '../-sync.pipeline';
+import { SYNC_SOURCES } from '../-sync.sources';
+import { asString } from '../-sync.url-tabs';
+import { useExportJobs } from '../-sync.use-export';
 import { AutoSyncWeeklyEditor } from './autosync-weekly';
-import { PlaylistCard, playlistCardPrimaryLabel } from './playlist-card';
-import { ScheduleMenu } from './schedule-menu';
-import { usePopoverDismiss } from './use-popover-dismiss';
-import { usePopoverPosition } from './use-popover-position';
-import { SourceIcon } from './source-icon';
 import { ExportModal, ExportStatusSpan } from './export-modal';
 import { MirroredDetailModal } from './mirrored-detail-modal';
+import { PlaylistCard, playlistCardPrimaryLabel } from './playlist-card';
+import { ScheduleMenu } from './schedule-menu';
+import { SourceIcon } from './source-icon';
 import { SourceRefModal } from './source-ref-modal';
 import { hydrateStatesForLoaded } from './url-import-tab';
+import { usePopoverDismiss } from './use-popover-dismiss';
+import { usePopoverPosition } from './use-popover-position';
 
 export interface MirroredTabProps {
   vertical: SourceVertical;
@@ -283,9 +281,7 @@ export function MirroredTab({
     top: number;
     left: number;
     anchor: HTMLElement;
-  } | null>(
-    null,
-  );
+  } | null>(null);
   /** The schedule picker, and the weekly editor it can open. */
   const [schedMenu, setSchedMenu] = useState<{
     row: MirroredPlaylistRow;
@@ -294,7 +290,6 @@ export function MirroredTab({
     anchor: HTMLElement;
   } | null>(null);
   const [weeklyDraft, setWeeklyDraft] = useState<AutoSyncWeeklyDraft | null>(null);
-
 
   const [renaming, setRenaming] = useState<number | null>(null);
   const [renameValue, setRenameValue] = useState('');
@@ -546,10 +541,7 @@ export function MirroredTab({
         );
         await load();
       } catch (err) {
-        window.showToast?.(
-          `Error: ${err instanceof Error ? err.message : String(err)}`,
-          'error',
-        );
+        window.showToast?.(`Error: ${err instanceof Error ? err.message : String(err)}`, 'error');
       }
     },
     [load],
@@ -824,118 +816,120 @@ export function MirroredTab({
         ) : (
           <div className="pl-grid">
             {librarySortedRows(visibleRows, sort).map((row) => {
-            const displayName = row.display_name || row.name || '';
-            // The live phase line, unchanged — its percentages and its
-            // Discovered N/M are information the resting meta line cannot
-            // carry, so the existing (tested) writer still produces them.
-            const hash = mirroredHash(row.id);
-            const live = vertical.states[hash];
-            const phaseLine = mirroredPhaseLine(
-              live?.phase ?? pipelinePhaseFor(row),
-              live
-                ? {
-                    discoveryProgress: live.discoveryProgress,
-                    spotifyMatches: live.spotifyMatches,
-                    spotifyTotal: live.spotifyTotal,
-                    pipeline_progress: live.pipeline_progress,
-                    pipeline_phase: live.pipeline_phase,
+              const displayName = row.display_name || row.name || '';
+              // The live phase line, unchanged — its percentages and its
+              // Discovered N/M are information the resting meta line cannot
+              // carry, so the existing (tested) writer still produces them.
+              const hash = mirroredHash(row.id);
+              const live = vertical.states[hash];
+              const phaseLine = mirroredPhaseLine(
+                live?.phase ?? pipelinePhaseFor(row),
+                live
+                  ? {
+                      discoveryProgress: live.discoveryProgress,
+                      spotifyMatches: live.spotifyMatches,
+                      spotifyTotal: live.spotifyTotal,
+                      pipeline_progress: live.pipeline_progress,
+                      pipeline_phase: live.pipeline_phase,
+                    }
+                  : {
+                      pipeline_progress: row.pipeline_state?.progress,
+                      pipeline_phase: row.pipeline_state?.phase,
+                    },
+                row,
+              );
+              const exportStatus = exportJobs.statuses[row.id];
+              const state = libraryCardState(row);
+              return renaming === row.id ? (
+                // Rename stays INLINE on the card: a modal for one text field is
+                // heavier than the edit itself.
+                <div className="pl-card pl-card--renaming" key={row.id}>
+                  <input
+                    className="card-name mirrored-rename-input"
+                    autoFocus
+                    value={renameValue}
+                    placeholder="Leave blank to use the original name"
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onKeyDown={(e) => {
+                      e.stopPropagation();
+                      if (e.key === 'Enter') void commitRename(row);
+                      if (e.key === 'Escape') setRenaming(null);
+                    }}
+                    onBlur={() => setRenaming(null)}
+                  />
+                </div>
+              ) : (
+                <PlaylistCard
+                  key={row.id}
+                  row={row}
+                  name={displayName}
+                  nameTitle={
+                    row.custom_name
+                      ? `${displayName} — originally "${row.name ?? ''}"`
+                      : displayName
                   }
-                : {
-                    pipeline_progress: row.pipeline_state?.progress,
-                    pipeline_phase: row.pipeline_state?.phase,
-                  },
-              row,
-            );
-            const exportStatus = exportJobs.statuses[row.id];
-            const state = libraryCardState(row);
-            return renaming === row.id ? (
-              // Rename stays INLINE on the card: a modal for one text field is
-              // heavier than the edit itself.
-              <div className="pl-card pl-card--renaming" key={row.id}>
-                <input
-                  className="card-name mirrored-rename-input"
-                  autoFocus
-                  value={renameValue}
-                  placeholder="Leave blank to use the original name"
-                  onClick={(e) => e.stopPropagation()}
-                  onChange={(e) => setRenameValue(e.target.value)}
-                  onKeyDown={(e) => {
-                    e.stopPropagation();
-                    if (e.key === 'Enter') void commitRename(row);
-                    if (e.key === 'Escape') setRenaming(null);
-                  }}
-                  onBlur={() => setRenaming(null)}
-                />
-              </div>
-            ) : (
-              <PlaylistCard
-                key={row.id}
-                row={row}
-                name={displayName}
-                nameTitle={
-                  row.custom_name ? `${displayName} — originally "${row.name ?? ''}"` : displayName
-                }
-                // "Mirrored 30m ago", the vanilla's own wording — it names what
-                // the timestamp actually is (the last mirror refresh), where a
-                // bare "30m ago" leaves you guessing.
-                when={`Mirrored ${timeAgo(row.updated_at || row.mirrored_at, Date.now())}`}
-                schedule={cardScheduleLabel(cardSchedules.schedules[String(row.id)], Date.now())}
-                scheduled={Boolean(cardSchedules.schedules[String(row.id)])}
-                health={autoSyncPlaylistHealth(cardSchedules.history, row.id)}
-                status={
-                  exportStatus ? (
-                    <ExportStatusSpan status={exportStatus} />
-                  ) : phaseLine ? (
-                    <span className="card-phase" style={{ color: phaseLine.color }}>
-                      {phaseLine.text}
-                    </span>
-                  ) : null
-                }
-                onOpen={() => onCardClick(row)}
-                primary={
-                  // The pipeline endpoint rejects file/beatport outright, and
-                  // lastfm cannot be scheduled either — same guard the board
-                  // uses, so the card never offers a run that 400s.
-                  !autoSyncCanSchedulePlaylist(row)
-                    ? null
-                    : {
-                  label: playlistCardPrimaryLabel(row),
-                  danger: state === 'error',
-                  onClick: () => {
-                    // "View progress" opens the card; everything else runs the
-                    // pipeline, which IS refresh + discover + sync + queue the
-                    // missing tracks — so "Find N missing" is literal, not a
-                    // friendlier name for something else.
-                    if (state === 'working') onCardClick(row);
-                    else void pipeline.run(row.id, row.name ?? '');
-                  },
-                      }
-                }
-                onSchedule={
-                  autoSyncCanSchedulePlaylist(row)
-                    ? (anchor) => {
-                        // Toggles, like the overflow trigger.
-                        const box = anchor.getBoundingClientRect();
-                        setSchedMenu((prev) =>
-                          prev?.row.id === row.id
-                            ? null
-                            : { row, top: box.bottom + 6, left: box.left, anchor },
-                        );
-                      }
-                    : undefined
-                }
-                onMore={(anchor) => {
-                  // A TOGGLE, not a set: clicking the trigger of an open menu
-                  // closes it, which is what the control looks like it does.
-                  const box = anchor.getBoundingClientRect();
-                  setMenu((prev) =>
-                    prev?.row.id === row.id
+                  // "Mirrored 30m ago", the vanilla's own wording — it names what
+                  // the timestamp actually is (the last mirror refresh), where a
+                  // bare "30m ago" leaves you guessing.
+                  when={`Mirrored ${timeAgo(row.updated_at || row.mirrored_at, Date.now())}`}
+                  schedule={cardScheduleLabel(cardSchedules.schedules[String(row.id)], Date.now())}
+                  scheduled={Boolean(cardSchedules.schedules[String(row.id)])}
+                  health={autoSyncPlaylistHealth(cardSchedules.history, row.id)}
+                  status={
+                    exportStatus ? (
+                      <ExportStatusSpan status={exportStatus} />
+                    ) : phaseLine ? (
+                      <span className="card-phase" style={{ color: phaseLine.color }}>
+                        {phaseLine.text}
+                      </span>
+                    ) : null
+                  }
+                  onOpen={() => onCardClick(row)}
+                  primary={
+                    // The pipeline endpoint rejects file/beatport outright, and
+                    // lastfm cannot be scheduled either — same guard the board
+                    // uses, so the card never offers a run that 400s.
+                    !autoSyncCanSchedulePlaylist(row)
                       ? null
-                      : { row, top: box.bottom + 6, left: box.right - 188, anchor },
-                  );
-                }}
-              />
-            );
+                      : {
+                          label: playlistCardPrimaryLabel(row),
+                          danger: state === 'error',
+                          onClick: () => {
+                            // "View progress" opens the card; everything else runs the
+                            // pipeline, which IS refresh + discover + sync + queue the
+                            // missing tracks — so "Find N missing" is literal, not a
+                            // friendlier name for something else.
+                            if (state === 'working') onCardClick(row);
+                            else void pipeline.run(row.id, row.name ?? '');
+                          },
+                        }
+                  }
+                  onSchedule={
+                    autoSyncCanSchedulePlaylist(row)
+                      ? (anchor) => {
+                          // Toggles, like the overflow trigger.
+                          const box = anchor.getBoundingClientRect();
+                          setSchedMenu((prev) =>
+                            prev?.row.id === row.id
+                              ? null
+                              : { row, top: box.bottom + 6, left: box.left, anchor },
+                          );
+                        }
+                      : undefined
+                  }
+                  onMore={(anchor) => {
+                    // A TOGGLE, not a set: clicking the trigger of an open menu
+                    // closes it, which is what the control looks like it does.
+                    const box = anchor.getBoundingClientRect();
+                    setMenu((prev) =>
+                      prev?.row.id === row.id
+                        ? null
+                        : { row, top: box.bottom + 6, left: box.right - 188, anchor },
+                    );
+                  }}
+                />
+              );
             })}
           </div>
         )}
@@ -972,9 +966,7 @@ export function MirroredTab({
             rows?.find((r) => r.id === weeklyDraft.playlistId)?.name ??
             ''
           }
-          hasExisting={Boolean(
-            cardSchedules.schedules[String(weeklyDraft.playlistId)]?.weekly,
-          )}
+          hasExisting={Boolean(cardSchedules.schedules[String(weeklyDraft.playlistId)]?.weekly)}
           onChange={setWeeklyDraft}
           onSave={() => {
             const target = rows?.find((r) => r.id === weeklyDraft.playlistId);

--- a/webui/src/routes/sync/-ui/mobile-layout.test.ts
+++ b/webui/src/routes/sync/-ui/mobile-layout.test.ts
@@ -26,7 +26,6 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
 /** Comments stripped: they discuss the very properties being asserted. */
@@ -35,9 +34,9 @@ const css = readFileSync(resolve(process.cwd(), 'static/style.css'), 'utf8').rep
   '',
 );
 
-const phoneBlocks = [
-  ...css.matchAll(/@media[^{]*max-width:\s*768px[^{]*\{([\s\S]*?)\n\}/g),
-].map((m) => m[1]);
+const phoneBlocks = [...css.matchAll(/@media[^{]*max-width:\s*768px[^{]*\{([\s\S]*?)\n\}/g)].map(
+  (m) => m[1],
+);
 
 function phoneRule(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/webui/src/routes/sync/-ui/playlist-art.test.tsx
+++ b/webui/src/routes/sync/-ui/playlist-art.test.tsx
@@ -87,7 +87,15 @@ describe('playlistArtUrl', () => {
   });
 
   it('is safe on the shapes a SELECT * or an untyped payload can produce', () => {
-    for (const row of [null, undefined, 'a string', 42, {}, { image_url: null }, { image_url: 7 }]) {
+    for (const row of [
+      null,
+      undefined,
+      'a string',
+      42,
+      {},
+      { image_url: null },
+      { image_url: 7 },
+    ]) {
       expect(playlistArtUrl(row)).toBeUndefined();
     }
   });
@@ -103,9 +111,17 @@ describe('playlistCoverTiles', () => {
   });
 
   it('is empty for the shapes a nullable JSON column really produces', () => {
-    for (const row of [null, undefined, {}, { cover_tiles: null }, { cover_tiles: '' },
-                       { cover_tiles: '[]' }, { cover_tiles: 'not json' },
-                       { cover_tiles: '{"a":1}' }, { cover_tiles: 42 }]) {
+    for (const row of [
+      null,
+      undefined,
+      {},
+      { cover_tiles: null },
+      { cover_tiles: '' },
+      { cover_tiles: '[]' },
+      { cover_tiles: 'not json' },
+      { cover_tiles: '{"a":1}' },
+      { cover_tiles: 42 },
+    ]) {
       expect(playlistCoverTiles(row)).toEqual([]);
     }
   });
@@ -146,7 +162,14 @@ describe('PlaylistCollage', () => {
 
   it('asks the cache for card-sized copies, like every other cover here', () => {
     const { container } = render(
-      <PlaylistCollage tiles={['/api/image-cache/a', '/api/image-cache/b', '/api/image-cache/c', '/api/image-cache/d']} />,
+      <PlaylistCollage
+        tiles={[
+          '/api/image-cache/a',
+          '/api/image-cache/b',
+          '/api/image-cache/c',
+          '/api/image-cache/d',
+        ]}
+      />,
     );
     expect(container.querySelector('img')?.getAttribute('src')).toBe('/api/image-cache/a?v=card');
   });

--- a/webui/src/routes/sync/-ui/playlist-card.test.tsx
+++ b/webui/src/routes/sync/-ui/playlist-card.test.tsx
@@ -6,9 +6,9 @@
  * design, and it is the first thing a future change would erode.
  */
 
+import { fireEvent, render, screen } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { MirroredPlaylistRow } from '../-sync.mirrored';
@@ -81,9 +81,9 @@ describe('the ring — what a healthy card does NOT show', () => {
 describe('the meta line', () => {
   it('states the count alone when everything is fine', () => {
     // "140 tracks · 140 discovered" says the same thing twice.
-    expect(playlistCardMeta(row({ total_count: 140, discovered_count: 140 }), 'synced 3h ago')).toBe(
-      '140 tracks · synced 3h ago',
-    );
+    expect(
+      playlistCardMeta(row({ total_count: 140, discovered_count: 140 }), 'synced 3h ago'),
+    ).toBe('140 tracks · synced 3h ago');
   });
 
   it('says what is in the library only when it differs', () => {

--- a/webui/src/routes/sync/-ui/playlist-card.tsx
+++ b/webui/src/routes/sync/-ui/playlist-card.tsx
@@ -253,9 +253,7 @@ export function PlaylistCard({
             </span>
           ) : null}
         </div>
-        <div className="pl-card-meta card-meta">
-          {status ?? playlistCardMeta(row, when)}
-        </div>
+        <div className="pl-card-meta card-meta">{status ?? playlistCardMeta(row, when)}</div>
         {/* The schedule is a CONTROL, not a label: with Auto-Sync's board
             gone this is the only place a cadence gets set. It still reads as a
             quiet pill at rest — a dropdown sitting open on every card was the

--- a/webui/src/routes/sync/-ui/schedule-menu.test.tsx
+++ b/webui/src/routes/sync/-ui/schedule-menu.test.tsx
@@ -112,9 +112,7 @@ describe('what it shows as current', () => {
 describe('dismissal', () => {
   it('names the playlist for assistive tech', () => {
     renderMenu();
-    expect(screen.getByRole('menu').getAttribute('aria-label')).toBe(
-      'Sync schedule for Road Trip',
-    );
+    expect(screen.getByRole('menu').getAttribute('aria-label')).toBe('Sync schedule for Road Trip');
   });
 
   it('closes on Escape', () => {

--- a/webui/src/routes/sync/-ui/schedule-menu.tsx
+++ b/webui/src/routes/sync/-ui/schedule-menu.tsx
@@ -19,14 +19,13 @@ import { useRef, useState } from 'react';
 
 import type { MirroredRow } from '../-sync.autosync';
 
-import { usePopoverDismiss } from './use-popover-dismiss';
-import { usePopoverPosition } from './use-popover-position';
-
 import {
   AUTO_SYNC_BUCKETS,
   autoSyncIntervalLabel,
   autoSyncParseCustomInterval,
 } from '../-sync.autosync';
+import { usePopoverDismiss } from './use-popover-dismiss';
+import { usePopoverPosition } from './use-popover-position';
 
 /** The day-sets worth a one-click preset; everything else is Custom. */
 export const SCHEDULE_WEEKLY_PRESETS: readonly { label: string; days: string[] }[] = [
@@ -107,8 +106,8 @@ export function ScheduleMenu({
 
       {custom === null ? (
         // Ticked only when the current interval is NOT one of the presets,
-          // which is exactly when 'custom' is the true answer.
-          item('Custom interval…', hours !== null && !AUTO_SYNC_BUCKETS.includes(hours), () => {
+        // which is exactly when 'custom' is the true answer.
+        item('Custom interval…', hours !== null && !AUTO_SYNC_BUCKETS.includes(hours), () => {
           setCustom(String(hours ?? 6));
         })
       ) : (

--- a/webui/src/routes/sync/-ui/server-compare-editor.tsx
+++ b/webui/src/routes/sync/-ui/server-compare-editor.tsx
@@ -179,7 +179,10 @@ function ServerRow({
               row is indistinguishable from one that was never matched and the
               user re-matches the same track forever. The real sync DOES use it. */}
           {track.has_manual_match ? (
-            <span className="empty-slot-matched-note" title="Your manual match is saved and will be used on the next sync — this track just isn't in the server playlist yet.">
+            <span
+              className="empty-slot-matched-note"
+              title="Your manual match is saved and will be used on the next sync — this track just isn't in the server playlist yet."
+            >
               Already matched &middot; will be added on sync
             </span>
           ) : null}

--- a/webui/src/routes/sync/-ui/server-playlist-list.tsx
+++ b/webui/src/routes/sync/-ui/server-playlist-list.tsx
@@ -18,7 +18,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MirroredMatch, ServerPlaylist } from '../-sync.server';
 
 import { recordServerLink } from '../-sync.api';
-
 import { timeAgo } from '../-sync.mirrored';
 import {
   fetchMirroredMatches,

--- a/webui/src/routes/sync/-ui/sync-page.tsx
+++ b/webui/src/routes/sync/-ui/sync-page.tsx
@@ -22,16 +22,17 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { LbCardData } from '../-sync.lb-tabs';
 import type { MirroredMatch, ServerPlaylist } from '../-sync.server';
-import { normalizeSyncTab } from '../-sync.shell';
 import type { SyncTabId } from '../-sync.shell';
 
 import { metadataSourceLabel } from '../-sync.modal-core';
+import { normalizeSyncTab } from '../-sync.shell';
 import { useAutoSync } from '../-sync.use-autosync';
 import { useSyncHistory } from '../-sync.use-history';
 import { useSyncPage } from '../-sync.use-page';
 import { QobuzTab, TidalTab } from './account-tab';
 import { DeezerArlTab, SpotifyTab } from './account-tabs';
 import { ActivityModal, type ActivityTab } from './activity-modal';
+import { AddPlaylistSheet } from './add-playlist-sheet';
 import { AutoSyncModal } from './autosync-modal';
 import { BeatportTab } from './beatport-tab';
 import { ImportFileTab } from './import-file-tab';
@@ -44,7 +45,6 @@ import { SoulsyncDiscoveryTab } from './soulsync-discovery-tab';
 import { SyncModals } from './sync-modals';
 import { SyncShell } from './sync-shell';
 import { SyncSidebar } from './sync-sidebar';
-import { AddPlaylistSheet } from './add-playlist-sheet';
 import { DeezerLinkTab, ITunesLinkTab, SpotifyPublicTab, YouTubeTab } from './url-import-tab';
 
 /** The server tab's two views (2226-2236 vs the compare editor). */

--- a/webui/src/routes/sync/-ui/sync-shell.test.tsx
+++ b/webui/src/routes/sync/-ui/sync-shell.test.tsx
@@ -3,9 +3,9 @@
  * tab handler at sync-services.js 3694-3811.
  */
 
+import { act, fireEvent, render } from '@testing-library/react';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { act, fireEvent, render } from '@testing-library/react';
 import { useEffect } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -130,11 +130,7 @@ describe('the tab strip', () => {
     // through Add playlist now, which detects the service from the link.
     const { container } = renderShell();
     const btns = Array.from(container.querySelectorAll('.sync-tab-button'));
-    expect(btns.map((b) => b.getAttribute('data-tab'))).toEqual([
-      'mirrored',
-      'server',
-      'beatport',
-    ]);
+    expect(btns.map((b) => b.getAttribute('data-tab'))).toEqual(['mirrored', 'server', 'beatport']);
   });
 
   it('opens on Mirrored — the library, not a source directory', () => {

--- a/webui/src/routes/sync/-ui/sync-shell.tsx
+++ b/webui/src/routes/sync/-ui/sync-shell.tsx
@@ -190,18 +190,18 @@ export function SyncShell({
                 {/* Divides the two actions that CHANGE something from the four
                     that only report what already happened. */}
                 {index === 1 && <span className="sync-header-divider" />}
-              <button
-                type="button"
-                className={`btn btn--sm btn--secondary sync-history-btn${
-                  action.key === 'auto-sync' ? ' auto-sync-manager-btn' : ''
-                }`}
-                title={action.title}
-                onClick={() => {
-                  runHeaderAction(action.key, onAutoSync, onActivity);
-                }}
-              >
-                {action.label}
-              </button>
+                <button
+                  type="button"
+                  className={`btn btn--sm btn--secondary sync-history-btn${
+                    action.key === 'auto-sync' ? ' auto-sync-manager-btn' : ''
+                  }`}
+                  title={action.title}
+                  onClick={() => {
+                    runHeaderAction(action.key, onAutoSync, onActivity);
+                  }}
+                >
+                  {action.label}
+                </button>
               </Fragment>
             ))}
           </div>

--- a/webui/src/routes/sync/-ui/url-import-tab.test.tsx
+++ b/webui/src/routes/sync/-ui/url-import-tab.test.tsx
@@ -9,8 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { UrlTabPlaylist } from '../-sync.url-tabs';
 
-import { fetchYouTubePlaylists } from '../-sync.api';
 import { forgetAccountPlaylists } from '../-sync.account-cache';
+import { fetchYouTubePlaylists } from '../-sync.api';
 import { SYNC_SOURCES } from '../-sync.sources';
 import { useSourceVertical } from '../-sync.use-vertical';
 import { UrlHistoryBar, useUrlHistory } from './url-history-bar';

--- a/webui/src/routes/sync/-ui/url-import-tab.tsx
+++ b/webui/src/routes/sync/-ui/url-import-tab.tsx
@@ -23,6 +23,7 @@ import type { SourceVerticalConfig } from '../-sync.sources';
 import type { UrlTabPlaylist } from '../-sync.url-tabs';
 import type { SourceVertical } from '../-sync.use-vertical';
 
+import { urlTabCacheKey, useRememberedPlaylists } from '../-sync.account-cache';
 import {
   fetchDeezerLinkPlaylist,
   fetchSourcePlaylistsStates,
@@ -65,7 +66,6 @@ import { URL_HISTORY_SOURCES } from '../-sync.urls';
 import { fetchAndHydrateState } from '../-sync.use-vertical';
 import { cardProgressLine } from './card-progress';
 import { playlistArtUrl } from './playlist-art';
-import { urlTabCacheKey, useRememberedPlaylists } from '../-sync.account-cache';
 import { SourceCard } from './source-card';
 import { UrlHistoryBar, useUrlHistory } from './url-history-bar';
 

--- a/webui/src/routes/sync/-ui/use-popover-dismiss.test.ts
+++ b/webui/src/routes/sync/-ui/use-popover-dismiss.test.ts
@@ -41,9 +41,7 @@ function settle() {
 
 function mount(anchor?: HTMLElement | null) {
   const onClose = vi.fn();
-  const hook = renderHook(() =>
-    usePopoverDismiss({ ref: { current: popover }, anchor, onClose }),
-  );
+  const hook = renderHook(() => usePopoverDismiss({ ref: { current: popover }, anchor, onClose }));
   settle();
   return { onClose, ...hook };
 }

--- a/webui/src/routes/sync/-ui/use-popover-position.test.ts
+++ b/webui/src/routes/sync/-ui/use-popover-position.test.ts
@@ -140,7 +140,9 @@ describe('usePopoverPosition', () => {
 
     const el = document.createElement('div');
     el.getBoundingClientRect = () => ({ width: 200, height }) as DOMRect;
-    const { result } = renderHook(() => usePopoverPosition({ top: 460, left: 100 }, { current: el }));
+    const { result } = renderHook(() =>
+      usePopoverPosition({ top: 460, left: 100 }, { current: el }),
+    );
     expect(result.current).toEqual({ top: 460, left: 100 }); // 800 - 300 - 8
 
     height = 500;

--- a/webui/src/routes/tools/-tools.groups.test.ts
+++ b/webui/src/routes/tools/-tools.groups.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { FindingGroup, FindingTypeInfo } from './-tools.groups';
+
 import {
   contributionSegments,
   FINDING_TYPE_BLURBS,

--- a/webui/src/routes/tools/-tools.ops.test.ts
+++ b/webui/src/routes/tools/-tools.ops.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { RepairJob } from './-tools.types';
+
 import {
   CATEGORY_ORDER,
   cadenceFromHours,
@@ -140,10 +141,7 @@ describe('jobFamilies', () => {
       ],
       NOW,
     );
-    expect(families.map((f) => f.category)).toEqual([
-      'Files & storage',
-      'Invented By The Backend',
-    ]);
+    expect(families.map((f) => f.category)).toEqual(['Files & storage', 'Invented By The Backend']);
   });
 
   it('counts running, due and pending per family', () => {
@@ -202,8 +200,6 @@ describe('mostOverdueJob', () => {
   });
 
   it('ignores disabled jobs — an off job is not late, it is off', () => {
-    expect(
-      mostOverdueJob([job({ enabled: false, next_run: hoursFromNow(-500) })], NOW),
-    ).toBeNull();
+    expect(mostOverdueJob([job({ enabled: false, next_run: hoursFromNow(-500) })], NOW)).toBeNull();
   });
 });

--- a/webui/src/routes/tools/-tools.ops.ts
+++ b/webui/src/routes/tools/-tools.ops.ts
@@ -131,7 +131,11 @@ export function jobSchedule(job: RepairJob, now: number = Date.now()): JobSchedu
     // Under an interval's grace, "due" is the honest word; a job that has
     // been waiting days is a different story and should look like one.
     if (overdue >= Math.max(2, (job.interval_hours || 24) * 0.5)) {
-      return { state: 'overdue', label: `overdue by ${roughDuration(overdue)}`, overdueHours: overdue };
+      return {
+        state: 'overdue',
+        label: `overdue by ${roughDuration(overdue)}`,
+        overdueHours: overdue,
+      };
     }
     return { state: 'due', label: 'due now' };
   }
@@ -187,7 +191,9 @@ export function jobFamilies(jobs: readonly RepairJob[], now: number = Date.now()
       running: sorted.filter((job) => job.is_running).length,
       waiting: sorted.filter((job) => {
         const schedule = jobSchedule(job, now);
-        return schedule.state === 'due' || schedule.state === 'overdue' || schedule.state === 'never';
+        return (
+          schedule.state === 'due' || schedule.state === 'overdue' || schedule.state === 'never'
+        );
       }).length,
       pending: sorted.reduce((sum, job) => sum + (job.pending_findings_count || 0), 0),
     });
@@ -218,11 +224,7 @@ export function familySummary(family: JobFamily): string {
 // ── Sparkline source ─────────────────────────────────────────────────────────
 
 /** Findings-per-run for one job, oldest → newest, from the shared history. */
-export function jobTrend(
-  runs: readonly RepairJobRun[],
-  jobId: string,
-  limit = 12,
-): number[] {
+export function jobTrend(runs: readonly RepairJobRun[], jobId: string, limit = 12): number[] {
   return runs
     .filter((run) => run.job_id === jobId)
     .slice(0, limit)
@@ -232,7 +234,10 @@ export function jobTrend(
 
 /** The job the page would point at first: enabled, most overdue, and with
  *  something to show for it. Null when nothing is waiting. */
-export function mostOverdueJob(jobs: readonly RepairJob[], now: number = Date.now()): RepairJob | null {
+export function mostOverdueJob(
+  jobs: readonly RepairJob[],
+  now: number = Date.now(),
+): RepairJob | null {
   let best: RepairJob | null = null;
   let worst = 0;
   for (const job of jobs) {

--- a/webui/src/routes/tools/-tools.runs.test.ts
+++ b/webui/src/routes/tools/-tools.runs.test.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { RepairJobRun } from './-tools.types';
+
 import { formatCacheAge, parseDbTimestamp } from './-tools.core';
 import {
   filterRuns,
@@ -49,9 +50,7 @@ describe('parseDbTimestamp', () => {
   });
 
   it('handles fractional seconds', () => {
-    expect(parseDbTimestamp('2026-08-12 09:00:00.500')).toBe(
-      Date.UTC(2026, 7, 12, 9, 0, 0) + 500,
-    );
+    expect(parseDbTimestamp('2026-08-12 09:00:00.500')).toBe(Date.UTC(2026, 7, 12, 9, 0, 0) + 500);
   });
 });
 
@@ -213,8 +212,9 @@ describe('filterRuns', () => {
 describe('runCounters', () => {
   it('always shows checked and took, and drops the zeroes between them', () => {
     expect(runCounters(run()).map((c) => c.label)).toEqual(['Checked', 'Took']);
-    expect(runCounters(run({ findings_created: 3, auto_fixed: 1, errors: 2 })).map((c) => c.label))
-      .toEqual(['Checked', 'Findings raised', 'Auto-fixed', 'Errors', 'Took']);
+    expect(
+      runCounters(run({ findings_created: 3, auto_fixed: 1, errors: 2 })).map((c) => c.label),
+    ).toEqual(['Checked', 'Findings raised', 'Auto-fixed', 'Errors', 'Took']);
   });
 });
 

--- a/webui/src/routes/tools/-tools.runs.ts
+++ b/webui/src/routes/tools/-tools.runs.ts
@@ -182,9 +182,7 @@ export function runJobFilters(runs: readonly RepairJobRun[]): RunJobFilter[] {
     if (runOutcome(run) === 'failed') entry.hasFailure = true;
     byJob.set(jobId, entry);
   }
-  return [...byJob.values()].sort(
-    (a, b) => b.count - a.count || a.label.localeCompare(b.label),
-  );
+  return [...byJob.values()].sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
 }
 
 export function filterRuns(

--- a/webui/src/routes/tools/-ui/findings-inbox.tsx
+++ b/webui/src/routes/tools/-ui/findings-inbox.tsx
@@ -15,8 +15,9 @@
 import type { ReactNode } from 'react';
 
 import type { FindingGroup, FindingTypeInfo } from '../-tools.groups';
-import { findingTypeBlurb, groupCountForStatus, sortInboxGroups } from '../-tools.groups';
+
 import { findingSeverityClass, findingSeverityIcon } from '../-tools.core';
+import { findingTypeBlurb, groupCountForStatus, sortInboxGroups } from '../-tools.groups';
 
 export interface FindingsInboxProps {
   /** Already filtered by the toolbar; ordering is this component's job. */

--- a/webui/src/routes/tools/-ui/findings-surface.tsx
+++ b/webui/src/routes/tools/-ui/findings-surface.tsx
@@ -31,6 +31,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import type { FindingGroup, FindingTypeInfo } from '../-tools.groups';
 import type {
   BulkFixStatus,
   CacheHealthStats,
@@ -38,7 +39,6 @@ import type {
   RepairJob,
   RepairJobRun,
 } from '../-tools.types';
-import type { FindingGroup, FindingTypeInfo } from '../-tools.groups';
 
 import {
   bulkFindingAction,
@@ -697,7 +697,10 @@ export function FindingsSurface({
                     // you cleared one group (the #1142 family).
                     findingType: group.finding_type,
                   })
-                : { success: true, deleted: (await dismissFindingType(group.finding_type)).updated };
+                : {
+                    success: true,
+                    deleted: (await dismissFindingType(group.finding_type)).updated,
+                  };
             toast(
               result.success
                 ? `Cleared ${(result.deleted || 0).toLocaleString()} findings`
@@ -913,7 +916,11 @@ export function FindingsSurface({
    *  auto-fixes never grows a control that always reads zero. */
   const statusSegments =
     (counts?.auto_fixed || 0) > 0
-      ? [...STATUS_SEGMENTS.slice(0, 3), { value: 'auto_fixed', label: 'Auto-fixed' }, STATUS_SEGMENTS[3]]
+      ? [
+          ...STATUS_SEGMENTS.slice(0, 3),
+          { value: 'auto_fixed', label: 'Auto-fixed' },
+          STATUS_SEGMENTS[3],
+        ]
       : STATUS_SEGMENTS;
 
   /**

--- a/webui/src/routes/tools/-ui/health-hero.tsx
+++ b/webui/src/routes/tools/-ui/health-hero.tsx
@@ -11,9 +11,9 @@
  * this file is the rendering of it.
  */
 
+import type { FindingGroup, FindingTypeInfo } from '../-tools.groups';
 import type { RepairJobRun } from '../-tools.types';
 
-import type { FindingGroup, FindingTypeInfo } from '../-tools.groups';
 import {
   contributionSegments,
   findingsTrend,

--- a/webui/src/routes/tools/-ui/operations.tsx
+++ b/webui/src/routes/tools/-ui/operations.tsx
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import type { Cadence, IntervalUnit } from '../-tools.ops';
 import type { RepairJob, RepairJobProgress, RepairJobRun } from '../-tools.types';
 
 import {
@@ -45,7 +46,7 @@ import {
   repairJobMeta,
   repairSettingInput,
 } from '../-tools.core';
-import type { Cadence, IntervalUnit } from '../-tools.ops';
+import { sparklinePoints } from '../-tools.groups';
 import {
   cadenceFromHours,
   cadenceLabel,
@@ -55,7 +56,6 @@ import {
   jobSchedule,
   jobTrend,
 } from '../-tools.ops';
-import { sparklinePoints } from '../-tools.groups';
 
 function toast(message: string, type = 'info') {
   window.showToast?.(message, type);
@@ -154,10 +154,19 @@ function CadenceEditor({ job, onSaved }: { job: RepairJob; onSaved: () => void }
           </option>
         ))}
       </select>
-      <button type="button" className="repair-tile-cadence-save" disabled={saving} onClick={() => void save()}>
+      <button
+        type="button"
+        className="repair-tile-cadence-save"
+        disabled={saving}
+        onClick={() => void save()}
+      >
         {saving ? '…' : 'Save'}
       </button>
-      <button type="button" className="repair-tile-cadence-cancel" onClick={() => setEditing(false)}>
+      <button
+        type="button"
+        className="repair-tile-cadence-cancel"
+        onClick={() => setEditing(false)}
+      >
         Cancel
       </button>
     </span>
@@ -202,83 +211,83 @@ function JobSettings({
       id={`repair-settings-${job.job_id}`}
       style={{ display: open ? '' : 'none' }}
     >
-        {Object.entries(job.settings || {}).map(([key, value]) => {
-          const field = repairSettingInput(key, value, job.setting_options?.[key]);
-          if (field.kind === 'section') {
-            return (
-              <div className="repair-setting-section" key={key}>
-                {field.title}
-              </div>
-            );
-          }
-          const current = values[key];
+      {Object.entries(job.settings || {}).map(([key, value]) => {
+        const field = repairSettingInput(key, value, job.setting_options?.[key]);
+        if (field.kind === 'section') {
           return (
-            <div className="repair-setting-row" key={key}>
-              <label>{prettifyRepairSettingKey(key)}</label>
-              {field.kind === 'select' ? (
-                <select
-                  className="repair-setting-input"
-                  data-job={job.job_id}
-                  data-key={key}
-                  value={settingText(current)}
-                  onChange={(event) =>
-                    setValues((previous) => ({ ...previous, [key]: event.target.value }))
-                  }
-                >
-                  {field.options.map((option) => (
-                    <option value={option} key={option}>
-                      {prettifyRepairSettingKey(option)}
-                    </option>
-                  ))}
-                </select>
-              ) : field.kind === 'checkbox' ? (
-                <input
-                  type="checkbox"
-                  className="repair-setting-input"
-                  data-job={job.job_id}
-                  data-key={key}
-                  checked={Boolean(current)}
-                  onChange={(event) =>
-                    setValues((previous) => ({ ...previous, [key]: event.target.checked }))
-                  }
-                />
-              ) : field.kind === 'number' ? (
-                <input
-                  type="number"
-                  className="repair-setting-input"
-                  data-job={job.job_id}
-                  data-key={key}
-                  value={settingText(current)}
-                  step="0.01"
-                  // A setting that is CURRENTLY negative gets no floor — some
-                  // thresholds are legitimately below zero and a min of 0 would
-                  // make them un-editable.
-                  {...(field.allowNegative ? {} : { min: '0' })}
-                  onChange={(event) =>
-                    setValues((previous) => ({
-                      ...previous,
-                      [key]: Number.parseFloat(event.target.value),
-                    }))
-                  }
-                />
-              ) : (
-                <input
-                  type="text"
-                  className="repair-setting-input"
-                  data-job={job.job_id}
-                  data-key={key}
-                  value={settingText(current)}
-                  onChange={(event) =>
-                    setValues((previous) => ({ ...previous, [key]: event.target.value }))
-                  }
-                />
-              )}
+            <div className="repair-setting-section" key={key}>
+              {field.title}
             </div>
           );
-        })}
-        <button className="repair-save-settings-btn" type="button" onClick={() => void save()}>
-          Save Settings
-        </button>
+        }
+        const current = values[key];
+        return (
+          <div className="repair-setting-row" key={key}>
+            <label>{prettifyRepairSettingKey(key)}</label>
+            {field.kind === 'select' ? (
+              <select
+                className="repair-setting-input"
+                data-job={job.job_id}
+                data-key={key}
+                value={settingText(current)}
+                onChange={(event) =>
+                  setValues((previous) => ({ ...previous, [key]: event.target.value }))
+                }
+              >
+                {field.options.map((option) => (
+                  <option value={option} key={option}>
+                    {prettifyRepairSettingKey(option)}
+                  </option>
+                ))}
+              </select>
+            ) : field.kind === 'checkbox' ? (
+              <input
+                type="checkbox"
+                className="repair-setting-input"
+                data-job={job.job_id}
+                data-key={key}
+                checked={Boolean(current)}
+                onChange={(event) =>
+                  setValues((previous) => ({ ...previous, [key]: event.target.checked }))
+                }
+              />
+            ) : field.kind === 'number' ? (
+              <input
+                type="number"
+                className="repair-setting-input"
+                data-job={job.job_id}
+                data-key={key}
+                value={settingText(current)}
+                step="0.01"
+                // A setting that is CURRENTLY negative gets no floor — some
+                // thresholds are legitimately below zero and a min of 0 would
+                // make them un-editable.
+                {...(field.allowNegative ? {} : { min: '0' })}
+                onChange={(event) =>
+                  setValues((previous) => ({
+                    ...previous,
+                    [key]: Number.parseFloat(event.target.value),
+                  }))
+                }
+              />
+            ) : (
+              <input
+                type="text"
+                className="repair-setting-input"
+                data-job={job.job_id}
+                data-key={key}
+                value={settingText(current)}
+                onChange={(event) =>
+                  setValues((previous) => ({ ...previous, [key]: event.target.value }))
+                }
+              />
+            )}
+          </div>
+        );
+      })}
+      <button className="repair-save-settings-btn" type="button" onClick={() => void save()}>
+        Save Settings
+      </button>
     </div>
   );
 }
@@ -432,7 +441,10 @@ export function OperationTile({
         )}
 
         <div className="repair-job-actions">
-          <label className="repair-job-toggle" title={enabled ? 'Disable this job' : 'Enable this job'}>
+          <label
+            className="repair-job-toggle"
+            title={enabled ? 'Disable this job' : 'Enable this job'}
+          >
             <input
               type="checkbox"
               checked={enabled}
@@ -496,7 +508,10 @@ export function OperationTile({
           <div className="repair-progress-phase">{progress.phase || ''}</div>
           <div className="repair-progress-log">
             {(progress.log || []).map((line, index) => (
-              <div className={`repair-log-line ${line.type || 'info'}`} key={`${index}-${line.text}`}>
+              <div
+                className={`repair-log-line ${line.type || 'info'}`}
+                key={`${index}-${line.text}`}
+              >
                 {line.text}
               </div>
             ))}

--- a/webui/src/routes/tools/-ui/run-history.test.tsx
+++ b/webui/src/routes/tools/-ui/run-history.test.tsx
@@ -102,9 +102,7 @@ describe('rows', () => {
   });
 
   it('shows the recorded reason when a run failed', () => {
-    renderHistory([
-      run({ status: 'failed', errors: 1, error_text: 'AcoustID API key missing' }),
-    ]);
+    renderHistory([run({ status: 'failed', errors: 1, error_text: 'AcoustID API key missing' })]);
     fireEvent.click(document.querySelector('.repair-run-head') as HTMLElement);
     expect(screen.getByText('AcoustID API key missing')).toBeTruthy();
   });

--- a/webui/src/routes/tools/-ui/settings-panel-fit.test.ts
+++ b/webui/src/routes/tools/-ui/settings-panel-fit.test.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-
 import { describe, expect, it } from 'vitest';
 
 /**

--- a/webui/src/routes/wishlist/-ui/wishlist-list.tsx
+++ b/webui/src/routes/wishlist/-ui/wishlist-list.tsx
@@ -24,11 +24,11 @@ const SORTS: { key: WishlistListSort; label: string; title: string }[] = [
 function sortGroups(groups: WishlistArtistGroup[], sort: WishlistListSort): WishlistArtistGroup[] {
   const copy = [...groups];
   if (sort === 'name') return copy.sort((a, b) => a.name.localeCompare(b.name));
-  if (sort === 'size') return copy.sort((a, b) => b.total - a.total || a.name.localeCompare(b.name));
+  if (sort === 'size')
+    return copy.sort((a, b) => b.total - a.total || a.name.localeCompare(b.name));
   // failing: stuck counts first, then size, then name — the triage order.
   return copy.sort(
-    (a, b) =>
-      b.failingCount - a.failingCount || b.total - a.total || a.name.localeCompare(b.name),
+    (a, b) => b.failingCount - a.failingCount || b.total - a.total || a.name.localeCompare(b.name),
   );
 }
 


### PR DESCRIPTION
`dev` is at **18 test failures and 4 lint errors** on a clean checkout right
now. Every one of them is fixed here, plus the atomic-publish bug the first of
them was hiding.

Two commits: the fixes, then an `oxfmt` pass on its own so the fixes stay
readable.

---

## The publish bug

`iter_staged_files` walked `os.walk` order — directory order, which is the
filesystem's business. The same album publishes `01` then `02` on ext4 and `02`
then `01` on btrfs.

Publish order decides which files are already live when a later one fails, so it
decides what the rollback has to undo. An all-or-nothing publish whose behaviour
under failure depends on the host filesystem can't really be reasoned about.
Sorted now, and pinned by a test.

It was also **disarming the guard for the rollback repoint from 73a68c6f6**. On a
box that walks `02` first, the failing track is the *first* one — nothing has
published yet, so `_roll_back` never runs. I checked it directly: with
`db_path_update_fn(final, staged)` deleted, `test_rollback_takes_the_db_pointer_
back_with_the_file` still passed here before this change, and fails after it.
Its sibling `test_a_file_that_will_not_roll_back_keeps_its_db_row` is the one
that went red, which is what led me here.

## The suite

**29 setup errors — `duplicate column name: channel_id`.**
`VideoDatabase._ensure_columns` was a check-then-act: PRAGMA says absent, ALTER
adds it, two processes doing that at once means the loser raises. That error
isn't contained — `_initialize_database` rolls back and re-raises, so the whole
video database comes up unusable over a column that *is* now there. The suite
hits it because every xdist worker initialises the one shared temp DB; in
production the same window is a restart racing a live enrichment worker. The
duplicate is swallowed now, and only the duplicate — a missing table or a bad
type is still a real migration failure. A test for each half.

**24 failures in `test_vanilla_globals_resolve`.** All 43 parametrized cases
wrote their oxlint config to one shared filename in `webui/` and unlinked it
under each other, so a case linted its neighbour's globals and reported
`no-undef` for names that were legitimately excluded. One file per case now.
Serial 14.5s → parallel 3.5s, and the pattern is gitignored so a killed run
leaves nothing behind.

**`test_tidal_collection_tracks`, the virtual-playlist guard.** It asserted
`not mock_get.called` on a patched `core.tidal_client.requests.get` — an object
the path under test can't reach at all, since the real fallthrough issues
`self.session.get(.../playlists/<id>)` and `get_collection_tracks` is mocked out.
So it couldn't fail for the reason it claimed, and could only fail for an
unrelated one: `import web_server` starts 27 background workers, one was
mid-request through the same shared `requests` module, `.called` flipped, and a
Tidal playlist test went red over a JioSaavn 429. Rewritten to assert on
`client.session`, where the endpoint it cares about actually lives.
Negative-checked — delete the virtual dispatch and it fails now; before, it
didn't.

**3 failures in `test_watchlist_blind_source_fallthrough`.** Every assertion is
about the *order* sources are asked in, and the un-preferred path derives that
from `get_primary_source()`, which reads the shared process-wide
`config_manager`. An earlier test in the same worker sets a different primary,
and this one reads `['itunes']` where it expects `['deezer']` — which reads as a
real regression. The chain is pinned now. The `preferred` path deliberately
keeps the real `get_source_priority`, since that's what
`test_per_artist_override_still_wins` is checking.

**4 `oxlint --type-check` errors**, all TS2493 in
`listening-history-band.test.tsx`: `vi.fn(async () => {})` infers `calls: []`,
an empty tuple, so every `mock.calls[0][n]` is a type error. Typed to the real
arity. CI gates on this, so those four turn `npm run check` red on every branch,
not just that file.

## The formatting commit

`build-and-test.yml` runs `npm run check`, and its trigger is
`push: branches-ignore: [main, dev]` — so the gate never runs on a `dev` push,
drift accumulates there unseen, and every branch cut from `dev` inherits a red CI
for files it never touched. This one did: `oxfmt --check` failed on 101 files,
none of them mine. Almost all import-group blank lines and JSX attribute
wrapping.

Might be worth letting the workflow run on `dev` too, or an `oxfmt` before a
release tag — otherwise the next contributor pays this again.

---

## Verification

- **14,643 python tests pass, 0 failures** (from 18), across three consecutive
  `-n 8` runs
- 7,904 vitest pass
- `ruff` clean, `oxlint` 0 errors, `oxfmt --check` clean, `npm run build` clean
- Every fix was negative-checked: break it, watch the test fall over, put it
  back

## One thing I did NOT fix

`import web_server` unconditionally starts **27 background worker threads**, and
under pytest they poll the shared test DB and call third-party APIs for the rest
of the session. The run log has JioSaavn returning `429 Too Many Requests` from
`saavn.sumit.co` — CI and every dev machine are hitting live third-party
services on every run. That's the root cause of the Tidal flake above (which I
fixed at the assertion instead, since the assertion was wrong on its own terms).

I left it alone because gating it touches ~27 sites in `web_server.py` and
that's your call on scope, not mine. Happy to do it in a follow-up if you want
it.

