### PR TITLE
Cross-script identity: stop quarantining correct downloads, and make the scan agree with the download

### DIFF
--- a/core/acoustid_verification.py
+++ b/core/acoustid_verification.py
@@ -241,7 +241,8 @@ class AcoustIDVerification:
         audio_file_path: str,
         expected_track_name: str,
         expected_artist_name: str,
-        context: Optional[Dict[str, Any]] = None
+        context: Optional[Dict[str, Any]] = None,
+        min_score: Optional[float] = None,
     ) -> Tuple[VerificationResult, str]:
         """
         Verify that an audio file matches expected track metadata.
@@ -249,28 +250,52 @@ class AcoustIDVerification:
         Compares title/artist from AcoustID fingerprint results against
         the expected track info. No MusicBrainz lookup needed.
 
+        This is the ONE verification path. The library scan calls it too
+        (``core/repair_jobs/acoustid_scanner``) rather than repeating the
+        availability check, the lookup, the score gate, the MusicBrainz
+        enrichment of title-less recordings and the alias wiring — which is how
+        those five drifted apart in the first place, while only the final
+        decision was shared.
+
         Args:
             audio_file_path: Path to the downloaded audio file
             expected_track_name: Track name we expected to download
             expected_artist_name: Artist name we expected
-            context: Optional download context for logging/debugging
+            context: Optional dict. Used for download-specific hints on the way
+                in, and written back on the way out with what this lookup saw
+                (``_acoustid_recordings``, ``_acoustid_best_score``,
+                ``_acoustid_decision``) so a caller needing the evidence does
+                not have to fingerprint the file a second time.
+            min_score: Override the fingerprint-confidence floor. The scan
+                exposes it as a job setting; the download uses the constant.
 
         Returns:
             Tuple of (VerificationResult, reason_message)
         """
         try:
-            # Step 1: Check availability
-            available, reason = self.acoustid_client.is_available()
-            if not available:
-                logger.debug(f"AcoustID verification skipped: {reason}")
-                return VerificationResult.SKIP, reason
+            # Step 1: Check availability. A caller that injected its own client
+            # has already decided the client is usable, and need not implement
+            # the probe — the library scan passes whatever the job context
+            # carries.
+            probe_available = getattr(self.acoustid_client, 'is_available', None)
+            if callable(probe_available):
+                available, reason = probe_available()
+                if not available:
+                    logger.debug(f"AcoustID verification skipped: {reason}")
+                    return VerificationResult.SKIP, reason
 
             # Step 2: Fingerprint and lookup in AcoustID (structured so an
             # actual error — invalid key / rate limit / no chromaprint — is
             # reported distinctly from a genuine no-match, instead of both
             # silently surfacing as "Skipped").
             logger.info(f"Fingerprinting and looking up: {audio_file_path}")
-            lookup = self.acoustid_client.lookup_with_status(audio_file_path) or {}
+            if hasattr(self.acoustid_client, 'lookup_with_status'):
+                lookup = self.acoustid_client.lookup_with_status(audio_file_path) or {}
+            else:
+                # Older client shape: dict-or-None, with no way to tell a real
+                # no-match from a failed lookup. Treated as a no-match, which is
+                # the safe reading — it makes no claim about the file.
+                lookup = self.acoustid_client.fingerprint_and_lookup(audio_file_path) or {}
             status = lookup.get('status')
             # Infer status by content when absent (a caller/stub that returned
             # just recordings): recordings => matched, none => no match.
@@ -293,13 +318,17 @@ class AcoustIDVerification:
             if not recordings:
                 return VerificationResult.SKIP, "No match in AcoustID database"
 
+            if isinstance(context, dict):
+                context['_acoustid_best_score'] = best_score
+
             logger.debug(
                 f"AcoustID returned {len(recordings)} recording(s) "
                 f"(best fingerprint score: {best_score:.2f})"
             )
 
             # Step 3: Check fingerprint confidence
-            if best_score < MIN_ACOUSTID_SCORE:
+            floor = MIN_ACOUSTID_SCORE if min_score is None else float(min_score)
+            if best_score < floor:
                 msg = f"AcoustID fingerprint score too low ({best_score:.2f}) to verify"
                 logger.info(msg)
                 return VerificationResult.SKIP, msg
@@ -358,6 +387,12 @@ class AcoustIDVerification:
                 _CoreDecision.SKIP: VerificationResult.SKIP,
                 _CoreDecision.FAIL: VerificationResult.FAIL,
             }
+            if isinstance(context, dict):
+                # The evidence, for a caller that has to say more than
+                # pass/fail about it — which candidates were in contention, and
+                # what the core concluded.
+                context['_acoustid_recordings'] = recordings
+                context['_acoustid_decision'] = outcome
             result = _decision_map[outcome.decision]
             if result == VerificationResult.PASS:
                 logger.info("AcoustID verification PASSED - %s", outcome.reason)
@@ -368,9 +403,16 @@ class AcoustIDVerification:
             return result, outcome.reason
 
         except Exception as e:
-            # Any unexpected error -> SKIP (fail open)
+            # An unexpected fault in OUR code, or in a lookup it depends on, is
+            # not a statement about the file. Reported as SKIP it became one:
+            # the library scan turns a SKIP on an untagged file into
+            # 'unverified', so a database error or a MusicBrainz outage
+            # mid-verification got written down as a verdict — and with
+            # `require_verified` on, the download path turns the same SKIP into
+            # a rejection. ERROR says what it is, and both callers already
+            # handle it without touching the file's standing.
             logger.error(f"Unexpected error during AcoustID verification: {e}")
-            return VerificationResult.SKIP, f"Verification error: {str(e)}"
+            return VerificationResult.ERROR, f"Verification error: {str(e)}"
 
     def quick_check_available(self) -> Tuple[bool, str]:
         """

--- a/core/library/service_search.py
+++ b/core/library/service_search.py
@@ -159,9 +159,24 @@ def _search_service(service, entity_type, query):
             return [{'id': t.id, 'name': t.name, 'image': t.image_url, 'extra': f"{', '.join(t.artists)} · {t.album or ''}"} for t in items]
 
     elif service == 'musicbrainz':
-        if not mb_worker or not mb_worker.mb_service:
-            raise ValueError("MusicBrainz worker not initialized")
-        mb_client = mb_worker.mb_service.mb_client
+        # MusicBrainz needs no credentials and no worker — only a client. When
+        # the worker is there, use its service so both share one rate limiter;
+        # otherwise fall back to the process-wide shared instance. Requiring
+        # the worker meant a failed worker init took manual MusicBrainz search
+        # and enrichment down with it, reported as "worker not initialized" to
+        # a user who never asked for a worker.
+        mb_client = None
+        if mb_worker is not None and getattr(mb_worker, 'mb_service', None):
+            mb_client = mb_worker.mb_service.mb_client
+        else:
+            try:
+                from core.musicbrainz_service import get_musicbrainz_service
+
+                mb_client = get_musicbrainz_service().mb_client
+            except Exception as e:
+                logger.debug("shared MusicBrainz service unavailable: %s", e)
+        if mb_client is None:
+            raise ValueError("MusicBrainz client not available")
         # User-facing manual search — prefer recall (fuzzy / alias / diacritic-
         # folded) over strict phrase precision. User picks correct hit from list.
         if entity_type == 'artist':

--- a/core/matching/audio_verification.py
+++ b/core/matching/audio_verification.py
@@ -322,6 +322,18 @@ def evaluate(expected_title: str, expected_artist: str,
     matched_title = best_rec.get('title', '?') or '?'
     matched_artist = best_rec.get('artist', '?') or '?'
 
+    # Is each dimension's score EVIDENCE at all? A similarity between two
+    # different writing systems carries no information — romaji vs kanji scores
+    # 0.00 whether or not it names the same thing — so such a dimension is
+    # UNKNOWN, never FAILED, and must never be what a FAIL rests on. Two
+    # production findings came from ignoring that: a 100% fingerprint with a
+    # 100% title match was reported as "Wrong download" because
+    # 'Sawano Hiroyuki' vs '澤野弘之' scored 0.00 and 0.00 is below
+    # CLEAR_MISMATCH_THRESHOLD. Same-script disagreement stays real evidence,
+    # so a genuinely wrong artist or song fails exactly as before.
+    title_comparable = not is_cross_script_mismatch(expected_title, matched_title)
+    artist_comparable = not is_cross_script_mismatch(expected_artist, matched_artist)
+
     def out(dec, reason):
         return Outcome(dec, title_sim, artist_sim, matched_title, matched_artist, reason)
 
@@ -352,6 +364,22 @@ def evaluate(expected_title: str, expected_artist: str,
                 expected_artist, rec.get('artist', ''), aliases_provider,
             ) >= ARTIST_MATCH_THRESHOLD:
                 return out(Decision.PASS, "Expected artist found in AcoustID results")
+        if not artist_comparable:
+            # The title already agrees and the artist score is unreadable, so
+            # there is nothing here that says the file is wrong.
+            #
+            # Deliberate and known: a cover of the right song by a non-Latin
+            # artist is a real wrong download and is unreportable through this
+            # branch. Nothing cheap distinguishes it — MusicBrainz alias lists
+            # are incomplete often enough that "the aliases did not match" is
+            # not evidence either, and a fingerprint bar here would re-quarantine
+            # the correct files this change exists for. A matching title after a
+            # matching fingerprint is corroboration; we take it.
+            return out(Decision.SKIP,
+                       f"Title matches and the artist is written in a different "
+                       f"script, so the names cannot be compared: "
+                       f"'{matched_title}' by '{matched_artist}' "
+                       f"(expected '{expected_artist}')")
         if artist_sim < CLEAR_MISMATCH_THRESHOLD:
             return out(Decision.FAIL,
                        f"Audio mismatch: '{matched_title}' by '{matched_artist}' "
@@ -388,9 +416,30 @@ def evaluate(expected_title: str, expected_artist: str,
                                          and artist_sim >= ARTIST_MATCH_THRESHOLD)
     cross_script_artist_skip = (fingerprint_score >= MIN_ACOUSTID_SCORE
                                 and artist_sim >= ARTIST_MATCH_THRESHOLD
-                                and is_cross_script_mismatch(expected_artist, matched_artist))
+                                and not artist_comparable)
+    # The title is the dimension that disagreed — but if it is written in
+    # another script its score was never readable, and the artist either agrees
+    # or is unreadable too. Nothing comparable disagrees, so no claim can be
+    # made. `language_script_skip` above covered a slice of this behind a
+    # fingerprint >= 0.95 bar, which left an ordinary 0.90 match on a
+    # Japanese-titled track quarantined; the script signal does not depend on
+    # how well the fingerprint scored.
+    #
+    # Known and accepted: when BOTH dimensions are unreadable there is no
+    # evidence in either direction, so a genuinely wrong non-Latin download is
+    # unreportable here. Re-adding a fingerprint bar for that case was tried and
+    # reverted — it does not separate the two, because the score says nothing
+    # about the NAMES. What it does instead is quarantine the correct file this
+    # change exists for: "Zankoku na Tenshi no These" by "Yoko Takahashi"
+    # against 残酷な天使のテーゼ by 高橋洋子 at a perfectly ordinary 0.90 is the
+    # same shape as a wrong one, and that is the direction that costs a user
+    # their file. Silence is the safe half of an unanswerable question.
+    incomparable_title_skip = (
+        not title_comparable
+        and (not artist_comparable or artist_sim >= ARTIST_MATCH_THRESHOLD)
+    )
     if (language_script_skip or high_confidence_strong_match_skip
-            or cross_script_artist_skip):
+            or cross_script_artist_skip or incomparable_title_skip):
         return out(Decision.SKIP, "Likely same song in different language/script")
 
     return out(Decision.FAIL,

--- a/core/musicbrainz_client.py
+++ b/core/musicbrainz_client.py
@@ -164,7 +164,8 @@ class MusicBrainzClient:
         raise last_exc or RuntimeError('MusicBrainz request failed')
     
     @rate_limited
-    def search_artist(self, artist_name: str, limit: int = 10, strict: bool = True) -> List[Dict[str, Any]]:
+    def search_artist(self, artist_name: str, limit: int = 10, strict: bool = True,
+                      raise_on_error: bool = False) -> List[Dict[str, Any]]:
         """
         Search for artists by name.
 
@@ -178,6 +179,13 @@ class MusicBrainzClient:
                 sortname indexes — the right behavior for user-facing fuzzy
                 search (finds "Metallica" from typing "metalica", matches
                 aliased names, etc.).
+            raise_on_error: Re-raise a transport failure instead of reporting
+                it as an empty result. The default is the historical
+                fail-soft behaviour, which suits callers that only want a
+                best-effort list. It does NOT suit a caller that WRITES the
+                answer down: a timeout and "MusicBrainz knows nobody by that
+                name" are the same `[]` here, and the alias cache stored the
+                second meaning for a month after seeing the first.
 
         Returns:
             List of artist results with id, name, score, etc. MusicBrainz
@@ -213,6 +221,8 @@ class MusicBrainzClient:
 
         except Exception as e:
             logger.error(f"Error searching for artist '{artist_name}': {e}")
+            if raise_on_error:
+                raise
             return []
     
     @rate_limited
@@ -490,13 +500,18 @@ class MusicBrainzClient:
             return []
 
     @rate_limited
