### PR TITLE
Fix/path organization unification

### DIFF
--- a/core/imports/file_ops.py
+++ b/core/imports/file_ops.py
@@ -251,11 +251,18 @@ def protected_root_dirs():
     """
     roots = set()
     try:
-        from core.imports.paths import docker_resolve_path
-        for key in ('soulseek.staging_path', 'soulseek.download_path', 'soulseek.transfer_path'):
-            raw = config_manager.get(key, '') or ''
-            if raw:
-                roots.add(os.path.normpath(docker_resolve_path(raw)))
+        from core.imports.paths import config_root_path
+        # `import.staging_path` is the key the settings page writes (see
+        # webui/static/settings.js) and the key every other reader uses. This
+        # read used to name `soulseek.staging_path`, which nothing writes: the
+        # lookup returned '', the import folder never made it into the protected
+        # set, and #976's whole point — the cleanup must not rmdir the staging
+        # root when it sits under the download folder — silently did not apply.
+        for key in ('import.staging_path', 'soulseek.download_path',
+                    'soulseek.transfer_path'):
+            resolved = config_root_path(config_manager.get(key, '') or '')
+            if resolved:
+                roots.add(resolved)
     except Exception as e:
         logger.debug(f"protected_root_dirs: could not resolve configured roots: {e}")
     return roots
@@ -275,11 +282,14 @@ def ensure_staging_dir():
     not-yet-mounted volume path (which would mask the real mount).
     """
     try:
-        from core.imports.paths import docker_resolve_path
-        raw = config_manager.get('soulseek.staging_path', './Staging') or ''
-        if not raw:
+        from core.imports.paths import config_root_path
+        # Same key correction as protected_root_dirs(): reading the key nothing
+        # writes made this recreate a literal ./Staging next to the app instead
+        # of the import folder the user configured.
+        staging = config_root_path(
+            config_manager.get('import.staging_path', './Staging') or '')
+        if not staging:
             return
-        staging = os.path.normpath(docker_resolve_path(raw))
         if os.path.isdir(staging):
             return
         parent = os.path.dirname(staging)

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -720,12 +720,22 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
             "_artists_list": _album_artists_for_collab if _album_artists_for_collab else _artists,
             "_itunes_artist_id": _itunes_aid,
         }
-        total_discs = _coerce_int(album_context.get("total_discs", 1) if album_context else 1, 1)
+        # "Declared" means the CALLER stated the disc count. A declared value is
+        # authoritative: re-deriving it from a live provider tracklist made the
+        # destination depend on whether that lookup happened to succeed, so a
+        # cache miss or an offline provider filed two tracks of one album in two
+        # different folders (Album/01.flac vs Album/Disc 1/01.flac). The lookup
+        # stays as the fallback for callers that genuinely do not know - a
+        # single-track download carries no album context of its own (#981).
+        _declared_total_discs = album_context.get("total_discs") if album_context else None
+        total_discs = _coerce_int(_declared_total_discs, 1)
 
         if total_discs <= 1 and album_context and album_context.get("id"):
             if disc_number > 1:
+                # A track that is itself on disc 2+ proves the release is
+                # multi-disc whatever the caller declared.
                 total_discs = disc_number
-            else:
+            elif _declared_total_discs in (None, ""):
                 try:
                     _album_tracks = _get_album_tracks_for_source(source, str(album_context["id"]))
                     if _album_tracks:

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -364,6 +364,45 @@ def apply_path_template(template: str, context: dict) -> str:
     return _replace_template_variables(template, context)
 
 
+# A folder segment that carried nothing but a disc label ("Disc $discnum") has
+# to disappear on a single-disc album — leaving a literal "Disc" folder behind
+# would silently collapse every disc of a release into one directory.
+_DANGLING_DISC_LABEL_RE = re.compile(
+    r"^(disc|disk|cd|volume|vol)\s*[.\-\u2013\u2014:]?\s*$", re.IGNORECASE)
+
+
+def _clean_folder_segment(part: str, disc_value: str, disc_value_raw: str) -> str:
+    """Resolve one FOLDER segment of a rendered path template.
+
+    ``$quality`` is the one variable the settings page documents as
+    filename-only, and it is stripped here. ``$disc`` and ``$discnum`` used to
+    be stripped alongside it, undocumented — so a user asking for a disc folder
+    got the folder silently deleted from their path, while ``$cdnum`` and the
+    ``${...}`` bracket forms (substituted globally, before the path is split)
+    worked. Same family of variables, three different behaviours. They now
+    substitute here exactly as they do in the filename, and resolve to the empty
+    string on a single-disc album — the ``$cdnum`` rule all along (#981).
+
+    ``$cdnum`` is already gone by this point; the replace is kept as a no-op
+    guard so a future change to the global pass cannot leak a raw token into a
+    directory name.
+    """
+    had_disc_var = "$discnum" in part or "$disc" in part
+    part = part.replace("$quality", "")
+    part = part.replace("$discnum", disc_value_raw)
+    part = part.replace("$disc", disc_value)
+    part = part.replace("$cdnum", "")
+    part = re.sub(r"\s*\[\s*\]", "", part)
+    part = re.sub(r"\s*\(\s*\)", "", part)
+    part = re.sub(r"\s*\{\s*\}", "", part)
+    part = re.sub(r"\s*-\s*$", "", part)
+    part = re.sub(r"^\s*-\s*", "", part)
+    part = re.sub(r"\s+", " ", part).strip()
+    if had_disc_var and not disc_value_raw and _DANGLING_DISC_LABEL_RE.match(part):
+        return ""
+    return part
+
+
 def get_file_path_from_template_raw(template: str, context: dict) -> tuple[str, str]:
     """Build file path using a user-provided template string directly."""
     full_path = apply_path_template(template, context)
