### PR TITLE
improve(settings): save edits to the selected quality profile

### DIFF
--- a/tests/test_quality_profile_preview_nudge.py
+++ b/tests/test_quality_profile_preview_nudge.py
@@ -1,18 +1,11 @@
-"""Editing a profile-captured toggle while previewing somebody else's profile
-must say so.
+"""The profile shown in Settings -> Quality is the save target.
 
-The Settings -> Quality page owns two kinds of control. The ranked-target
-ladder saves through `debouncedSaveQualityProfile`, which already refuses to
-write while a non-default profile is previewed and shows the editing banner
-instead. The other eight (AcoustID strictness, downsample, deep verify,
-replace-lower-quality and the lossy-copy group) are ordinary config keys saved
-by the whole-page `saveSettings`, and that one substitutes the real default's
-stored values back in for exactly those keys before sending — so the edit is
-correctly NOT written anywhere.
-
-Correct, but silent: the user toggled something, no banner appeared, and the
-value read Off again after switching profiles and back. These assertions pin
-the nudge that closes the gap.
+Historically a non-default row was only a preview: autosave and the prominent
+"Save Settings" button both reported success without writing it, while the
+small per-row pencil button was the only real save. These source-level seams
+pin the intuitive contract: every profile-owned control uses profile autosave,
+the target and payload survive a quick profile switch, and the full bundle is
+written through the id-qualified endpoint.
 """
 
 from __future__ import annotations
@@ -48,9 +41,17 @@ BUNDLE_CONTROL_IDS = (
     "lossy-copy-delete-original",
 )
 
+LADDER_CONTROL_IDS = (
+    "quality-fallback-enabled",
+    "quality-search-mode",
+    "quality-rank-candidates",
+    "quality-upgrade-policy",
+    "quality-upgrade-cutoff",
+)
+
 
 @pytest.mark.parametrize("control_id", BUNDLE_CONTROL_IDS)
-def test_every_profile_captured_control_is_in_the_nudge_set(settings_js, control_id):
+def test_every_profile_captured_control_is_in_the_bundle_set(settings_js, control_id):
     """A control missing here edits silently again — the exact bug."""
     start = settings_js.index("_QP_BUNDLE_CONTROL_IDS = new Set([")
     end = settings_js.index("]);", start)
@@ -58,8 +59,8 @@ def test_every_profile_captured_control_is_in_the_nudge_set(settings_js, control
 
 
 @pytest.mark.parametrize("control_id", BUNDLE_CONTROL_IDS)
-def test_the_nudge_set_matches_what_the_profile_actually_captures(settings_js,
-                                                                  control_id):
+def test_the_bundle_set_matches_what_the_profile_actually_captures(settings_js,
+                                                                   control_id):
     """Guard against the two lists drifting: every id in the nudge set must
     really be read by collectFullQualityBundleFromUI."""
     start = settings_js.index("function collectFullQualityBundleFromUI()")
@@ -67,40 +68,75 @@ def test_the_nudge_set_matches_what_the_profile_actually_captures(settings_js,
     assert f"'{control_id}'" in settings_js[start:end]
 
 
-def test_the_settings_autosave_runs_the_nudge(settings_js):
-    """It has to hang off the whole-page autosave, not the quality one — those
-    eight controls never reach debouncedSaveQualityProfile."""
+@pytest.mark.parametrize("control_id", LADDER_CONTROL_IDS)
+def test_every_ladder_control_routes_to_profile_autosave(settings_js, control_id):
+    start = settings_js.index("_QP_PROFILE_CONTROL_IDS = new Set([")
+    end = settings_js.index("]);", start)
+    assert f"'{control_id}'" in settings_js[start:end]
+
+
+def test_the_full_bundle_is_included_in_profile_autosave(settings_js):
+    start = settings_js.index("_QP_PROFILE_CONTROL_IDS = new Set([")
+    end = settings_js.index("]);", start)
+    assert "..._QP_BUNDLE_CONTROL_IDS" in settings_js[start:end]
+
+
+def test_the_settings_autosave_routes_quality_changes_and_stops(settings_js):
     start = settings_js.index("function debouncedAutoSaveSettings(event)")
     end = settings_js.index("\n}", start)
     body = settings_js[start:end]
-    assert "_qpNudgeIfEditingForeignProfile(event)" in body
-    # The event is what identifies the control; a no-arg signature cannot tell
-    # a lossy-copy toggle from a Plex URL.
+    assert "if (_qpHandleProfileControlChange(event)) return" in body
     assert "debouncedAutoSaveSettings(event)" in settings_js
 
 
-def test_the_nudge_only_fires_for_a_foreign_profile(settings_js):
-    """Editing the live default is the normal case and must stay quiet."""
-    start = settings_js.index("function _qpNudgeIfEditingForeignProfile(event)")
+def test_the_quality_change_handler_schedules_profile_autosave(settings_js):
+    start = settings_js.index("function _qpHandleProfileControlChange(event)")
     end = settings_js.index("\n}", start)
     body = settings_js[start:end]
-    assert "_qpEditingProfileId === null" in body
-    assert "_qpEditingProfileId === _qpDefaultProfileId()" in body
-    assert "qpShowEditingBanner()" in body
+    assert "_QP_PROFILE_CONTROL_IDS.has(id)" in body
+    assert "debouncedSaveQualityProfile()" in body
+    assert "return true" in body
 
 
-def test_the_nudge_does_not_block_the_save(settings_js):
-    """saveSettings already substitutes the default's values back in for these
-    keys, so the save is a no-op for them — skipping it outright would drop
-    whatever unrelated edit was debounced alongside."""
-    start = settings_js.index("function _qpNudgeIfEditingForeignProfile(event)")
+def test_debounce_captures_profile_id_and_full_payload_before_switch(settings_js):
+    start = settings_js.index("function debouncedSaveQualityProfile()")
     end = settings_js.index("\n}", start)
     body = settings_js[start:end]
-    # It may return early (nothing to say), but it must never report back.
-    assert "return true" not in body and "return false" not in body
+    assert "const targetProfileId = _qpEditingProfileId ?? _qpDefaultProfileId()" in body
+    assert "const profile = collectFullQualityBundleFromUI()" in body
+    assert "saveQualityProfile({ targetProfileId, profile })" in body
 
 
-def test_the_substitution_block_that_makes_the_nudge_honest_is_still_there(
+def test_save_targets_the_displayed_profile_and_refreshes_rows(settings_js):
+    start = settings_js.index("async function saveQualityProfile(")
+    end = settings_js.index("\n}\n\n//", start)
+    body = settings_js[start:end]
+    assert "`/api/quality-profile/custom/${resolvedTargetId}/update`" in body
+    assert "body: JSON.stringify(payload)" in body
+    assert "_qpSetProfileRows(data.profiles)" in body
+    assert "renderCustomQualityProfiles(_qpProfileRows)" in body
+
+
+def test_loading_settings_resets_view_to_full_default_bundle(settings_js):
+    start = settings_js.index("async function loadQualityProfile()")
+    end = settings_js.index("\n}\n\n//", start)
+    body = settings_js[start:end]
+    assert "_qpEditingProfileId = null" in body
+    assert "populateQualityProfileUI(currentQualityProfile)" in body
+    assert "applyFullQualityBundleToDom(currentQualityProfile)" in body
+    assert "qpHideEditingBanner()" in body
+
+
+def test_quick_preset_on_named_profile_uses_the_same_autosave(settings_js):
+    start = settings_js.index("async function applyQualityPreset(presetName)")
+    end = settings_js.index("\n}\n\n// Discard", start)
+    body = settings_js[start:end]
+    assert "currentQualityProfile = merged" in body
+    assert "debouncedSaveQualityProfile()" in body
+    assert "click ✎" not in body
+
+
+def test_full_settings_save_still_protects_the_default_while_editing_another(
         settings_js):
     """If this ever goes away the nudge becomes a lie: the edit WOULD then be
     written, straight into the wrong profile."""
@@ -113,12 +149,9 @@ def test_the_substitution_block_that_makes_the_nudge_honest_is_still_there(
         assert line in settings_js
 
 
-def test_the_banner_tells_the_user_what_to_do(index_html):
-    """It used to say 'changes on the left', which is the ladder tiles — but
-    six of the eight controls this now fires for live in completely different
-    sections of the page."""
+def test_the_banner_explains_intuitive_save_behaviour(index_html):
     start = index_html.index('id="qp-editing-banner"')
     end = index_html.index("</div>", start)
     banner = index_html[start:end]
-    assert "on this page" in banner
-    assert "✎" in banner
+    assert "Changes autosave to this profile" in banner
+    assert "Save Settings saves it too" in banner

--- a/webui/index.html
+++ b/webui/index.html
@@ -4670,7 +4670,7 @@
 
                             <!-- Right: detached, sticky Quality Profiles panel — everything on
                                  the 4 tiles to the left is saved under whichever profile is
-                                 active here. Always visible (no collapse), protruding to the
+                                 selected here for editing. Always visible (no collapse), protruding to the
                                  right of the settings column on wide screens so it never takes
                                  width away from the tiles. -->
                             <div class="qp-side-panel" id="qp-side-panel" data-stg="quality">
@@ -4678,9 +4678,9 @@
                                     <h3 class="qp-side-panel-title">Quality Profiles</h3>
                                     <button type="button" class="qp-manage-btn" onclick="openQualityProfileManager()">Manage</button>
                                 </div>
-                                <p class="qp-side-panel-hint">Click a profile's name to view/edit its settings on the left (this alone never activates it). Per row: ● set as the active default, ✏ rename, ✎ save the settings shown on the left into this profile, ⇩ use for Auto-Import instead of the default, × delete. "Manage" above shows what's active for what.</p>
+                                <p class="qp-side-panel-hint">Click a profile's name to view/edit its settings on the left. Changes autosave to that profile, and Save Settings saves it too; viewing never activates it. Per row: ● set as active default, ✏ rename, ✎ save now, ⇩ use for Auto-Import, × delete.</p>
                                 <div class="qp-editing-banner" id="qp-editing-banner" style="display:none">
-                                    Viewing <strong class="qp-editing-banner-name">this profile</strong> — not the active default. Any quality setting you change on this page only saves into it once you click its ✎.
+                                    Editing <strong class="qp-editing-banner-name">this profile</strong> — not the active default. Changes autosave to this profile; Save Settings saves it too.
                                 </div>
                                 <div class="qp-profile-list" id="qp-profile-list">
                                     <!-- rows injected by renderCustomQualityProfiles() -->

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -78,28 +78,31 @@ function syncRetryConditionalRows() {
 }
 window.syncRetryConditionalRows = syncRetryConditionalRows;
 
-// The Settings -> Quality controls that a PROFILE captures but the whole-page
-// save sends as ordinary config keys. Editing one of these while previewing a
-// non-default profile is deliberately not persisted by the page save (see the
-// substitution block in saveSettings), so the edit only reaches the profile
-// once the user clicks that row's Update (v) button. Without a nudge that
-// looked like a silent failure: toggle it, switch profiles, come back, and it
-// reads Off again with nothing having told you why.
+// Every Settings -> Quality control belongs to the profile currently shown in
+// the editor. Keep this list separate from ordinary app settings so a quality
+// edit uses the profile endpoint (and does not re-initialize every service
+// client through the full settings endpoint). The eight bundle controls live
+// outside the main ladder tile, but are profile-owned just the same.
 const _QP_BUNDLE_CONTROL_IDS = new Set([
     'acoustid-require-verified', 'downsample-hires', 'audio-completeness-check',
     'import-replace-lower-quality', 'lossy-copy-enabled', 'lossy-copy-codec',
     'lossy-copy-bitrate', 'lossy-copy-delete-original',
 ]);
+const _QP_PROFILE_CONTROL_IDS = new Set([
+    ..._QP_BUNDLE_CONTROL_IDS,
+    'quality-fallback-enabled', 'quality-search-mode', 'quality-rank-candidates',
+    'quality-upgrade-policy', 'quality-upgrade-cutoff',
+]);
 
-// Show the "you are editing <profile>" banner when a profile-captured control
-// is edited while previewing somebody else's profile. Only a notice — the save
-// itself is left alone, because saveSettings already substitutes the real
-// default's values back in for exactly these keys.
-function _qpNudgeIfEditingForeignProfile(event) {
+// Route a Quality-page change to the profile editor's lightweight autosave.
+// Returning true lets the full-page autosave stop here: the profile endpoint
+// persists the complete bundle and, for the default row, mirrors its global
+// config keys server-side as well.
+function _qpHandleProfileControlChange(event) {
     const id = event && event.target && event.target.id;
-    if (!id || !_QP_BUNDLE_CONTROL_IDS.has(id)) return;
-    if (_qpEditingProfileId === null || _qpEditingProfileId === _qpDefaultProfileId()) return;
-    qpShowEditingBanner();
+    if (!id || !_QP_PROFILE_CONTROL_IDS.has(id)) return false;
+    debouncedSaveQualityProfile();
+    return true;
 }
 
 function debouncedAutoSaveSettings(event) {
@@ -107,7 +110,7 @@ function debouncedAutoSaveSettings(event) {
     // fields on load — those aren't user edits and must not trigger a full
     // save (which re-initializes every backend service client).
     if (window._suppressSettingsAutoSave) return;
-    _qpNudgeIfEditingForeignProfile(event);
+    if (_qpHandleProfileControlChange(event)) return;
     // ISOLATION: the video side reuses this shared settings page, so editing a
     // VIDEO field (TMDB key, region, autoplay…) would otherwise fire this MUSIC
     // auto-save — which reads the server toggle from the DOM and would persist
@@ -128,6 +131,7 @@ function debouncedAutoSaveSettings(event) {
 
 function handleManualSaveClick() {
     if (settingsAutoSaveTimer) clearTimeout(settingsAutoSaveTimer);
+    if (qualityProfileAutoSaveTimer) clearTimeout(qualityProfileAutoSaveTimer);
     saveSettings(false);
 }
 
@@ -2462,12 +2466,9 @@ function updateHybridSecondaryOptions() {
 let currentQualityProfile = null;
 let qualityProfileAutoSaveTimer = null;
 
-// Which profile the tiles currently show. null = "the live default", the
-// only state that existed before profiles were previewable — autosave keeps
-// writing straight into the active default/global config exactly as always.
-// Set to a specific id by previewQualityProfile() when the user clicks a
-// DIFFERENT (non-default) profile's row to look at/edit it; in that state
-// autosave must NOT touch the live default — see debouncedSaveQualityProfile.
+// Which non-default profile the editor currently shows. null means the active
+// default. This is an edit target, not an activation flag: selecting a profile
+// to edit never makes it the default, but every save goes back to this row.
 let _qpEditingProfileId = null;
 
 function _qpDefaultProfileId() {
@@ -2480,18 +2481,15 @@ function _qpDefaultProfileId() {
 function debouncedSaveQualityProfile() {
     if (window._suppressSettingsAutoSave) return;
     if (window._settingsLoadFailed) return;
-    // Previewing a specific NON-default profile: the legacy save endpoint
-    // below always writes the LIVE default row + pushes into global config —
-    // autosaving here would silently overwrite the active profile (and
-    // anything downloading right now under it) while the user is just
-    // looking at/tweaking a different one. Edits only persist once the user
-    // explicitly clicks that profile row's Update (✎) button.
-    if (_qpEditingProfileId !== null && _qpEditingProfileId !== _qpDefaultProfileId()) {
-        qpShowEditingBanner();
-        return;
-    }
     if (qualityProfileAutoSaveTimer) clearTimeout(qualityProfileAutoSaveTimer);
-    qualityProfileAutoSaveTimer = setTimeout(() => saveQualityProfile(), 800);
+    // Capture both target and values now. If the user switches profiles before
+    // the debounce expires, the pending write still belongs to the profile
+    // that was on screen when the edit happened instead of overwriting the
+    // newly selected profile.
+    const targetProfileId = _qpEditingProfileId ?? _qpDefaultProfileId();
+    const profile = collectFullQualityBundleFromUI();
+    qualityProfileAutoSaveTimer = setTimeout(
+        () => saveQualityProfile({ targetProfileId, profile }), 800);
 }
 
 async function loadQualityProfile() {
@@ -2501,7 +2499,10 @@ async function loadQualityProfile() {
 
         if (data.success) {
             currentQualityProfile = data.profile;
+            _qpEditingProfileId = null;
             populateQualityProfileUI(currentQualityProfile);
+            applyFullQualityBundleToDom(currentQualityProfile);
+            qpHideEditingBanner();
         }
     } catch (error) {
         console.error('Error loading quality profile:', error);
@@ -2763,9 +2764,8 @@ async function applyQualityPreset(presetName) {
     // clicking a Quick-Set button while just looking at a different profile
     // would silently destroy the real default's settings and then swap the
     // tiles to show it instead (looks like the preview "jumps" to a random
-    // profile). Load the preset's values locally instead — read-only, never
-    // touches the server — same as previewQualityProfile; it only persists
-    // once the user explicitly clicks that profile row's Update (✎).
+    // profile). Load the preset's values locally, then save the resulting full
+    // bundle through this profile's id-qualified endpoint.
     if (_qpEditingProfileId !== null && _qpEditingProfileId !== _qpDefaultProfileId()) {
         try {
             const response = await fetch('/api/quality-profile/presets');
@@ -2783,13 +2783,15 @@ async function applyQualityPreset(presetName) {
                 search_mode: uiState.search_mode,
                 rank_candidates_by_quality: uiState.rank_candidates_by_quality,
             };
+            currentQualityProfile = merged;
             window._suppressSettingsAutoSave = true;
             try {
                 populateQualityProfileUI(merged);
             } finally {
                 window._suppressSettingsAutoSave = false;
             }
-            showToast(`Previewing '${PRESET_LABELS[presetName] || presetName}' — click ✎ on the profile row to save it here`, 'success');
+            debouncedSaveQualityProfile();
+            showToast(`Applied '${PRESET_LABELS[presetName] || presetName}' to this profile`, 'success');
         } catch (error) {
             console.error('Error loading quality preset:', error);
             showToast('Failed to load preset', 'error');
@@ -2811,7 +2813,7 @@ async function applyQualityPreset(presetName) {
             } finally {
                 window._suppressSettingsAutoSave = false;
             }
-            renderCustomQualityProfiles(_qpProfileRows);
+            await loadCustomQualityProfiles();
             showToast(`Switched to '${PRESET_LABELS[presetName] || presetName}'`, 'success');
         } else {
             showToast(`Failed to apply preset: ${data.error}`, 'error');
@@ -2853,6 +2855,7 @@ async function resetActiveQualityPreset() {
             } finally {
                 window._suppressSettingsAutoSave = false;
             }
+            await loadCustomQualityProfiles();
             showToast(`Reset '${PRESET_LABELS[presetName] || presetName}' to defaults`, 'success');
         } else {
             showToast(`Failed to reset preset: ${data.error}`, 'error');
@@ -2887,34 +2890,40 @@ function collectQualityProfileFromUI() {
     };
 }
 
-async function saveQualityProfile() {
-    // Same guard as debouncedSaveQualityProfile, enforced here too — this is
-    // also called directly by the page-wide "Save Settings" button
-    // (saveSettings), which bypasses the debounce path entirely. Without
-    // this, clicking Save Settings for some unrelated setting while merely
-    // PREVIEWING a different profile would still silently push what's on
-    // screen into the live default. Returns true (not false/"failed") —
-    // the banner already explains the skip; saveSettings() would otherwise
-    // report it as an error toast, which it isn't.
-    if (_qpEditingProfileId !== null && _qpEditingProfileId !== _qpDefaultProfileId()) {
-        qpShowEditingBanner();
-        return true;
-    }
+async function saveQualityProfile({ targetProfileId, profile } = {}) {
     try {
-        const profile = collectQualityProfileFromUI();
+        const resolvedTargetId = targetProfileId ?? _qpEditingProfileId ?? _qpDefaultProfileId();
+        const payload = profile || collectFullQualityBundleFromUI();
 
-        const response = await fetch('/api/quality-profile', {
+        // Named-profile CRUD is the one endpoint that can save the complete
+        // Quality-page bundle to a specific row. The old singleton endpoint
+        // can only safely target the default and is retained as a defensive
+        // fallback while the profile list is unavailable.
+        const url = resolvedTargetId == null
+            ? '/api/quality-profile'
+            : `/api/quality-profile/custom/${resolvedTargetId}/update`;
+
+        const response = await fetch(url, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(profile)
+            body: JSON.stringify(payload)
         });
 
         const data = await response.json();
 
         if (data.success) {
-            currentQualityProfile = profile;
+            if (resolvedTargetId === (_qpEditingProfileId ?? _qpDefaultProfileId())) {
+                currentQualityProfile = payload;
+            }
+            if (Array.isArray(data.profiles)) {
+                _qpSetProfileRows(data.profiles);
+                renderCustomQualityProfiles(_qpProfileRows);
+                if (document.getElementById('qp-manager-overlay')) {
+                    renderQualityProfileManager();
+                }
+            }
             console.log('Quality profile saved successfully');
             return true;
         } else {
@@ -3114,15 +3123,13 @@ function renderCustomQualityProfiles(profiles) {
         };
         actions.appendChild(ren);
 
-        // Update: overwrite this profile's stored settings with whatever is
-        // currently on the page (edit-in-place, keeps the name). Allowed on
-        // every profile, including the starter ones — it's an overwrite,
-        // not a delete.
+        // Optional explicit save-now action. Normal edits already autosave to
+        // the selected row, and the page-wide Save Settings button does too.
         const upd = document.createElement('button');
         upd.type = 'button';
         upd.className = 'qp-profile-action qp-action-update';
         upd.textContent = '✎';
-        upd.title = `Update '${profile.name}' with the current page settings`;
+        upd.title = `Save the current Quality-page settings to '${profile.name}' now`;
         upd.onclick = (e) => {
             e.stopPropagation();
             updateCustomQualityProfile(profile.id, profile.name);
@@ -3289,6 +3296,7 @@ function applyFullQualityBundleToDom(profile) {
     set('import-replace-lower-quality', profile.replace_lower_quality);
     set('lossy-copy-enabled', profile.lossy_copy_enabled);
     set('lossy-copy-codec', profile.lossy_copy_codec);
+    updateLossyBitrateOptions();
     set('lossy-copy-bitrate', profile.lossy_copy_bitrate);
     set('lossy-copy-delete-original', profile.lossy_copy_delete_original);
     const lossyOptions = document.getElementById('lossy-copy-options');
@@ -3425,10 +3433,8 @@ function confirmSetDefaultQualityProfileById(profileId) {
 
 // Load a profile's settings into the tile editor for viewing/editing —
 // purely read-only against the DB (a dedicated GET, not the mutating
-// /apply endpoint) so it can never make the previewed profile the live
-// default or touch anything mid-download. Edits made while previewing are
-// local until the row's Update (✎) button explicitly saves them into THIS
-// profile — see debouncedSaveQualityProfile.
+// /apply endpoint) so selecting it can never make it the live default.
+// Subsequent edits autosave back to this id — see debouncedSaveQualityProfile.
 async function previewQualityProfile(profileId) {
     try {
         const response = await fetch(`/api/quality-profile/custom/${profileId}`);
@@ -3443,7 +3449,7 @@ async function previewQualityProfile(profileId) {
         // before previewing this profile was exactly the kind of drift that made
         // preset actions apply to the wrong thing.
         currentQualityProfile = data.profile;
-        _qpEditingProfileId = profileId;
+        _qpEditingProfileId = data.profile.is_default ? null : profileId;
         window._suppressSettingsAutoSave = true;
         try {
             populateQualityProfileUI(data.profile);
@@ -3452,7 +3458,8 @@ async function previewQualityProfile(profileId) {
             window._suppressSettingsAutoSave = false;
         }
         renderCustomQualityProfiles(_qpProfileRows);
-        qpShowEditingBanner();
+        if (_qpEditingProfileId === null) qpHideEditingBanner();
+        else qpShowEditingBanner();
     } catch (error) {
         console.error('Error previewing quality profile:', error);
         showToast('Failed to load profile', 'error');
@@ -3471,7 +3478,7 @@ function qpShowEditingBanner() {
     // The id not resolving means the cache is stale or the profile is gone —
     // showing a nameless "viewing this profile" is just confusing; hide
     // instead of guessing.
-    if (!profile) {
+    if (!profile || profile.is_default) {
         banner.style.display = 'none';
         return;
     }
@@ -3553,8 +3560,8 @@ async function toggleAutoImportQualityProfile(profileId) {
 // (Settings → Import, falls back to Default when unset). Both assignments
 // are also reachable
 // inline from the row list (the dot / the ⇩ button); this is the overview +
-// explanation surface, not a second way to edit a profile's own settings —
-// that only ever happens via previewQualityProfile + a row's Update (✎).
+// explanation surface, not a second profile editor — selecting a row on the
+// Quality page and changing its controls is the editing path.
 function qpManagerOverlay() {
     let overlay = document.getElementById('qp-manager-overlay');
     if (overlay) return overlay;


### PR DESCRIPTION
the quality profile page made it look like settings were saved, but the pencil was the real save path.. that isnt intuitive.. change quality on import or any of the other profile settings, hit save, switch profiles and come back, and the ui showed the old values again.

the selected profile saves directly now, and the normal Save Settings button saves the profile you're looking at too. the delayed save captures the profile id and the full settings first, so switching profiles quickly can't write the changes into the wrong one.. presets and reset refresh the same state as well.