-    def get_artist(self, mbid: str, includes: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
+    def get_artist(self, mbid: str, includes: Optional[List[str]] = None,
+                   raise_on_error: bool = False) -> Optional[Dict[str, Any]]:
         """
         Get full artist details by MusicBrainz ID
         
         Args:
             mbid: MusicBrainz ID of the artist
             includes: Optional list of additional data to include (e.g., 'url-rels', 'genres')
+            raise_on_error: Re-raise a transport failure instead of collapsing
+                it into the same ``None`` a genuine miss returns. See
+                :meth:`search_artist` — a caller that caches the answer has to
+                be able to tell those apart.
             
         Returns:
             Artist data or None if not found
@@ -513,6 +528,8 @@ class MusicBrainzClient:
             
         except Exception as e:
             logger.error(f"Error fetching artist {mbid}: {e}")
+            if raise_on_error:
+                raise
             return None
     
     @rate_limited

--- a/core/musicbrainz_service.py
+++ b/core/musicbrainz_service.py
@@ -162,6 +162,39 @@ class MusicBrainzService:
             if conn:
                 conn.close()
     
+    def _cross_script_catalogue_match(self, artist_name, scored, owned_titles):
+        """A match for an artist whose MusicBrainz name is in another script.
+
+        Returns the same dict shape as :meth:`match_artist`, or None when no
+        candidate clears the evidence bar and the normal name-based path should
+        continue.
+        """
+        from core.matching.script_compat import is_cross_script_mismatch
+
+        if not owned_titles:
+            return None
+        for _confidence, result in scored:
+            mb_name = result.get('name', '') or ''
+            if not is_cross_script_mismatch(artist_name, mb_name):
+                continue
+            if (result.get('score') or 0) < 90:
+                continue
+            overlap = catalog_overlap_score(
+                owned_titles, self._candidate_release_titles(result.get('id')))
+            if overlap < 1:
+                continue
+            mbid = result.get('id')
+            confidence = min(100, 60 + overlap * 20)
+            self._save_to_cache(
+                'artist', artist_name, None, mbid, result, confidence)
+            logger.info(
+                "Matched artist %r → %r across scripts on %d shared album(s) "
+                "(MBID: %s)", artist_name, mb_name, overlap, mbid,
+            )
+            return {'mbid': mbid, 'name': mb_name,
+                    'confidence': confidence, 'cached': False}
+        return None
+
     def _candidate_release_titles(self, mbid: str) -> list:
         """Release-group titles for a candidate MBID — the catalog side of
         same-name artist disambiguation."""
@@ -211,7 +244,15 @@ class MusicBrainzService:
         # Search MusicBrainz
         try:
             results = self.mb_client.search_artist(artist_name, limit=5)
-            
+            # Issue #586, which was fixed for the alias lookup and not for this:
+            # a strict query hits the `artist` field alone and skips the alias
+            # and sortname indexes — which is exactly where the romanised
+            # spelling of a natively-scripted artist lives. Ask the fuzzy index
+            # too when strict comes back empty.
+            if not results:
+                results = self.mb_client.search_artist(
+                    artist_name, limit=5, strict=False)
+
             if not results:
                 logger.info(f"No MusicBrainz results for artist '{artist_name}'")
                 self._save_to_cache('artist', artist_name, None, None, None, 0)
@@ -257,11 +298,34 @@ class MusicBrainzService:
                     'confidence': best_confidence,
                     'cached': False
                 }
-            else:
-                logger.info(f"Low confidence match for artist '{artist_name}' (best: {best_confidence})")
-                self._save_to_cache('artist', artist_name, None, None, None, best_confidence)
-                return None
-                
+            # Nothing written in our own script cleared the bar. A name in
+            # another script scores 0.0 against ours however certain
+            # MusicBrainz is, so the formula above caps such a candidate at 40
+            # against a gate of 70 — cross-script artists were structurally
+            # unmatchable, and the only way to give one an id was by hand. The
+            # name carries no information here, but the CATALOGUE does: album
+            # titles survive a script difference far better than names, and an
+            # entity holding records this library owns is not somebody else.
+            # Deliberately strict — MusicBrainz confident about the name AND at
+            # least one owned album in that entity's catalogue. Without owned
+            # albums to check against there is no evidence, and it stays
+            # unmatched rather than guessing.
+            #
+            # Runs LAST on purpose. Ahead of the gate it beat a same-script
+            # candidate scoring 95 with one scoring 80, on nothing more than a
+            # shared album title as common as "Home" — and the id it picked was
+            # then written onto the artist row and fed the alias bridge from
+            # there on. A fallback cannot do that: it only ever speaks where the
+            # name path found nobody.
+            cross = self._cross_script_catalogue_match(
+                artist_name, scored, owned_titles)
+            if cross is not None:
+                return cross
+
+            logger.info(f"Low confidence match for artist '{artist_name}' (best: {best_confidence})")
+            self._save_to_cache('artist', artist_name, None, None, None, best_confidence)
+            return None
+
         except Exception as e:
             logger.error(f"Error matching artist '{artist_name}': {e}")
             return None

--- a/core/musicbrainz_service.py
+++ b/core/musicbrainz_service.py
@@ -173,6 +173,14 @@ class MusicBrainzService:
 
         if not owned_titles:
             return None
+        # Every candidate is scored before any is chosen. Taking the first one
+        # that clears the bar would be taking MusicBrainz's result ORDER as the
+        # tie-break — and that order is decided by name relevance, which is the
+        # one signal this whole branch exists because it cannot use. A title as
+        # ordinary as "Home" overlaps several catalogues, so the first hit is
+        # not the best hit.
+        best = None            # (overlap, result, mb_name)
+        contested = False
         for _confidence, result in scored:
             mb_name = result.get('name', '') or ''
             if not is_cross_script_mismatch(artist_name, mb_name):
@@ -183,17 +191,33 @@ class MusicBrainzService:
                 owned_titles, self._candidate_release_titles(result.get('id')))
             if overlap < 1:
                 continue
-            mbid = result.get('id')
-            confidence = min(100, 60 + overlap * 20)
-            self._save_to_cache(
-                'artist', artist_name, None, mbid, result, confidence)
+            if best is None or overlap > best[0]:
+                best, contested = (overlap, result, mb_name), False
+            elif overlap == best[0]:
+                contested = True
+        if best is None:
+            return None
+        if contested:
+            # Two entities the library owns records by, and no readable name to
+            # separate them. The id would be written onto the artist row and
+            # feed the alias bridge from there, so a coin flip here is a wrong
+            # identity that outlives this call.
             logger.info(
-                "Matched artist %r → %r across scripts on %d shared album(s) "
-                "(MBID: %s)", artist_name, mb_name, overlap, mbid,
+                "Cross-script match for %r refused: candidates tie on owned-album "
+                "overlap (%d), and their names cannot be compared",
+                artist_name, best[0],
             )
-            return {'mbid': mbid, 'name': mb_name,
-                    'confidence': confidence, 'cached': False}
-        return None
+            return None
+        overlap, result, mb_name = best
+        mbid = result.get('id')
+        confidence = min(100, 60 + overlap * 20)
+        self._save_to_cache('artist', artist_name, None, mbid, result, confidence)
+        logger.info(
+            "Matched artist %r → %r across scripts on %d shared album(s) "
+            "(MBID: %s)", artist_name, mb_name, overlap, mbid,
+        )
+        return {'mbid': mbid, 'name': mb_name,
+                'confidence': confidence, 'cached': False}
 
     def _candidate_release_titles(self, mbid: str) -> list:
         """Release-group titles for a candidate MBID — the catalog side of
@@ -641,14 +665,27 @@ class MusicBrainzService:
                 scored = non_strict
                 lookup_failed = False
 
-        if not scored:
+        def _remember_no_aliases():
+            """Write "no alternate spellings" down — unless a search failed.
+
+            Every gate below can reject the candidates it was given and land
+            here, and a rejection is only a verdict if the SEARCH was complete.
+            When the strict query returned weak candidates and the non-strict
+            one timed out, `scored` is non-empty (so the guard above does not
+            fire) while the entity that would have passed may only have existed
+            in the query that never answered. Caching then blocks the retry that
+            would have found it.
+            """
             if lookup_failed:
                 logger.debug(
-                    "lookup_artist_aliases: search for %r did not complete — "
+                    "lookup_artist_aliases: a search for %r did not complete — "
                     "not recording an empty result", artist_name,
                 )
-                return []
+                return
             self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
+
+        if not scored:
+            _remember_no_aliases()
             return []
 
         scored.sort(key=lambda x: -x[0])
@@ -681,7 +718,7 @@ class MusicBrainzService:
                 "threshold (combined=%.2f, best_mb=%d, leader_mb=%d)",
                 artist_name, best_score, best_mb_score, mb_leader[2],
             )
-            self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
+            _remember_no_aliases()
             return []
 
         # Pick the entity to pull aliases from. Combined-strong matches use
@@ -704,7 +741,7 @@ class MusicBrainzService:
                 "two results within 0.1 (%.2f / %.2f). Skipping alias lookup.",
                 artist_name, scored[0][0], scored[1][0],
             )
-            self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
+            _remember_no_aliases()
             return []
 
         aliases = self.resolve_artist_aliases(chosen_mbid)
@@ -746,13 +783,27 @@ class MusicBrainzService:
         conn = None
         try:
             conn = self.db._get_connection()
-            row = conn.execute(
-                "SELECT musicbrainz_id FROM artists "
+            # DISTINCT, not LIMIT 1. A library can hold several rows under one
+            # display name — the same artist indexed on two media servers, or
+            # two genuinely different artists who share it. Taking whichever row
+            # sorted first would make an arbitrary pick authoritative for every
+            # verification that ever compares against this name, and its aliases
+            # could then let a wrong artist pass. Same-name rows agreeing on the
+            # id is the normal case and stays free; disagreement means the name
+            # does not identify anybody, so fall back to resolving it.
+            rows = conn.execute(
+                "SELECT DISTINCT musicbrainz_id FROM artists "
                 "WHERE name = ? COLLATE NOCASE "
-                "AND COALESCE(musicbrainz_id,'') <> '' LIMIT 1",
+                "AND COALESCE(musicbrainz_id,'') <> ''",
                 (artist_name,),
-            ).fetchone()
-            return str(row[0]) if row and row[0] else None
+            ).fetchall()
+            mbids = {str(r[0]) for r in rows if r and r[0]}
+            if len(mbids) > 1:
+                logger.debug(
+                    "artist mbid lookup for %r is ambiguous — %d rows with that "
+                    "name hold different MusicBrainz ids", artist_name, len(mbids))
+                return None
+            return next(iter(mbids)) if mbids else None
         except Exception as e:  # noqa: BLE001
             logger.debug("artist mbid lookup failed for %r: %s", artist_name, e)
             return None
@@ -772,67 +823,80 @@ class MusicBrainzService:
         artist already holding this MBID means the name search landed on the
         wrong entity, so the same gate every enrichment worker passes through
         applies here too: better no id than one smeared across two artists.
+
+        A name can also address several rows — the same artist indexed on two
+        media servers is the ordinary case, which is exactly why
+        ``source_id_conflict`` treats a same-named holder as no conflict. So
+        every row under the name is read, and the write only happens when they
+        AGREE about the identity: one of them already saying a different MBID
+        means this name does not identify anybody, and picking a row would make
+        the choice arbitrary.
         """
         if not artist_name or not mbid:
             return
         conn = None
         try:
             conn = self.db._get_connection()
-            row = conn.execute(
-                "SELECT id, musicbrainz_id FROM artists "
-                "WHERE name = ? COLLATE NOCASE LIMIT 1",
+            rows = conn.execute(
+                "SELECT id, musicbrainz_id FROM artists WHERE name = ? COLLATE NOCASE",
                 (artist_name,),
-            ).fetchone()
+            ).fetchall()
         finally:
             if conn:
                 conn.close()
-        if not row:
+        if not rows:
             return
-        artist_id, stored_mbid = int(row[0]), row[1]
-        write_mbid = False
-        if stored_mbid:
+        # Ids stay exactly as the catalogue stores them. A migrated library
+        # keys artists by the media server's id, which for Jellyfin is a GUID —
+        # int() raised there, the caller swallowed it as a best-effort failure,
+        # and the deterministic identity tier silently never became available.
+        targets = [r[0] for r in rows]
+        stored = {str(r[1]) for r in rows if r[1]}
+        if stored - {str(mbid)}:
             # The aliases were fetched FROM this MBID, so they are only this
             # artist's aliases if this MBID is. Writing them without that is
             # how one artist's alternate spellings end up on another's row.
-            if str(stored_mbid) != str(mbid):
-                logger.debug(
-                    "alias write-back skipped for %r: row holds MBID %s, "
-                    "the name search resolved %s", artist_name, stored_mbid, mbid)
-                return
-        else:
+            logger.debug(
+                "alias write-back skipped for %r: rows under that name hold "
+                "MBID(s) %s, the name search resolved %s",
+                artist_name, sorted(stored), mbid)
+            return
+        write_mbid = not stored
+        if write_mbid:
             # Checked before the write connection is opened — the guard reads
             # through its own connection, and nesting one inside an open write
             # is how a SQLite writer deadlocks itself.
             conflict = source_id_conflict(
-                self.db, 'musicbrainz_id', mbid, artist_id, artist_name)
+                self.db, 'musicbrainz_id', mbid, targets[0], artist_name)
             if conflict:
                 logger.debug(
                     "alias write-back skipped for %r: MBID %s already held "
                     "by %r", artist_name, mbid, conflict)
                 return
-            write_mbid = True
 
         conn = None
         try:
             conn = self.db._get_connection()
-            if write_mbid:
-                conn.execute(
-                    "UPDATE artists SET musicbrainz_id = ?, "
-                    "musicbrainz_last_attempted = ?, "
-                    "musicbrainz_match_status = 'matched' WHERE id = ?",
-                    (mbid, datetime.now(), artist_id))
-            if aliases:
-                conn.execute(
-                    "UPDATE artists SET aliases = ?, "
-                    "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-                    (json.dumps(aliases), artist_id))
+            for artist_id in targets:
+                if write_mbid:
+                    conn.execute(
+                        "UPDATE artists SET musicbrainz_id = ?, "
+                        "musicbrainz_last_attempted = ?, "
+                        "musicbrainz_match_status = 'matched' WHERE id = ?",
+                        (mbid, datetime.now(), artist_id))
+                if aliases:
+                    conn.execute(
+                        "UPDATE artists SET aliases = ?, "
+                        "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                        (json.dumps(aliases), artist_id))
             conn.commit()
         finally:
             if conn:
                 conn.close()
         logger.info(
-            "Stored MusicBrainz identity for artist %r (mbid=%s, %d aliases)",
-            artist_name, mbid, len(aliases or []),
+            "Stored MusicBrainz identity for artist %r on %d row(s) "
+            "(mbid=%s, %d aliases)",
+            artist_name, len(targets), mbid, len(aliases or []),
         )
 
     def _search_and_score_artists(self, artist_name: str, strict: bool):
@@ -851,7 +915,13 @@ class MusicBrainzService:
         verdict worth caching.
         """
         try:
-            results = self.mb_client.search_artist(artist_name, limit=3, strict=strict)
+            # `raise_on_error` matters more than it looks: without it the client
+            # catches a timeout / 429 / 503 and hands back `[]`, which is the
+            # exact value it uses for "MusicBrainz knows nobody by that name".
+            # Every distinction below would then be decided on a value that
+            # cannot carry it, and the outage would be cached as a verdict.
+            results = self.mb_client.search_artist(
+                artist_name, limit=3, strict=strict, raise_on_error=True)
         except Exception as e:
             logger.debug(
                 "lookup_artist_aliases: search_artist(%r, strict=%s) raised: %s",
@@ -909,7 +979,8 @@ class MusicBrainzService:
         if not mbid:
             return None
         try:
-            data = self.mb_client.get_artist(mbid, includes=['aliases'])
+            data = self.mb_client.get_artist(
+                mbid, includes=['aliases'], raise_on_error=True)
         except Exception as e:
             logger.debug("resolve_artist_aliases: get_artist(%s) raised: %s", mbid, e)
             return None

--- a/core/musicbrainz_service.py
+++ b/core/musicbrainz_service.py
@@ -11,6 +11,12 @@ from database.music_database import MusicDatabase
 
 logger = get_logger("musicbrainz_service")
 
+# What a cache row looks like when MusicBrainz genuinely answered "this artist
+# has no alternate spellings". The `resolved` marker is what separates that
+# from a row written by a lookup that never came back — see `_cached_aliases`.
+_NO_ALIASES = {'aliases': [], 'resolved': True}
+
+
 class MusicBrainzService:
     """Service layer for MusicBrainz integration with caching and matching logic"""
     
@@ -91,6 +97,39 @@ class MusicBrainzService:
             if conn:
                 conn.close()
     
+    @staticmethod
+    def _cached_aliases(cached: Optional[Dict[str, Any]], *,
+                        for_mbid: Optional[str] = None) -> Optional[list]:
+        """What a cache row settles about an artist's aliases, or None.
+
+        An EMPTY list is an answer only when the row records that MusicBrainz
+        actually answered (the ``resolved`` marker). It used to count as one
+        unconditionally, and it must not: ``fetch_artist_aliases`` returned
+        ``[]`` for a timeout exactly as readily as for a genuine absence, so a
+        single rate-limited fetch wrote "this artist has no aliases" against a
+        perfectly good identity and held it for the row's whole TTL. A bulk
+        AcoustID scan is precisely the workload that trips MusicBrainz's rate
+        limit, so the bridge went down exactly when it was being leaned on.
+
+        Rows written before the marker existed return None — one retry each,
+        rather than standing forever.
+
+        ``for_mbid`` restricts the answer to a row resolved against that
+        identity; a name-keyed row for some other entity says nothing about it.
+        """
+        if not cached:
+            return None
+        metadata = cached.get('metadata')
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if for_mbid is not None and str(cached.get('musicbrainz_id') or '') != str(for_mbid):
+            return None
+        raw = metadata.get('aliases')
+        cleaned = ([str(x).strip() for x in raw if x]
+                   if isinstance(raw, list) else [])
+        if cleaned:
+            return cleaned
+        return [] if metadata.get('resolved') else None
+
     def _save_to_cache(self, entity_type: str, entity_name: str, artist_name: Optional[str],
                        musicbrainz_id: Optional[str], metadata: Optional[Dict], confidence: int):
         """Save MusicBrainz result to cache"""
@@ -472,13 +511,9 @@ class MusicBrainzService:
 
         # Tier 2: cached live lookup (re-uses musicbrainz_cache table)
         cached = self._check_cache('artist_aliases', artist_name)
-        if cached:
-            metadata = cached.get('metadata') or {}
-            aliases = metadata.get('aliases') if isinstance(metadata, dict) else None
-            if isinstance(aliases, list):
-                return [str(x).strip() for x in aliases if x]
-            # Cache hit with empty result — respect it (don't re-query)
-            return []
+        answered = self._cached_aliases(cached)
+        if answered is not None:
+            return answered
 
         # Tier 3: live MB lookup. Search → fetch by MBID → cache.
         # Issue #586 — strict search queries `artist:"..."` only and
@@ -488,14 +523,30 @@ class MusicBrainzService:
         # Fall back to non-strict (bare query, hits alias + sortname
         # indexes) when strict returns empty OR all results fail the
         # trust gate.
-        scored = self._search_and_score_artists(artist_name, strict=True)
+        # `None` from a search means MusicBrainz never answered (timeout, rate
+        # limit, 503). That is not the same as "no such artist", and caching it
+        # as an empty alias list is how a single bulk-scan rate-limit could
+        # silence the romaji-kanji bridge for the whole cache TTL.
+        strict_hits = self._search_and_score_artists(artist_name, strict=True)
+        lookup_failed = strict_hits is None
+        scored = strict_hits or []
         if not scored or self._best_score(scored) < 0.85:
             non_strict = self._search_and_score_artists(artist_name, strict=False)
-            if non_strict and (not scored or self._best_score(non_strict) > self._best_score(scored)):
+            if non_strict is None:
+                lookup_failed = True
+            elif non_strict and (not scored
+                                 or self._best_score(non_strict) > self._best_score(scored)):
                 scored = non_strict
+                lookup_failed = False
 
         if not scored:
-            self._save_to_cache('artist_aliases', artist_name, None, None, {'aliases': []}, 0)
+            if lookup_failed:
+                logger.debug(
+                    "lookup_artist_aliases: search for %r did not complete — "
+                    "not recording an empty result", artist_name,
+                )
+                return []
+            self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
             return []
 
         scored.sort(key=lambda x: -x[0])
@@ -528,7 +579,7 @@ class MusicBrainzService:
                 "threshold (combined=%.2f, best_mb=%d, leader_mb=%d)",
                 artist_name, best_score, best_mb_score, mb_leader[2],
             )