@@ -382,16 +421,7 @@ def get_file_path_from_template_raw(template: str, context: dict) -> tuple[str, 
 
         cleaned_folders = []
         for part in folder_parts:
-            part = part.replace("$quality", "")
-            part = part.replace("$discnum", "")
-            part = part.replace("$disc", "")
-            part = part.replace("$cdnum", "")
-            part = re.sub(r"\s*\[\s*\]", "", part)
-            part = re.sub(r"\s*\(\s*\)", "", part)
-            part = re.sub(r"\s*\{\s*\}", "", part)
-            part = re.sub(r"\s*-\s*$", "", part)
-            part = re.sub(r"^\s*-\s*", "", part)
-            part = re.sub(r"\s+", " ", part).strip()
+            part = _clean_folder_segment(part, disc_value, disc_value_raw)
             if part:
                 cleaned_folders.append(part)
 
@@ -470,16 +500,7 @@ def get_file_path_from_template(context: dict, template_type: str = "album_path"
 
         cleaned_folders = []
         for part in folder_parts:
-            part = part.replace("$quality", "")
-            part = part.replace("$discnum", "")
-            part = part.replace("$disc", "")
-            part = part.replace("$cdnum", "")
-            part = re.sub(r"\s*\[\s*\]", "", part)
-            part = re.sub(r"\s*\(\s*\)", "", part)
-            part = re.sub(r"\s*\{\s*\}", "", part)
-            part = re.sub(r"\s*-\s*$", "", part)
-            part = re.sub(r"^\s*-\s*", "", part)
-            part = re.sub(r"\s+", " ", part).strip()
+            part = _clean_folder_segment(part, disc_value, disc_value_raw)
             if part:
                 cleaned_folders.append(part)
 

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -110,12 +110,26 @@ def _get_album_tracks_for_source(source: str, album_id: str):
 
 
 def docker_resolve_path(path_str: str) -> str:
-    """Resolve Docker-hosted Windows paths into container paths."""
+    """Resolve a configured folder to the canonical absolute path this process
+    can use: Docker-hosted Windows drives mapped, ``~`` expanded, made absolute.
+
+    Every caller of this hands the result to the filesystem, and several of them
+    also STORE it or compare it against a stored value. Returning a relative root
+    verbatim (``./Transfer`` is the shipped default) meant the same folder was
+    spelled three different ways depending on which code path produced it, and no
+    two of them compared equal. Absolutising here is what makes "the path in the
+    catalogue", "the path on disk" and "the path in a root comparison" one string.
+
+    An empty value stays empty: ``os.path.abspath('')`` is the CWD, which would
+    turn "this folder is not configured" into the application directory.
+    """
+    if not path_str:
+        return path_str
     if os.path.exists("/.dockerenv") and len(path_str) >= 3 and path_str[1] == ":" and path_str[0].isalpha():
         drive_letter = path_str[0].lower()
         rest_of_path = path_str[2:].replace("\\", "/")
         return f"/host/mnt/{drive_letter}{rest_of_path}"
-    return path_str
+    return os.path.abspath(os.path.expanduser(path_str))
 
 
 def config_root_path(path_str: Any, default: str = "") -> str:
@@ -142,7 +156,7 @@ def config_root_path(path_str: Any, default: str = "") -> str:
     raw = str(path_str if path_str not in (None, "") else (default or "")).strip()
     if not raw:
         return ""
-    return os.path.abspath(docker_resolve_path(os.path.expanduser(raw)))
+    return docker_resolve_path(raw)
 
 
 def build_simple_download_destination(context, file_path: str):
@@ -371,7 +385,19 @@ _DANGLING_DISC_LABEL_RE = re.compile(
     r"^(disc|disk|cd|volume|vol)\s*[.\-\u2013\u2014:]?\s*$", re.IGNORECASE)
 
 
-def _clean_folder_segment(part: str, disc_value: str, disc_value_raw: str) -> str:
+def template_uses_disc_variable(template: str) -> bool:
+    """Does ``template`` place the disc anywhere, in any of its spellings?
+
+    Must be asked of the RAW template. ``${disc}``, ``${discnum}`` and ``$cdnum``
+    are substituted globally, before the rendered path is split into segments, so
+    a per-segment look for "$disc" sees only the bare forms and misses the rest.
+    """
+    return any(token in (template or "")
+               for token in ("$disc", "$cdnum", "${disc", "${cdnum"))
+
+
+def _clean_folder_segment(part: str, disc_value: str, disc_value_raw: str,
+                          template_has_disc: bool = False) -> str:
     """Resolve one FOLDER segment of a rendered path template.
 
     ``$quality`` is the one variable the settings page documents as
@@ -387,7 +413,7 @@ def _clean_folder_segment(part: str, disc_value: str, disc_value_raw: str) -> st
     guard so a future change to the global pass cannot leak a raw token into a
     directory name.
     """
-    had_disc_var = "$discnum" in part or "$disc" in part
+    had_disc_var = template_has_disc or "$discnum" in part or "$disc" in part
     part = part.replace("$quality", "")
     part = part.replace("$discnum", disc_value_raw)
     part = part.replace("$disc", disc_value)
@@ -405,6 +431,7 @@ def _clean_folder_segment(part: str, disc_value: str, disc_value_raw: str) -> st
 
 def get_file_path_from_template_raw(template: str, context: dict) -> tuple[str, str]:
     """Build file path using a user-provided template string directly."""
+    _template_has_disc = template_uses_disc_variable(template)
     full_path = apply_path_template(template, context)
 
     quality_value = context.get("quality", "")
@@ -421,7 +448,8 @@ def get_file_path_from_template_raw(template: str, context: dict) -> tuple[str, 
 
         cleaned_folders = []
         for part in folder_parts:
-            part = _clean_folder_segment(part, disc_value, disc_value_raw)
+            part = _clean_folder_segment(part, disc_value, disc_value_raw,
+                                         _template_has_disc)
             if part:
                 cleaned_folders.append(part)
 
@@ -480,6 +508,7 @@ def get_file_path_from_template(context: dict, template_type: str = "album_path"
         }
         template = default_templates.get(template_type, "$artist/$album/$track - $title")
 
+    _template_has_disc = template_uses_disc_variable(template)
     full_path = apply_path_template(template, context)
 
     path_parts = full_path.split("/")
@@ -500,7 +529,8 @@ def get_file_path_from_template(context: dict, template_type: str = "album_path"
 
         cleaned_folders = []
         for part in folder_parts:
-            part = _clean_folder_segment(part, disc_value, disc_value_raw)
+            part = _clean_folder_segment(part, disc_value, disc_value_raw,
+                                         _template_has_disc)
             if part:
                 cleaned_folders.append(part)
 
@@ -741,22 +771,29 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
             "_artists_list": _album_artists_for_collab if _album_artists_for_collab else _artists,
             "_itunes_artist_id": _itunes_aid,
         }
-        # "Declared" means the CALLER stated the disc count. A declared value is
-        # authoritative: re-deriving it from a live provider tracklist made the
-        # destination depend on whether that lookup happened to succeed, so a
-        # cache miss or an offline provider filed two tracks of one album in two
-        # different folders (Album/01.flac vs Album/Disc 1/01.flac). The lookup
-        # stays as the fallback for callers that genuinely do not know - a
-        # single-track download carries no album context of its own (#981).
-        _declared_total_discs = album_context.get("total_discs") if album_context else None
-        total_discs = _coerce_int(_declared_total_discs, 1)
+        # A caller that KNOWS the disc count is authoritative: re-deriving it from
+        # a live provider tracklist made the destination depend on whether that
+        # lookup happened to succeed, so a cache miss or an offline provider filed
+        # two tracks of one album in two folders (Album/01.flac vs
+        # Album/Disc 1/01.flac).
+        #
+        # "Knows" has to be stated, not inferred from the value. Almost every
+        # context builder writes `.get("total_discs", 1)` (core/downloads/
+        # candidates.py, staging.py, master.py) and a Spotify album object carries
+        # no disc count at all, so a bare 1 means "nobody told me". Reading that as
+        # a declaration would silence the #981 lookup for playlist and wishlist
+        # downloads and file a disc-1 track of a real 2-disc release flat.
+        _declared_total_discs = bool(
+            album_context.get("total_discs_declared")) if album_context else False
+        total_discs = _coerce_int(
+            album_context.get("total_discs") if album_context else None, 1)
 
         if total_discs <= 1 and album_context and album_context.get("id"):
             if disc_number > 1:
                 # A track that is itself on disc 2+ proves the release is
-                # multi-disc whatever the caller declared.
+                # multi-disc whatever the caller said.
                 total_discs = disc_number
-            elif _declared_total_discs in (None, ""):
+            elif not _declared_total_discs:
                 try:
                     _album_tracks = _get_album_tracks_for_source(source, str(album_context["id"]))
                     if _album_tracks:

--- a/core/imports/paths.py
+++ b/core/imports/paths.py
@@ -118,6 +118,33 @@ def docker_resolve_path(path_str: str) -> str:
     return path_str
 
 
+def config_root_path(path_str: Any, default: str = "") -> str:
+    """Canonical absolute form of a CONFIGURED root folder.
+
+    Every root in Settings (music library, downloads, import, music videos,
+    playlists) may be written relative — ``./Transfer`` is the shipped default
+    and what the settings page shows. :func:`docker_resolve_path` only maps
+    Windows drive letters, so that value used to reach the filesystem verbatim
+    and one folder ended up with three spellings that never compared equal:
+
+      * ``./Transfer/Artist/…``   — the album path builder (raw string)
+      * ``Transfer/Artist/…``     — the single/simple builder (``Path()`` eats
+        the leading ``./``)
+      * ``/app/Transfer/Artist/…``— anything that realpath()s, e.g. the repair
+        filesystem scan
+
+    The first two were written into the catalogue, so a stored path depended on
+    the process CWD, and every ``startswith(root)`` check silently missed.
+    Resolving once, here, is what makes "the path in the catalogue", "the path
+    on disk" and "the path in a root comparison" the same string. A root the
+    user already gave in full comes back unchanged apart from normalisation.
+    """
+    raw = str(path_str if path_str not in (None, "") else (default or "")).strip()
+    if not raw:
+        return ""
+    return os.path.abspath(docker_resolve_path(os.path.expanduser(raw)))
+
+
 def build_simple_download_destination(context, file_path: str):
     """Build the destination path for a simple download into Transfer."""
     context = normalize_import_context(context)
@@ -125,7 +152,8 @@ def build_simple_download_destination(context, file_path: str):
     if not isinstance(search_result, dict):
         search_result = {}
 
-    transfer_dir = Path(docker_resolve_path(_get_config_manager().get("soulseek.transfer_path", "./Transfer")))
+    transfer_dir = Path(config_root_path(
+        _get_config_manager().get("soulseek.transfer_path", "./Transfer"), "./Transfer"))
     album_name = None
     original_filename = search_result.get("filename", "")
     if "/" in original_filename or "\\" in original_filename:
@@ -568,7 +596,7 @@ def _configured_root_dirs() -> set[str]:
         raw.extend(music_paths)
         for value in raw:
             if isinstance(value, str) and value.strip():
-                roots.add(os.path.normpath(docker_resolve_path(value)))
+                roots.add(config_root_path(value))
     except Exception as exc:  # noqa: BLE001 - a missing config must not block the upgrade
         logger.debug("[Enhance] could not read the configured roots: %s", exc)
     return roots
@@ -588,7 +616,8 @@ def build_final_path_for_track(context, artist_context, album_info, file_ext, cr
         if create_dirs:
             _real_makedirs(path, exist_ok=True)
 
-    transfer_dir = docker_resolve_path(_get_config_manager().get("soulseek.transfer_path", "./Transfer"))
+    transfer_dir = config_root_path(
+        _get_config_manager().get("soulseek.transfer_path", "./Transfer"), "./Transfer")
     context = normalize_import_context(context)
     track_info = get_import_track_info(context)
     original_search = get_import_original_search(context)

--- a/core/imports/staging.py
+++ b/core/imports/staging.py
@@ -40,9 +40,12 @@ def _get_config_manager():
 
 
 def get_staging_path() -> str:
-    """Resolve the configured staging folder path."""
-    raw = _get_config_manager().get("import.staging_path", "./Staging")
-    return docker_resolve_path(raw)
+    """Resolve the configured import/staging folder to one canonical absolute
+    path, so the value stored, compared and walked is always the same string."""
+    from core.imports.paths import config_root_path
+
+    return config_root_path(
+        _get_config_manager().get("import.staging_path", "./Staging"), "./Staging")
 
 
 def get_import_suggestions_cache() -> Dict[str, Any]:

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -1175,6 +1175,19 @@ def _build_post_process_context(
         # that stayed happily in the library (TheHomeGuy: 'Through Glass'
         # 283s vs Discogs' 241s). Size + parse corruption legs still run.
         'is_local_import': True,
+        # ...and for the same reason, the AcoustID identity leg does not get to
+        # quarantine this file. A reorganize stages a COPY of a track the user
+        # ALREADY OWNS and runs it through the download post-process; when the
+        # fingerprint disagreed, that leg moved the copy into ss_quarantine and
+        # the whole run reported `failed`, so a rename that should have been a
+        # no-op only worked on a second attempt with "Rename only" ticked. The
+        # disagreement is routinely legitimate — a different master, a regional
+        # release, or an artist credited in another script (Sawano Hiroyuki
+        # fingerprints as 澤野弘之). Identity of files already in the library is
+        # the AcoustID Scanner's job, and that one raises a finding instead of
+        # moving anyone's audio. The size and parse-corruption legs still run:
+        # skipping identity is not skipping safety.
+        '_skip_quarantine_check': 'acoustid',
         # Reorganize destinations must come from the CURRENT template alone.
         # The #829 existing-folder reuse would resolve to the folder the album
         # already lives in — the very folder reorganize is trying to move it

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -438,6 +438,38 @@ def _feat_in_title_enabled() -> bool:
         return False
 
 
+# A folder the organizer itself writes for one disc of a multi-disc release:
+# "Disc 1" / "CD 1" (the `file_organization.disc_label` setting) and "CD01"
+# (the `$cdnum` template variable). Anchored and numeric so a real album called
+# "Discovery" or an artist called "CD" is never mistaken for one.
+_DISC_FOLDER_RE = re.compile(r'^(disc|disk|cd|volume|vol)\s*\.?\s*\d+$', re.IGNORECASE)
+
+
+def _already_organized_by_disc(tracks) -> bool:
+    """Do the user's files already sit in per-disc folders?
+
+    The single-disc cap below reads the user's layout from their track NUMBERS,
+    which cannot distinguish "a single-disc edition mis-matched against a deluxe"
+    (#1080) from "a multi-disc album that is still downloading". A part-downloaded
+    box set has only disc 1 on disk, uniquely numbered and inside disc 1 — exactly
+    what the cap keys on — so Reorganize proposed moving the album straight back
+    out of the disc folders the download pipeline had just created, and flipped it
+    back again once disc 2 arrived.
+
+    The files settle it. SoulSync only writes a disc folder when the release IS
+    multi-disc, so an album already living in one is organized, not mis-matched,
+    and the setting gating this cap is "preserve my organization".
+    """
+    for track in tracks or []:
+        path = str(track.get('file_path') or '').replace('\\', '/')
+        if not path:
+            continue                      # a missing file carries no evidence
+        parent = os.path.basename(os.path.dirname(path))
+        if parent and _DISC_FOLDER_RE.match(parent):
+            return True
+    return False
+
+
 def _preserve_casing_enabled() -> bool:
     """Whether the reorganize leaves a title/album alone when the metadata
     source differs from the user's file only by letter-case (#1078 QT3496:
@@ -1007,7 +1039,8 @@ def plan_album_reorganize(
     #   * every user track fits within the source's disc 1  → a continuously-
     #     numbered 2-disc set (1..25) spills past disc 1 → left multi-disc.
     # Gated on the same preserve-my-organization setting as casing/year.
-    if total_discs > 1 and _preserve_casing_enabled():
+    if (total_discs > 1 and _preserve_casing_enabled()
+            and not _already_organized_by_disc(tracks)):
         try:
             user_nums = [int(t.get('track_number')) for t in tracks
                          if str(t.get('track_number') or '').strip().isdigit()]

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -1320,11 +1320,7 @@ def preview_album_reorganize(
                 context, spotify_artist, album_info, file_ext, create_dirs=False
             )
             item['new_path_abs'] = new_full or ''
-            item['new_path'] = (
-                os.path.relpath(new_full, transfer_dir)
-                if transfer_dir and new_full and new_full.startswith(transfer_dir)
-                else new_full or ''
-            )
+            item['new_path'] = _display_relative_to_root(new_full, transfer_dir)
             if resolved and new_full and os.path.normpath(resolved) == os.path.normpath(new_full):
                 item['unchanged'] = True
         except Exception as e:
@@ -1388,11 +1384,35 @@ def _is_in_deleted_quarantine(resolved_path, transfer_dir) -> bool:
     return 'deleted' in norm.split('/')
 
 
+def _display_relative_to_root(path, root):
+    """``path`` shown relative to ``root`` when it lives inside it, else whole.
+
+    A raw ``startswith`` was wrong twice over. It matched a SIBLING root
+    (``/music/Transfer2`` starts with ``/music/Transfer``), and it compared two
+    strings that different code paths had spelled differently — the proposed
+    path came from the path builder rooted at the config value, the current
+    path from the resolver (absolute, symlinks resolved). With a relative root
+    configured the two never shared a prefix, so the preview trimmed one column
+    and printed the raw stored value in the other, for the very same file.
+    """
+    if not path or not root:
+        return path or ''
+    p = os.path.normpath(str(path))
+    r = os.path.normpath(str(root))
+    if p == r:
+        return ''
+    if p.startswith(r + os.sep) or (os.altsep and p.startswith(r + os.altsep)):
+        return p[len(r):].lstrip(os.sep).lstrip('/')
+    return path
+
+
 def _trim_to_transfer(db_path, resolved, transfer_dir):
     """Compose the user-facing 'current path' string — relative to the
     transfer dir if the file lives there, else the raw DB value."""
-    if resolved and transfer_dir and resolved.startswith(transfer_dir):
-        return resolved[len(transfer_dir):].lstrip(os.sep).lstrip('/')
+    if resolved and transfer_dir:
+        trimmed = _display_relative_to_root(resolved, transfer_dir)
+        if trimmed != resolved:
+            return trimmed
     return db_path or 'No file'
 
 

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -2087,8 +2087,14 @@ def reorganize_album_rename_only(
 
         # Skip anything that isn't a real, changing move. `unchanged` is the key one —
         # it's why a rename no longer rewrites files whose name didn't change.
+        # `current_path_abs` is the other one: the preview leaves it empty when the
+        # stored path resolves to nothing on disk (`file_exists` False). Passing that
+        # to the mover fails on os.rename — but only AFTER os.makedirs has built the
+        # destination tree, so an unresolvable track used to litter the library with
+        # empty folders, which is exactly what the preview avoids with create_dirs=False.
         if (not t.get('matched') or t.get('unchanged')
-                or t.get('collision') or not t.get('new_path_abs')):
+                or t.get('collision') or not t.get('new_path_abs')
+                or not t.get('current_path_abs')):
             summary['skipped'] += 1
             _emit(skipped=summary['skipped'])
             continue
@@ -2106,17 +2112,41 @@ def reorganize_album_rename_only(
             continue
 
         # File is at its new home — update the DB directly (authoritative; no need to
-        # round-trip through a server scan to learn what we just did). On DB failure the
-        # file still moved; a library scan reconciles it, so we don't fail the track.
+        # round-trip through a server scan to learn what we just did).
+        #
+        # A rename MOVES the only copy, so a failed catalogue update is NOT
+        # recoverable by "a scan will reconcile": the file sits at a path nothing
+        # points at, the track reads as MISSING, and the wishlist re-downloads
+        # something the user already owns. Reported against a fresh library — songs
+        # downloaded, Reorganize run while the import still held the write lock.
+        # Put the file back and fail the track loudly instead.
         if update_track_path_fn:
             try:
                 update_track_path_fn(t.get('track_id'), new_abs)
             except Exception as db_err:
-                logger.warning(
-                    "[Reorganize/rename] DB path update failed for %s: %s "
-                    "(file moved to %s; a scan will reconcile)",
-                    t.get('track_id'), db_err, new_abs,
-                )
+                undone, undo_err = _rename_track_in_place(new_abs, current_abs)
+                if undone:
+                    detail = f'{db_err} (move undone)'
+                    logger.warning(
+                        "[Reorganize/rename] catalogue update failed for %s: %s "
+                        "— moved %s back to %s",
+                        t.get('track_id'), db_err, new_abs, current_abs,
+                    )
+                else:
+                    detail = (f'{db_err} — and the file could not be moved back '
+                              f'to {current_abs}: {undo_err}')
+                    logger.error(
+                        "[Reorganize/rename] catalogue update failed for %s (%s) AND "
+                        "the rollback failed (%s): the file is at %s while the "
+                        "catalogue still names %s",
+                        t.get('track_id'), db_err, undo_err, new_abs, current_abs,
+                    )
+                summary['failed'] += 1
+                summary['errors'].append({
+                    'track_id': t.get('track_id'), 'title': title, 'error': detail,
+                })
+                _emit(failed=summary['failed'], errors=list(summary['errors']))
+                continue
         if current_abs:
             src_dirs_touched.add(os.path.dirname(current_abs))
         summary['moved'] += 1

--- a/core/library_reorganize.py
+++ b/core/library_reorganize.py
@@ -1143,6 +1143,11 @@ def _build_post_process_context(
             'release_date': api_album_release,
             'total_tracks': api_album_total_tracks,
             'total_discs': total_discs,
+            # Reorganize is the caller that really knows: it counted the discs
+            # off the source tracklist it just resolved, so the path builder must
+            # not go and ask a provider again (that lookup's success or failure
+            # would decide the destination).
+            'total_discs_declared': True,
             'image_url': api_album_image,
         },
         'track_info': {

--- a/core/playlists/materialize_service.py
+++ b/core/playlists/materialize_service.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
-from core.imports.paths import docker_resolve_path
+from core.imports.paths import config_root_path
 from core.playlists.materialize import (
     RebuildSummary,
     normalize_mode,
@@ -72,7 +72,8 @@ def materialize_playlist_from_batch(batch: dict, download_tasks: dict, config_ma
         return None
     name = batch.get("playlist_name") or "Unknown Playlist"
     real_paths = collect_batch_real_paths(batch, download_tasks, config_manager=config_manager)
-    root = docker_resolve_path(config_manager.get("playlists.materialize_path", "./Playlists"))
+    root = config_root_path(config_manager.get("playlists.materialize_path", "./Playlists"),
+                            "./Playlists")
     mode = normalize_mode(config_manager.get("playlists.materialize_mode", "symlink"))
     return rebuild_playlist_folder(root, name, real_paths, mode)
 
@@ -160,7 +161,8 @@ def _rebuild_one_from_db(db, config_manager, playlist: dict):
     from core.library.path_resolver import resolve_library_file_path
     from core.playlists.item_naming import render_playlist_item_name
 
-    root = docker_resolve_path(config_manager.get("playlists.materialize_path", "./Playlists"))
+    root = config_root_path(config_manager.get("playlists.materialize_path", "./Playlists"),
+                            "./Playlists")
     mode = normalize_mode(config_manager.get("playlists.materialize_mode", "symlink"))
     item_template = ((config_manager.get("file_organization.templates", {}) or {})
                      .get("playlist_item", "") or "").strip()

--- a/core/reorganize_runner.py
+++ b/core/reorganize_runner.py
@@ -114,23 +114,46 @@ def build_runner(
             logger.debug("[Reorganize] Could not re-point findings: %s", e)
 
     def _update_track_path(track_id, new_path):
-        try:
-            db = get_database()
-            with db._get_connection() as conn:
-                # Read the old path BEFORE overwriting it — it is the only key
-                # the findings rows can be matched on.
-                row = conn.execute(
-                    "SELECT file_path FROM tracks WHERE id = ?", (str(track_id),)
-                ).fetchone()
-                old_path = row[0] if row else None
-                conn.execute(
-                    "UPDATE tracks SET file_path = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-                    (new_path, str(track_id)),
+        """Repoint the catalogue at ``new_path``.
+
+        This MUST raise when the catalogue was not updated. ``_finalize_track``
+        detects a failed path update SOLELY by catching an exception out of this
+        callback, and on success it goes on to ``os.remove`` the original.
+        Swallowing the error here therefore deleted the user's only copy while
+        the catalogue still pointed at the old path — reported as "moved", read
+        by the library as MISSING, and re-downloaded later as if it had never
+        been there.
+
+        The realistic trigger is the SQLite write lock being held elsewhere (an
+        import commit, ``recompute_wanted``): the connection raises ``database
+        is locked``, the whole transaction rolls back, and the file is destroyed
+        anyway. Reported against a fresh library — songs downloaded, Reorganize
+        run straight afterwards, tracks came back missing.
+
+        A 0-row UPDATE is NOT an SQLite error — it is silent success — so the
+        rowcount is checked explicitly: an id the catalogue does not know has to
+        fail just as loudly as a locked database.
+        """
+        db = get_database()
+        with db._get_connection() as conn:
+            # Read the old path BEFORE overwriting it — it is the only key
+            # the findings rows can be matched on.
+            row = conn.execute(
+                "SELECT file_path FROM tracks WHERE id = ?", (str(track_id),)
+            ).fetchone()
+            old_path = row[0] if row else None
+            cursor = conn.execute(
+                "UPDATE tracks SET file_path = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (new_path, str(track_id)),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"track {track_id} was not repointed — the UPDATE matched "
+                    f"{cursor.rowcount} rows, so the catalogue still names the "
+                    f"old path"
                 )
-                _repoint_findings(conn, old_path, new_path)
-                conn.commit()
-        except Exception as db_err:
-            logger.warning(f"[Reorganize] DB path update failed for {track_id}: {db_err}")
+            _repoint_findings(conn, old_path, new_path)
+            conn.commit()
 
     def runner(item):
         # Read config per-run so the user changing their download path

--- a/core/repair_jobs/audio_corruption_detector.py
+++ b/core/repair_jobs/audio_corruption_detector.py
@@ -108,6 +108,15 @@ def check_flac_integrity(path: str) -> Tuple[bool, str]:
     return True, ''
 
 
+def _file_identity(path: str):
+    """``(size, mtime_ns)`` of ``path``, or ``None`` when it is not there."""
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return None
+    return (stat.st_size, stat.st_mtime_ns)
+
+
 def _decoder_available() -> bool:
     return bool(shutil.which('flac') or shutil.which('ffmpeg'))
 
@@ -234,6 +243,13 @@ class AudioCorruptionDetectorJob(RepairJob):
                     log_line=f'{artist} — {title}', log_type='info')
 
             tested += 1
+            # A decode verdict only means something if the bytes under it held
+            # still. The scan walks the library while the import pipeline is
+            # still moving files into it, and a cross-device move is
+            # copy-then-delete — so `flac -t` reading a half-written FLAC
+            # reports exactly what a genuinely damaged one does. The finding was
+            # then written against a path that had already moved on.
+            identity_before = _file_identity(resolved)
             try:
                 ok, reason = check_flac_integrity(resolved)
             except Exception as e:
@@ -245,6 +261,22 @@ class AudioCorruptionDetectorJob(RepairJob):
                 continue
 
             if ok:
+                if context.update_progress and (i + 1) % 5 == 0:
+                    context.update_progress(i + 1, total)
+                continue
+
+            identity_after = _file_identity(resolved)
+            if identity_after is None or identity_after != identity_before:
+                # Moved, replaced or still growing under the test — not evidence.
+                logger.debug(
+                    "[Corrupt File Detector] %s changed during the decode test "
+                    "(%s -> %s) — not flagging",
+                    os.path.basename(resolved), identity_before, identity_after)
+                result.skipped += 1
+                if context.report_progress:
+                    context.report_progress(
+                        log_line=(f'Skipped {artist} — {title}: the file changed '
+                                  f'while it was being tested'), log_type='info')
                 if context.update_progress and (i + 1) % 5 == 0:
                     context.update_progress(i + 1, total)
                 continue

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -5597,12 +5597,16 @@ class RepairWorker:
     # ------------------------------------------------------------------
     @staticmethod
     def _resolve_path(path_str: str) -> str:
-        """Resolve Docker path mapping if running in a container."""
-        if os.path.exists('/.dockerenv') and len(path_str) >= 3 and path_str[1] == ':' and path_str[0].isalpha():
-            drive_letter = path_str[0].lower()
-            rest_of_path = path_str[2:].replace('\\', '/')
-            return f"/host/mnt/{drive_letter}{rest_of_path}"
-        return path_str
+        """Canonical absolute form of a configured folder (Docker mapping included).
+
+        Roots are routinely configured relative ("./Transfer" is the shipped
+        default). Returning them verbatim made every root comparison in the
+        repair jobs a string compare between "./Transfer/…" and the realpath'd
+        "/app/Transfer/…" of the very same file — which never matched.
+        """
+        from core.imports.paths import config_root_path
+
+        return config_root_path(path_str) or path_str
 
     def _get_transfer_path_from_db(self) -> str:
         """Read transfer path directly from the database app_config."""

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -44,6 +44,16 @@ RESOLVED_RECURRENCE_GRACE_DAYS = 7
 # bulk run takes when nobody chose anything — not by its worst-case action.
 # The UI never one-clicks these: they go through the preview + confirm path,
 # and "Fix all safe" skips them entirely.
+# Finding types whose subject IS a path that is not there. The sweep below runs
+# right after the scan that raised them, scoped to that same job, so without this
+# exclusion both would be retired the instant they were created and their jobs
+# would report "N findings created" over an empty list.
+#
+#   dead_file    names the missing file of a track that still has a catalogue row
+#   empty_folder names a directory that is empty by definition
+_ABSENCE_IS_THE_FINDING = frozenset({'dead_file', 'empty_folder'})
+
+
 DESTRUCTIVE_FINDING_TYPES = frozenset({
     'orphan_file',            # default 'staging' MOVES the file; 'delete' removes it
     'dead_file',              # 'remove' drops the library row + file
@@ -1437,11 +1447,13 @@ class RepairWorker:
         retired = 0
         try:
             conn = self.db._get_connection()
+            marks = ','.join('?' for _ in _ABSENCE_IS_THE_FINDING)
             rows = conn.execute(
                 "SELECT id, file_path FROM repair_findings "
                 "WHERE job_id = ? AND status = 'pending' "
-                "AND file_path IS NOT NULL AND file_path <> ''",
-                (job_id,),
+                "AND file_path IS NOT NULL AND file_path <> '' "
+                f"AND finding_type NOT IN ({marks})",
+                (job_id, *sorted(_ABSENCE_IS_THE_FINDING)),
             ).fetchall()
             download_folder = None
             if self._config_manager:
@@ -1453,7 +1465,9 @@ class RepairWorker:
                 resolved = _resolve_file_path(
                     raw, self.transfer_folder, download_folder,
                     config_manager=self._config_manager) or raw
-                if os.path.isfile(resolved):
+                if os.path.exists(resolved):
+                    # exists(), not isfile(): a finding may legitimately name a
+                    # DIRECTORY, and isfile() of one is False.
                     continue
                 parent = os.path.dirname(resolved)
                 if not parent or not os.path.isdir(parent):

--- a/core/repair_worker.py
+++ b/core/repair_worker.py
@@ -948,6 +948,12 @@ class RepairWorker:
         if run_status == 'completed' and self._cancel_current_job.is_set():
             run_status = 'cancelled'
 
+        # A completed sweep is the moment we know the library's real state, so
+        # it is also the moment to close findings whose file has since gone.
+        # Skipped after a failure or a user stop: a partial view is not evidence.
+        if run_status == 'completed':
+            self.retire_vanished_findings(job_id)
+
         duration = time.time() - start_time
 
         # Update aggregate stats
@@ -1406,6 +1412,71 @@ class RepairWorker:
         finally:
             if conn:
                 conn.close()
+
+    def retire_vanished_findings(self, job_id: str) -> int:
+        """Close this job's pending findings whose file is no longer on disk.
+
+        A finding carries its own snapshot of a path, and nothing ever closed one
+        after the file moved, was replaced or was deleted. The stale snapshot
+        stayed in the list with a Fix button that could only fail — reported as
+        Corrupt Audio findings naming files that no longer existed by the time
+        the user looked.
+
+        The trap a sweep like this has to avoid is retiring findings because THIS
+        process cannot see the library. A Docker install whose catalogue holds
+        the media server's paths ("/music/…") resolves nothing locally, and a
+        naive "the file is not there" test would wipe every finding it has. So a
+        finding is retired only when its CONTAINING FOLDER is right there and the
+        file is not: the folder is the proof that we are looking at the real
+        library and the file really did go away.
+
+        Returns the number retired. Best-effort — a maintenance sweep must never
+        be the reason a scan reports failure.
+        """
+        conn = None
+        retired = 0
+        try:
+            conn = self.db._get_connection()
+            rows = conn.execute(
+                "SELECT id, file_path FROM repair_findings "
+                "WHERE job_id = ? AND status = 'pending' "
+                "AND file_path IS NOT NULL AND file_path <> ''",
+                (job_id,),
+            ).fetchall()
+            download_folder = None
+            if self._config_manager:
+                download_folder = self._config_manager.get('soulseek.download_path', '')
+            gone = []
+            for row in rows:
+                raw = row['file_path'] if not isinstance(row, tuple) else row[1]
+                finding_id = row['id'] if not isinstance(row, tuple) else row[0]
+                resolved = _resolve_file_path(
+                    raw, self.transfer_folder, download_folder,
+                    config_manager=self._config_manager) or raw
+                if os.path.isfile(resolved):
+                    continue
+                parent = os.path.dirname(resolved)
+                if not parent or not os.path.isdir(parent):
+                    continue      # the library itself is out of reach from here
+                gone.append(finding_id)
+            for finding_id in gone:
+                conn.execute(
+                    "UPDATE repair_findings SET status = 'resolved', "
+                    "user_action = 'obsolete', resolved_at = CURRENT_TIMESTAMP, "
+                    "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (finding_id,),
+                )
+                retired += 1
+            if retired:
+                conn.commit()
+                logger.info("[%s] Retired %d finding(s) whose file is gone",
+                            job_id, retired)
+        except Exception as e:
+            logger.debug("Vanished-findings sweep skipped for %s: %s", job_id, e)
+        finally:
+            if conn:
+                conn.close()
+        return retired
 
     def resolve_finding(self, finding_id: int, action: str = None) -> bool:
         """Resolve a finding with an optional action."""

--- a/tests/imports/test_configured_root_folders.py
+++ b/tests/imports/test_configured_root_folders.py
@@ -89,3 +89,39 @@ def test_config_root_path_is_stable_across_spellings(monkeypatch, tmp_path):
 def test_config_root_path_leaves_an_empty_value_empty():
     assert import_paths.config_root_path("") == ""
     assert import_paths.config_root_path(None) == ""
+
+
+# ── the canonical form has to reach EVERY reader, not just the builders ──────
+#
+# Half-applying it is worse than not applying it. The path builder wrote
+# /app/Transfer/... into the catalogue while SoulSync Deep Scan still walked
+# ./Transfer/... and compared the two as strings, so on a relative root every
+# tracked file suddenly read as untracked ("your library isn't in the database").
+# docker_resolve_path is the single funnel all of those go through.
+
+def test_docker_resolve_path_returns_an_absolute_root(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    assert import_paths.docker_resolve_path("./Transfer") == str(tmp_path / "Transfer")
+    assert import_paths.docker_resolve_path("Transfer") == str(tmp_path / "Transfer")
+
+
+def test_docker_resolve_path_leaves_an_absolute_root_alone(tmp_path):
+    assert import_paths.docker_resolve_path(str(tmp_path / "T")) == str(tmp_path / "T")
+
+
+def test_docker_resolve_path_keeps_an_empty_value_empty():
+    """os.path.abspath('') is the CWD. An unconfigured folder must stay
+    unconfigured, not silently become the application directory."""
+    assert import_paths.docker_resolve_path("") == ""
+    assert import_paths.docker_resolve_path(None) is None
+
+
+def test_the_web_server_copy_agrees_with_the_shared_one(monkeypatch, tmp_path):
+    """web_server keeps its own docker_resolve_path and hands it to the download
+    and automation handlers as a dependency, so a divergence there re-opens the
+    same split."""
+    import web_server
+
+    monkeypatch.chdir(tmp_path)
+    for value in ("./Transfer", "Transfer", str(tmp_path / "T"), ""):
+        assert web_server.docker_resolve_path(value) == import_paths.docker_resolve_path(value)

--- a/tests/imports/test_configured_root_folders.py
+++ b/tests/imports/test_configured_root_folders.py
@@ -1,0 +1,91 @@
+"""Every configured root folder must be read under the key the settings page
+writes, and must resolve to one canonical absolute form.
+
+Two separate defects lived here:
+
+* ``core/imports/file_ops.py`` read ``soulseek.staging_path``. The settings page
+  writes ``import.staging_path`` (``webui/static/settings.js``), and every other
+  reader uses that key. So the import folder was NOT in the protected-root set
+  that issue #976 added to stop the post-import cleanup ``rmdir``-ing it, and the
+  self-heal recreated a literal ``./Staging`` instead of the folder the user
+  configured.
+* A root written relative ("./Staging", the shipped default) was compared and
+  stored verbatim, so it never matched the same folder spelled absolutely.
+"""
+
+import os
+
+import pytest
+
+import core.imports.file_ops as file_ops
+import core.imports.paths as import_paths
+import core.imports.staging as staging_mod
+
+
+class _Config:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+
+@pytest.fixture()
+def configured(monkeypatch, tmp_path):
+    """The five roots exactly as the settings page stores them."""
+    cfg = _Config({
+        "import.staging_path": str(tmp_path / "Staging"),
+        "soulseek.download_path": str(tmp_path / "downloads"),
+        "soulseek.transfer_path": str(tmp_path / "Transfer"),
+    })
+    monkeypatch.setattr(file_ops, "config_manager", cfg)
+    monkeypatch.setattr(staging_mod, "_get_config_manager", lambda: cfg)
+    return tmp_path
+
+
+# ── the import folder is a protected root (#976) ─────────────────────────────
+
+def test_the_configured_import_folder_is_protected(configured):
+    roots = file_ops.protected_root_dirs()
+    assert str(configured / "Staging") in roots, (
+        "the import folder is not protected — the post-import cleanup can rmdir it"
+    )
+
+
+def test_download_and_library_roots_stay_protected(configured):
+    roots = file_ops.protected_root_dirs()
+    assert str(configured / "downloads") in roots
+    assert str(configured / "Transfer") in roots
+
+
+def test_the_self_heal_recreates_the_configured_folder(configured):
+    file_ops.ensure_staging_dir()
+    assert (configured / "Staging").is_dir()
+    assert not (configured / "." / "Staging" / "Staging").exists()
+
+
+# ── relative roots resolve to the same string everywhere ─────────────────────
+
+def test_a_relative_import_folder_resolves_absolutely(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    cfg = _Config({"import.staging_path": "./Staging",
+                   "soulseek.download_path": "./downloads",
+                   "soulseek.transfer_path": "./Transfer"})
+    monkeypatch.setattr(file_ops, "config_manager", cfg)
+    monkeypatch.setattr(staging_mod, "_get_config_manager", lambda: cfg)
+
+    assert staging_mod.get_staging_path() == str(tmp_path / "Staging")
+    assert str(tmp_path / "Staging") in file_ops.protected_root_dirs()
+
+
+def test_config_root_path_is_stable_across_spellings(monkeypatch, tmp_path):
+    """The three spellings that used to name one folder must collapse to one."""
+    monkeypatch.chdir(tmp_path)
+    canonical = str(tmp_path / "Transfer")
+    for spelling in ("./Transfer", "Transfer", canonical, canonical + "/"):
+        assert import_paths.config_root_path(spelling) == canonical
+
+
+def test_config_root_path_leaves_an_empty_value_empty():
+    assert import_paths.config_root_path("") == ""
+    assert import_paths.config_root_path(None) == ""

--- a/tests/imports/test_import_paths.py
+++ b/tests/imports/test_import_paths.py
@@ -1000,3 +1000,71 @@ def test_enhance_preview_still_creates_nothing(monkeypatch, tmp_path):
 
     assert final_path == str(album_dir / "01 - The Show.flac")
     assert not (tmp_path / "Transfer").exists()
+
+
+# ── a relative library root must still produce an absolute destination ───────
+#
+# "./Transfer" is the shipped default and what the settings page shows. It was
+# passed through docker_resolve_path (which only maps Windows drive letters) and
+# used verbatim, so the destination the builder returned — and therefore the path
+# written into the catalogue — was RELATIVE. Every consumer that realpath()s a
+# path (the repair filesystem scan) then saw "/app/Transfer/…" for the very same
+# file, and every consumer that compared roots with startswith() silently missed.
+# Same file, three spellings, no two of them equal.
+
+def _relative_root_config():
+    return _Config({
+        "soulseek.transfer_path": "./Transfer",
+        "file_organization.enabled": True,
+        "file_organization.templates": {
+            "album_path": "$albumartist/$album/$track - $title",
+            "single_path": "$albumartist/$albumartist - $title/$title",
+        },
+        "file_organization.collab_artist_mode": "first",
+        "file_organization.disc_label": "Disc",
+    })
+
+
+def test_relative_transfer_root_yields_an_absolute_album_destination(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(import_paths, "_get_config_manager", _relative_root_config)
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+
+    final_path, _ = import_paths.build_final_path_for_track(
+        _album_context(), {"name": "Lenka"},
+        {"is_album": True, "album_name": "Lenka", "track_number": 1, "disc_number": 1},
+        ".flac", create_dirs=False,
+    )
+
+    assert os.path.isabs(final_path), f"catalogue would store a relative path: {final_path}"
+    assert final_path == str(tmp_path / "Transfer" / "Lenka" / "Lenka" / "01 - The Show.flac")
+
+
+def test_relative_transfer_root_yields_an_absolute_single_destination(monkeypatch, tmp_path):
+    """The single/simple builder took the same raw value through pathlib.Path,
+    which additionally ate the leading './' — a THIRD spelling of one root."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(import_paths, "_get_config_manager", _relative_root_config)
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+
+    final_path, _ = import_paths.build_final_path_for_track(
+        _album_context(), {"name": "Lenka"}, None, ".flac", create_dirs=False,
+    )
+
+    assert os.path.isabs(final_path), f"catalogue would store a relative path: {final_path}"
+    assert final_path.startswith(str(tmp_path / "Transfer") + os.sep)
+
+
+def test_an_absolute_root_is_left_exactly_as_configured(monkeypatch, tmp_path):
+    """Canonicalising must not rewrite a root the user already gave in full."""
+    monkeypatch.setattr(import_paths, "_get_config_manager",
+                        lambda: _album_path_config(tmp_path))
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+
+    final_path, _ = import_paths.build_final_path_for_track(
+        _album_context(), {"name": "Lenka"},
+        {"is_album": True, "album_name": "Lenka", "track_number": 1, "disc_number": 1},
+        ".flac", create_dirs=False,
+    )
+
+    assert final_path == str(tmp_path / "Transfer" / "Lenka" / "Lenka - Lenka" / "01 - The Show.flac")

--- a/tests/imports/test_template_disc_variables.py
+++ b/tests/imports/test_template_disc_variables.py
@@ -89,3 +89,40 @@ def test_quality_stays_filename_only():
         == "Sawano Hiroyuki/AoT OST"
     assert _filename("$albumartist/$album/$track - $title [$quality]") \
         == "03 - Apetitan [FLAC]"
+
+
+# ── every spelling of a disc variable, not just the bare ones ────────────────
+#
+# `${disc}`, `${discnum}` and `$cdnum` are substituted globally, before the path
+# is split into segments, so by the time the segment cleanup looked for "$disc"
+# they were already gone and the dangling-label drop never fired. A label next
+# to one of those on a single-disc album was left standing:
+#
+#     $artist/$album/Disc ${discnum}/...  ->  A/B/Disc
+#     $artist/$album/CD $cdnum/...        ->  A/B/CD
+#
+# which is the same collapse-every-disc-into-one-folder problem the bare form
+# had, and the settings page now tells users all three forms work in a folder.
+
+def test_a_bracket_form_label_is_dropped_on_a_single_disc_album():
+    assert _folder("$albumartist/$album/Disc ${discnum}/$track - $title",
+                   disc_number=1, total_discs=1) == "Sawano Hiroyuki/AoT OST"
+
+
+def test_a_cdnum_label_is_dropped_on_a_single_disc_album():
+    assert _folder("$albumartist/$album/CD $cdnum/$track - $title",
+                   disc_number=1, total_discs=1) == "Sawano Hiroyuki/AoT OST"
+
+
+def test_those_forms_still_render_on_a_multi_disc_album():
+    assert _folder("$albumartist/$album/Disc ${discnum}/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/Disc 2"
+    assert _folder("$albumartist/$album/CD $cdnum/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/CD CD02"
+
+
+def test_a_template_without_any_disc_variable_keeps_a_literal_label():
+    """The drop is scoped to templates that actually use a disc variable, so a
+    folder someone deliberately called "CD" is never swallowed."""
+    assert _folder("$albumartist/CD/$album/$track - $title",
+                   disc_number=1, total_discs=1) == "Sawano Hiroyuki/CD/AoT OST"

--- a/tests/imports/test_template_disc_variables.py
+++ b/tests/imports/test_template_disc_variables.py
@@ -1,0 +1,91 @@
+"""Disc variables must behave the same in a FOLDER segment as in the filename.
+
+The settings page documents exactly one filename-only variable, ``$quality``.
+But the per-segment cleanup also stripped ``$disc`` and ``$discnum`` out of
+folder parts, while ``$cdnum`` and the ``${...}`` bracket forms were substituted
+globally and therefore did work. The result was three different behaviours for
+one family of variables, none of them documented:
+
+    $albumartist/$album/$disc/$track - $title        -> the folder vanished
+    $albumartist/$album/Disc $discnum/$track - $title-> a folder literally "Disc"
+    $albumartist/$album/$cdnum/$track - $title       -> "CD01"          (worked)
+    $albumartist/$album/${discnum}/$track - $title   -> "1"             (worked)
+
+"a folder literally named Disc" is the worst of them: every disc of the album
+collides in one folder, silently.
+"""
+
+from __future__ import annotations
+
+import core.imports.paths as import_paths
+
+
+def _ctx(disc_number=2, total_discs=2):
+    return {
+        "albumartist": "Sawano Hiroyuki", "artist": "Sawano Hiroyuki",
+        "album": "AoT OST", "title": "Apetitan",
+        "track_number": 3, "disc_number": disc_number, "total_discs": total_discs,
+        "year": "2017", "quality": "FLAC",
+    }
+
+
+def _folder(template, **kw):
+    return import_paths.get_file_path_from_template_raw(template, _ctx(**kw))[0]
+
+
+def _filename(template, **kw):
+    return import_paths.get_file_path_from_template_raw(template, _ctx(**kw))[1]
+
+
+# ── multi-disc: the folder segment gets the value ────────────────────────────
+
+def test_bare_disc_works_in_a_folder_segment():
+    assert _folder("$albumartist/$album/$disc/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/02"
+
+
+def test_bare_discnum_works_in_a_folder_segment():
+    assert _folder("$albumartist/$album/Disc $discnum/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/Disc 2"
+
+
+def test_cdnum_is_unchanged():
+    assert _folder("$albumartist/$album/$cdnum/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/CD02"
+
+
+def test_bracket_forms_are_unchanged():
+    assert _folder("$albumartist/$album/${discnum}/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST/2"
+
+
+# ── single disc: the segment disappears, exactly like $cdnum already did ─────
+
+def test_disc_folders_vanish_on_a_single_disc_album():
+    for template in ("$albumartist/$album/$disc/$track - $title",
+                     "$albumartist/$album/$cdnum/$track - $title"):
+        assert _folder(template, disc_number=1, total_discs=1) \
+            == "Sawano Hiroyuki/AoT OST", template
+
+
+def test_a_label_left_alone_by_an_empty_disc_number_is_dropped_whole():
+    """"Disc $discnum" with nothing to fill in must not leave a folder called
+    "Disc" that every disc of the album then shares."""
+    assert _folder("$albumartist/$album/Disc $discnum/$track - $title",
+                   disc_number=1, total_discs=1) == "Sawano Hiroyuki/AoT OST"
+
+
+# ── the filename side keeps working ─────────────────────────────────────────
+
+def test_the_filename_still_substitutes_disc():
+    assert _filename("$albumartist/$album/$disc-$track - $title") == "02-03 - Apetitan"
+    assert _filename("$albumartist/$album/$disc-$track - $title",
+                     disc_number=1, total_discs=1) == "03 - Apetitan"
+
+
+def test_quality_stays_filename_only():
+    """The one variable the settings page really does document as filename-only."""
+    assert _folder("$albumartist/$quality/$album/$track - $title") \
+        == "Sawano Hiroyuki/AoT OST"
+    assert _filename("$albumartist/$album/$track - $title [$quality]") \
+        == "03 - Apetitan [FLAC]"

--- a/tests/repair_jobs/test_audio_corruption_detector.py
+++ b/tests/repair_jobs/test_audio_corruption_detector.py
@@ -10,6 +10,8 @@ Covered:
 
 from __future__ import annotations
 
+import os
+
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -239,3 +241,65 @@ def test_scan_surfaces_total_resolution_failure(tmp_path, monkeypatch):
     assert result.skipped == 1 and result.findings_created == 0
     assert any(r.get("log_type") == "error" and "No library paths" in (r.get("log_line") or "")
                for r in reports)
+
+
+# ── a file that changed under the decode test is not evidence ────────────────
+#
+# The scan walks the library while the import pipeline is still moving files
+# into it. A cross-device move is copy-then-delete, so `flac -t` reading a
+# half-written FLAC reports exactly what a genuinely damaged one does
+# ("LOST_SYNC after processing N samples"). The finding was then written with a
+# path that no longer existed by the time the user looked at it.
+#
+# The decode verdict only means something if the bytes under it held still.
+
+def test_a_file_that_vanished_during_the_test_is_not_flagged(tmp_path, monkeypatch):
+    gone = tmp_path / "01 - Gone.flac"
+    gone.write_bytes(b"x")
+
+    def _decode(path):
+        os.remove(path)               # the mover finishes mid-test
+        return False, "LOST_SYNC after processing 0 samples"
+
+    monkeypatch.setattr(mod, "_decoder_available", lambda: True)
+    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p, **kw: p)
+    monkeypatch.setattr(mod, "check_flac_integrity", _decode)
+
+    ctx, findings = _context([_row(20, "Gone", str(gone))], tmp_path)
+    result = AudioCorruptionDetectorJob().scan(ctx)
+
+    assert findings == [], "flagged a file that no longer exists"
+    assert result.findings_created == 0 and result.skipped == 1
+
+
+def test_a_file_still_being_written_is_not_flagged(tmp_path, monkeypatch):
+    """Same race, caught by size instead of absence: the copy is still growing."""
+    growing = tmp_path / "02 - Growing.flac"
+    growing.write_bytes(b"x")
+
+    def _decode(path):
+        with open(path, "ab") as fh:
+            fh.write(b"more bytes arriving")
+        return False, "LOST_SYNC after processing 6418432 samples"
+
+    monkeypatch.setattr(mod, "_decoder_available", lambda: True)
+    monkeypatch.setattr(mod, "resolve_library_file_path", lambda p, **kw: p)
+    monkeypatch.setattr(mod, "check_flac_integrity", _decode)
+
+    ctx, findings = _context([_row(21, "Growing", str(growing))], tmp_path)
+    result = AudioCorruptionDetectorJob().scan(ctx)
+
+    assert findings == [], "flagged a file that was still being written"
+    assert result.findings_created == 0 and result.skipped == 1
+
+
+def test_a_file_that_held_still_is_still_flagged(tmp_path, monkeypatch):
+    """The guard must not swallow real corruption."""
+    bad = tmp_path / "03 - Really Bad.flac"
+    bad.write_bytes(b"x")
+    _prep(monkeypatch, {str(bad): (False, "FRAME_CRC_MISMATCH")})
+
+    ctx, findings = _context([_row(22, "Really Bad", str(bad))], tmp_path)
+    result = AudioCorruptionDetectorJob().scan(ctx)
+
+    assert result.findings_created == 1 and len(findings) == 1

--- a/tests/test_cleanup_protected_roots.py
+++ b/tests/test_cleanup_protected_roots.py
@@ -8,6 +8,11 @@ import feature until the folder was manually recreated.
 
 The fix: every empty-folder cleanup treats all configured roots
 (staging/download/transfer) as protected and never removes them, however nested.
+
+The key is ``import.staging_path`` — what ``core/settings.py`` defines and what
+the settings page writes. These tests used to pin ``soulseek.staging_path``,
+which nothing writes, so they agreed with a reader that always looked the folder
+up as '' and the #976 protection never actually applied in production.
 """
 import os
 
@@ -35,7 +40,7 @@ def test_nested_staging_root_is_not_deleted(tmp_path, monkeypatch):
     moved_file = str(album / "01 - song.flac")  # already moved to library (dir empty)
 
     _patch_roots(monkeypatch, {
-        'soulseek.staging_path': str(staging),
+        'import.staging_path': str(staging),
         'soulseek.download_path': str(downloads),
         'soulseek.transfer_path': str(tmp_path / "library"),
     })
@@ -55,7 +60,7 @@ def test_transient_subfolders_still_removed(tmp_path, monkeypatch):
     moved_file = str(sub / "1.flac")
 
     _patch_roots(monkeypatch, {
-        'soulseek.staging_path': str(tmp_path / "staging"),   # separate, not nested
+        'import.staging_path': str(tmp_path / "staging"),   # separate, not nested
         'soulseek.download_path': str(downloads),
         'soulseek.transfer_path': str(tmp_path / "library"),
     })
@@ -73,7 +78,7 @@ def test_ensure_staging_recreates_when_parent_exists(tmp_path, monkeypatch):
     downloads = tmp_path / "downloads"
     staging = downloads / "staging"
     downloads.mkdir()                       # parent exists, staging does not
-    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+    _patch_roots(monkeypatch, {'import.staging_path': str(staging)})
 
     assert not staging.exists()
     ensure_staging_dir()
@@ -84,7 +89,7 @@ def test_ensure_staging_skips_when_parent_missing(tmp_path, monkeypatch):
     """Mount safety: never fabricate a not-yet-mounted volume path — if the
     parent doesn't exist we leave it alone rather than mask a missing mount."""
     staging = tmp_path / "not_mounted_yet" / "staging"   # parent absent
-    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+    _patch_roots(monkeypatch, {'import.staging_path': str(staging)})
 
     ensure_staging_dir()
     assert not staging.exists()
@@ -95,7 +100,7 @@ def test_ensure_staging_noop_when_present(tmp_path, monkeypatch):
     staging = tmp_path / "staging"
     staging.mkdir()
     (staging / "keep.flac").write_text("x")
-    _patch_roots(monkeypatch, {'soulseek.staging_path': str(staging)})
+    _patch_roots(monkeypatch, {'import.staging_path': str(staging)})
 
     ensure_staging_dir()
     assert (staging / "keep.flac").is_file()   # untouched
@@ -103,7 +108,7 @@ def test_ensure_staging_noop_when_present(tmp_path, monkeypatch):
 
 def test_protected_roots_reads_all_three_configs(tmp_path, monkeypatch):
     _patch_roots(monkeypatch, {
-        'soulseek.staging_path': str(tmp_path / "s"),
+        'import.staging_path': str(tmp_path / "s"),
         'soulseek.download_path': str(tmp_path / "d"),
         'soulseek.transfer_path': str(tmp_path / "t"),
     })
@@ -111,3 +116,20 @@ def test_protected_roots_reads_all_three_configs(tmp_path, monkeypatch):
     assert os.path.normpath(str(tmp_path / "s")) in roots
     assert os.path.normpath(str(tmp_path / "d")) in roots
     assert os.path.normpath(str(tmp_path / "t")) in roots
+
+
+def test_the_import_folder_is_read_under_the_key_the_settings_page_writes(
+        tmp_path, monkeypatch):
+    """`soulseek.staging_path` is not in the config schema and nothing writes it
+    (core/settings.py defines `import.staging_path`, webui/static/settings.js
+    saves it). Reading the phantom key made protected_root_dirs() silently drop
+    the import folder — the exact thing #976 added it for."""
+    _patch_roots(monkeypatch, {
+        'soulseek.staging_path': str(tmp_path / "phantom"),
+        'import.staging_path': str(tmp_path / "real"),
+        'soulseek.download_path': str(tmp_path / "d"),
+        'soulseek.transfer_path': str(tmp_path / "t"),
+    })
+    roots = protected_root_dirs()
+    assert str(tmp_path / "real") in roots
+    assert str(tmp_path / "phantom") not in roots

--- a/tests/test_download_reorganize_agree.py
+++ b/tests/test_download_reorganize_agree.py
@@ -145,19 +145,25 @@ def test_the_destination_is_absolute_so_the_catalogue_can_store_it(cfg):
 
 
 def test_the_destination_does_not_depend_on_a_provider_lookup(cfg, monkeypatch):
-    """`total_discs` explicitly supplied by the caller must be trusted.
+    """A caller that KNOWS the disc count must be trusted.
 
-    The builder re-derived the disc count from a live provider tracklist
-    whenever the supplied value was <= 1 — so the same track landed in
-    `Album/01 - x.flac` or `Album/Disc 1/01 - x.flac` depending on whether that
-    lookup happened to succeed. A cache miss or an offline provider was enough
-    to file two tracks of one album in two different folders.
+    The builder re-derived the count from a live provider tracklist whenever the
+    supplied value was <= 1, so the same track landed in `Album/01 - x.flac` or
+    `Album/Disc 1/01 - x.flac` depending on whether that lookup happened to
+    succeed. A cache miss or an offline provider was enough to file two tracks
+    of one album in two different folders.
+
+    "Knows" has to be explicit. Almost every context builder writes
+    `.get('total_discs', 1)`, where the 1 means "nobody told me" — reading that
+    as a declaration would silence the #981 lookup for playlist and wishlist
+    downloads and file disc-1 tracks of a real 2-disc release flat.
     """
     def _ctx(total_discs):
         return {
             "artist": {"name": ARTIST},
             "album": {"name": ALBUM, "id": "sp1", "release_date": "2017-06-28",
                       "total_tracks": len(API_TRACKS), "total_discs": total_discs,
+                      "total_discs_declared": True,
                       "album_type": "album", "artists": [{"name": ARTIST}]},
             "track_info": {"name": "D1-01", "id": "t", "track_number": 1,
                            "disc_number": 1, "artists": [{"name": ARTIST}]},
@@ -205,3 +211,39 @@ def test_an_absent_total_discs_still_asks_the_provider(cfg, monkeypatch):
         {"is_album": True, "album_name": ALBUM, "track_number": 1, "disc_number": 1},
         ".flac", create_dirs=False)
     assert os.sep + "Disc 1" + os.sep in path
+
+
+def test_a_defaulted_total_discs_still_asks_the_provider(cfg, monkeypatch):
+    """The regression guard for the above: `total_discs: 1` written by a caller
+    that merely defaulted it (core/downloads/candidates.py, staging.py,
+    master.py all do `.get('total_discs', 1)`) is NOT a declaration. Spotify
+    album objects carry no disc count at all, so 1 there means unknown."""
+    ctx = {
+        "artist": {"name": ARTIST},
+        "album": {"name": ALBUM, "id": "sp1", "release_date": "2017-06-28",
+                  "total_tracks": len(API_TRACKS), "total_discs": 1,
+                  "album_type": "album", "artists": [{"name": ARTIST}]},
+        "track_info": {"name": "D1-01", "id": "t", "track_number": 1,
+                       "disc_number": 1, "artists": [{"name": ARTIST}]},
+        "original_search_result": {"title": "D1-01", "clean_title": "D1-01",
+                                   "clean_album": ALBUM, "clean_artist": ARTIST,
+                                   "artists": [{"name": ARTIST}]},
+        "source": "spotify", "is_album_download": True,
+    }
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: API_TRACKS)
+    path, _ = build_final_path_for_track(
+        ctx, {"name": ARTIST},
+        {"is_album": True, "album_name": ALBUM, "track_number": 1, "disc_number": 1},
+        ".flac", create_dirs=False)
+    assert os.sep + "Disc 1" + os.sep in path, (
+        "a defaulted 1 was read as a declaration, so the #981 lookup never ran"
+    )
+
+
+def test_the_reorganize_context_declares_its_disc_count():
+    """Reorganize is the caller that really knows: it counted the discs off the
+    source tracklist it just resolved."""
+    ctx = lr._build_post_process_context(
+        API_ALBUM, API_TRACKS[0], ARTIST, ALBUM, 2, local_title="D1-01")
+    assert ctx["spotify_album"]["total_discs"] == 2
+    assert ctx["spotify_album"]["total_discs_declared"] is True

--- a/tests/test_download_reorganize_agree.py
+++ b/tests/test_download_reorganize_agree.py
@@ -1,0 +1,207 @@
+"""A freshly downloaded album must already sit where Reorganize would put it.
+
+Both pipelines call the SAME builder (``core.imports.paths.build_final_path_for_track``),
+so the destination can only diverge through the context they feed it. It did:
+Reorganize applied a single-disc cap that the download pipeline knows nothing
+about, so an album whose tracks the downloader had just filed under "Disc 1/"
+was immediately proposed for a move back out — and moved back in again once the
+second disc arrived.
+
+The acceptance criterion is the user's: download an album, press Reorganize,
+nothing moves.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import core.imports.paths as import_paths
+import core.library_reorganize as lr
+from core.imports.paths import build_final_path_for_track
+
+
+class _Config:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, key, default=None):
+        return self._values.get(key, default)
+
+    def get_active_media_server(self):
+        return "primary"
+
+
+ARTIST = "Sawano Hiroyuki"
+ALBUM = "TV Anime Attack on Titan Season 2 (Original Soundtrack)"
+# A genuine 2-disc release, numbered per disc.
+API_TRACKS = ([{"name": "D1-%02d" % n, "track_number": n, "disc_number": 1,
+                "artists": [{"name": ARTIST}]} for n in range(1, 26)]
+              + [{"name": "D2-%02d" % n, "track_number": n, "disc_number": 2,
+                  "artists": [{"name": ARTIST}]} for n in range(1, 21)])
+API_ALBUM = {"id": "sp1", "name": ALBUM, "release_date": "2017-06-28",
+             "total_tracks": len(API_TRACKS), "images": [{"url": ""}]}
+
+
+@pytest.fixture()
+def cfg(monkeypatch, tmp_path):
+    config = _Config({
+        # The shipped default spelling — relative, exactly what the settings
+        # page shows and what a container install carries.
+        "soulseek.transfer_path": "./Transfer",
+        "file_organization.enabled": True,
+        "file_organization.templates": {
+            "album_path": "$albumartist/$album/$track - $title",
+            "single_path": "$albumartist/$albumartist - $title/$title",
+        },
+        "file_organization.collab_artist_mode": "first",
+        "file_organization.disc_label": "Disc",
+    })
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(import_paths, "_get_config_manager", lambda: config)
+    # The provider tracklist lookup the builder may make. Returning None is the
+    # realistic worst case (cache miss, provider down) AND the case that used to
+    # change the destination: see
+    # test_the_destination_does_not_depend_on_a_provider_lookup below.
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+    monkeypatch.setattr(lr, "_preserve_casing_enabled", lambda: True)
+    monkeypatch.setattr(lr, "_feat_in_title_enabled", lambda: False)
+    return tmp_path
+
+
+def _download_destination(track_number, disc_number, title):
+    """What the download/import pipeline files a finished track as."""
+    context = {
+        "artist": {"name": ARTIST},
+        "album": {"name": ALBUM, "id": "sp1", "release_date": "2017-06-28",
+                  "total_tracks": len(API_TRACKS), "total_discs": 2,
+                  "album_type": "album", "artists": [{"name": ARTIST}]},
+        "track_info": {"name": title, "id": "t", "track_number": track_number,
+                       "disc_number": disc_number, "artists": [{"name": ARTIST}]},
+        "original_search_result": {"title": title, "clean_title": title,
+                                   "clean_album": ALBUM, "clean_artist": ARTIST,
+                                   "artists": [{"name": ARTIST}]},
+        "source": "spotify", "is_album_download": True,
+    }
+    path, _ = build_final_path_for_track(
+        context, {"name": ARTIST},
+        {"is_album": True, "album_name": ALBUM,
+         "track_number": track_number, "disc_number": disc_number},
+        ".flac", create_dirs=False)
+    return path
+
+
+def _reorganize_destination(user_tracks, monkeypatch):
+    """What Reorganize proposes for the same album, via the real planner."""
+    album_data = {"id": "AL1", "title": ALBUM, "artist_name": ARTIST,
+                  "artist_id": "AR1", "spotify_album_id": "sp1"}
+    monkeypatch.setattr(
+        lr, "_resolve_source",
+        lambda ad, ps, strict_source=False, **kw: ("spotify", API_ALBUM, API_TRACKS))
+    plan = lr.plan_album_reorganize(album_data, user_tracks, "spotify")
+
+    out = []
+    for item in plan["items"]:
+        assert item["matched"], item.get("reason")
+        ctx = lr._build_post_process_context(
+            API_ALBUM, item["api_track"], ARTIST, ALBUM, plan["total_discs"],
+            local_title=item["track"]["title"])
+        path, _ = build_final_path_for_track(
+            ctx, ctx["spotify_artist"], lr._build_album_info(ctx), ".flac",
+            create_dirs=False)
+        out.append(path)
+    return out
+
+
+def test_reorganize_proposes_nothing_for_a_part_downloaded_multi_disc_album(cfg, monkeypatch):
+    """Three tracks of disc 1 have landed. This is the reported case."""
+    downloaded = [_download_destination(n, 1, "D1-%02d" % n) for n in (1, 2, 3)]
+    assert all(os.sep + "Disc 1" + os.sep in p for p in downloaded), downloaded
+
+    user_tracks = [{"id": "T%d" % n, "title": "D1-%02d" % n, "track_number": n,
+                    "file_path": downloaded[i]}
+                   for i, n in enumerate((1, 2, 3))]
+
+    assert _reorganize_destination(user_tracks, monkeypatch) == downloaded
+
+
+def test_reorganize_proposes_nothing_once_both_discs_have_landed(cfg, monkeypatch):
+    """And it must not flip back the other way when the album completes."""
+    picks = [(1, 1, "D1-01"), (25, 1, "D1-25"), (1, 2, "D2-01"), (20, 2, "D2-20")]
+    downloaded = [_download_destination(tn, dn, title) for tn, dn, title in picks]
+
+    user_tracks = [{"id": "T%d" % i, "title": title, "track_number": tn,
+                    "file_path": downloaded[i]}
+                   for i, (tn, dn, title) in enumerate(picks)]
+
+    assert _reorganize_destination(user_tracks, monkeypatch) == downloaded
+
+
+def test_the_destination_is_absolute_so_the_catalogue_can_store_it(cfg):
+    path = _download_destination(1, 1, "D1-01")
+    assert os.path.isabs(path), path
+    assert path.startswith(str(cfg / "Transfer") + os.sep)
+
+
+def test_the_destination_does_not_depend_on_a_provider_lookup(cfg, monkeypatch):
+    """`total_discs` explicitly supplied by the caller must be trusted.
+
+    The builder re-derived the disc count from a live provider tracklist
+    whenever the supplied value was <= 1 — so the same track landed in
+    `Album/01 - x.flac` or `Album/Disc 1/01 - x.flac` depending on whether that
+    lookup happened to succeed. A cache miss or an offline provider was enough
+    to file two tracks of one album in two different folders.
+    """
+    def _ctx(total_discs):
+        return {
+            "artist": {"name": ARTIST},
+            "album": {"name": ALBUM, "id": "sp1", "release_date": "2017-06-28",
+                      "total_tracks": len(API_TRACKS), "total_discs": total_discs,
+                      "album_type": "album", "artists": [{"name": ARTIST}]},
+            "track_info": {"name": "D1-01", "id": "t", "track_number": 1,
+                           "disc_number": 1, "artists": [{"name": ARTIST}]},
+            "original_search_result": {"title": "D1-01", "clean_title": "D1-01",
+                                       "clean_album": ALBUM, "clean_artist": ARTIST,
+                                       "artists": [{"name": ARTIST}]},
+            "source": "spotify", "is_album_download": True,
+        }
+
+    album_info = {"is_album": True, "album_name": ALBUM,
+                  "track_number": 1, "disc_number": 1}
+
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: API_TRACKS)
+    with_lookup, _ = build_final_path_for_track(
+        _ctx(1), {"name": ARTIST}, album_info, ".flac", create_dirs=False)
+
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: None)
+    without_lookup, _ = build_final_path_for_track(
+        _ctx(1), {"name": ARTIST}, album_info, ".flac", create_dirs=False)
+
+    assert with_lookup == without_lookup, (
+        "an explicit total_discs=1 was overridden by a provider lookup"
+    )
+    assert os.sep + "Disc 1" + os.sep not in with_lookup
+
+
+def test_an_absent_total_discs_still_asks_the_provider(cfg, monkeypatch):
+    """The lookup is the fallback for callers that genuinely do not know — a
+    single-track download has no album context of its own (#981)."""
+    ctx = {
+        "artist": {"name": ARTIST},
+        "album": {"name": ALBUM, "id": "sp1", "release_date": "2017-06-28",
+                  "total_tracks": len(API_TRACKS),
+                  "album_type": "album", "artists": [{"name": ARTIST}]},
+        "track_info": {"name": "D1-01", "id": "t", "track_number": 1,
+                       "disc_number": 1, "artists": [{"name": ARTIST}]},
+        "original_search_result": {"title": "D1-01", "clean_title": "D1-01",
+                                   "clean_album": ALBUM, "clean_artist": ARTIST,
+                                   "artists": [{"name": ARTIST}]},
+        "source": "spotify", "is_album_download": True,
+    }
+    monkeypatch.setattr(import_paths, "_get_album_tracks_for_source", lambda *a: API_TRACKS)
+    path, _ = build_final_path_for_track(
+        ctx, {"name": ARTIST},
+        {"is_album": True, "album_name": ALBUM, "track_number": 1, "disc_number": 1},
+        ".flac", create_dirs=False)
+    assert os.sep + "Disc 1" + os.sep in path

--- a/tests/test_reorganize_disc_layout.py
+++ b/tests/test_reorganize_disc_layout.py
@@ -111,3 +111,57 @@ def test_non_numeric_track_numbers_never_crash(plan_with):
     plan = plan_with(user, api)          # must not raise
     assert plan["status"] == "planned"
     assert plan["total_discs"] == 2      # no numeric nums → heuristic skipped
+
+
+# ── a library already organized by disc must not be flattened ────────────────
+#
+# The cap reads the user's disc layout from their track NUMBERS, which cannot
+# tell "a single-disc edition mis-matched to a deluxe" from "a multi-disc album
+# that is still downloading". A freshly downloaded box set has only disc 1 on
+# disk, uniquely numbered and inside disc 1 — so the cap fired every time and
+# Reorganize proposed moving the album straight back OUT of the "Disc N" folders
+# the download pipeline had just created. Pressing Reorganize after a download
+# was never a no-op, and the layout flipped again once disc 2 arrived.
+#
+# The files themselves settle it: SoulSync only writes a disc folder when the
+# release IS multi-disc, so a library already sitting in one is organized, not
+# mis-matched — and the setting that gates this cap is "preserve my
+# organization".
+
+def _u_in(nums, folder):
+    return [{"id": "T%d" % i, "title": "S%d" % n, "track_number": n,
+             "file_path": "/music/X/A/%s/%02d - S%d.flac" % (folder, n, n)}
+            for i, n in enumerate(nums)]
+
+
+def test_a_part_downloaded_multi_disc_album_keeps_its_disc_structure(plan_with):
+    """Only disc 1 has landed so far — numbers are unique and fit inside disc 1,
+    which is exactly what the cap keys on."""
+    user = _u_in([1, 2, 3], "Disc 1")
+    api = _a([(n, 1) for n in range(1, 26)] + [(n, 2) for n in range(1, 21)])
+    plan = plan_with(user, api)
+    assert plan["total_discs"] == 2
+
+
+def test_a_cd_style_disc_folder_counts_too(plan_with):
+    """`$cdnum` writes "CD01"; the label setting can also be "CD"."""
+    for folder in ("CD01", "CD 1", "Disk 2", "Vol. 3"):
+        plan = plan_with(_u_in([1, 2, 3], folder),
+                         _a([(n, 1) for n in range(1, 26)] + [(n, 2) for n in range(1, 21)]))
+        assert plan["total_discs"] == 2, folder
+
+
+def test_a_flat_single_disc_album_is_still_capped(plan_with):
+    """The #1080 case is unchanged: no disc folder on disk, so the track numbers
+    remain the only evidence and they say single-disc."""
+    user = _u_in(range(1, 12), "X - A")
+    api = _a([(n, 1) for n in range(1, 14)] + [(n, 2) for n in range(1, 6)])
+    plan = plan_with(user, api)
+    assert plan["total_discs"] == 1
+
+
+def test_a_track_without_a_file_path_does_not_block_the_cap(plan_with):
+    """Missing files carry no layout evidence — they must not veto the cap."""
+    user = _u(range(1, 12))
+    api = _a([(n, 1) for n in range(1, 14)] + [(n, 2) for n in range(1, 6)])
+    assert plan_with(user, api)["total_discs"] == 1

--- a/tests/test_reorganize_no_acoustid_quarantine.py
+++ b/tests/test_reorganize_no_acoustid_quarantine.py
@@ -1,0 +1,87 @@
+"""Reorganize must not re-adjudicate the identity of a file already in the library.
+
+A reorganize stages a COPY of the user's own library file and runs it through the
+full download post-process, AcoustID identity check included. When the fingerprint
+disagrees, that check quarantines the file — so moving a track you already own
+into a differently-named folder ended in:
+
+    AcoustID verification result: fail - Audio mismatch:
+        'APETITAN' by '澤野弘之' — expected artist not found
+    File quarantined: downloads/ss_quarantine/...02 - Apetitan.flac.quarantined
+    [Queue] Finished ... status=failed, moved=0, failed=2
+
+The library original survives (only the staged copy is quarantined), which is why
+the run had to be repeated with "Rename only" to get anywhere — the reported
+"reorganize only works the second time". It also left a ~40 MB quarantined copy
+per attempt and a quarantine list full of files the user still owns.
+
+The duration leg was excluded from this pipeline for exactly the same reason
+(#804): a re-resolved API tracklist may legitimately disagree with the user's
+copy. A fingerprint may too — a different master, a regional release, or an
+artist credited in a different script, as here. Identity of library files is
+adjudicated by the AcoustID Scanner, which raises a finding instead of moving
+anyone's audio.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.imports.pipeline import _should_skip_quarantine_check
+from core.library_reorganize import _build_post_process_context
+
+
+@pytest.fixture(autouse=True)
+def _preserve(monkeypatch):
+    monkeypatch.setattr("core.library_reorganize._preserve_casing_enabled", lambda: True)
+    monkeypatch.setattr("core.library_reorganize._feat_in_title_enabled", lambda: False)
+
+
+def _ctx():
+    return _build_post_process_context(
+        {"id": "sp1", "name": "AoT S2 OST", "release_date": "2017",
+         "total_tracks": 45, "images": [{"url": ""}]},
+        {"name": "Apetitan", "track_number": 2, "disc_number": 1,
+         "artists": [{"name": "Sawano Hiroyuki"}]},
+        "Sawano Hiroyuki", "AoT S2 OST", 2, local_title="Apetitan")
+
+
+def test_the_acoustid_quarantine_leg_is_skipped():
+    assert _should_skip_quarantine_check(_ctx(), "acoustid") is True
+
+
+def test_the_corruption_legs_still_run():
+    """Skipping identity is not skipping safety: a truncated or unparseable file
+    must still be caught before it is moved anywhere."""
+    ctx = _ctx()
+    assert _should_skip_quarantine_check(ctx, "integrity") is False
+    assert _should_skip_quarantine_check(ctx, "bit_depth") is False
+
+
+def test_a_normal_download_still_gets_the_identity_check():
+    """The bypass belongs to the reorganize context, not to the pipeline."""
+    assert _should_skip_quarantine_check({}, "acoustid") is False
+
+
+# ── and it must not downgrade a verdict the download already made ────────────
+#
+# The file carries the import's decision in its own SOULSYNC_VERIFICATION tag
+# (core/matching/verification_status.py), and _persist_verification_status
+# rewrites that tag on every successful post-process exit. Skipping the identity
+# leg therefore must not be reported as "ran and could not confirm" — that maps
+# to `unverified` and would quietly downgrade a `verified` file every time it is
+# moved. Choosing not to run a check is not a finding.
+
+def test_a_reorganize_makes_no_verification_claim():
+    from core.matching.verification_status import status_for_import
+
+    assert status_for_import(_ctx()) is None
+
+
+def test_a_real_result_still_maps_to_a_status():
+    from core.matching.verification_status import (
+        UNVERIFIED, VERIFIED, status_for_import,
+    )
+
+    assert status_for_import({"_acoustid_result": "pass"}) == VERIFIED
+    assert status_for_import({"_acoustid_result": "skip"}) == UNVERIFIED

--- a/tests/test_reorganize_path_display.py
+++ b/tests/test_reorganize_path_display.py
@@ -1,0 +1,62 @@
+"""Both path columns of the reorganize preview are trimmed to the library root.
+
+The trim was a raw ``startswith`` on two strings that were produced by different
+code paths: the proposed path came from the path builder (rooted at the config
+value) while the current path came from the resolver (absolute, symlinks
+resolved). With a relative root configured the two never had a common prefix, so
+"New path" showed a tidy relative path and "Current path" fell back to the raw
+stored value — the same file, displayed two different ways, in adjacent columns.
+
+A raw prefix compare is also wrong on its own terms: ``/music/Transfer2`` starts
+with ``/music/Transfer``.
+"""
+
+import os
+
+from core.library_reorganize import _display_relative_to_root, _trim_to_transfer
+
+
+def test_a_path_inside_the_root_is_shown_relative():
+    assert _display_relative_to_root(
+        "/app/Transfer/Sawano/Album/02 - Apetitan.flac", "/app/Transfer"
+    ) == "Sawano/Album/02 - Apetitan.flac"
+
+
+def test_a_trailing_separator_on_the_root_is_tolerated():
+    assert _display_relative_to_root(
+        "/app/Transfer/Sawano/x.flac", "/app/Transfer/"
+    ) == "Sawano/x.flac"
+
+
+def test_a_sibling_root_is_not_treated_as_inside():
+    """`/app/Transfer2` merely starts with `/app/Transfer` — it is not inside it."""
+    assert _display_relative_to_root(
+        "/app/Transfer2/Sawano/x.flac", "/app/Transfer"
+    ) == "/app/Transfer2/Sawano/x.flac"
+
+
+def test_a_path_outside_the_root_is_returned_whole():
+    assert _display_relative_to_root(
+        "/mnt/other/x.flac", "/app/Transfer"
+    ) == "/mnt/other/x.flac"
+
+
+def test_no_root_configured_returns_the_path_unchanged():
+    assert _display_relative_to_root("/app/Transfer/x.flac", "") == "/app/Transfer/x.flac"
+    assert _display_relative_to_root("", "/app/Transfer") == ""
+
+
+def test_the_current_path_column_uses_the_same_trim():
+    """`_trim_to_transfer` displayed the raw DB value whenever the resolved path
+    did not literally start with the configured root."""
+    assert _trim_to_transfer(
+        "./Transfer/Sawano/x.flac",              # what the catalogue stored
+        "/app/Transfer/Sawano/x.flac",           # what the resolver returned
+        "/app/Transfer",
+    ) == "Sawano/x.flac"
+
+
+def test_the_current_path_column_falls_back_to_the_stored_value():
+    assert _trim_to_transfer("/music/Sawano/x.flac", None, "/app/Transfer") \
+        == "/music/Sawano/x.flac"
+    assert _trim_to_transfer(None, None, "/app/Transfer") == "No file"

--- a/tests/test_reorganize_rename_only.py
+++ b/tests/test_reorganize_rename_only.py
@@ -166,3 +166,67 @@ def test_cleanup_called_for_emptied_source_dirs(tmp_path):
         cleanup=lambda d: cleaned.append(d),
     )
     assert str(tmp_path / "old") in cleaned
+
+
+# ── the file and the catalogue must not drift apart ──────────────────────────
+#
+# A rename MOVES the only copy. If the catalogue update then fails, the old
+# "log it and carry on" left the file at a path nothing points at — the track
+# reads as MISSING and gets re-downloaded later. There is no second copy to
+# recover from, so the move must be undone.
+
+def test_a_failed_db_update_rolls_the_file_back(tmp_path):
+    src = tmp_path / "old" / "01 - A.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"a")
+    new = tmp_path / "new" / "A - Artist.flac"
+
+    def _boom(track_id, path):
+        raise RuntimeError("database is locked")
+
+    out = _run([{
+        "track_id": "t1", "title": "A", "matched": True, "unchanged": False,
+        "collision": False, "file_exists": True,
+        "current_path_abs": str(src), "new_path_abs": str(new),
+    }], update=_boom)
+
+    assert src.exists(), "the only copy was left at a path the catalogue never learned"
+    assert not new.exists()
+    assert out["moved"] == 0 and out["failed"] == 1
+    assert "database is locked" in out["errors"][0]["error"]
+
+
+def test_a_successful_db_update_keeps_the_move(tmp_path):
+    src = tmp_path / "old" / "01 - A.flac"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"a")
+    new = tmp_path / "new" / "A - Artist.flac"
+
+    out = _run([{
+        "track_id": "t1", "title": "A", "matched": True, "unchanged": False,
+        "collision": False, "file_exists": True,
+        "current_path_abs": str(src), "new_path_abs": str(new),
+    }], update=lambda *_a: None)
+
+    assert new.exists() and not src.exists()
+    assert out["moved"] == 1 and out["failed"] == 0
+
+
+# ── a track whose file could not be resolved is not a rename candidate ───────
+#
+# The preview sets current_path_abs='' when the stored path resolves to nothing
+# on disk. Feeding that to os.rename fails — but only AFTER os.makedirs has
+# already built the destination tree, littering the library with empty folders
+# (the #767 complaint the preview avoids with create_dirs=False).
+
+def test_an_unresolvable_source_is_skipped_without_creating_folders(tmp_path):
+    new = tmp_path / "new" / "Artist" / "Album" / "01 - A.flac"
+
+    out = _run([{
+        "track_id": "t1", "title": "A", "matched": True, "unchanged": False,
+        "collision": False, "file_exists": False,
+        "current_path_abs": "", "new_path_abs": str(new),
+    }], update=lambda *_a: None)
+
+    assert not new.parent.exists(), "an empty destination tree was created"
+    assert out["moved"] == 0 and out["failed"] == 0 and out["skipped"] == 1

--- a/tests/test_reorganize_runner.py
+++ b/tests/test_reorganize_runner.py
@@ -456,3 +456,51 @@ def test_a_missing_findings_table_does_not_break_the_reorganize(repoint):
 
     assert conn.execute(
         "SELECT file_path FROM tracks WHERE id = 't1'").fetchone()[0] == NEW
+
+
+# ── the catalogue update must never fail silently ────────────────────────────
+#
+# `_finalize_track` (core/library_reorganize.py) decides "the DB row now points
+# at the new path" SOLELY by whether this callback raised. On success it goes on
+# to `os.remove` the original. A callback that swallows its errors therefore
+# destroys the user's only copy while the catalogue still names the old path —
+# the track reads as MISSING and the file sits somewhere nothing points at.
+#
+# Reported against a fresh library: songs downloaded, Reorganize run while the
+# import pipeline still held the SQLite write lock, tracks came back missing.
+
+def test_a_failed_db_write_raises_instead_of_being_swallowed(repoint):
+    """`database is locked` (or any DB error) must reach the caller. Swallowing
+    it makes `_finalize_track` delete the original after a failed update."""
+    update_path, conn = repoint
+    _add_track(conn)
+    conn.execute("DROP TABLE tracks")
+    conn.commit()
+
+    with pytest.raises(Exception):
+        update_path('t1', NEW)
+
+
+def test_an_update_that_matched_no_row_raises(repoint):
+    """A 0-row UPDATE is not an SQLite error — it is silent success. Without an
+    explicit rowcount check the file is moved and deleted for a track the
+    catalogue never repointed."""
+    update_path, conn = repoint
+    _add_track(conn)          # id 't1' exists ...
+
+    with pytest.raises(Exception):
+        update_path('nope', NEW)   # ... but this one does not
+
+    assert conn.execute(
+        "SELECT file_path FROM tracks WHERE id = 't1'").fetchone()[0] == OLD
+
+
+def test_a_successful_update_still_does_not_raise(repoint):
+    """The guard must not turn ordinary success into a failure."""
+    update_path, conn = repoint
+    _add_track(conn)
+
+    update_path('t1', NEW)
+
+    assert conn.execute(
+        "SELECT file_path FROM tracks WHERE id = 't1'").fetchone()[0] == NEW

--- a/tests/test_repair_findings_retire_vanished.py
+++ b/tests/test_repair_findings_retire_vanished.py
@@ -1,0 +1,138 @@
+"""A finding whose file is gone must not sit in the list for ever.
+
+Findings store their own snapshot of a path. Nothing ever closed one whose file
+had since been moved, replaced or deleted, so a scan's stale momentary view
+stayed on screen with a Fix button that could only ever fail — the reported case
+was three Corrupt Audio findings naming files that no longer existed.
+
+The one thing a sweep must never do is retire findings because THIS process
+cannot see the library (a Docker install whose catalogue holds the media
+server's paths would lose every finding it has). So a finding is retired only
+when its containing folder is right there and the file is not: the folder is the
+proof that we are looking at the real library.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+
+import pytest
+
+from core.repair_worker import RepairWorker
+
+
+class _Db:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def _get_connection(self):
+        return self._conn
+
+
+class _KeepOpen(sqlite3.Connection):
+    def close(self):  # noqa: A003 - the test inspects the DB afterwards
+        pass
+
+
+@pytest.fixture()
+def worker(tmp_path):
+    conn = sqlite3.connect(":memory:", factory=_KeepOpen)
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE repair_findings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT NOT NULL, finding_type TEXT NOT NULL,
+            severity TEXT NOT NULL DEFAULT 'info',
+            status TEXT NOT NULL DEFAULT 'pending',
+            entity_type TEXT, entity_id TEXT, file_path TEXT,
+            title TEXT NOT NULL, description TEXT,
+            details_json TEXT DEFAULT '{}', user_action TEXT,
+            resolved_at TIMESTAMP,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_error TEXT
+        )
+    """)
+    conn.commit()
+    w = RepairWorker.__new__(RepairWorker)
+    w.db = _Db(conn)
+    w.transfer_folder = str(tmp_path)
+    w._config_manager = None
+    w._bulk_fix_lock = threading.Lock()
+    w.should_stop = False
+    return w
+
+
+def _add(worker, path, *, job_id="audio_corruption_detector",
+         finding_type="corrupt_audio", status="pending"):
+    cur = worker.db._conn.execute(
+        "INSERT INTO repair_findings (job_id, finding_type, status, entity_type, "
+        "entity_id, file_path, title) VALUES (?,?,?,'track','7',?, 'x')",
+        (job_id, finding_type, status, str(path)))
+    worker.db._conn.commit()
+    return cur.lastrowid
+
+
+def _row(worker, fid):
+    return worker.db._conn.execute(
+        "SELECT status, user_action FROM repair_findings WHERE id=?", (fid,)).fetchone()
+
+
+def test_a_finding_whose_file_is_gone_is_retired(worker, tmp_path):
+    album = tmp_path / "AC_DC" / "Back In Black"
+    album.mkdir(parents=True)                       # the folder is still there
+    fid = _add(worker, album / "02 - Shoot to Thrill.flac")   # the file is not
+
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 1
+    assert tuple(_row(worker, fid)) == ("resolved", "obsolete")
+
+
+def test_a_finding_whose_file_is_present_is_kept(worker, tmp_path):
+    album = tmp_path / "AC_DC" / "Back In Black"
+    album.mkdir(parents=True)
+    track = album / "02 - Shoot to Thrill.flac"
+    track.write_bytes(b"audio")
+    fid = _add(worker, track)
+
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 0
+    assert _row(worker, fid)["status"] == "pending"
+
+
+def test_an_unreachable_library_retires_nothing(worker, tmp_path):
+    """A Docker/NAS install stores the media server's paths. Neither the file
+    nor its folder is visible here — that is not evidence the file is gone."""
+    fid = _add(worker, "/music/AC_DC/Back In Black/02 - Shoot to Thrill.flac")
+
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 0
+    assert _row(worker, fid)["status"] == "pending"
+
+
+def test_other_jobs_are_left_alone(worker, tmp_path):
+    album = tmp_path / "X" / "Y"
+    album.mkdir(parents=True)
+    mine = _add(worker, album / "gone.flac")
+    theirs = _add(worker, album / "gone.flac", job_id="dead_file_cleaner",
+                  finding_type="dead_file")
+
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 1
+    assert _row(worker, mine)["status"] == "resolved"
+    assert _row(worker, theirs)["status"] == "pending"
+
+
+def test_resolved_and_dismissed_history_is_untouched(worker, tmp_path):
+    album = tmp_path / "X" / "Y"
+    album.mkdir(parents=True)
+    done = _add(worker, album / "gone.flac", status="resolved")
+    hidden = _add(worker, album / "gone.flac", status="dismissed")
+
+    worker.retire_vanished_findings("audio_corruption_detector")
+
+    assert _row(worker, done)["status"] == "resolved"
+    assert _row(worker, hidden)["status"] == "dismissed"
+
+
+def test_a_finding_without_a_path_is_not_a_candidate(worker):
+    fid = _add(worker, "")
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 0
+    assert _row(worker, fid)["status"] == "pending"

--- a/tests/test_repair_findings_retire_vanished.py
+++ b/tests/test_repair_findings_retire_vanished.py
@@ -136,3 +136,63 @@ def test_a_finding_without_a_path_is_not_a_candidate(worker):
     fid = _add(worker, "")
     assert worker.retire_vanished_findings("audio_corruption_detector") == 0
     assert _row(worker, fid)["status"] == "pending"
+
+
+# ── some findings are ABOUT a path that isn't there ──────────────────────────
+#
+# The sweep runs after the scan that just created these, scoped to that same
+# job. Two finding types would be wiped the instant they were raised:
+#
+#   dead_file    names the missing file of a track that still has a DB row.
+#                that absence IS the finding.
+#   empty_folder names a DIRECTORY, and os.path.isfile() of a directory is
+#                False.
+#
+# Both jobs would report "N findings created" and then show an empty list.
+
+def test_a_dead_file_finding_survives_its_own_sweep(worker, tmp_path):
+    album = tmp_path / "Artist" / "Album"
+    album.mkdir(parents=True)
+    (album / "01 - still here.flac").write_bytes(b"audio")
+    fid = _add(worker, album / "02 - gone.flac",
+               job_id="dead_file_cleaner", finding_type="dead_file")
+
+    assert worker.retire_vanished_findings("dead_file_cleaner") == 0
+    assert _row(worker, fid)["status"] == "pending"
+
+
+def test_an_empty_folder_finding_survives_its_own_sweep(worker, tmp_path):
+    folder = tmp_path / "Artist" / "Empty Album"
+    folder.mkdir(parents=True)
+    fid = _add(worker, folder,
+               job_id="empty_folder_cleaner", finding_type="empty_folder")
+
+    assert worker.retire_vanished_findings("empty_folder_cleaner") == 0
+    assert _row(worker, fid)["status"] == "pending"
+
+
+def test_a_directory_that_really_went_away_is_still_retired(worker, tmp_path):
+    """The exclusion is about the finding TYPE, not about giving directories a
+    free pass: a folder finding whose folder was removed is still stale."""
+    parent = tmp_path / "Artist"
+    parent.mkdir()
+    fid = _add(worker, parent / "Removed Album", job_id="orphan_file_detector",
+               finding_type="orphan_file")
+
+    assert worker.retire_vanished_findings("orphan_file_detector") == 1
+    assert _row(worker, fid)["status"] == "resolved"
+
+
+def test_the_sweep_is_scoped_to_the_job_that_just_ran(worker, tmp_path):
+    """Rewritten: the original version added the other job's finding and then
+    swept a THIRD job id, so it passed without ever exercising a self-sweep."""
+    album = tmp_path / "X" / "Y"
+    album.mkdir(parents=True)
+    mine = _add(worker, album / "gone.flac", job_id="audio_corruption_detector",
+                finding_type="corrupt_audio")
+    theirs = _add(worker, album / "gone.flac", job_id="short_preview_track",
+                  finding_type="short_preview_track")
+
+    assert worker.retire_vanished_findings("audio_corruption_detector") == 1
+    assert _row(worker, mine)["status"] == "resolved"
+    assert _row(worker, theirs)["status"] == "pending"

--- a/web_server.py
+++ b/web_server.py
@@ -190,6 +190,7 @@ from core.imports.routes import staging_hints as _import_staging_hints
 from core.imports.routes import staging_scan_status as _import_staging_scan_status
 from core.imports.routes import staging_suggestions as _import_staging_suggestions
 from core.imports.paths import build_final_path_for_track as _build_final_path_for_track
+from core.imports.paths import config_root_path
 from core.imports.pipeline import build_import_pipeline_runtime as _build_import_pipeline_runtime
 from core.metadata.common import get_file_lock
 from core.metadata.enrichment import build_metadata_enrichment_runtime as _build_metadata_enrichment_runtime
@@ -7214,7 +7215,7 @@ def download_music_video():
     music_videos_path = config_manager.get('library.music_videos_path', '') or ''
     if not music_videos_path.strip():
         return jsonify({"error": "Music Videos directory not configured. Set it in Settings > Downloads."}), 400
-    music_videos_path = docker_resolve_path(music_videos_path)
+    music_videos_path = config_root_path(music_videos_path)
     try:
         os.makedirs(music_videos_path, exist_ok=True)
         # Quick write test
@@ -13444,7 +13445,8 @@ def reorganize_album_preview(album_id):
         ) or 'api'
         if metadata_source not in ('api', 'tags'):
             metadata_source = 'api'
-        transfer_dir = docker_resolve_path(config_manager.get('soulseek.transfer_path', './Transfer'))
+        transfer_dir = config_root_path(
+            config_manager.get('soulseek.transfer_path', './Transfer'), './Transfer')
         result = preview_album_reorganize(
             album_id=album_id,
             db=get_database(),
@@ -13618,11 +13620,15 @@ try:
         post_process_fn=lambda *a, **kw: _post_process_matched_download(*a, **kw),
         cleanup_empty_directories_fn=lambda *a, **kw: _cleanup_empty_directories(*a, **kw),
         is_shutting_down_fn=lambda: bool(IS_SHUTTING_DOWN),
-        get_download_path=lambda: docker_resolve_path(
-            config_manager.get('soulseek.download_path', './downloads')
+        # Canonical absolute roots: the reorganize destination is written into
+        # the catalogue, so a relative './Transfer' would store a path whose
+        # meaning depends on the process CWD (and never matches the realpath'd
+        # form the repair scanners see for the same file).
+        get_download_path=lambda: config_root_path(
+            config_manager.get('soulseek.download_path', './downloads'), './downloads'
         ),
-        get_transfer_path=lambda: docker_resolve_path(
-            config_manager.get('soulseek.transfer_path', './Transfer')
+        get_transfer_path=lambda: config_root_path(
+            config_manager.get('soulseek.transfer_path', './Transfer'), './Transfer'
         ),
         # Rename-only mode (#875) computes destinations via the same path builder the
         # preview uses, so apply matches exactly what the user saw.

--- a/web_server.py
+++ b/web_server.py
@@ -191,6 +191,7 @@ from core.imports.routes import staging_scan_status as _import_staging_scan_stat
 from core.imports.routes import staging_suggestions as _import_staging_suggestions
 from core.imports.paths import build_final_path_for_track as _build_final_path_for_track
 from core.imports.paths import config_root_path
+from core.imports.paths import docker_resolve_path as _shared_docker_resolve_path
 from core.imports.pipeline import build_import_pipeline_runtime as _build_import_pipeline_runtime
 from core.metadata.common import get_file_lock
 from core.metadata.enrichment import build_metadata_enrichment_runtime as _build_metadata_enrichment_runtime
@@ -949,16 +950,14 @@ def check_download_permission():
 
 # --- Docker Helper Functions ---
 def docker_resolve_path(path_str):
+    """Canonical absolute form of a configured folder.
+
+    Delegates to the shared implementation. This module keeps the name because it
+    is handed to the download and automation handlers as a dependency
+    (``docker_resolve_path=docker_resolve_path``); a second implementation here
+    is exactly how the roots drifted apart in the first place.
     """
-    Resolve absolute paths for Docker container access
-    In Docker, Windows drive paths (E:/) need to be mapped to WSL mount points (/mnt/e/)
-    """
-    if os.path.exists('/.dockerenv') and len(path_str) >= 3 and path_str[1] == ':' and path_str[0].isalpha():
-        # Convert Windows path (E:/path) to WSL mount path (/mnt/e/path)
-        drive_letter = path_str[0].lower()
-        rest_of_path = path_str[2:].replace('\\', '/')  # Remove E: and convert backslashes
-        return f"/host/mnt/{drive_letter}{rest_of_path}"
-    return path_str
+    return _shared_docker_resolve_path(path_str)
 
 def extract_filename(full_path):
     """

--- a/webui/index.html
+++ b/webui/index.html
@@ -5203,7 +5203,7 @@
                                     <input type="text" id="template-album-path"
                                         placeholder="$albumartist/$albumartist - $album/$track - $title">
                                     <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
-                                    <small class="settings-hint setting-help-body" hidden>Variables: <code>$albumartist</code>, <code>$artist</code>, <code>$artistletter</code>, <code>$album</code>, <code>$albumtype</code>, <code>$title</code>, <code>$track</code>, <code>$disc</code> (01), <code>$discnum</code> (1), <code>$cdnum</code> (CD01 on multi-disc, empty on single), <code>$year</code>, <code>$quality</code> (filename only). Use <code>${var}</code> to append text: <code>${albumtype}s</code> → Albums</small>
+                                    <small class="settings-hint setting-help-body" hidden>Variables: <code>$albumartist</code>, <code>$artist</code>, <code>$artistletter</code>, <code>$album</code>, <code>$albumtype</code>, <code>$title</code>, <code>$track</code>, <code>$disc</code> (01), <code>$discnum</code> (1), <code>$cdnum</code> (CD01), <code>$year</code>, <code>$quality</code> (filename only). The three disc variables work in a folder segment as well as in the filename and are empty on a single-disc album, so <code>$albumartist/$album/Disc $discnum/$track - $title</code> gives you a disc folder only where there is more than one disc. Put any of them in the template and it replaces the automatic disc folder from &ldquo;Multi-Disc Folder Label&rdquo; below. Use <code>${var}</code> to append text: <code>${albumtype}s</code> → Albums</small>
                                 </div>
 
                                 <div class="form-group">
@@ -5249,7 +5249,7 @@
                                         <option value="CD">CD (e.g., CD 1/)</option>
                                     </select>
                                     <span class="info-icon" role="button" tabindex="0" title="What's this?" onclick="toggleSettingHelp(this)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleSettingHelp(this);}">i</span>
-                                    <small class="settings-hint setting-help-body" hidden>Label used for auto-created disc subfolders on multi-disc albums.</small>
+                                    <small class="settings-hint setting-help-body" hidden>Label for the disc subfolder SoulSync adds automatically on a multi-disc album (<code>Disc 1/</code>). Ignored when your path template already places the disc itself with <code>$disc</code>, <code>$discnum</code> or <code>$cdnum</code> &mdash; the template wins.</small>
                                 </div>
 
                                 <div class="form-group">


### PR DESCRIPTION
started from reorganize moving a fresh download back out of the `Disc 1/` folder the download had just made. chasing that turned up two ways to lose a file, so those go first.

## reorganize can delete your only copy

**you reorganize right after a download and a track comes back missing, then gets re downloaded.** `_finalize_track` has exactly one signal for "did the catalogue get repointed": whether `update_track_path_fn` raised. if it didn't, it does `os.remove(resolved_src)`. the callback in `reorganize_runner.py` caught everything and logged a warning, so a busy sqlite (an import commit, which is precisely what's running if you reorganize after a download) rolled the update back, the callback returned normally, and the original was deleted anyway.. catalogue still names the old path, so the track reads as missing. a 0 row UPDATE isn't an sqlite error either, so an unknown id failed just as quietly. it raises now, and the rowcount is asserted.

rename only has the same hole and no staged copy to fall back on. it logged the failure, said "a scan will reconcile" and counted the track as `moved`.. nothing recorded where the file went, so nothing can reconcile it. the move gets rolled back now and the track is reported failed. also, a track whose source path couldn't be resolved still reached `os.rename`, but only after `os.makedirs` had built the destination tree, so a failed rename left empty folders behind.

## reorganize quarantines files you already own

**reorganize ends in `failed`, nothing moves, and a copy of your own track shows up in `ss_quarantine`.** a full reorganize stages a copy of a library file and sends it through the download post process, acoustid identity leg included:

```
AcoustID verification result: fail - Audio mismatch: 'APETITAN' by '澤野弘之' - expected artist not found
File quarantined: downloads/ss_quarantine/...02 - Apetitan.flac.quarantined
[Queue] Finished - status=failed, moved=0, skipped=0, failed=2
```

that file imported clean and is marked verified. the kanji/romaji bridge exists only through `_resolve_expected_artist_aliases`, which is best effort by design: any miss returns `[]` and the comparison drops to raw similarity, which scores ~0 across scripts. so the same file passes at import and fails on a move depending on whether that alias lookup worked at that moment. re deciding identity on a *move* is wrong regardless, the verdict is already persisted in `tracks.verification_status` and the embedded `SOULSYNC_VERIFICATION` tag, and the duration leg was cut from this same pipeline for the same reason in #804. so: `_skip_quarantine_check: 'acoustid'` on the reorganize context, and it makes no verification claim at all so the file keeps the tag its import wrote. size and parse corruption legs still run.

## one root, three spellings

**the track table shows `./Transfer/...` while maintenance findings show `/app/Transfer/...` for the same file.** `./Transfer` is the shipped default and what settings shows, and `docker_resolve_path()` only mapped windows drive letters. so one folder had three names: `./Transfer/...` from the album builder, `Transfer/...` from the single builder (`Path()` eats the `./`), `/app/Transfer/...` from anything that realpaths. the first two go into the catalogue, so a stored path depended on the process cwd and every `startswith(root)` check quietly missed. invisible if your root is absolute.

`docker_resolve_path()` canonicalises now (windows mapping, `~`, abspath) and every root reader already funnels through it, web_server's second copy delegates instead of drifting again, empty stays empty since `abspath('')` is the cwd. doing this halfway is worse than not at all: with the builder absolute and Deep Scan still walking the relative root, string comparison made every tracked file read as untracked. two things fell out. **#976 has never worked:** `file_ops.py` read `soulseek.staging_path`, settings writes `import.staging_path`, so the import folder was never in the protected root set and the self heal recreated a literal `./Staging`. and the reorganize preview trimmed only one of its two path columns, same file shown two ways side by side.

## a fresh download didn't land where reorganize would put it

**download an album, press reorganize, it wants to move everything.** same builder on both sides, so it could only be the context, and it was twice.

reorganize caps a multi disc release to one disc when the track numbers look single disc (#1080). a part downloaded box set has only disc 1 on the platter, uniquely numbered, inside disc 1.. exactly what the cap keys on. so it proposed moving the album out of the `Disc N` folders the download just made, and back in once disc 2 arrived. the cap stands down now when the files are already filed by disc, since soulsync only writes those folders when the release really is multi disc.

the builder also re derived `total_discs` from a live provider tracklist whenever the given value was `<= 1`, so the same track landed in `Album/` or `Album/Disc 1/` depending on whether that lookup happened to work. a caller that knows says so explicitly now (`total_discs_declared`, which only reorganize sets). a bare 1 doesn't count: `candidates.py`, `staging.py` and `master.py` all write `.get('total_discs', 1)` and a spotify album object has no disc count at all, so 1 means nobody told us and the #981 lookup still runs.

## disc variables didn't work in folder segments

**you put a disc folder in your template and either get no folder at all, or one literally called `Disc` that every disc of the album shares.** `$quality` is the one filename only variable settings documents, but the segment cleanup stripped `$disc` and `$discnum` out of folders too, while `$cdnum` and `${...}` worked. and `user_controls_disc` turns the automatic disc folder off as soon as `$disc` appears, so those users lost the automatic one and got nothing back.

the two byte identical cleanup loops are one helper now, disc variables substitute there like they do in the filename and go empty on single disc, which is the `$cdnum` rule from #981 anyway. the dangling label drop asks the RAW template whether it uses a disc variable, since `${disc}` and `$cdnum` are substituted before the path is split.. a template with no disc variable can still have a folder deliberately called `CD`.

## corrupt audio findings for files that were never corrupt

**findings naming paths that don't exist, `LOST_SYNC after processing 0 samples`.** the scan walks the library while the import pipeline is still moving files into it, and a cross device move is copy then delete, so `flac -t` on a half written flac reports what a damaged one does. `0 samples` is a file caught at the start of its copy. size and mtime are compared either side of the decode test now, a file that changed under it is skipped.

nothing closed a finding whose file had gone either. a completed scan retires its own now, but only where the containing folder is present and the file isn't.. without that an install holding media server paths resolves nothing locally and wipes every finding it has. `dead_file` and `empty_folder` are excluded, the first names the missing file of a track that still has a row (that absence IS the finding) and the second names a directory.

## left out on purpose

#829 album folder reuse stays, on a fresh library the resolver finds no folder and multi disc skips reuse anyway. existing relative paths aren't migrated, new writes are absolute and the resolver handles both. the disc cap escape hatch trusts any existing disc folder, so an album already mis filed into `Disc N/` by the bug the cap fixes can't be flattened any more.. requiring more than one disc folder would break the case this branch is for, a part downloaded box set has exactly one.
