### PR TITLE
fix(downloads): stop re-reading every staging tag for every download task

### DIFF
--- a/tests/downloads/test_staging_tag_cache.py
+++ b/tests/downloads/test_staging_tag_cache.py
@@ -1,0 +1,129 @@
+"""The staging scan must not re-read every tag for every download task.
+
+``_get_staging_file_cache`` walks the staging tree before each download task
+to check whether the track is already staged. Walking + stat-ing is cheap;
+reading the tags is not (~60ms/file cold, i.e. minutes for a few thousand
+files). The cache used to be keyed by ``batch_id``, but the wishlist
+dispatches ONE BATCH PER TRACK — so the key never repeated, every track
+re-read every tag in staging, and each download stalled for minutes before
+its first search. That is longer than the 30-45s search timeout, which is how
+tracks that were perfectly available ended up marked "Download failed".
+
+The cache is now keyed per file by ``(path, mtime, size)``, so a scan only
+pays for files that are new or actually changed.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def _write_audio(path, data=b'x' * 64):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as fh:
+        fh.write(data)
+
+
+def _caches(web_server):
+    """Whichever staging cache the module has — so these tests exercise
+    behaviour rather than passing/failing on a symbol rename."""
+    return [c for c in (getattr(web_server, '_staging_tag_cache', None),
+                        getattr(web_server, '_staging_cache', None))
+            if c is not None]
+
+
+def _cached_paths(web_server):
+    """Every staging path currently retained, whatever the cache shape."""
+    paths = set()
+    for cache in _caches(web_server):
+        for key, value in cache.items():
+            if isinstance(value, list):      # old shape: batch_id -> [file dicts]
+                paths.update(f.get('full_path', '') for f in value)
+            else:                            # new shape: path -> (mtime, size, meta)
+                paths.add(key)
+    return {p for p in paths if p}
+
+
+def _install_staging(monkeypatch, tmp_path, files):
+    """Point web_server at a staging dir and count tag reads."""
+    import web_server
+
+    for name in files:
+        _write_audio(str(tmp_path / name))
+
+    monkeypatch.setattr(web_server, 'get_staging_path', lambda: str(tmp_path))
+    for cache in _caches(web_server):
+        cache.clear()
+
+    calls = []
+
+    def fake_read(full_path, rel_path):
+        calls.append(full_path)
+        return {
+            'title': os.path.basename(full_path),
+            'artist': 'A',
+            'albumartist': 'A',
+            'album': 'Alb',
+            'track_number': 1,
+            'disc_number': 1,
+        }
+
+    monkeypatch.setattr(web_server, '_read_staging_file_metadata', fake_read)
+    return web_server, calls
+
+
+def test_tags_are_not_reread_for_a_different_batch(monkeypatch, tmp_path):
+    """The regression: a second batch_id must not re-read every tag."""
+    web_server, calls = _install_staging(
+        monkeypatch, tmp_path, ['a/one.flac', 'b/two.mp3', 'three.m4a'])
+
+    first = web_server._get_staging_file_cache('batch-1')
+    assert len(first) == 3
+    assert len(calls) == 3, 'first scan must read each file once'
+
+    # Pre-fix this re-read all three files, because the cache key was the
+    # batch_id and the wishlist never reuses one.
+    second = web_server._get_staging_file_cache('batch-2')
+    assert len(second) == 3
+    assert len(calls) == 3, 'second scan must reuse cached tags'
+
+    assert {f['full_path'] for f in first} == {f['full_path'] for f in second}
+
+
+def test_changed_mtime_reloads_that_file_only(monkeypatch, tmp_path):
+    """A retag bumps mtime but can leave size identical — must not go stale."""
+    web_server, calls = _install_staging(
+        monkeypatch, tmp_path, ['one.flac', 'two.flac'])
+
+    web_server._get_staging_file_cache('batch-1')
+    assert len(calls) == 2
+
+    # Same size, newer mtime — exactly what mutagen's .save() does to a FLAC
+    # whose padding absorbs the tag change. A (path, size) key misses this.
+    target = str(tmp_path / 'one.flac')
+    st = os.stat(target)
+    os.utime(target, (st.st_atime + 10, st.st_mtime + 10))
+    assert os.stat(target).st_size == st.st_size
+
+    calls.clear()
+    web_server._get_staging_file_cache('batch-2')
+    assert calls == [target], 'only the retagged file should be re-read'
+
+
+def test_vanished_files_are_dropped_from_cache(monkeypatch, tmp_path):
+    """The old dict grew per batch_id and was never pruned."""
+    web_server, _calls = _install_staging(
+        monkeypatch, tmp_path, ['one.flac', 'two.flac'])
+
+    web_server._get_staging_file_cache('batch-1')
+    assert _cached_paths(web_server) == {
+        str(tmp_path / 'one.flac'), str(tmp_path / 'two.flac')}
+
+    gone = str(tmp_path / 'two.flac')
+    os.remove(gone)
+    remaining = web_server._get_staging_file_cache('batch-2')
+
+    assert len(remaining) == 1
+    # Pre-fix the per-batch lists were never freed, so batch-1's entry for the
+    # deleted file stayed resident (and grew again with every new batch_id).
+    assert gone not in _cached_paths(web_server), 'stale entry must be pruned'

--- a/tests/downloads/test_staging_tag_cache.py
+++ b/tests/downloads/test_staging_tag_cache.py
@@ -127,3 +127,40 @@ def test_vanished_files_are_dropped_from_cache(monkeypatch, tmp_path):
     # Pre-fix the per-batch lists were never freed, so batch-1's entry for the
     # deleted file stayed resident (and grew again with every new batch_id).
     assert gone not in _cached_paths(web_server), 'stale entry must be pruned'
+
+
+def test_removed_private_staging_root_is_pruned(monkeypatch, tmp_path):
+    """An album-bundle batch's private staging dir can be cleaned up whole
+    once the batch finishes. That must not orphan its cache entries forever —
+    the early-return for a missing directory has to prune too, not just the
+    walk path (CodeRabbit #18, review 844c9c72)."""
+    import web_server
+
+    root = tmp_path / 'private-staging'
+    for name in ('one.flac', 'two.flac'):
+        _write_audio(str(root / name))
+
+    monkeypatch.setattr(web_server, '_get_album_bundle_staging_path',
+                         lambda batch_id: str(root))
+    monkeypatch.setattr(web_server, '_read_staging_file_metadata',
+                         lambda full_path, rel_path: {
+                             'title': os.path.basename(full_path), 'artist': 'A',
+                             'albumartist': 'A', 'album': 'Alb',
+                             'track_number': 1, 'disc_number': 1})
+    for cache in _caches(web_server):
+        cache.clear()
+
+    found = web_server._get_staging_file_cache('bundle-batch')
+    assert len(found) == 2
+    assert _cached_paths(web_server) == {str(root / 'one.flac'), str(root / 'two.flac')}
+
+    # The whole batch-private root disappears (batch finished, cleaned up) —
+    # not just one file within it.
+    import shutil
+    shutil.rmtree(root)
+
+    empty = web_server._get_staging_file_cache('bundle-batch')
+
+    assert empty == []
+    assert _cached_paths(web_server) == set(), \
+        'cache entries under a removed staging root must be evicted, not orphaned'

--- a/web_server.py
+++ b/web_server.py
@@ -20863,6 +20863,13 @@ def _get_staging_file_cache(batch_id):
     """List staging audio files with their tags, re-reading only what changed."""
     staging_path = _get_album_bundle_staging_path(batch_id) or get_staging_path()
     if not os.path.isdir(staging_path):
+        # A per-batch album-bundle staging root can be cleaned up out from
+        # under us once its batch finishes — evict its cache entries here too,
+        # or they'd never hit the pruning below (which only runs on a walk).
+        prefix = os.path.join(staging_path, '')
+        with _staging_cache_lock:
+            for path in [p for p in _staging_tag_cache if p.startswith(prefix)]:
+                del _staging_tag_cache[path]
         return []
 
     files = []

--- a/web_server.py
+++ b/web_server.py
@@ -20835,36 +20835,62 @@ def _attempt_download_with_candidates(task_id, candidates, track, batch_id=None,
     )
 
 
-# ── Staging folder match cache (per-batch, avoids re-scanning for every track) ──
-_staging_cache = {}  # batch_id -> list of {full_path, title, artist, album, extension}
+# ── Staging folder scan cache ──
+#
+# Every download task walks the staging tree before searching, to see whether
+# the track is already sitting there. Walking + stat-ing that tree is cheap
+# (~0.1s for ~3.6k files); READING THE TAGS is not (~60ms/file cold — ~3.6
+# MINUTES for the same tree). So cache the expensive half, the parsed tags,
+# and rebuild the cheap half on every call.
+#
+# This used to be keyed by batch_id, which meant it never hit for wishlist
+# work: the wishlist dispatches ONE BATCH PER TRACK, so every track re-read
+# every tag in staging. That stalled each download for minutes before its
+# first search — longer than the 30-45s search timeout — which is how
+# available tracks ended up marked "Download failed" and retried forever.
+# The old dict also leaked: entries were added per batch_id and never freed.
+#
+# mtime is the load-bearing part of the key. Writing a tag with mutagen bumps
+# mtime but can leave the size byte-identical (FLAC padding absorbs it), so a
+# (path, size) key would keep serving stale tags after every library_retag.
+_staging_tag_cache = {}  # full_path -> (mtime, size, meta)
 _staging_cache_lock = threading.Lock()
 
 STAGING_AUDIO_EXTENSIONS = {'.mp3', '.flac', '.ogg', '.opus', '.m4a', '.aac', '.wav', '.wma', '.aiff', '.aif'}
 
 
 def _get_staging_file_cache(batch_id):
-    """Scan staging folder once per batch and cache the results."""
-    with _staging_cache_lock:
-        if batch_id in _staging_cache:
-            cached = _staging_cache[batch_id]
-            return [f for f in cached if os.path.exists(f.get('full_path', ''))]
-
+    """List staging audio files with their tags, re-reading only what changed."""
     staging_path = _get_album_bundle_staging_path(batch_id) or get_staging_path()
     if not os.path.isdir(staging_path):
-        with _staging_cache_lock:
-            _staging_cache[batch_id] = []
         return []
 
     files = []
+    fresh = {}
+    reused = 0
     for root, _dirs, filenames in os.walk(staging_path):
         for fname in filenames:
             ext = os.path.splitext(fname)[1].lower()
             if ext not in STAGING_AUDIO_EXTENSIONS:
                 continue
             full_path = os.path.join(root, fname)
-            rel_path = os.path.relpath(full_path, staging_path)
+            try:
+                st = os.stat(full_path)
+            except OSError:
+                # Vanished mid-walk (import moved it out) — same outcome as
+                # the old cache-hit path, which filtered on os.path.exists.
+                continue
+            key = (st.st_mtime, st.st_size)
 
-            meta = _read_staging_file_metadata(full_path, rel_path)
+            with _staging_cache_lock:
+                hit = _staging_tag_cache.get(full_path)
+            if hit is not None and hit[:2] == key:
+                meta = hit[2]
+                reused += 1
+            else:
+                rel_path = os.path.relpath(full_path, staging_path)
+                meta = _read_staging_file_metadata(full_path, rel_path)
+            fresh[full_path] = (key[0], key[1], meta)
 
             files.append({
                 'full_path': full_path,
@@ -20876,9 +20902,20 @@ def _get_staging_file_cache(batch_id):
                 'extension': ext,
             })
 
-    logger.info(f"[Staging] Scanned {len(files)} audio files in staging folder")
+    prefix = os.path.join(staging_path, '')
     with _staging_cache_lock:
-        _staging_cache[batch_id] = files
+        # Bound the cache: drop anything under the root we just walked that is
+        # no longer there, and anything from another root (album-bundle private
+        # staging) whose file is gone. Only out-of-root entries need a stat.
+        for path in [p for p in _staging_tag_cache
+                     if p not in fresh and (p.startswith(prefix) or not os.path.exists(p))]:
+            del _staging_tag_cache[path]
+        _staging_tag_cache.update(fresh)
+
+    logger.info(
+        f"[Staging] Scanned {len(files)} audio files in staging folder "
+        f"({reused} tags reused from cache)"
+    )
     return files
 
 


### PR DESCRIPTION
## The problem

`_get_staging_file_cache` walks the staging tree before every download task, to check whether the track is already staged. The walk itself is cheap. Reading the tags is not.

Measured on a staging folder of 3,619 audio files:

| Step | Cost |
|---|---|
| `os.walk` | 0.07s |
| `stat` every file | 0.03s |
| Tag read, per file (cold) | ~60ms |
| **Tag reads, whole tree** | **~219s** |

So the scan is ~99.97% tag reads — and the cache covered the cheap half while re-doing the expensive half.

It was keyed by `batch_id`, on the reasonable assumption that a batch is a multi-track download where one scan amortises across its tracks. The wishlist doesn't work that way — it dispatches **one batch per track**:

```
[Manual-Wishlist] Dispatched 0 album batch(es) + 1 residual track(s) via the shared engine
```

So the key never repeated, and every single track re-read every tag in staging.

## Why it shows up as "Download failed"

Each download sat in `searching` for ~3.6 minutes before issuing its first query — well past the 30–45s search timeout. Observed live on an unmodified install:

```
14:33:11  [Modal Worker] Starting download task for: Natsu No Mirage by Kanako Wada
14:36:29  [Staging] Scanned 3619 audio files in staging folder
14:36:30  [Modal Worker] Generated 4 smart search queries for 'Natsu No Mirage'
14:36:30  Starting search for: 'kanako wada ...' (slskd timeout: 30s)
```

Three and a half minutes of dead time before the first search. Tracks that are plainly available on the network then get marked `Download failed`, retried, and eventually parked for a week by the retry-backoff ladder. (For the track above: a direct slskd search returns 17 files from 8 peers, two of them FLAC with free upload slots.)

## Second bug in the same function

The dict also leaked. Entries were added per `batch_id` and never removed — nothing in the file deletes from `_staging_cache` — so a wishlist cycle retained one full file list per track, none of them freed.

## The fix

Cache the expensive half, keyed per file by `(path, mtime, size)`, and rebuild the cheap half on every call. Steady state is a walk plus stats (~0.1s), with tag reads only for files that are new or changed.

`mtime` is the load-bearing part of the key. A mutagen `.save()` bumps mtime but can leave the size byte-identical when FLAC padding absorbs the change — verified:

```
before: mtime=1783245371.273 size=27320249
after : mtime=1787580323.444 size=27320249
mtime changed: True | size changed: False
```

A `(path, size)` key would therefore serve stale tags after every `library_retag` pass. Nothing in the tree calls `os.utime` to restore mtimes, so no writer hides a change from this check.

Pruning keeps the cache bounded: entries under the walked root that are gone are dropped, and entries from another root (album-bundle private staging) are dropped once their file disappears. Only out-of-root entries need a `stat`.

## Tests

Three tests in `tests/downloads/test_staging_tag_cache.py`. They assert on behaviour, not on the renamed global, so they fail meaningfully against the old code:

- a second `batch_id` reuses cached tags — `assert 6 == 3` before
- a same-size mtime bump re-reads only that file
- a deleted file does not stay resident in the cache

`tests/downloads/`, `tests/imports/` and the staging provenance test pass (1,856 passed). `ruff check` clean.