-            self._save_to_cache('artist_aliases', artist_name, None, None, {'aliases': []}, 0)
+            self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
             return []
 
         # Pick the entity to pull aliases from. Combined-strong matches use
@@ -551,13 +602,23 @@ class MusicBrainzService:
                 "two results within 0.1 (%.2f / %.2f). Skipping alias lookup.",
                 artist_name, scored[0][0], scored[1][0],
             )
-            self._save_to_cache('artist_aliases', artist_name, None, None, {'aliases': []}, 0)
+            self._save_to_cache('artist_aliases', artist_name, None, None, _NO_ALIASES, 0)
             return []
 
-        aliases = self.fetch_artist_aliases(chosen_mbid)
+        aliases = self.resolve_artist_aliases(chosen_mbid)
+        if aliases is None:
+            # The identity resolved, the alias fetch did not come back. Writing
+            # that down as "no aliases" is precisely what froze this lookup for
+            # a full TTL and took the romaji-kanji bridge with it; leave the
+            # question open instead.
+            logger.debug(
+                "lookup_artist_aliases: alias fetch for %r (%s) did not "
+                "complete — not recording a result", artist_name, chosen_mbid,
+            )
+            return []
         self._save_to_cache(
             'artist_aliases', artist_name, None, chosen_mbid,
-            {'aliases': aliases}, int(chosen_conf * 100),
+            {'aliases': aliases, 'resolved': True}, int(chosen_conf * 100),
         )
         return aliases
 
@@ -570,7 +631,11 @@ class MusicBrainzService:
         gate can prefer high-MB-score results in cross-script cases
         where local similarity is near zero.
 
-        Returns empty list on any failure.
+        Returns ``None`` when the search itself did not complete (timeout,
+        rate limit, transport error) and a list otherwise — including the
+        empty list, which is MusicBrainz genuinely answering "nobody by that
+        name". The caller has to tell those apart: only the second is a
+        verdict worth caching.
         """
         try:
             results = self.mb_client.search_artist(artist_name, limit=3, strict=strict)
@@ -579,7 +644,7 @@ class MusicBrainzService:
                 "lookup_artist_aliases: search_artist(%r, strict=%s) raised: %s",
                 artist_name, strict, e,
             )
-            return []
+            return None
         scored = []
         for result in results or []:
             mb_name = result.get('name', '')
@@ -596,6 +661,16 @@ class MusicBrainzService:
         return max((s[0] for s in scored), default=0.0) if scored else 0.0
 
     def fetch_artist_aliases(self, mbid: str) -> list:
+        """Alias list for an artist, with a failed fetch reported as empty.
+
+        Kept for callers that genuinely cannot act on the difference (the
+        enrichment worker, which only ever stores a non-empty list). Anything
+        that CACHES the answer must use :meth:`resolve_artist_aliases` — see
+        the note there.
+        """
+        return self.resolve_artist_aliases(mbid) or []
+
+    def resolve_artist_aliases(self, mbid: str) -> Optional[list]:
         """Fetch the alias list for an artist from MusicBrainz.
 
         Issue #442 — Japanese kanji / Cyrillic / etc. spellings of an
@@ -611,21 +686,22 @@ class MusicBrainzService:
         themselves valid alternate spellings for matching purposes,
         so include them alongside the explicit alias entries.
 
-        Returns the deduplicated list of alias `name` strings. Returns
-        empty list (NOT None) on any failure — caller should treat
-        empty as "no aliases available, fall back to direct match" so
-        a transient MB outage never causes a stricter verification
-        decision than today.
+        Returns the deduplicated list of alias `name` strings, or **None**
+        when MusicBrainz never answered. That distinction is the whole point:
+        an empty list means "MusicBrainz lists no alternate spelling", None
+        means "we do not know", and only the first may ever be written down as
+        a result. Collapsing the two is what let one timeout freeze a working
+        cross-script bridge for the length of a cache TTL.
         """
         if not mbid:
-            return []
+            return None
         try:
             data = self.mb_client.get_artist(mbid, includes=['aliases'])
         except Exception as e:
-            logger.debug("fetch_artist_aliases: get_artist(%s) raised: %s", mbid, e)
-            return []
+            logger.debug("resolve_artist_aliases: get_artist(%s) raised: %s", mbid, e)
+            return None
         if not data:
-            return []
+            return None
 
         seen = set()
         cleaned = []

--- a/core/musicbrainz_service.py
+++ b/core/musicbrainz_service.py
@@ -6,7 +6,11 @@ from datetime import datetime, timedelta
 from difflib import SequenceMatcher
 from utils.logging_config import get_logger
 from core.musicbrainz_client import MusicBrainzClient
-from core.worker_utils import catalog_overlap_score, pick_artist_by_catalog
+from core.worker_utils import (
+    catalog_overlap_score,
+    pick_artist_by_catalog,
+    source_id_conflict,
+)
 from database.music_database import MusicDatabase
 
 logger = get_logger("musicbrainz_service")
@@ -509,8 +513,42 @@ class MusicBrainzService:
         if library:
             return library
 
-        # Tier 2: cached live lookup (re-uses musicbrainz_cache table)
+        # Tier 1b: the artist's own MusicBrainz identity, when the catalogue
+        # already knows it. Everything below this line GUESSES from the name,
+        # and for a cross-script artist that guess is exactly what fails: the
+        # trust gate's own comment names `Sawano Hiroyuki` as the case where a
+        # decoy entity outscores the real `澤野弘之`, and MusicBrainz's
+        # relevance scores are not stable enough for the escape hatch to be
+        # relied on. That is why the bridge could work one day and not the
+        # next. There is nothing to guess once the row carries the MBID.
         cached = self._check_cache('artist_aliases', artist_name)
+        row_mbid = self._artist_row_mbid(artist_name)
+        if row_mbid:
+            # A cache row resolved against THIS identity says exactly what a
+            # fresh fetch would say, and every fetch spends a second of the
+            # process-wide MusicBrainz budget — one per scanned file for an
+            # artist MusicBrainz lists no alias for, all of it contending with
+            # the enrichment worker on the same limiter.
+            known = self._cached_aliases(cached, for_mbid=row_mbid)
+            if known is not None:
+                return known
+            aliases = self.resolve_artist_aliases(row_mbid)
+            if aliases is not None:
+                self._save_to_cache(
+                    'artist_aliases', artist_name, None, row_mbid,
+                    {'aliases': aliases, 'resolved': True}, 100,
+                )
+                if aliases:
+                    try:
+                        self._persist_artist_identity(artist_name, row_mbid, aliases)
+                    except Exception as e:  # noqa: BLE001
+                        logger.debug("alias write-back for %r failed: %s",
+                                     artist_name, e)
+                return aliases
+            # The fetch did not come back. That settles nothing, so carry on
+            # rather than reporting "no aliases" off the back of it.
+
+        # Tier 2: cached live lookup (re-uses musicbrainz_cache table)
         answered = self._cached_aliases(cached)
         if answered is not None:
             return answered
@@ -620,7 +658,118 @@ class MusicBrainzService:
             'artist_aliases', artist_name, None, chosen_mbid,
             {'aliases': aliases, 'resolved': True}, int(chosen_conf * 100),
         )
+        # Keep what we just learned on the ARTIST, not only in a cache keyed by
+        # the spelling this caller happened to pass. Without this the knowledge
+        # that let a download pass expires with the cache row and is invisible
+        # to any later lookup that spells the name differently — which is how a
+        # library scan came to disagree with the download about the same file.
+        # Best-effort by design: the caller asked for aliases and has them.
+        try:
+            self._persist_artist_identity(artist_name, chosen_mbid, aliases)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("alias write-back for %r failed: %s", artist_name, e)
         return aliases
+
+    def _artist_row_mbid(self, artist_name: str) -> Optional[str]:
+        """The MusicBrainz id the catalogue already holds for this artist name.
+
+        Best-effort: any failure (no catalogue, no row, no id) returns None and
+        the caller falls back to resolving by name, which is what it did before
+        this existed.
+        """
+        if not artist_name:
+            return None
+        conn = None
+        try:
+            conn = self.db._get_connection()
+            row = conn.execute(
+                "SELECT musicbrainz_id FROM artists "
+                "WHERE name = ? COLLATE NOCASE "
+                "AND COALESCE(musicbrainz_id,'') <> '' LIMIT 1",
+                (artist_name,),
+            ).fetchone()
+            return str(row[0]) if row and row[0] else None
+        except Exception as e:  # noqa: BLE001
+            logger.debug("artist mbid lookup failed for %r: %s", artist_name, e)
+            return None
+        finally:
+            if conn:
+                try:
+                    conn.close()
+                except Exception:  # noqa: BLE001, S110 — best effort
+                    pass
+
+    def _persist_artist_identity(self, artist_name: str, mbid: Optional[str],
+                                 aliases: Optional[list]) -> None:
+        """Store a live-resolved MBID + alias list on the library artist row.
+
+        Matched by name because that is all the verifier ever has — it compares
+        against a metadata-source string, not a library id. A differently-named
+        artist already holding this MBID means the name search landed on the
+        wrong entity, so the same gate every enrichment worker passes through
+        applies here too: better no id than one smeared across two artists.
+        """
+        if not artist_name or not mbid:
+            return
+        conn = None
+        try:
+            conn = self.db._get_connection()
+            row = conn.execute(
+                "SELECT id, musicbrainz_id FROM artists "
+                "WHERE name = ? COLLATE NOCASE LIMIT 1",
+                (artist_name,),
+            ).fetchone()
+        finally:
+            if conn:
+                conn.close()
+        if not row:
+            return
+        artist_id, stored_mbid = int(row[0]), row[1]
+        write_mbid = False
+        if stored_mbid:
+            # The aliases were fetched FROM this MBID, so they are only this
+            # artist's aliases if this MBID is. Writing them without that is
+            # how one artist's alternate spellings end up on another's row.
+            if str(stored_mbid) != str(mbid):
+                logger.debug(
+                    "alias write-back skipped for %r: row holds MBID %s, "
+                    "the name search resolved %s", artist_name, stored_mbid, mbid)
+                return
+        else:
+            # Checked before the write connection is opened — the guard reads
+            # through its own connection, and nesting one inside an open write
+            # is how a SQLite writer deadlocks itself.
+            conflict = source_id_conflict(
+                self.db, 'musicbrainz_id', mbid, artist_id, artist_name)
+            if conflict:
+                logger.debug(
+                    "alias write-back skipped for %r: MBID %s already held "
+                    "by %r", artist_name, mbid, conflict)
+                return
+            write_mbid = True
+
+        conn = None
+        try:
+            conn = self.db._get_connection()
+            if write_mbid:
+                conn.execute(
+                    "UPDATE artists SET musicbrainz_id = ?, "
+                    "musicbrainz_last_attempted = ?, "
+                    "musicbrainz_match_status = 'matched' WHERE id = ?",
+                    (mbid, datetime.now(), artist_id))
+            if aliases:
+                conn.execute(
+                    "UPDATE artists SET aliases = ?, "
+                    "updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (json.dumps(aliases), artist_id))
+            conn.commit()
+        finally:
+            if conn:
+                conn.close()
+        logger.info(
+            "Stored MusicBrainz identity for artist %r (mbid=%s, %d aliases)",
+            artist_name, mbid, len(aliases or []),
+        )
 
     def _search_and_score_artists(self, artist_name: str, strict: bool):
         """Search MB for an artist and score each result.

--- a/core/repair_jobs/acoustid_scanner.py
+++ b/core/repair_jobs/acoustid_scanner.py
@@ -235,7 +235,14 @@ class AcoustIDScannerJob(RepairJob):
             file_verif_status = (_rft(fpath) or {}).get('verification_status')
         except Exception:  # noqa: S110 — verification tag is optional context; None is fine
             pass
-        if file_verif_status == 'human_verified':
+        # The tag and the catalogue column are two records of ONE fact, and the
+        # tag is the losable one: an import write that did not stick, a copy, a
+        # retag. Reading the standing from the tag alone while WRITING to the
+        # column is what let a scan demote a verified file to 'unverified' — it
+        # saw an untagged file and applied the rule for one. Either record
+        # saying so is the file standing verified.
+        verif_status = file_verif_status or expected.get('db_verification_status')
+        if verif_status == 'human_verified':
             # The user explicitly confirmed this file via the review queue —
             # never second-guess a human decision.
             if context.report_progress:
@@ -306,10 +313,13 @@ class AcoustIDScannerJob(RepairJob):
         # the title check) and 'verified' is never downgraded by a SKIP (the
         # import-time check ran with richer candidate metadata). FAIL keeps
         # the finding flow below.
-        new_status = file_verif_status
-        if outcome.decision == Decision.PASS and file_verif_status in (None, '', 'unverified'):
+        # Judged on `verif_status` — the standing across BOTH records — while
+        # `new_status` still starts from it so a file whose tag went missing
+        # gets it written back rather than replaced with the scan's guess.
+        new_status = verif_status
+        if outcome.decision == Decision.PASS and verif_status in (None, '', 'unverified'):
             new_status = 'verified'
-        elif outcome.decision == Decision.SKIP and not file_verif_status:
+        elif outcome.decision == Decision.SKIP and not verif_status:
             new_status = 'unverified'
         if new_status:
             self._persist_status(
@@ -367,7 +377,7 @@ class AcoustIDScannerJob(RepairJob):
                 log_type='error'
             )
         if context.create_finding:
-            _is_force = file_verif_status == 'force_imported'
+            _is_force = verif_status == 'force_imported'
             severity = 'info' if _is_force else ('warning' if best_score >= 0.90 else 'info')
             if _ambiguous:
                 _title = (
@@ -415,7 +425,7 @@ class AcoustIDScannerJob(RepairJob):
                     'artist_id': expected.get('artist_id'),
                     'album_title': expected.get('album_title', ''),
                     'track_number': expected.get('track_number'),
-                    'force_imported': file_verif_status == 'force_imported',
+                    'force_imported': verif_status == 'force_imported',
                     # #1132: True when the fingerprint's top recordings name
                     # different songs, so `acoustid_title`/`acoustid_artist`
                     # are one arbitrary pick among equals. Anything that would
@@ -541,7 +551,8 @@ class AcoustIDScannerJob(RepairJob):
                        NULLIF(t.track_artist, '') AS track_artist,
                        ar.name AS album_artist,
                        t.duration,
-                       ar.id AS artist_row_id
+                       ar.id AS artist_row_id,
+                       t.verification_status
                 FROM tracks t
                 LEFT JOIN artists ar ON ar.id = t.artist_id
                 LEFT JOIN albums al ON al.id = t.album_id
@@ -573,6 +584,11 @@ class AcoustIDScannerJob(RepairJob):
                     # totally different length.
                     'duration_ms': row[10] or 0,
                     'artist_id': row[11],
+                    # The second record of the file's verification standing.
+                    # The scan writes here and reads the tag, so it has to
+                    # consult both or it demotes a verified file whose tag
+                    # went missing.
+                    'db_verification_status': row[12] or None,
                 }
         except Exception as e:
             logger.error("Error loading tracks from DB: %s", e)

--- a/core/repair_jobs/acoustid_scanner.py
+++ b/core/repair_jobs/acoustid_scanner.py
@@ -15,9 +15,8 @@ from typing import Optional
 from core.repair_jobs import register_job
 from core.repair_jobs.base import JobContext, JobResult, RepairJob
 from utils.logging_config import get_logger
-from core.matching.audio_verification import evaluate, fingerprint_is_ambiguous, Decision
+from core.matching.audio_verification import fingerprint_is_ambiguous, Decision
 from core.matching.acoustid_candidates import duration_mismatches_strongly
-from core.acoustid_verification import _resolve_expected_artist_aliases
 
 logger = get_logger("repair_job.acoustid")
 
@@ -73,6 +72,28 @@ class AcoustIDScannerJob(RepairJob):
                 acoustid_client = AcoustIDClient()
             except Exception as e:
                 logger.warning("AcoustID client not available: %s", e)
+                return result
+
+        # Is the client usable AT ALL? `verify_audio_file` probes this per file
+        # and answers SKIP when it is not -- and for this job a SKIP on an
+        # untagged file means 'unverified'. So a disabled integration, a
+        # missing API key or no chromaprint binary would walk the whole library
+        # into the review queue and report a clean run. That is a property of
+        # the RUN, not a verdict about any file, so it belongs here, once, as a
+        # refusal to start.
+        probe_available = getattr(acoustid_client, 'is_available', None)
+        if callable(probe_available):
+            try:
+                available, reason = probe_available()
+            except Exception as e:  # noqa: BLE001 — a broken probe is not a verdict
+                available, reason = False, f'availability check failed: {e}'
+            if not available:
+                logger.warning("AcoustID scan not started: %s", reason)
+                if context.report_progress:
+                    context.report_progress(
+                        log_line=f'AcoustID unavailable — nothing scanned: {reason}',
+                        log_type='error')
+                result.errors += 1
                 return result
 
         # Load all library tracks from DB with their file paths
@@ -166,62 +187,25 @@ class AcoustIDScannerJob(RepairJob):
 
     def _scan_file(self, fpath, track_id, expected, acoustid_client, context, result,
                    fp_threshold, title_threshold, artist_threshold):
-        """Fingerprint a single file and check for mismatches."""
+        """Fingerprint a single file and check for mismatches.
+
+        ONE verification path. Everything from "is AcoustID usable" through the
+        lookup, the confidence floor, the MusicBrainz enrichment of title-less
+        recordings, the lazy alias resolution and the final decision lives in
+        ``AcoustIDVerification.verify_audio_file`` -- the same call the download
+        makes. The scan used to repeat all five steps around a shared decision
+        core, which is precisely where the two drifted apart: the scan never
+        enriched its recordings, so a fingerprint hit whose title AcoustID does
+        not carry was dropped where the download would have resolved it from
+        MusicBrainz and judged it. What stays here is what the scan alone has
+        to answer: which files to look at, and what to do with a verdict.
+        """
         fname = os.path.basename(fpath)
 
-        # Fingerprint the file
-        try:
-            fp_result = acoustid_client.fingerprint_and_lookup(fpath)
-        except Exception as e:
-            logger.debug("Fingerprint failed for %s: %s", fname, e)
-            result.errors += 1
-            if context.report_progress:
-                context.report_progress(log_line=f'Error: {fname} — {e}', log_type='error')
-            return
-
-        if not fp_result or not fp_result.get('recordings'):
-            if context.report_progress:
-                context.report_progress(log_line=f'No match: {fname}', log_type='skip')
-            return
-
-        best_score = fp_result.get('best_score', 0)
-        if best_score < fp_threshold:
-            return
-
-        best_recording = fp_result['recordings'][0]
-        aid_title = best_recording.get('title', '')
-        aid_artist = best_recording.get('artist', '')
-
-        if not aid_title:
-            return
-
-        # Resolve which artist value to compare against, in priority order:
-        #   1. DB `track_artist` (per-track, manually curated or scanner-
-        #      populated) — trust it when populated. Respects user edits
-        #      from the enhanced library view.
-        #   2. File's ARTIST tag — ground truth for what's on disk.
-        #      Catches legacy compilation tracks where `track_artist`
-        #      column is NULL because they were downloaded before that
-        #      column existed; the file itself has the correct per-
-        #      track artist (Tidal/Spotify/Deezer all write it).
-        #   3. Album artist — final fallback for files without proper
-        #      ARTIST tags AND no DB track_artist.
-        track_artist = (expected.get('track_artist') or '').strip()
-        if track_artist:
-            expected_artist = track_artist
-        else:
-            file_artist = None
-            try:
-                from core.tag_writer import read_file_tags
-                file_tags = read_file_tags(fpath)
-                file_artist = (file_tags.get('artist') or '').strip() or None
-            except Exception as e:
-                logger.debug("file-tag artist read failed for %s: %s", fname, e)
-            expected_artist = (
-                file_artist
-                or (expected.get('album_artist') or '').strip()
-                or expected['artist']
-            )
+        # The expected artist is the one input the download gets from its
+        # provider payload and the scan has to derive, so it is resolved before
+        # the call rather than inside it.
+        expected_artist = self._expected_artist(fpath, expected, fname)
 
         # Verification status from the embedded SOULSYNC_VERIFICATION tag.
         # Only a human decision short-circuits the scan: the user explicitly
@@ -250,6 +234,50 @@ class AcoustIDScannerJob(RepairJob):
                     log_line=f'Skipped (human-verified): {fname}', log_type='skip')
             return
 
+        probe = {}
+        try:
+            from core.acoustid_verification import (
+                AcoustIDVerification, VerificationResult,
+            )
+
+            verifier = AcoustIDVerification()
+            if acoustid_client is not None:
+                verifier.acoustid_client = acoustid_client
+            _verdict, message = verifier.verify_audio_file(
+                fpath, expected['title'], expected_artist, probe,
+                min_score=fp_threshold,
+            )
+        except Exception as e:
+            logger.debug("Fingerprint failed for %s: %s", fname, e)
+            result.errors += 1
+            if context.report_progress:
+                context.report_progress(log_line=f'Error: {fname} — {e}', log_type='error')
+            return
+
+        if _verdict == VerificationResult.ERROR:
+            # Broken, not answered. Leave the standing alone so a rate limit or
+            # a missing chromaprint does not get written down as a verdict.
+            if context.report_progress:
+                context.report_progress(
+                    log_line=f'Error: {fname} — {message}', log_type='error')
+            result.errors += 1
+            return
+
+        outcome = probe.get('_acoustid_decision')
+        recordings = probe.get('_acoustid_recordings') or []
+        best_score = probe.get('_acoustid_best_score') or 0.0
+        if outcome is None:
+            # No match, or a fingerprint too weak to trust. Nothing is written:
+            # an unanswered check is not a verdict about the file.
+            if context.report_progress:
+                context.report_progress(log_line=f'No match: {fname}', log_type='skip')
+            return
+        if not any(r.get('title') for r in recordings):
+            return
+        best_recording = recordings[0]
+        aid_title = best_recording.get('title', '')
+        aid_artist = best_recording.get('artist', '')
+
         # Fingerprint-collision guard: when the match's length is wildly
         # different from the file, the fingerprint hit is a hash collision (the
         # 17-min mashup → 5-min track case), not a real match — skip BEFORE any
@@ -266,7 +294,7 @@ class AcoustIDScannerJob(RepairJob):
             file_duration_s = (expected.get('duration_ms') or 0) / 1000.0
         except Exception:
             file_duration_s = 0.0
-        _recs = fp_result['recordings']
+        _recs = recordings
         _scored = [r for r in _recs if r.get('score') is not None]
         _top = max((r['score'] for r in _scored), default=None)
         _judge = [r for r in _scored if r['score'] >= _top] if _top is not None else _recs
@@ -283,26 +311,6 @@ class AcoustIDScannerJob(RepairJob):
                               f'collision): {fname}'),
                     log_type='skip')
             return
-
-        # Decision via the shared verification core — identical logic to import-
-        # time verification (alias-aware artist match + cross-script SKIP), so the
-        # scan no longer false-flags correct cross-script tracks. Only a FAIL
-        # produces a "Wrong download" finding.
-        _alias_cache = {}
-
-        def _aliases():
-            if 'v' not in _alias_cache:
-                try:
-                    _alias_cache['v'] = _resolve_expected_artist_aliases(expected_artist)
-                except Exception:
-                    _alias_cache['v'] = []
-            return _alias_cache['v']
-
-        outcome = evaluate(
-            expected['title'], expected_artist, fp_result['recordings'],
-            fingerprint_score=best_score,
-            aliases_provider=_aliases,
-        )
 
         # Persist the scan outcome so it feeds the same review pipeline as
         # import-time verification: PASS backfills 'verified' on untagged or
@@ -348,7 +356,7 @@ class AcoustIDScannerJob(RepairJob):
         # The DETECTION stands either way — it only asks whether ANY candidate
         # matched, which ties don't affect. What gets withheld is the single
         # "is actually Y" claim, replaced by the candidate list.
-        _ambiguous = fingerprint_is_ambiguous(fp_result['recordings'])
+        _ambiguous = fingerprint_is_ambiguous(recordings)
 
         title_sim = outcome.title_sim
         artist_sim = outcome.artist_sim
@@ -438,6 +446,35 @@ class AcoustIDScannerJob(RepairJob):
                 result.findings_created += 1
             else:
                 result.findings_skipped_dedup += 1
+
+    def _expected_artist(self, fpath, expected, fname):
+        """Which artist value the scan compares against, in priority order:
+
+        1. the catalogue's per-track artist — manually curated or scanner
+           populated, so it wins when it is there (Skowl's compilation report:
+           `tracks.artist_id` points at the ALBUM artist, which for a
+           label-curated compilation is the label);
+        2. the file's ARTIST tag — ground truth for what is on disk, and the
+           rescue for compilation rows whose per-track artist is NULL because
+           they predate that column;
+        3. the album artist, for files with neither.
+
+        This is the one input the download gets from its provider payload and
+        the scan has to derive, which is why it lives here and not in the
+        shared verifier.
+        """
+        track_artist = (expected.get('track_artist') or '').strip()
+        if track_artist:
+            return track_artist
+        file_artist = None
+        try:
+            from core.tag_writer import read_file_tags
+            file_artist = ((read_file_tags(fpath) or {}).get('artist') or '').strip() or None
+        except Exception as e:  # noqa: BLE001
+            logger.debug("file-tag artist read failed for %s: %s", fname, e)
+        return (file_artist
+                or (expected.get('album_artist') or '').strip()
+                or expected['artist'])
 
     def _persist_status(self, context, track_id, fpath, db_path, status, write_tag,
                         expected=None):

--- a/tests/library/test_musicbrainz_search_without_worker.py
+++ b/tests/library/test_musicbrainz_search_without_worker.py
@@ -1,0 +1,68 @@
+"""MusicBrainz search must not depend on the worker handle.
+
+`_search_service` reached MusicBrainz through `mb_worker.mb_service` and
+raised "MusicBrainz worker not initialized" when there was no worker object.
+That handle is set by the app at startup and is None whenever the worker's
+init failed — so a manual MusicBrainz match, and every enrichment path that
+goes through this function, went down with it and reported a worker the user
+never asked for.
+
+MusicBrainz needs no credentials and no worker — only a client, and the
+process already keeps a shared, rate-limited one (`get_musicbrainz_service`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import core.library.service_search as service_search
+
+
+def _stub_service():
+    svc = MagicMock()
+    svc.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100,
+         "disambiguation": "composer"},
+    ]
+    return svc
+
+
+def test_artist_search_works_with_no_worker(monkeypatch):
+    monkeypatch.setattr(service_search, "mb_worker", None)
+    monkeypatch.setattr("core.musicbrainz_service.get_musicbrainz_service",
+                        _stub_service)
+
+    hits = service_search._search_service("musicbrainz", "artist", "Sawano Hiroyuki")
+
+    assert [h["id"] for h in hits] == ["mbid-sawano"]
+
+
+def test_a_present_worker_is_still_preferred(monkeypatch):
+    """The worker owns the rate limiter it shares with its own loop — when it
+    is there, keep using it rather than introducing a second client."""
+    worker = MagicMock()
+    worker.mb_service.mb_client.search_artist.return_value = [
+        {"id": "from-worker", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    monkeypatch.setattr(service_search, "mb_worker", worker)
+    monkeypatch.setattr("core.musicbrainz_service.get_musicbrainz_service",
+                        _stub_service)
+
+    hits = service_search._search_service("musicbrainz", "artist", "Sawano Hiroyuki")
+
+    assert [h["id"] for h in hits] == ["from-worker"]
+
+
+def test_it_still_raises_when_no_client_can_be_had(monkeypatch):
+    def _boom():
+        raise RuntimeError("no database")
+
+    monkeypatch.setattr(service_search, "mb_worker", None)
+    monkeypatch.setattr("core.musicbrainz_service.get_musicbrainz_service", _boom)
+
+    try:
+        service_search._search_service("musicbrainz", "artist", "x")
+    except ValueError as exc:
+        assert "MusicBrainz" in str(exc)
+    else:  # pragma: no cover - the call must not silently succeed
+        raise AssertionError("expected a ValueError")

--- a/tests/matching/test_alias_lookup_resilience.py
+++ b/tests/matching/test_alias_lookup_resilience.py
@@ -1,0 +1,132 @@
+"""Alias lookup: a failure is not an answer, and an answer must be kept.
+
+The first of two defects behind the production "Wrong download" findings for
+`Sawano Hiroyuki` / `澤野弘之`, in `lookup_artist_aliases`:
+
+1. **A lookup failure was cached as "this artist has no aliases".**
+   `_search_and_score_artists` returns an empty list for *any* exception —
+   timeout, rate limit, 503 — indistinguishable from a genuine empty result.
+   The caller then wrote `{"aliases": []}` into `musicbrainz_cache` where it
+   blocked every retry for its 30-day TTL. A bulk AcoustID scan is exactly
+   the workload that trips MusicBrainz's rate limit, so one sweep could
+   poison the only bridge between a romaji and a kanji spelling. The user's
+   database contains such a row (`Hiroyuki Sawano`, confidence 0).
+
+The second half of the pair — writing a successful lookup back onto the
+artist row instead of only into a name-keyed cache — is the next commit.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.musicbrainz_service import MusicBrainzService
+
+
+def _simple_sim(a: str, b: str) -> float:
+    if not a or not b:
+        return 0.0
+    return 1.0 if a.lower() == b.lower() else 0.0
+
+
+@pytest.fixture
+def service():
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.mb_client = MagicMock()
+    svc._calculate_similarity = _simple_sim
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    return svc
+
+
+# --- 1. a failed lookup must not be cached as an answer --------------------
+
+
+def test_search_failure_is_not_cached_as_empty(service):
+    service.mb_client.search_artist.side_effect = TimeoutError("read timed out")
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_not_called()
+
+
+def test_genuine_no_results_is_still_cached(service):
+    # MusicBrainz answered and knows nobody by that name — a real verdict,
+    # worth remembering so the next lookup doesn't re-ask.
+    service.mb_client.search_artist.return_value = []
+
+    assert service.lookup_artist_aliases("Not An Artist At All") == []
+    service._save_to_cache.assert_called_once()
+
+
+def test_strict_failure_still_uses_a_working_non_strict_result(service):
+    def _search(name, limit=3, strict=True):
+        if strict:
+            raise TimeoutError("read timed out")
+        return [{"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100}]
+
+    service.mb_client.search_artist.side_effect = _search
+    service.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+
+
+def test_poisoned_empty_cache_row_does_not_block_a_retry(service):
+    # A cached empty result with NO mbid and zero confidence is the shape the
+    # old failure path wrote. It is not a verdict, so it must not stand in for
+    # one — fall through and ask again.
+    service._check_cache.return_value = {
+        "musicbrainz_id": None, "metadata": {"aliases": []}, "confidence": 0,
+    }
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    service.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+
+
+def test_genuine_empty_cache_row_is_still_respected(service):
+    # MusicBrainz answered and the artist truly has no aliases. The `resolved`
+    # marker is what says so, and it must be honoured without re-querying.
+    service._check_cache.return_value = {
+        "musicbrainz_id": "mbid-x", "confidence": 95,
+        "metadata": {"aliases": [], "resolved": True},
+    }
+
+    assert service.lookup_artist_aliases("Some Artist") == []
+    service.mb_client.search_artist.assert_not_called()
+
+
+def test_an_mbid_alone_never_makes_an_empty_row_a_verdict(service):
+    """The production failure, as a test.
+
+    A row carrying an MBID and an empty alias list used to count as "this
+    artist has no aliases" for the full 90-day TTL. But `fetch_artist_aliases`
+    returned `[]` for a rate-limited fetch exactly as readily as for a genuine
+    absence, so one timeout during a download froze the romaji-kanji bridge —
+    and every later scan of those files reported "cannot compare the names"
+    while the download that wrote the row had passed them.
+    """
+    service._check_cache.return_value = {
+        "musicbrainz_id": "mbid-sawano", "metadata": {"aliases": []},
+        "confidence": 100,
+    }
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    service.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+
+
+def test_a_fetch_that_did_not_come_back_is_never_written_down(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    service.resolve_artist_aliases = MagicMock(return_value=None)
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_not_called()

--- a/tests/matching/test_alias_lookup_resilience.py
+++ b/tests/matching/test_alias_lookup_resilience.py
@@ -68,7 +68,7 @@ def test_genuine_no_results_is_still_cached(service):
 
 
 def test_strict_failure_still_uses_a_working_non_strict_result(service):
-    def _search(name, limit=3, strict=True):
+    def _search(name, limit=3, strict=True, **_kw):
         if strict:
             raise TimeoutError("read timed out")
         return [{"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100}]
@@ -406,3 +406,167 @@ def test_no_mbid_on_the_row_still_searches_by_name(tmp_path):
 
     assert svc.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
     svc.mb_client.search_artist.assert_called()
+
+
+# --- review round: the five ways the guards above could still be bypassed ---
+
+
+def test_a_client_that_swallows_a_timeout_is_still_a_failure(service):
+    """The one that defeated everything else.
+
+    `MusicBrainzClient.search_artist` catches its own exceptions and returns
+    `[]` — the same value it uses for "MusicBrainz knows nobody by that name".
+    Read through that lens the outage becomes a completed no-result search, and
+    the negative cache is written exactly as before. The service asks for the
+    failure to be raised.
+    """
+    def _search(name, limit=3, strict=True, raise_on_error=False):
+        if raise_on_error:
+            raise TimeoutError("read timed out")
+        return []
+
+    service.mb_client.search_artist.side_effect = _search
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_not_called()
+
+
+def test_a_failed_fallback_search_does_not_cache_through_the_trust_gate(service):
+    """Strict answered with something weak, non-strict never answered.
+
+    `scored` is non-empty, so the "no results" guard does not fire — and the
+    candidates then fail the trust gate, which used to cache "no aliases" on
+    the way out. But the entity that would have passed may only ever have
+    existed in the query that timed out: for a cross-script artist the alias
+    index IS the non-strict one.
+    """
+    def _search(name, limit=3, strict=True, **_kw):
+        if strict:
+            return [{"id": "mbid-decoy", "name": "Someone Else", "score": 50}]
+        raise TimeoutError("read timed out")
+
+    service.mb_client.search_artist.side_effect = _search
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_not_called()
+
+
+def test_two_indistinguishable_candidates_are_still_cached_when_the_search_ran(service):
+    """The ambiguity gate keeps its negative-cache write.
+
+    It cannot currently be reached with a failed search — the fallback only
+    runs when the strict score is weak, and a weak score fails the trust gate
+    before this. It carries the same guard anyway, because that reachability
+    argument is a property of the code above it, not of this branch.
+    """
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-a", "name": "Sawano Hiroyuki", "score": 80},
+        {"id": "mbid-b", "name": "Sawano Hiroyuki", "score": 79},
+    ]
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_called_once()
+
+
+def test_a_complete_search_that_rejects_its_candidates_is_still_cached(service):
+    """The guards above must not turn every rejection into a retry."""
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-decoy", "name": "Someone Else Entirely", "score": 50},
+    ]
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
+    service._save_to_cache.assert_called_once()
+
+
+# --- the name has to identify ONE artist -----------------------------------
+
+
+# The shipped schema starts artists.id as INTEGER and MIGRATES it to TEXT
+# (`artists_new` in database/music_database.py), because a library keys artists
+# by the media server's id — a GUID on Jellyfin. Rows here use the migrated
+# shape, which is what an installed database actually has.
+_ARTISTS_DDL_TEXT_ID = _ARTISTS_DDL.replace(
+    "id INTEGER PRIMARY KEY", "id TEXT PRIMARY KEY")
+
+
+def _two_rows(tmp_path, rows):
+    import sqlite3
+
+    db_path = tmp_path / "dupes.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(_ARTISTS_DDL_TEXT_ID)
+    for row in rows:
+        conn.execute(
+            "INSERT INTO artists (id, name, musicbrainz_id) VALUES (?, ?, ?)", row)
+    conn.commit()
+    conn.close()
+
+    class _DB:
+        def _get_connection(self):
+            c = sqlite3.connect(str(db_path))
+            c.row_factory = sqlite3.Row
+            return c
+
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.db = _DB()
+    return svc, db_path
+
+
+def test_same_name_rows_with_different_mbids_do_not_settle_the_identity(tmp_path):
+    """Two artists share a display name. Whichever row sorted first would
+    otherwise become authoritative for every verification against that name,
+    and its aliases could let the wrong artist pass."""
+    svc, _ = _two_rows(tmp_path, [
+        ("1", "Rone", "mbid-rone-fr"),
+        ("2", "Rone", "mbid-rone-us"),
+    ])
+
+    assert svc._artist_row_mbid("Rone") is None
+
+
+def test_same_name_rows_agreeing_on_one_mbid_still_settle_it(tmp_path):
+    """The ordinary case: one artist indexed on two media servers."""
+    svc, _ = _two_rows(tmp_path, [
+        ("1", "Sawano Hiroyuki", "mbid-sawano"),
+        ("2", "Sawano Hiroyuki", "mbid-sawano"),
+    ])
+
+    assert svc._artist_row_mbid("Sawano Hiroyuki") == "mbid-sawano"
+
+
+def test_write_back_refuses_when_one_of_the_rows_names_another_identity(tmp_path):
+    svc, db_path = _two_rows(tmp_path, [
+        ("1", "Rone", None),
+        ("2", "Rone", "mbid-rone-us"),
+    ])
+
+    svc._persist_artist_identity("Rone", "mbid-rone-fr", ["Erwan Castex"])
+
+    assert _stored(db_path, "1") == (None, [])
+    assert _stored(db_path, "2")[0] == "mbid-rone-us"
+
+
+def test_write_back_reaches_every_row_the_name_addresses(tmp_path):
+    svc, db_path = _two_rows(tmp_path, [
+        ("1", "Sawano Hiroyuki", None),
+        ("2", "Sawano Hiroyuki", None),
+    ])
+
+    svc._persist_artist_identity("Sawano Hiroyuki", "mbid-sawano", ["澤野弘之"])
+
+    assert _stored(db_path, "1") == ("mbid-sawano", ["澤野弘之"])
+    assert _stored(db_path, "2") == ("mbid-sawano", ["澤野弘之"])
+
+
+def test_a_non_numeric_artist_id_is_written_not_dropped(tmp_path):
+    """A migrated library keys artists by the media server's id — a GUID on
+    Jellyfin. int() raised there, the caller swallowed it as a best-effort
+    failure, and the deterministic identity tier silently never arrived."""
+    svc, db_path = _two_rows(tmp_path, [
+        ("a1b2c3d4-e5f6-7890-abcd-ef1234567890", "Sawano Hiroyuki", None),
+    ])
+
+    svc._persist_artist_identity("Sawano Hiroyuki", "mbid-sawano", ["澤野弘之"])
+
+    assert _stored(db_path, "a1b2c3d4-e5f6-7890-abcd-ef1234567890") == (
+        "mbid-sawano", ["澤野弘之"])

--- a/tests/matching/test_alias_lookup_resilience.py
+++ b/tests/matching/test_alias_lookup_resilience.py
@@ -1,7 +1,7 @@
 """Alias lookup: a failure is not an answer, and an answer must be kept.
 
-The first of two defects behind the production "Wrong download" findings for
-`Sawano Hiroyuki` / `澤野弘之`, in `lookup_artist_aliases`:
+Two defects behind the production "Wrong download" findings for
+`Sawano Hiroyuki` / `澤野弘之`, both in `lookup_artist_aliases`:
 
 1. **A lookup failure was cached as "this artist has no aliases".**
    `_search_and_score_artists` returns an empty list for *any* exception —
@@ -12,8 +12,12 @@ The first of two defects behind the production "Wrong download" findings for
    poison the only bridge between a romaji and a kanji spelling. The user's
    database contains such a row (`Hiroyuki Sawano`, confidence 0).
 
-The second half of the pair — writing a successful lookup back onto the
-artist row instead of only into a name-keyed cache — is the next commit.
+2. **A successful lookup was never written back to the catalogue.** The
+   resolved MBID and alias list went into `musicbrainz_cache` keyed by the
+   *name string* the caller happened to pass, and nowhere else — so the
+   knowledge that let a download pass was not attached to the artist, did
+   not survive the cache TTL, and was invisible to any later lookup that
+   spelled the name differently.
 """
 
 from __future__ import annotations
@@ -39,6 +43,8 @@ def service():
     svc.get_artist_aliases = MagicMock(return_value=[])
     svc._check_cache = MagicMock(return_value=None)
     svc._save_to_cache = MagicMock()
+    svc._persist_artist_identity = MagicMock()
+    svc._artist_row_mbid = MagicMock(return_value=None)
     return svc
 
 
@@ -130,3 +136,273 @@ def test_a_fetch_that_did_not_come_back_is_never_written_down(service):
 
     assert service.lookup_artist_aliases("Sawano Hiroyuki") == []
     service._save_to_cache.assert_not_called()
+
+
+# --- 2. a successful lookup is written back onto the catalogue -------------
+
+
+def test_successful_lookup_is_persisted_to_the_catalogue(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    service.resolve_artist_aliases = MagicMock(
+        return_value=["澤野弘之", "Sawano, Hiroyuki"])
+
+    aliases = service.lookup_artist_aliases("Sawano Hiroyuki")
+
+    assert "澤野弘之" in aliases
+    service._persist_artist_identity.assert_called_once_with(
+        "Sawano Hiroyuki", "mbid-sawano", ["澤野弘之", "Sawano, Hiroyuki"])
+
+
+def test_populated_aliases_short_circuit_before_any_write_back(service):
+    # Tier 1 answered, so no search, no cache write and no write-back: an
+    # alias list already on the artist is authoritative and left alone.
+    service.get_artist_aliases.return_value = ["澤野弘之", "Sawano, Hiroyuki"]
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == [
+        "澤野弘之", "Sawano, Hiroyuki"]
+    service.mb_client.search_artist.assert_not_called()
+    service._persist_artist_identity.assert_not_called()
+    service._save_to_cache.assert_not_called()
+
+
+def test_write_back_failure_never_costs_the_caller_its_aliases(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "Sawano Hiroyuki", "score": 100},
+    ]
+    service.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+    service._persist_artist_identity.side_effect = RuntimeError("db is locked")
+
+    assert service.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+
+
+# --- the write-back must not put one artist's aliases on another ------------
+
+
+_ARTISTS_DDL = """
+CREATE TABLE artists (
+    id INTEGER PRIMARY KEY,
+    name TEXT NOT NULL,
+    musicbrainz_id TEXT,
+    musicbrainz_match_status TEXT,
+    musicbrainz_last_attempted TIMESTAMP,
+    aliases TEXT,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
+
+def _artist_row_service(tmp_path, name, mbid=None, aliases=None):
+    """A real `artists` table with one artist, so the write-back's guards run
+    against actual rows rather than mocks."""
+    import json
+    import sqlite3
+
+    db_path = tmp_path / "aliases.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(_ARTISTS_DDL)
+    conn.execute(
+        "INSERT INTO artists (id, name, musicbrainz_id, aliases) "
+        "VALUES (1, ?, ?, ?)",
+        (name, mbid, json.dumps(aliases) if aliases else None),
+    )
+    # A second artist that already owns the MBID our name search resolves to.
+    conn.execute(
+        "INSERT INTO artists (id, name, musicbrainz_id) "
+        "VALUES (2, 'Someone Else', 'mbid-taken')")
+    conn.commit()
+    conn.close()
+
+    class _DB:
+        def _get_connection(self):
+            c = sqlite3.connect(str(db_path))
+            c.row_factory = sqlite3.Row
+            return c
+
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.db = _DB()
+    return svc, db_path
+
+
+def _stored(db_path, artist_id):
+    """``(musicbrainz_id, aliases)`` with the alias column decoded."""
+    import json
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    mbid, aliases = conn.execute(
+        "SELECT musicbrainz_id, aliases FROM artists WHERE id=?",
+        (artist_id,)).fetchone()
+    conn.close()
+    return mbid, json.loads(aliases) if aliases else []
+
+
+def test_write_back_stores_identity_on_an_unmatched_artist(tmp_path):
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki")
+
+    svc._persist_artist_identity("Sawano Hiroyuki", "mbid-sawano", ["澤野弘之"])
+
+    mbid, aliases = _stored(db_path, 1)
+    assert mbid == "mbid-sawano"
+    assert aliases == ["澤野弘之"]
+
+
+def test_a_conflicting_mbid_writes_neither_id_nor_its_aliases(tmp_path):
+    # 'mbid-taken' belongs to another artist, so the name search landed on the
+    # wrong entity — and its alias list is just as wrong as its id.
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki")
+
+    svc._persist_artist_identity("Sawano Hiroyuki", "mbid-taken", ["Someone Else"])
+
+    assert _stored(db_path, 1) == (None, [])
+
+
+def test_an_artist_matched_to_a_different_mbid_keeps_its_own_aliases(tmp_path):
+    svc, db_path = _artist_row_service(
+        tmp_path, "Sawano Hiroyuki", mbid="mbid-already-set",
+        aliases=["澤野弘之"])
+
+    svc._persist_artist_identity("Sawano Hiroyuki", "mbid-other", ["Wrong Person"])
+
+    mbid, aliases = _stored(db_path, 1)
+    assert mbid == "mbid-already-set"
+    assert aliases == ["澤野弘之"]
+
+
+def test_the_same_mbid_refreshes_the_alias_list(tmp_path):
+    svc, db_path = _artist_row_service(
+        tmp_path, "Sawano Hiroyuki", mbid="mbid-sawano", aliases=["澤野弘之"])
+
+    svc._persist_artist_identity(
+        "Sawano Hiroyuki", "mbid-sawano", ["澤野弘之", "さわの ひろゆき"])
+
+    _mbid, aliases = _stored(db_path, 1)
+    assert aliases == ["澤野弘之", "さわの ひろゆき"]
+
+
+# --- the artist's own MBID beats guessing by name --------------------------
+
+
+def test_a_known_mbid_is_used_instead_of_searching_by_name(tmp_path):
+    """`Sawano Hiroyuki` is the case the trust gate was already documented as
+    losing: MusicBrainz has several entities matching that string, so the name
+    search either picks a decoy or refuses as ambiguous. None of that guessing
+    is necessary once the catalogue row carries the artist's MBID — the aliases
+    can be fetched from the identity we already know."""
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                       mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+    svc.resolve_artist_aliases.assert_called_once_with("mbid-sawano")
+    svc.mb_client.search_artist.assert_not_called()
+
+
+def test_the_mbid_fetch_persists_so_the_next_lookup_is_free(tmp_path):
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                       mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    svc.lookup_artist_aliases("Sawano Hiroyuki")
+
+    _mbid, aliases = _stored(db_path, 1)
+    assert aliases == ["澤野弘之"]
+
+
+def test_a_fetch_for_the_row_mbid_that_failed_falls_through_to_the_name_search(tmp_path):
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                       mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.mb_client.search_artist.return_value = [
+        {"id": "mbid-other", "name": "Sawano Hiroyuki", "score": 100}]
+    svc._calculate_similarity = _simple_sim
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.resolve_artist_aliases = MagicMock(side_effect=[None, ["from-search"]])
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == ["from-search"]
+    svc.mb_client.search_artist.assert_called()
+
+
+def test_the_row_mbid_answering_none_is_an_answer_not_a_reason_to_guess(tmp_path):
+    """MusicBrainz listing no alias for the artist's OWN identity settles it.
+
+    Falling through to the name search here would be guessing about an artist
+    we have already identified — which is how a decoy entity's aliases got
+    attached to the wrong artist in the first place.
+    """
+    svc, _db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                        mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.resolve_artist_aliases = MagicMock(return_value=[])
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == []
+    svc.mb_client.search_artist.assert_not_called()
+
+
+def test_a_cache_row_for_the_same_mbid_spares_the_fetch(tmp_path):
+    """One rate-limited MusicBrainz call per scanned file, removed.
+
+    Tier 1b sits in front of the cache, so without this an artist MusicBrainz
+    lists no alias for would cost a blocking request on every single
+    comparison — all of it queued behind the enrichment worker on the same
+    one-per-second lock.
+    """
+    svc, _db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                        mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._save_to_cache = MagicMock()
+    svc._check_cache = MagicMock(return_value={
+        "musicbrainz_id": "mbid-sawano", "confidence": 100,
+        "metadata": {"aliases": [], "resolved": True},
+    })
+    svc.resolve_artist_aliases = MagicMock()
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == []
+    svc.resolve_artist_aliases.assert_not_called()
+    svc.mb_client.search_artist.assert_not_called()
+
+
+def test_a_cache_row_for_a_different_mbid_does_not_answer_for_this_one(tmp_path):
+    svc, _db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki",
+                                        mbid="mbid-sawano")
+    svc.mb_client = MagicMock()
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._save_to_cache = MagicMock()
+    svc._check_cache = MagicMock(return_value={
+        "musicbrainz_id": "mbid-decoy", "confidence": 100,
+        "metadata": {"aliases": [], "resolved": True},
+    })
+    svc.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+    svc.resolve_artist_aliases.assert_called_once_with("mbid-sawano")
+
+
+def test_no_mbid_on_the_row_still_searches_by_name(tmp_path):
+    svc, db_path = _artist_row_service(tmp_path, "Sawano Hiroyuki")
+    svc.mb_client = MagicMock()
+    svc.mb_client.search_artist.return_value = [
+        {"id": "mbid-found", "name": "Sawano Hiroyuki", "score": 100}]
+    svc._calculate_similarity = _simple_sim
+    svc.get_artist_aliases = MagicMock(return_value=[])
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.resolve_artist_aliases = MagicMock(return_value=["澤野弘之"])
+
+    assert svc.lookup_artist_aliases("Sawano Hiroyuki") == ["澤野弘之"]
+    svc.mb_client.search_artist.assert_called()

--- a/tests/matching/test_artist_alias_lookup_586.py
+++ b/tests/matching/test_artist_alias_lookup_586.py
@@ -112,7 +112,7 @@ def test_fetch_aliases_returns_empty_on_exception(service):
 def test_lookup_falls_back_to_non_strict_when_strict_returns_nothing(service):
     # Strict search returns nothing (typical cross-script case).
     # Non-strict hits the alias index and finds the artist.
-    def search(name, limit, strict):
+    def search(name, limit, strict, **_kw):
         if strict:
             return []
         return [{'id': 'mbid-yab', 'name': 'Дмитрий Яблонский', 'score': 100}]
@@ -135,7 +135,7 @@ def test_lookup_falls_back_to_non_strict_when_strict_returns_nothing(service):
 def test_lookup_falls_back_to_non_strict_when_strict_score_too_low(service):
     # Strict returns a low-confidence match (cross-script — local sim
     # near 0). Non-strict hits a stronger match via alias index.
-    def search(name, limit, strict):
+    def search(name, limit, strict, **_kw):
         if strict:
             return [{'id': 'mbid-other', 'name': 'Some Other Artist', 'score': 30}]
         return [{'id': 'mbid-yab', 'name': 'Дмитрий Яблонский', 'score': 100}]
@@ -244,7 +244,7 @@ def test_yablonsky_reporter_scenario_end_to_end(service):
     'Русская филармония, Дмитрий Яблонский', MB returns artist with
     canonical name in Cyrillic and Latin in aliases. Strict search
     finds nothing; non-strict finds the artist with high MB score."""
-    def search(name, limit, strict):
+    def search(name, limit, strict, **_kw):
         if strict:
             return []
         return [{'id': 'mbid-yab', 'name': 'Дмитрий Яблонский', 'score': 100}]

--- a/tests/matching/test_artist_alias_service.py
+++ b/tests/matching/test_artist_alias_service.py
@@ -168,7 +168,7 @@ class TestFetchArtistAliases:
         service.mb_client.get_artist.return_value = {'aliases': []}
         service.fetch_artist_aliases('mbid-x')
         service.mb_client.get_artist.assert_called_once_with(
-            'mbid-x', includes=['aliases'],
+            'mbid-x', includes=['aliases'], raise_on_error=True,
         )
 
 
@@ -446,7 +446,7 @@ class TestLookupArtistAliasesMultiTier:
         assert '澤野弘之' in aliases
         service.mb_client.search_artist.assert_called_once()
         service.mb_client.get_artist.assert_called_once_with(
-            'mb-sawano', includes=['aliases'],
+            'mb-sawano', includes=['aliases'], raise_on_error=True,
         )
 
     def test_tier2_cache_hit_skips_live_lookup(self, service, temp_db):

--- a/tests/matching/test_cross_script_evidence.py
+++ b/tests/matching/test_cross_script_evidence.py
@@ -1,0 +1,193 @@
+"""A similarity score across two writing systems is not evidence.
+
+Real findings from the user's production library (2026-08-25), both on the
+same album, both reported as "Wrong download" by the AcoustID scan while the
+download-time check had passed the very same files:
+
+    Wrong download: "Apetitan" is actually "APETITAN"
+    Expected "Apetitan" by Sawano Hiroyuki, but audio fingerprint matches
+    "APETITAN" by 澤野弘之 (fingerprint: 100%, title 100%, artist 0%)
+
+    Wrong download: "You See Big Girl / T:T" is actually "YouSeeBIGGIRL/T:T"
+    (fingerprint: 100%, title 92%, artist 0%)
+
+`artist_sim` is 0.00 there because romaji and kanji cannot be string-compared,
+not because the artist is wrong — yet `evaluate` read "below
+CLEAR_MISMATCH_THRESHOLD" as "clear wrong song". The rule these tests pin is
+the general one: a dimension whose two sides are written in different scripts
+is UNKNOWN, never FAILED, so it can never be the evidence a FAIL rests on.
+Applies to Cyrillic / Greek / Hangul / Arabic exactly as it does to Japanese,
+and to titles exactly as it does to artists.
+"""
+
+from core.matching.audio_verification import Decision, evaluate
+
+
+def _rec(title, artist, score=1.0):
+    return {"title": title, "artist": artist, "score": score, "mbid": "mb-1"}
+
+
+# --- the two production findings -------------------------------------------
+
+
+def test_kanji_artist_with_matching_title_is_not_a_wrong_download():
+    out = evaluate(
+        "Apetitan", "Sawano Hiroyuki",
+        [_rec("APETITAN", "澤野弘之")],
+        fingerprint_score=1.0,
+        aliases_provider=None,          # alias bridge unavailable, as in prod
+    )
+    assert out.decision is not Decision.FAIL
+    assert out.artist_sim == 0.0        # still reported honestly
+
+
+def test_kanji_artist_with_near_matching_title_is_not_a_wrong_download():
+    out = evaluate(
+        "You See Big Girl / T:T", "Sawano Hiroyuki",
+        [_rec("YouSeeBIGGIRL/T:T", "澤野弘之")],
+        fingerprint_score=1.0,
+        aliases_provider=None,
+    )
+    assert out.decision is not Decision.FAIL
+
+
+# --- the same rule, other scripts ------------------------------------------
+
+
+def test_cyrillic_artist_with_matching_title_is_not_a_wrong_download():
+    out = evaluate(
+        "Nocturne", "Dmitry Yablonsky",
+        [_rec("Nocturne", "Дмитрий Яблонский")],
+        fingerprint_score=0.88,
+        aliases_provider=None,
+    )
+    assert out.decision is not Decision.FAIL
+
+
+def test_hangul_artist_with_matching_title_is_not_a_wrong_download():
+    out = evaluate(
+        "Spring Day", "BTS",
+        [_rec("Spring Day", "방탄소년단")],
+        fingerprint_score=0.86,
+        aliases_provider=None,
+    )
+    assert out.decision is not Decision.FAIL
+
+
+# --- cross-script TITLE, artist agrees -------------------------------------
+#
+# The old code only rescued this above a fingerprint of 0.95, so an ordinary
+# 0.90 match on a Japanese-titled track was quarantined. The script signal
+# says the title is incomparable regardless of how the fingerprint scored.
+
+
+def test_kanji_title_with_matching_artist_is_not_a_wrong_download():
+    out = evaluate(
+        "Zankoku na Tenshi no Thesis", "Yoko Takahashi",
+        [_rec("残酷な天使のテーゼ", "Yoko Takahashi", score=0.90)],
+        fingerprint_score=0.90,
+        aliases_provider=None,
+    )
+    assert out.decision is not Decision.FAIL
+
+
+def test_both_sides_cross_script_is_not_a_wrong_download():
+    out = evaluate(
+        "Zankoku na Tenshi no Thesis", "Yoko Takahashi",
+        [_rec("残酷な天使のテーゼ", "高橋洋子", score=0.90)],
+        fingerprint_score=0.90,
+        aliases_provider=None,
+    )
+    assert out.decision is not Decision.FAIL
+
+
+# --- and it must NOT blunt a real mismatch ---------------------------------
+
+
+def test_same_script_wrong_artist_still_fails():
+    out = evaluate(
+        "Apetitan", "Sawano Hiroyuki",
+        [_rec("Apetitan", "Taylor Swift")],
+        fingerprint_score=1.0,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.FAIL
+
+
+def test_same_script_wrong_song_still_fails():
+    out = evaluate(
+        "Barricades", "Sawano Hiroyuki",
+        [_rec("Wanna Be Startin' Somethin'", "Michael Jackson")],
+        fingerprint_score=1.0,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.FAIL
+
+
+def test_two_different_kanji_artists_still_fail():
+    # Both sides non-Latin: same script class, so the comparison IS meaningful
+    # and a disagreement is real evidence.
+    out = evaluate(
+        "残酷な天使のテーゼ", "澤野弘之",
+        [_rec("残酷な天使のテーゼ", "米津玄師")],
+        fingerprint_score=1.0,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.FAIL
+
+
+def test_cross_script_artist_but_genuinely_different_song_still_fails():
+    # Artist incomparable, but the title IS comparable and disagrees — one
+    # comparable dimension in disagreement is enough to fail.
+    out = evaluate(
+        "Barricades", "Sawano Hiroyuki",
+        [_rec("Wanna Be Startin' Somethin'", "澤野弘之")],
+        fingerprint_score=1.0,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.FAIL
+
+
+# --- the accepted cost of the rule above -----------------------------------
+
+
+def test_a_wrong_download_in_another_script_is_knowingly_unreportable():
+    """The blind spot, pinned so nobody "fixes" it by accident.
+
+    Both dimensions are unreadable, so nothing disagrees and nothing agrees —
+    and a Latin expectation against a Japanese recording looks identical whether
+    it is the same song or a completely different one. A fingerprint bar was
+    tried here and reverted: the score is not evidence about the NAMES, so all
+    it does is quarantine the correct files in the test above. Closing this
+    needs a signal that actually distinguishes the two — a duration or an MBID
+    the import already recorded — not a stricter reading of a silence.
+    """
+    out = evaluate(
+        "Blinding Lights", "The Weeknd",
+        [_rec("残酷な天使のテーゼ", "高橋洋子")],
+        fingerprint_score=0.90,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.SKIP
+
+
+def test_an_agreeing_artist_corroborates_an_unreadable_title():
+    """One comparable dimension that AGREES is evidence; two silences are not."""
+    out = evaluate(
+        "Zankoku na Tenshi no These", "Yoko Takahashi",
+        [_rec("残酷な天使のテーゼ", "Yoko Takahashi")],
+        fingerprint_score=0.82,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.SKIP
+
+
+def test_a_readable_artist_that_disagrees_is_still_a_wrong_download():
+    """The rule only ever protects UNREADABLE dimensions."""
+    out = evaluate(
+        "Zankoku na Tenshi no These", "Yoko Takahashi",
+        [_rec("残酷な天使のテーゼ", "Metallica")],
+        fingerprint_score=0.90,
+        aliases_provider=None,
+    )
+    assert out.decision is Decision.FAIL

--- a/tests/matching/test_match_artist_cross_script.py
+++ b/tests/matching/test_match_artist_cross_script.py
@@ -90,7 +90,7 @@ def test_a_lukewarm_cross_script_candidate_is_refused(service):
 
 
 def test_the_alias_index_is_consulted_when_a_strict_search_finds_nothing(service):
-    def _search(name, limit=5, strict=True):
+    def _search(name, limit=5, strict=True, **_kw):
         return [] if strict else [
             {"id": "mbid-sawano", "name": "澤野弘之", "score": 100}]
 
@@ -165,3 +165,46 @@ def test_the_rescue_still_speaks_when_no_name_clears_the_gate():
 
     assert out is not None
     assert out["mbid"] == "mbid-cross"
+
+
+# --- when two candidates both hold something we own ------------------------
+
+
+def test_two_tied_cross_script_candidates_are_refused_rather_than_ordered(service):
+    """Result ORDER must not be the tie-break.
+
+    Both candidates are written in another script, so the ranking above is
+    decided almost entirely by MusicBrainz's name relevance — the one signal
+    this branch exists precisely because it cannot use. And an album title as
+    ordinary as "Home" overlaps several catalogues. Taking the first hit would
+    write a coin flip onto the artist row, where it then feeds the alias
+    bridge for every later verification.
+    """
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-first", "name": "米津玄師", "score": 98},
+        {"id": "mbid-second", "name": "澤野弘之", "score": 97},
+    ]
+    _catalogue(service, {"mbid-first": ["Home"], "mbid-second": ["Home"]})
+
+    assert service.match_artist("Sawano Hiroyuki", owned_titles=["Home"]) is None
+    service._save_to_cache.assert_called_once()   # the "no match" row, not a pick
+    assert service._save_to_cache.call_args.args[3] is None
+
+
+def test_the_candidate_with_more_owned_albums_wins_regardless_of_order(service):
+    """A decisive winner is still taken — and it is not the one MusicBrainz
+    happened to rank first."""
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-decoy", "name": "米津玄師", "score": 99},
+        {"id": "mbid-sawano", "name": "澤野弘之", "score": 95},
+    ]
+    owned = OWNED + ["Kill la Kill Original Soundtrack"]
+    _catalogue(service, {
+        "mbid-decoy": [OWNED[0]],
+        "mbid-sawano": owned,
+    })
+
+    out = service.match_artist("Sawano Hiroyuki", owned_titles=owned)
+
+    assert out is not None
+    assert out["mbid"] == "mbid-sawano"

--- a/tests/matching/test_match_artist_cross_script.py
+++ b/tests/matching/test_match_artist_cross_script.py
@@ -1,0 +1,167 @@
+"""Automatic MusicBrainz artist matching has to reach a cross-script artist.
+
+Manual matching should be the exception, so the worker has to be able to land
+`Sawano Hiroyuki` on `澤野弘之` by itself. Today it structurally cannot, for two
+reasons that compound:
+
+1. ``match_artist`` searches strict-only. A strict query hits the ``artist``
+   field alone and skips MusicBrainz's alias and sortname indexes, which is
+   where a romanised spelling of a natively-scripted artist lives. Issue #586
+   fixed this in ``lookup_artist_aliases`` and never came back for this one.
+
+2. Its confidence is ``similarity * 60 + mb_score * 0.4``. Across scripts the
+   similarity is 0.0 by construction, so the ceiling is 40 against a gate of
+   70 — unreachable no matter how certain MusicBrainz is.
+
+And the signal that *would* settle it is already computed here and thrown away:
+the overlap between the albums the user owns and the candidate's release
+groups. Album titles survive a script difference far better than names, and an
+entity whose catalogue contains records this library holds is not a different
+person. It was only ever consulted to disambiguate candidates that had already
+passed the name gate — never for the case where the name is worthless.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.musicbrainz_service import MusicBrainzService
+
+OWNED = ['TV Anime "Attack on Titan Season 2" (Original Soundtrack)']
+
+
+@pytest.fixture
+def service():
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.mb_client = MagicMock()
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    return svc
+
+
+def _catalogue(svc, titles_by_mbid):
+    svc._candidate_release_titles = lambda mbid: titles_by_mbid.get(mbid, [])
+
+
+def test_a_cross_script_artist_is_matched_on_its_catalogue(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "澤野弘之", "score": 100},
+    ]
+    _catalogue(service, {"mbid-sawano": OWNED})
+
+    out = service.match_artist("Sawano Hiroyuki", owned_titles=OWNED)
+
+    assert out is not None
+    assert out["mbid"] == "mbid-sawano"
+
+
+def test_a_cross_script_candidate_without_catalogue_overlap_is_refused(service):
+    # MusicBrainz is confident about the name, but nothing this library owns
+    # is in that entity's catalogue — so there is no evidence it is the same
+    # artist, and inventing one would smear an id onto the wrong row.
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-someone", "name": "米津玄師", "score": 100},
+    ]
+    _catalogue(service, {"mbid-someone": ["Some Other Album"]})
+
+    assert service.match_artist("Sawano Hiroyuki", owned_titles=OWNED) is None
+
+
+def test_a_cross_script_candidate_is_refused_when_we_own_nothing_yet(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "澤野弘之", "score": 100},
+    ]
+    _catalogue(service, {"mbid-sawano": OWNED})
+
+    assert service.match_artist("Sawano Hiroyuki", owned_titles=[]) is None
+
+
+def test_a_lukewarm_cross_script_candidate_is_refused(service):
+    # MusicBrainz itself is unsure; catalogue overlap alone is not enough to
+    # override that.
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-sawano", "name": "澤野弘之", "score": 55},
+    ]
+    _catalogue(service, {"mbid-sawano": OWNED})
+
+    assert service.match_artist("Sawano Hiroyuki", owned_titles=OWNED) is None
+
+
+def test_the_alias_index_is_consulted_when_a_strict_search_finds_nothing(service):
+    def _search(name, limit=5, strict=True):
+        return [] if strict else [
+            {"id": "mbid-sawano", "name": "澤野弘之", "score": 100}]
+
+    service.mb_client.search_artist.side_effect = _search
+    _catalogue(service, {"mbid-sawano": OWNED})
+
+    out = service.match_artist("Sawano Hiroyuki", owned_titles=OWNED)
+
+    assert out is not None and out["mbid"] == "mbid-sawano"
+
+
+def test_a_same_script_match_is_unchanged(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-mj", "name": "Michael Jackson", "score": 100},
+    ]
+    _catalogue(service, {"mbid-mj": ["Thriller"]})
+
+    out = service.match_artist("Michael Jackson", owned_titles=["Thriller"])
+
+    assert out is not None
+    assert out["mbid"] == "mbid-mj"
+    assert out["confidence"] >= 70
+
+
+def test_a_same_script_near_miss_is_still_refused(service):
+    service.mb_client.search_artist.return_value = [
+        {"id": "mbid-grant", "name": "Amy Grant", "score": 60},
+    ]
+    _catalogue(service, {"mbid-grant": ["Heart in Motion"]})
+
+    assert service.match_artist("Grant", owned_titles=["Heart in Motion"]) is None
+
+
+def test_a_shared_album_title_does_not_outrank_a_same_script_name_match():
+    """The cross-script rescue is a fallback, never a preemption.
+
+    Ahead of the name gate it returned the FIRST cross-script candidate with one
+    overlapping album — worth 80 by its own formula — before a same-script
+    candidate scoring 95 was ever considered. One shared title is a low bar:
+    "Home", "Anthology", a soundtrack two artists both appear on. And the id it
+    picked did not just answer this call, it was written onto the artist row and
+    fed the alias bridge from then on.
+    """
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.mb_client = MagicMock()
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.mb_client.search_artist.return_value = [
+        {"id": "mbid-right", "name": "Sawano Hiroyuki", "score": 95},
+        {"id": "mbid-cross", "name": "澤野弘之", "score": 100},
+    ]
+    _catalogue(svc, {"mbid-right": OWNED, "mbid-cross": OWNED})
+
+    out = svc.match_artist("Sawano Hiroyuki", owned_titles=OWNED)
+
+    assert out is not None
+    assert out["mbid"] == "mbid-right"
+
+
+def test_the_rescue_still_speaks_when_no_name_clears_the_gate():
+    svc = MusicBrainzService.__new__(MusicBrainzService)
+    svc.mb_client = MagicMock()
+    svc._check_cache = MagicMock(return_value=None)
+    svc._save_to_cache = MagicMock()
+    svc.mb_client.search_artist.return_value = [
+        {"id": "mbid-noise", "name": "Somebody Else", "score": 40},
+        {"id": "mbid-cross", "name": "澤野弘之", "score": 100},
+    ]
+    _catalogue(svc, {"mbid-noise": [], "mbid-cross": OWNED})
+
+    out = svc.match_artist("Sawano Hiroyuki", owned_titles=OWNED)
+
+    assert out is not None
+    assert out["mbid"] == "mbid-cross"

--- a/tests/test_acoustid_ambiguous_fingerprint.py
+++ b/tests/test_acoustid_ambiguous_fingerprint.py
@@ -320,7 +320,7 @@ def test_the_scanner_imports_and_uses_the_guard():
     from core.repair_jobs import acoustid_scanner
 
     src = inspect.getsource(acoustid_scanner.AcoustIDScannerJob._scan_file)
-    assert "fingerprint_is_ambiguous(fp_result['recordings'])" in src, (
+    assert "fingerprint_is_ambiguous(recordings)" in src, (
         "the ambiguity guard is no longer consulted before creating a finding")
     # It must run BEFORE the finding is built, not after.
     assert src.index("fingerprint_is_ambiguous") < src.index("create_finding")

--- a/tests/test_acoustid_one_pipeline.py
+++ b/tests/test_acoustid_one_pipeline.py
@@ -1,0 +1,174 @@
+"""Download and scan are one pipeline, and this is what says so.
+
+The requirement, stated plainly: the same file with the same expected metadata
+must get the same verdict whether it came through the download or through the
+library scan. That was true of the final decision — both called
+``audio_verification.evaluate`` — and false of everything leading up to it. The
+scan had its own copy of the availability check, the lookup, the confidence
+floor and the alias wiring, and it never enriched title-less recordings from
+MusicBrainz the way the download did. Five steps of drift around one shared
+conclusion.
+
+The scan now calls ``AcoustIDVerification.verify_audio_file`` — the download's
+entry point. Two things legitimately differ and always will: where the expected
+title and artist come from (the download has a provider payload, the scan has a
+catalogue row) and what each side does with the verdict (quarantine and retry
+vs. persist and file a finding). Everything between those two ends is one path,
+and this test walks both ends of it over the same inputs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.acoustid_verification import AcoustIDVerification, VerificationResult
+from core.repair_jobs.acoustid_scanner import AcoustIDScannerJob
+from core.repair_jobs.base import JobResult
+
+# (label, expected title, expected artist, fingerprinted title, artist, score)
+CASES = [
+    ("exact match", "Apetitan", "Sawano Hiroyuki", "APETITAN", "Sawano Hiroyuki", 1.0),
+    ("cross-script artist", "Apetitan", "Sawano Hiroyuki", "APETITAN", "澤野弘之", 1.0),
+    ("cross-script title", "Zankoku na Tenshi no Thesis", "Yoko Takahashi",
+     "残酷な天使のテーゼ", "Yoko Takahashi", 0.90),
+    ("both cross-script", "Zankoku na Tenshi no Thesis", "Yoko Takahashi",
+     "残酷な天使のテーゼ", "高橋洋子", 0.90),
+    ("genuinely wrong song", "Barricades", "Sawano Hiroyuki",
+     "Wanna Be Startin' Somethin'", "Michael Jackson", 1.0),
+    ("genuinely wrong artist", "Apetitan", "Sawano Hiroyuki", "Apetitan",
+     "Taylor Swift", 1.0),
+    ("fingerprint below the floor", "Apetitan", "Sawano Hiroyuki", "APETITAN",
+     "Sawano Hiroyuki", 0.40),
+    ("cover by another artist", "Hurt", "Johnny Cash", "Hurt", "Nine Inch Nails", 0.95),
+]
+
+
+def _client(title, artist, score):
+    return SimpleNamespace(
+        lookup_with_status=lambda _p: {
+            "status": "ok", "best_score": score, "recording_mbids": ["mb-1"],
+            "recordings": [{"mbid": "mb-1", "title": title, "artist": artist,
+                            "score": score}],
+        },
+    )
+
+
+def _download_verdict(client, title, artist):
+    verifier = AcoustIDVerification()
+    verifier.acoustid_client = client
+    probe: dict = {}
+    result, _msg = verifier.verify_audio_file("/x.flac", title, artist, probe)
+    return result, probe.get("_acoustid_decision")
+
+
+def _scan_verdict(monkeypatch, client, title, artist):
+    """Drive the scanner over one catalogue row carrying the same metadata.
+
+    The scan has no verdict column of its own on this branch, so its verdict is
+    read from what it DOES with one: an untagged file becomes 'verified' on a
+    PASS and 'unverified' on a SKIP, a FAIL raises a finding and moves nothing,
+    and a lookup that reached no judgement writes nothing at all.
+    """
+    persisted, findings = [], []
+    context = SimpleNamespace(
+        db=None, transfer_folder="/music",
+        config_manager=SimpleNamespace(get=lambda *a, **k: None,
+                                       set=lambda *a, **k: None),
+        acoustid_client=None,
+        create_finding=lambda **kw: findings.append(kw) or True,
+        report_progress=lambda **kw: None, update_progress=lambda *a, **k: None,
+        check_stop=lambda: False, wait_if_paused=lambda: False,
+        sleep_or_stop=lambda *a, **k: False,
+    )
+
+    job = AcoustIDScannerJob()
+    monkeypatch.setattr(job, "_resolve_path", lambda p, _c: p)
+    monkeypatch.setattr(job, "_persist_status",
+                        lambda *a, **kw: persisted.append(a[4]))
+    monkeypatch.setattr("core.tag_writer.read_file_tags", lambda _p: {})
+    job._scan_file("/music/track.flac", "42",
+                   {"title": title, "artist": artist, "track_artist": artist,
+                    "album_artist": artist},
+                   client, context, JobResult(), 0.80, 0.70, 0.60)
+
+    if findings:
+        return "fail"
+    if not persisted:
+        return None
+    return {"verified": "pass", "unverified": "skip"}.get(persisted[0], persisted[0])
+
+
+@pytest.mark.parametrize(
+    "label,title,artist,found_title,found_artist,score",
+    CASES, ids=[c[0] for c in CASES])
+def test_both_paths_reach_the_same_verdict(
+    monkeypatch, label, title, artist, found_title, found_artist, score,
+):
+    monkeypatch.setattr(
+        "core.acoustid_verification._resolve_expected_artist_aliases", lambda _n: [])
+    client = _client(found_title, found_artist, score)
+
+    download_result, download_outcome = _download_verdict(client, title, artist)
+    scan_status = _scan_verdict(monkeypatch, client, title, artist)
+
+    if download_outcome is None:
+        # The verifier never reached a judgement — the scan must not invent
+        # one, and above all must not write "unverified" off the back of it.
+        assert download_result == VerificationResult.SKIP
+        assert scan_status is None
+    else:
+        assert scan_status == download_outcome.decision.value, (
+            f"{label}: download said {download_outcome.decision.value}, "
+            f"scan said {scan_status}")
+
+
+def test_the_scanner_does_not_carry_its_own_verification_logic():
+    """A structural guard, because the drift came back the moment the two
+    halves could evolve apart. The scan may not call the decision core, resolve
+    aliases, gate on the fingerprint score or enrich recordings itself — all of
+    that belongs to the one entry point it now shares with the download."""
+    import inspect
+
+    from core.repair_jobs import acoustid_scanner
+
+    src = inspect.getsource(acoustid_scanner)
+    assert "verify_audio_file" in src
+    for owned_by_the_verifier in (
+        "evaluate(",
+        "_resolve_expected_artist_aliases",
+        "MIN_ACOUSTID_SCORE",
+        "_enrich_recordings_from_musicbrainz",
+    ):
+        assert owned_by_the_verifier not in src, (
+            f"{owned_by_the_verifier} is the verifier's job; the scan calling it "
+            f"is how the two paths drifted apart before"
+        )
+
+
+def test_an_unusable_client_stops_the_run_instead_of_flagging_the_library():
+    """`verify_audio_file` answers SKIP when AcoustID is not usable, and a SKIP
+    on an untagged file is 'unverified'. Without a check up front, a missing API
+    key would walk every file in the library into the review queue and report a
+    clean run."""
+    job = AcoustIDScannerJob()
+    scanned = []
+    context = SimpleNamespace(
+        db=None, transfer_folder="/music",
+        config_manager=SimpleNamespace(get=lambda key, default=None: default,
+                                       set=lambda *a, **k: None),
+        acoustid_client=SimpleNamespace(
+            is_available=lambda: (False, "no API key configured")),
+        create_finding=lambda **kw: True,
+        report_progress=lambda **kw: None, update_progress=lambda *a, **k: None,
+        check_stop=lambda: False, wait_if_paused=lambda: False,
+        sleep_or_stop=lambda *a, **k: False,
+    )
+    context.db = SimpleNamespace(_get_connection=lambda: scanned.append("db"))
+
+    result = job.scan(context)
+
+    assert result.errors == 1
+    assert result.scanned == 0
+    assert scanned == [], "the run must stop before it reads the catalogue"

--- a/tests/test_acoustid_scan_never_downgrades.py
+++ b/tests/test_acoustid_scan_never_downgrades.py
@@ -1,0 +1,179 @@
+"""A scan may not demote a file that already stands verified.
+
+Reported sequence for one file, in this order:
+
+    download            -> verified
+    scan (before fix)   -> Mismatch
+    scan (after fix)    -> unverified
+
+All three are the same defect seen from different angles. The scan reads the
+file's verification standing from the EMBEDDED TAG and writes its conclusion to
+the CATALOGUE COLUMN (`tracks.verification_status`). When the tag is missing —
+the import's tag write did not stick, the file was copied, a later retag
+dropped it — the scan sees an untagged file, and its "an untagged file a scan
+could not confirm becomes unverified" rule fires against a row the catalogue
+says is verified. The tag is then stamped with that same wrong answer.
+
+Before the cross-script fix this was unreachable for these files: the decision
+was FAIL, which leaves `verification_status` alone — the "Mismatch" of step
+two. Turning that FAIL into an honest SKIP is what walked the file into the
+latent downgrade, so the sequence reads as though the fix caused it.
+
+The rule: the tag and the column are two records of one fact, so either one
+saying "verified" is the file standing verified. A scan that cannot confirm
+adds nothing and must take nothing away.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from core.repair_jobs.acoustid_scanner import AcoustIDScannerJob
+from core.repair_jobs.base import JobResult
+from database.music_database import MusicDatabase
+
+
+class _Config:
+    def get(self, key, default=None):
+        return default
+
+    def set(self, *args, **kwargs):
+        pass
+
+
+class _Client:
+    """A fingerprint whose artist is credited in another script — the shape
+    that produces an honest SKIP rather than a confirmation."""
+
+    def fingerprint_and_lookup(self, path):
+        return {
+            "best_score": 1.0,
+            "recordings": [{"mbid": "mb-1", "title": "APETITAN",
+                            "artist": "澤野弘之", "score": 1.0}],
+        }
+
+
+class _ConfirmingClient:
+    """A fingerprint that agrees with the catalogue outright."""
+
+    def fingerprint_and_lookup(self, path):
+        return {
+            "best_score": 1.0,
+            "recordings": [{"mbid": "mb-1", "title": "Apetitan",
+                            "artist": "Sawano Hiroyuki", "score": 1.0}],
+        }
+
+
+@pytest.fixture
+def scan(tmp_path, monkeypatch):
+    """Run one file through the scanner and report what was persisted."""
+    counter = {"n": 0}
+
+    def _run(*, db_status, tag_status, client=None):
+        counter["n"] += 1
+        db = MusicDatabase(str(tmp_path / f"m{counter['n']}.db"))
+        path = tmp_path / "02 - Apetitan.flac"
+        path.write_bytes(b"audio")
+
+        with db._get_connection() as conn:
+            conn.execute("INSERT INTO artists (id, name) VALUES ('a1', 'Sawano Hiroyuki')")
+            conn.execute("INSERT INTO albums (id, title, artist_id) "
+                         "VALUES ('al1', 'AoT Season 2 OST', 'a1')")
+            conn.execute(
+                "INSERT INTO tracks (id, title, artist_id, album_id, file_path, "
+                "duration, verification_status) VALUES ('t1', 'Apetitan', 'a1', "
+                "'al1', ?, 331000, ?)",
+                (str(path), db_status))
+            conn.commit()
+
+        findings, tags_written = [], []
+        context = SimpleNamespace(
+            db=db, transfer_folder=str(tmp_path), config_manager=_Config(),
+            acoustid_client=None,
+            create_finding=lambda **kw: findings.append(kw) or True,
+            report_progress=lambda **kw: None,
+            update_progress=lambda *a, **kw: None,
+            check_stop=lambda: False, wait_if_paused=lambda: False,
+            sleep_or_stop=lambda *a, **kw: False,
+        )
+
+        monkeypatch.setattr(
+            "core.tag_writer.read_file_tags",
+            lambda _p: {"verification_status": tag_status} if tag_status else {})
+        monkeypatch.setattr(
+            "core.tag_writer.write_verification_status",
+            lambda _p, status: tags_written.append(status) or True)
+        # The scanner binds this at import time, so the patch has to land on
+        # ITS name — patching the source module would leave the real lookup
+        # (and a real database connection) in the path.
+        monkeypatch.setattr(
+            "core.repair_jobs.acoustid_scanner._resolve_expected_artist_aliases",
+            lambda _n: [])
+
+        job = AcoustIDScannerJob()
+        monkeypatch.setattr(job, "_resolve_path", lambda p, _c: p)
+        tracks = job._load_db_tracks(context)
+        job._scan_file(str(path), "t1", tracks["t1"], client or _Client(),
+                       context, JobResult(), 0.80, 0.70, 0.60)
+
+        with db._get_connection() as conn:
+            stored = conn.execute(
+                "SELECT verification_status FROM tracks WHERE id = 't1'").fetchone()[0]
+        return SimpleNamespace(status=stored, tags_written=tags_written,
+                               findings=findings)
+
+    return _run
+
+
+def test_an_inconclusive_scan_does_not_demote_a_verified_row(scan):
+    # The user's exact case: catalogue says verified, the tag is gone.
+    out = scan(db_status="verified", tag_status=None)
+
+    assert out.status == "verified"
+    assert "unverified" not in out.tags_written
+
+
+def test_the_missing_tag_is_healed_rather_than_overwritten(scan):
+    out = scan(db_status="verified", tag_status=None)
+
+    assert out.tags_written == ["verified"]
+
+
+def test_a_genuinely_unconfirmed_file_still_becomes_unverified(scan):
+    # Nothing has ever verified this one, so there is no standing to protect.
+    out = scan(db_status=None, tag_status=None)
+
+    assert out.status == "unverified"
+
+
+def test_a_human_decision_in_the_catalogue_is_respected_without_a_tag(scan):
+    out = scan(db_status="human_verified", tag_status=None)
+
+    assert out.status == "human_verified"
+    assert out.tags_written == []
+    assert out.findings == []
+
+
+def test_a_force_import_is_not_promoted_by_a_confirming_scan(scan):
+    out = scan(db_status="force_imported", tag_status=None,
+               client=_ConfirmingClient())
+
+    assert out.status == "force_imported"
+
+
+def test_an_unverified_row_is_still_promoted_by_a_confirming_scan(scan):
+    out = scan(db_status="unverified", tag_status=None,
+               client=_ConfirmingClient())
+
+    assert out.status == "verified"
+
+
+def test_the_tag_still_wins_when_the_catalogue_has_nothing(scan):
+    """The tag travels with the file, so it is authoritative on a row the
+    catalogue never recorded a standing for."""
+    out = scan(db_status=None, tag_status="verified")
+
+    assert out.status == "verified"
+    assert out.tags_written == []

--- a/tests/test_acoustid_scan_never_downgrades.py
+++ b/tests/test_acoustid_scan_never_downgrades.py
@@ -105,11 +105,11 @@ def scan(tmp_path, monkeypatch):
         monkeypatch.setattr(
             "core.tag_writer.write_verification_status",
             lambda _p, status: tags_written.append(status) or True)
-        # The scanner binds this at import time, so the patch has to land on
-        # ITS name — patching the source module would leave the real lookup
-        # (and a real database connection) in the path.
+        # Alias resolution lives inside the shared verifier, which is where
+        # the scan reaches it from — the real one would open a database
+        # connection and hit MusicBrainz.
         monkeypatch.setattr(
-            "core.repair_jobs.acoustid_scanner._resolve_expected_artist_aliases",
+            "core.acoustid_verification._resolve_expected_artist_aliases",
             lambda _n: [])
 
         job = AcoustIDScannerJob()

--- a/tests/test_acoustid_scanner.py
+++ b/tests/test_acoustid_scanner.py
@@ -1,6 +1,24 @@
 from types import SimpleNamespace
 
+import pytest
+
 from core.repair_jobs.acoustid_scanner import AcoustIDScannerJob
+
+
+@pytest.fixture(autouse=True)
+def _no_live_alias_lookup(monkeypatch):
+    """Keep the alias chain off the network and off the real library database.
+
+    `_resolve_expected_artist_aliases` builds a MusicBrainzService over
+    `get_database()` — the process-wide, CONFIGURED library database — and then
+    queries MusicBrainz over HTTP. Reached from a unit test that means a live
+    request and a schema migration against whatever database this machine is
+    pointed at. Tests that are about the alias bridge override this with the
+    list they mean.
+    """
+    monkeypatch.setattr(
+        "core.acoustid_verification._resolve_expected_artist_aliases",
+        lambda name: [])
 
 
 class _FakeCursor:
@@ -802,9 +820,11 @@ def test_scanner_does_not_flag_cross_script_when_alias_bridges(monkeypatch):
     unified verification core recognises the match, so the library scan must NOT
     create a false 'Wrong download' finding (it did before, stripping all
     non-ASCII and never consulting aliases)."""
-    import core.repair_jobs.acoustid_scanner as scanner_mod
-    monkeypatch.setattr(scanner_mod, "_resolve_expected_artist_aliases",
-                        lambda name: ["澤野弘之"], raising=False)
+    # Alias resolution lives in the shared verifier the scan routes through;
+    # the real one opens a database connection and calls MusicBrainz.
+    monkeypatch.setattr(
+        "core.acoustid_verification._resolve_expected_artist_aliases",
+        lambda name: ["澤野弘之"])
     job = AcoustIDScannerJob()
     captured = []
     context = _make_finding_capturing_context(
@@ -830,9 +850,6 @@ def test_scanner_does_not_flag_cross_script_when_alias_bridges(monkeypatch):
 def _force_imported_scan(monkeypatch):
     """Drive a scan over a force-imported file whose fingerprint clearly
     mismatches. Returns the captured findings."""
-    import core.repair_jobs.acoustid_scanner as scanner_mod
-    monkeypatch.setattr(scanner_mod, "_resolve_expected_artist_aliases",
-                        lambda name: [], raising=False)
     monkeypatch.setattr(
         'core.tag_writer.read_file_tags',
         lambda fpath: {'artist': None, 'verification_status': 'force_imported'},
@@ -871,9 +888,9 @@ def test_force_imported_mismatch_is_reported_as_informational(monkeypatch):
 
 
 def test_human_verified_files_are_never_scanned(monkeypatch):
-    import core.repair_jobs.acoustid_scanner as scanner_mod
-    monkeypatch.setattr(scanner_mod, "_resolve_expected_artist_aliases",
-                        lambda name: [], raising=False)
+    monkeypatch.setattr(
+        "core.acoustid_verification._resolve_expected_artist_aliases",
+        lambda name: [])
     monkeypatch.setattr('core.tag_writer.read_file_tags',
                         lambda fpath: {'artist': None, 'verification_status': 'human_verified'})
     job = AcoustIDScannerJob()
@@ -900,9 +917,6 @@ def _run_persistence_scan(monkeypatch, *, file_status, aid_artist, expected_arti
     """Drive one _scan_file call and return (status_updates, tag_writes) where
     status_updates is the list of (query, params) UPDATEs the scanner ran.
     ``lib_rows`` seeds the library_history match SELECT (#934)."""
-    import core.repair_jobs.acoustid_scanner as scanner_mod
-    monkeypatch.setattr(scanner_mod, "_resolve_expected_artist_aliases",
-                        lambda name: [], raising=False)
     monkeypatch.setattr(
         'core.tag_writer.read_file_tags',
         lambda fpath: {'artist': None, 'verification_status': file_status})

--- a/tests/test_acoustid_scanner.py
+++ b/tests/test_acoustid_scanner.py
@@ -59,11 +59,12 @@ def _make_context(rows):
 def test_load_db_tracks_skips_null_ids_and_normalizes_track_ids():
     job = AcoustIDScannerJob()
     context = _make_context([
-        # 12 columns: id, title, artist (COALESCE'd), file_path, track_number,
+        # 13 columns: id, title, artist (COALESCE'd), file_path, track_number,
         # album_title, album_thumb, artist_thumb, track_artist (raw, may be ''),
-        # album_artist, duration_ms (issue #587 — duration guard), artist_row_id.
-        (None, "Broken Track", "Artist", "/music/broken.flac", 1, "Album", None, None, "", "Artist", 180000, 7),
-        (42, "Good Track", "Artist", "/music/good.flac", 2, "Album", "album-thumb", "artist-thumb", "", "Artist", 240000, 7),
+        # album_artist, duration_ms (issue #587 — duration guard), artist_row_id,
+        # verification_status (the catalogue's record of the file's standing).
+        (None, "Broken Track", "Artist", "/music/broken.flac", 1, "Album", None, None, "", "Artist", 180000, 7, None),
+        (42, "Good Track", "Artist", "/music/good.flac", 2, "Album", "album-thumb", "artist-thumb", "", "Artist", 240000, 7, "verified"),
     ])
 
     tracks = job._load_db_tracks(context)
@@ -72,16 +73,17 @@ def test_load_db_tracks_skips_null_ids_and_normalizes_track_ids():
     assert tracks["42"]["title"] == "Good Track"
     assert tracks["42"]["artist"] == "Artist"
     assert tracks["42"]["duration_ms"] == 240000
+    assert tracks["42"]["db_verification_status"] == "verified"
 
 
 def test_scan_handles_mixed_track_id_types(monkeypatch):
     job = AcoustIDScannerJob()
     context = _make_context([
-        # 11 columns: id, title, artist (COALESCE'd), file_path, track_number,
+        # 13 columns: id, title, artist (COALESCE'd), file_path, track_number,
         # album_title, album_thumb, artist_thumb, track_artist (raw, may be ''),
-        # album_artist, duration_ms.
-        (None, "Broken Track", "Artist", "/music/broken.flac", 1, "Album", None, None, "", "Artist", 180000, 7),
-        (42, "Good Track", "Artist", "/music/good.flac", 2, "Album", "album-thumb", "artist-thumb", "", "Artist", 240000, 7),
+        # album_artist, duration_ms, artist_row_id, verification_status.
+        (None, "Broken Track", "Artist", "/music/broken.flac", 1, "Album", None, None, "", "Artist", 180000, 7, None),
+        (42, "Good Track", "Artist", "/music/good.flac", 2, "Album", "album-thumb", "artist-thumb", "", "Artist", 240000, 7, None),
     ])
 
     monkeypatch.setattr(job, "_resolve_path", lambda file_path, _context: file_path)
@@ -287,7 +289,8 @@ def _make_real_db_context(tmp_path):
             file_path TEXT,
             track_number INTEGER,
             track_artist TEXT,
-            duration INTEGER
+            duration INTEGER,
+            verification_status TEXT
         );
     """)
     conn.commit()

--- a/tests/test_acoustid_skip_logic.py
+++ b/tests/test_acoustid_skip_logic.py
@@ -153,20 +153,31 @@ def test_minor_punctuation_difference_passes_outright(verifier):
     assert result != VerificationResult.FAIL
 
 
-def test_low_fingerprint_score_never_skipped(verifier):
-    """Below the 0.95 confidence floor, the skip exemption should
-    never fire — even for plausibly-real language/script cases. We
-    don't have enough signal to be sure the audio matches."""
+def test_cross_script_title_below_the_old_floor_is_not_a_failure(verifier):
+    """A cross-script TITLE is unreadable at every fingerprint score.
+
+    This used to assert FAIL: the language/script exemption was gated on
+    ``best_score >= 0.95``, so an ordinary 0.90 match on a Japanese-titled
+    track was quarantined. That gate answered the wrong question — the
+    fingerprint's confidence says nothing about whether romaji and kanji can
+    be string-compared, and they cannot at any score. With the artist
+    agreeing and the title incomparable, nothing here is evidence the file is
+    wrong, so the verdict is SKIP (unconfirmed) rather than FAIL
+    (quarantine). The English-vs-English over-skip this module exists to
+    prevent is unaffected — see the Kendrick tests above and
+    ``test_high_score_but_artist_mismatch_no_longer_skipped`` below, which
+    both still FAIL.
+    """
     _stub_lookup(verifier, recordings=[
         {'title': '残酷な天使のテーゼ', 'artist': 'Yoko Takahashi'},
-    ], best_score=0.80)  # below 0.95 floor
+    ], best_score=0.80)
 
     result, _msg = verifier.verify_audio_file(
         '/fake/path.flac',
         'Zankoku na Tenshi no Theze',
         'Yoko Takahashi',
     )
-    assert result == VerificationResult.FAIL
+    assert result == VerificationResult.SKIP
 
 
 def test_high_score_but_artist_mismatch_no_longer_skipped(verifier):
@@ -185,13 +196,15 @@ def test_high_score_but_artist_mismatch_no_longer_skipped(verifier):
     assert result == VerificationResult.FAIL
 
 
-def test_low_fingerprint_score_never_skipped_same_script_artist(verifier):
-    """#797 guard — the #607 protection for a SAME-SCRIPT artist (Latin
-    'Yoko Takahashi' on both sides) with only a cross-script TITLE must
-    stay FAIL below the 0.95 floor. The #797 relaxation is keyed on the
-    ARTIST spanning scripts, which this case is NOT, so nothing changes
-    here. (Duplicates test_low_fingerprint_score_never_skipped's intent
-    explicitly against the new code path.)"""
+def test_cross_script_title_with_same_script_artist_is_not_a_failure(verifier):
+    """The #797 relaxation was keyed on the ARTIST spanning scripts, which
+    left the far more common shape unprotected: a Japanese TITLE under an
+    artist already written in Latin ('Yoko Takahashi', 'YOASOBI', 'Ado').
+    Then the only incomparable dimension is the title, the artist agrees at
+    100%, and the old code still quarantined the file below 0.95. The rule is
+    per-dimension now, so this case is covered by the same reasoning as the
+    #797 one below.
+    """
     _stub_lookup(verifier, recordings=[
         {'title': '残酷な天使のテーゼ', 'artist': 'Yoko Takahashi'},
     ], best_score=0.85)
@@ -201,7 +214,7 @@ def test_low_fingerprint_score_never_skipped_same_script_artist(verifier):
         'Zankoku na Tenshi no Theze',
         'Yoko Takahashi',
     )
-    assert result == VerificationResult.FAIL
+    assert result == VerificationResult.SKIP
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_musicbrainz_artist_dedup.py
+++ b/tests/test_musicbrainz_artist_dedup.py
@@ -82,7 +82,7 @@ def _fake_mb_client(monkeypatch, relations, calls):
         def __init__(self, *a, **k):
             pass
 
-        def get_artist(self, mbid, includes=None):
+        def get_artist(self, mbid, includes=None, **_kw):
             calls.append(mbid)
             return {"relations": relations}
 


### PR DESCRIPTION
# AcoustID: correct downloads were being reported as wrong downloads

I found this while working on Library V2, not while looking for AcoustID bugs.

What kept happening: a file passed verification at download time, and later the
library scan called the same file a wrong download. Nothing changed in between.
Scan again and it said something else, first "Mismatch", then "unverified".

I chased this for a long time and every explanation I had was wrong. It looked
like a scanner bug, then a MusicBrainz bug, then a caching problem, then a
regression from my own earlier fix. It was all of them stacked, which is why
fixing any single one changed nothing I could see.

The trigger in my library, both files perfectly correct:

```
Wrong download: "Apetitan" is actually "APETITAN"
Expected "Apetitan" by Sawano Hiroyuki, but the audio fingerprint matches
"APETITAN" by 澤野弘之 (fingerprint 100%, title 100%, artist 0%)
```

8 commits, each a separate defect with its own tests.

### 1. A different writing system is not evidence

Romaji against kanji scores 0.00 whether or not it is the same person.
`evaluate` compared that to `CLEAR_MISMATCH_THRESHOLD` and called it a clear
wrong song. Now a dimension written in two different scripts counts as unknown,
never as failed, and can never be the reason for a FAIL. Same-script
disagreement is still evidence, so a wrong artist or song still fails (four
tests, including two kanji artists against each other).

This also drops the `fingerprint >= 0.95` floor for cross-script titles. Below
it, an ordinary 0.90 match on a Japanese title was getting quarantined.

Known gap, written down in a comment and a test: if title *and* artist are both
unreadable, nothing agrees and nothing disagrees, so a real wrong download with
a non-Latin recording cannot be reported here. I built a fingerprint bar for
that and reverted it. The score says nothing about the names, so all it does is
quarantine the correct files again.

### 2. A timeout is not an answer

This is what made it intermittent, and it took me longest to find.

`MusicBrainzClient.search_artist` returns `[]` for a timeout, a 429 and a 503.
It returns the same `[]` for "MusicBrainz knows nobody by that name". So the
alias lookup cached an outage as "this artist has no aliases" and blocked every
retry for the cache TTL. A bulk scan is exactly what trips the rate limit, so
one sweep could kill the romaji/kanji bridge for a month. My database had such
a row.

`search_artist` and `get_artist` now take `raise_on_error`, off by default so
other callers keep their fail-soft list. Only a real answer gets written down,
and rows from the old code get one retry, which heals the poisoned ones already
out there.

### 3. Use the MBID instead of guessing from the name

`lookup_artist_aliases` searched by name and pulled aliases from whatever
entity passed a trust gate. The gate's own comment names the artist it loses
on: for "Sawano Hiroyuki" a decoy leads at 0.82 while the real 澤野弘之 sorts
last. There is nothing to guess once `artists.musicbrainz_id` is set, so a new
tier in front of the name search uses it.

What a lookup learns now also stays on the artist row instead of only in a
cache keyed by whatever spelling the caller happened to pass, guarded by
`source_id_conflict` like the enrichment workers.

### 4. Cross-script artists could never be matched automatically

`match_artist` scores 60% name similarity plus 40% MB relevance, so a name in
another script caps at 40 against a gate of 70. Unmatchable by design, which is
why the MBID point 3 needs was never there.

When the name path finds nobody, candidates are now checked against the albums
the user owns (`catalog_overlap_score`, same signal as #868). Strict: MB score
>= 90 and at least one owned album. No owned albums, no match.

It runs last, and that is the safety argument. An earlier version ran it before
the confidence gate and beat a 95-scoring same-script candidate with an
80-scoring one, on a shared album title as common as "Home".

Also #586 for this function: it asks non-strict when strict returns nothing.
That was fixed for `lookup_artist_aliases` and never came back for this one.

### 5. MusicBrainz search needed a worker it does not need

`_search_service` raised "MusicBrainz worker not initialized" whenever
`mb_worker` was None, which it is if the worker's init failed. MusicBrainz needs
no credentials and there is already a shared, rate-limited client. The worker's
service is still preferred when it exists so both share one limiter.

### 6. A scan could take a "verified" away

The scan reads the standing from the file tag and writes it to
`tracks.verification_status`. With the tag missing (import write did not stick,
file copied, later retag) it saw an untagged file, applied the rule for one, and
downgraded a row the catalogue said was verified. Then it stamped that answer
onto the tag.

Before point 1 this was unreachable, because the decision was FAIL and FAIL
leaves the status alone. That is the "Mismatch" step. Turning that FAIL into an
honest SKIP walked the file into the downgrade, which is why the order I saw the
symptoms in reads as if my own fix caused it.

Either record saying "verified" now means verified, and a missing tag gets
healed instead of overwritten.

### 7. Scan and download are one path now

The final decision was already shared. Everything before it was not: the scan
had its own availability check, lookup, confidence floor and alias wiring, and
never enriched title-less recordings from MusicBrainz the way the download does.
So a fingerprint hit whose title AcoustID does not carry got dropped by one path
and judged by the other.

`_scan_file` calls `AcoustIDVerification.verify_audio_file` now. What is left in
the scanner is what only the scan can answer: which files, which artist value to
compare against, and what to do with a verdict.

Two behaviour changes fall out, both on purpose:

* An unexpected exception is `ERROR`, not `SKIP`. It was never a statement about
  the file, but read as one it became a verdict: the scan turns SKIP on an
  untagged file into "unverified", the download turns it into a rejection under
  `require_verified`.
* `scan()` refuses to start if the client is not usable. Per file that answers
  SKIP, so a missing API key would walk the whole library into the review queue
  and report a clean run.

Covered by a test that runs eight cases through both entry points and asserts
the same verdict, plus a structural guard so the scanner cannot grow its own
copy of the decision logic again.

### The last commit

I had the branch reviewed and it found five more things, all real. One is
serious: the `[]`-on-timeout in point 2 lives in the client, so the
service-level fix could not fire at all. The rest are a failed fallback search
still reaching the negative cache, MusicBrainz result order used as a tie-break
in point 4, a display name treated as an identity (`LIMIT 1` over rows sharing a
name), and `int()` on an artist id that is TEXT after the `artists_new`
migration, which raises on Jellyfin GUIDs.


One thing I fixed on the side: four tests in `test_acoustid_scanner.py` were
calling MusicBrainz over HTTP for real, 35 seconds each and a different answer
when rate-limited. An autouse fixture stubs it, 44s down to 0.3s.

Happy to split this into smaller PRs if you would rather take it in pieces.
