### PR TITLE
feat: auto-download missing queue tracks and add library play actions

### DIFF
--- a/core/discovery/playable.py
+++ b/core/discovery/playable.py
@@ -30,8 +30,9 @@ def resolve_playable_tracks(db, wanted: List[Dict[str, Any]]) -> Dict[str, Any]:
     """
     wanted = list(wanted or [])[:MAX_RESOLVE]
     rows: List[Dict[str, Any]] = []
+    queue_rows: List[Dict[str, Any]] = []
     if not wanted:
-        return {"tracks": rows, "matched": 0, "total": 0}
+        return {"tracks": rows, "queue_tracks": queue_rows, "matched": 0, "total": 0}
 
     conn = db._get_connection()
     try:
@@ -68,11 +69,27 @@ def resolve_playable_tracks(db, wanted: List[Dict[str, Any]]) -> Dict[str, Any]:
             )
             row = cursor.fetchone()
             if not row:
+                missing = dict(item)
+                missing.update(
+                    {
+                        "title": str(item.get("title") or item.get("name") or "").strip(),
+                        "name": str(item.get("title") or item.get("name") or "").strip(),
+                        "artist": str(item.get("artist") or "").strip(),
+                        "artists": item.get("artists") or [{"name": str(item.get("artist") or "").strip()}],
+                        "album": item.get("album") or item.get("album_title") or "",
+                        "file_path": "",
+                        "is_library": False,
+                        "playback_status": "missing",
+                    }
+                )
+                queue_rows.append(missing)
                 continue
             track = dict(row)
             if track.get("image_url"):
                 from core.metadata import normalize_image_url
                 track["image_url"] = normalize_image_url(track["image_url"]) or track["image_url"]
+            track["is_library"] = True
+            queue_rows.append(dict(track))
             # one copy per file - a mix repeating a track should not repeat it
             if track["file_path"] in seen_paths:
                 continue
@@ -80,10 +97,21 @@ def resolve_playable_tracks(db, wanted: List[Dict[str, Any]]) -> Dict[str, Any]:
             rows.append(track)
     except Exception as e:
         logger.error(f"resolve_playable_tracks failed: {e}")
-        return {"tracks": [], "matched": 0, "total": len(wanted), "error": str(e)}
+        return {
+            "tracks": [],
+            "queue_tracks": [],
+            "matched": 0,
+            "total": len(wanted),
+            "error": str(e),
+        }
     finally:
         try:
             conn.close()
         except Exception:  # noqa: BLE001, S110 - best effort
             pass
-    return {"tracks": rows, "matched": len(rows), "total": len(wanted)}
+    return {
+        "tracks": rows,
+        "queue_tracks": queue_rows,
+        "matched": len(rows),
+        "total": len(wanted),
+    }

--- a/core/downloads/status.py
+++ b/core/downloads/status.py
@@ -394,6 +394,14 @@ def build_batch_status_data(batch_id: str, batch: dict, live_transfers_lookup: d
                 # 'verified' / 'unverified' / 'force_imported' — set by the
                 # import pipeline once post-processing finishes.
                 'verification_status': task.get('verification_status'),
+                # Authenticated playback-queue polling needs the verified,
+                # imported file before it can turn a missing queue row into a
+                # playable library row. Never expose a staging path.
+                'final_file_path': (
+                    task.get('final_file_path')
+                    if task.get('status') == 'completed'
+                    else None
+                ),
                 # "2/5" while the quarantine-retry engine walks candidates.
                 'retry_info': task.get('retry_info'),
                 'retry_trigger': task.get('retry_trigger'),

--- a/core/imports/pipeline.py
+++ b/core/imports/pipeline.py
@@ -1687,6 +1687,13 @@ def post_process_matched_download_with_verification(context_key, context, file_p
             with tasks_lock:
                 if task_id in download_tasks:
                     _mark_task_completed(task_id, context.get('track_info'))
+                    # The playback queue polls the task status and needs the
+                    # verified library path before it can replace its original
+                    # ``missing`` row with a playable one.  The inner pipeline
+                    # cannot persist this itself because this wrapper removes
+                    # task_id/batch_id while post-processing runs.  Keep the
+                    # path on the task at the same point we mark it completed.
+                    download_tasks[task_id]['final_file_path'] = expected_final_path
                     download_tasks[task_id]['metadata_enhanced'] = True
                     if context.get('_verification_status'):
                         download_tasks[task_id]['verification_status'] = context['_verification_status']

--- a/core/playback/prefetch.py
+++ b/core/playback/prefetch.py
@@ -1,0 +1,150 @@
+"""Normalize and deduplicate playback-queue acquisition requests.
+
+The playback queue accepts rows from several metadata providers, while the
+download worker expects the Spotify-like ``name``/``artists``/``album`` shape.
+Keep that translation small and deterministic so the queue can reuse the
+existing verified download/import pipeline without creating a second matcher.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable
+
+
+MAX_PREFETCH_TRACKS = 250
+PLAYBACK_PREFETCH_MAX_CONCURRENT = 1
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _artist_names(track: dict[str, Any]) -> list[str]:
+    raw = track.get("artists")
+    values = raw if isinstance(raw, list) else []
+    names: list[str] = []
+    for value in values:
+        if isinstance(value, dict):
+            name = _text(value.get("name"))
+        else:
+            name = _text(value)
+        if name:
+            names.append(name)
+    fallback = _text(track.get("artist") or track.get("artist_name"))
+    if not names and fallback:
+        names.append(fallback)
+    return names
+
+
+def _album_name(track: dict[str, Any]) -> str:
+    raw = track.get("album")
+    if isinstance(raw, dict):
+        return _text(raw.get("name") or raw.get("title"))
+    return _text(raw or track.get("album_title"))
+
+
+def track_identity(track: dict[str, Any]) -> str:
+    """Return a stable, non-secret key for one musical recording request."""
+    source = _text(track.get("source") or track.get("metadata_source")).casefold()
+    source_id = _text(
+        track.get("source_track_id")
+        or track.get("spotify_track_id")
+        or track.get("tidal_track_id")
+        or track.get("deezer_id")
+        or track.get("itunes_track_id")
+        or track.get("musicbrainz_recording_id")
+        or track.get("track_id")
+    )
+    if source and source_id:
+        raw = f"source:{source}:{source_id}"
+    else:
+        title = _text(track.get("title") or track.get("name")).casefold()
+        artists = "|".join(name.casefold() for name in _artist_names(track))
+        album = _album_name(track).casefold()
+        raw = f"metadata:{title}|{artists}|{album}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def normalize_prefetch_track(track: dict[str, Any]) -> dict[str, Any]:
+    """Translate a queue row into the shape consumed by the download worker."""
+    if not isinstance(track, dict):
+        raise ValueError("Each playback queue track must be an object")
+    title = _text(track.get("title") or track.get("name"))
+    artists = _artist_names(track)
+    if not title or not artists:
+        raise ValueError("Each missing queue track needs a title and artist")
+
+    raw_duration_ms = track.get("duration_ms")
+    if raw_duration_ms in (None, ""):
+        raw_duration = track.get("duration") or 0
+        try:
+            duration_number = float(raw_duration)
+        except (TypeError, ValueError):
+            duration_number = 0
+        # Metadata APIs use milliseconds; library/player rows use seconds.
+        raw_duration_ms = duration_number if duration_number > 10_000 else duration_number * 1000
+    try:
+        duration_ms = max(0, int(float(raw_duration_ms or 0)))
+    except (TypeError, ValueError):
+        duration_ms = 0
+
+    identity = track_identity(track)
+    source_id = _text(
+        track.get("source_track_id")
+        or track.get("spotify_track_id")
+        or track.get("tidal_track_id")
+        or track.get("deezer_id")
+        or track.get("itunes_track_id")
+        or track.get("musicbrainz_recording_id")
+        or track.get("track_id")
+        or track.get("id")
+    )
+    normalized = dict(track)
+    normalized.update(
+        {
+            "id": source_id or identity,
+            "name": title,
+            "title": title,
+            "artists": [{"name": name} for name in artists],
+            "artist": artists[0],
+            "album": _album_name(track),
+            "duration_ms": duration_ms,
+            "_playback_queue_key": identity,
+            "_queue_request_id": _text(track.get("_queue_request_id")) or identity,
+        }
+    )
+    return normalized
+
+
+def deduplicate_prefetch_tracks(
+    tracks: Iterable[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, list[str]]]:
+    """Normalize requests and collapse duplicate recordings in queue order.
+
+    Returns the unique worker payloads plus every client request id associated
+    with each identity so repeated playlist entries can share one download.
+    """
+    unique: list[dict[str, Any]] = []
+    request_ids: dict[str, list[str]] = {}
+    seen: set[str] = set()
+    for raw in list(tracks or [])[:MAX_PREFETCH_TRACKS]:
+        normalized = normalize_prefetch_track(raw)
+        identity = normalized["_playback_queue_key"]
+        request_id = normalized["_queue_request_id"]
+        if request_id not in request_ids.setdefault(identity, []):
+            request_ids[identity].append(request_id)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        unique.append(normalized)
+    return unique, request_ids
+
+
+__all__ = [
+    "MAX_PREFETCH_TRACKS",
+    "PLAYBACK_PREFETCH_MAX_CONCURRENT",
+    "deduplicate_prefetch_tracks",
+    "normalize_prefetch_track",
+    "track_identity",
+]

--- a/tests/discovery/test_playable.py
+++ b/tests/discovery/test_playable.py
@@ -43,6 +43,10 @@ def test_resolves_owned_tracks_in_mix_order(db):
     assert result['total'] == 3
     assert result['matched'] == 2
     assert [t['title'] for t in result['tracks']] == ['Aerodynamic', 'One More Time']
+    assert [t['title'] for t in result['queue_tracks']] == [
+        'Aerodynamic', 'One More Time', 'Not Owned Song'
+    ]
+    assert result['queue_tracks'][-1]['playback_status'] == 'missing'
     assert all(t['file_path'] for t in result['tracks'])
     assert result['tracks'][0]['artist'] == 'Daft Punk'
     assert result['tracks'][0]['album'] == 'Discovery'
@@ -68,6 +72,8 @@ def test_repeated_tracks_resolve_once(db):
 
 
 def test_empty_and_nameless_input(db):
-    assert resolve_playable_tracks(db, []) == {'tracks': [], 'matched': 0, 'total': 0}
+    assert resolve_playable_tracks(db, []) == {
+        'tracks': [], 'queue_tracks': [], 'matched': 0, 'total': 0
+    }
     result = resolve_playable_tracks(db, [{'artist': '', 'title': 'X'}, {'title': ''}])
     assert result['matched'] == 0

--- a/tests/downloads/test_downloads_status.py
+++ b/tests/downloads/test_downloads_status.py
@@ -182,6 +182,26 @@ def test_tasks_sorted_by_track_index():
     assert [t['track_index'] for t in out['tasks']] == [0, 1, 2]
 
 
+def test_completed_task_exposes_only_its_verified_final_file_path():
+    deps, _ = _build_deps()
+    download_tasks['done'] = {
+        'track_index': 0,
+        'status': 'completed',
+        'track_info': {'name': 'Ready'},
+        'final_file_path': '/music/Ready.flac',
+    }
+    download_tasks['working'] = {
+        'track_index': 1,
+        'status': 'post_processing',
+        'track_info': {'name': 'Working'},
+        'final_file_path': '/staging/Working.flac',
+    }
+    batch = {'phase': 'downloading', 'queue': ['done', 'working']}
+    out = st.build_batch_status_data('b1', batch, {}, deps)
+    assert out['tasks'][0]['final_file_path'] == '/music/Ready.flac'
+    assert out['tasks'][1]['final_file_path'] is None
+
+
 def test_missing_task_in_queue_is_skipped():
     deps, _ = _build_deps()
     download_tasks['t1'] = {'track_index': 0, 'status': 'queued', 'track_info': {}}

--- a/tests/imports/test_import_pipeline.py
+++ b/tests/imports/test_import_pipeline.py
@@ -585,6 +585,67 @@ def test_verification_wrapper_applies_quarantine_entry_id_on_integrity_failure(m
         runtime_state.matched_downloads_context.update(original_ctx)
 
 
+def test_verification_wrapper_persists_final_path_for_playback_queue(tmp_path, monkeypatch):
+    """A completed playback-prefetch task must expose its imported path.
+
+    The queue status endpoint only turns a ``missing`` player row into a ready
+    row when ``final_file_path`` is present.  The verification wrapper owns
+    task completion, so it must copy the path produced by the inner importer.
+    """
+    task_id, batch_id, context_key = "play-task", "play-batch", "play-context"
+    final_path = tmp_path / "Library" / "Artist" / "Album" / "01 - Track.flac"
+    final_path.parent.mkdir(parents=True)
+    final_path.write_bytes(b"audio")
+    context = {
+        "track_info": {"name": "Track"},
+        "task_id": task_id,
+        "batch_id": batch_id,
+    }
+
+    def _fake_inner(_key, inner_context, _source, _runtime, metadata_runtime=None):
+        inner_context["_final_processed_path"] = str(final_path)
+
+    monkeypatch.setattr(import_pipeline, "post_process_matched_download", _fake_inner)
+
+    original_tasks = dict(runtime_state.download_tasks)
+    original_contexts = dict(runtime_state.matched_downloads_context)
+    try:
+        runtime_state.download_tasks.clear()
+        runtime_state.download_tasks[task_id] = {
+            "track_info": context["track_info"],
+            "status": "post_processing",
+            "playlist_id": "playback_queue",
+        }
+        runtime_state.matched_downloads_context.clear()
+        runtime_state.matched_downloads_context[context_key] = context
+        completion = []
+        runtime = types.SimpleNamespace(
+            automation_engine=None,
+            on_download_completed=lambda b, t, success: completion.append((b, t, success)),
+            web_scan_manager=None,
+            repair_worker=None,
+        )
+
+        import_pipeline.post_process_matched_download_with_verification(
+            context_key,
+            context,
+            "/downloads/Artist - Track.flac",
+            task_id,
+            batch_id,
+            runtime,
+        )
+
+        task = runtime_state.download_tasks[task_id]
+        assert task["status"] == "completed"
+        assert task["final_file_path"] == str(final_path)
+        assert completion == [(batch_id, task_id, True)]
+    finally:
+        runtime_state.download_tasks.clear()
+        runtime_state.download_tasks.update(original_tasks)
+        runtime_state.matched_downloads_context.clear()
+        runtime_state.matched_downloads_context.update(original_contexts)
+
+
 # ---------------------------------------------------------------------------
 # Next-best-candidate retry on AcoustID / integrity quarantine. When a
 # verification or integrity check quarantines the wrong/broken file, the wrapper

--- a/tests/playback/test_prefetch.py
+++ b/tests/playback/test_prefetch.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from core.playback.prefetch import (
+    deduplicate_prefetch_tracks,
+    normalize_prefetch_track,
+    track_identity,
+)
+
+
+def test_normalizes_provider_row_for_existing_download_worker():
+    track = normalize_prefetch_track(
+        {
+            "title": "Teardrop",
+            "artist": "Massive Attack",
+            "album_title": "Mezzanine",
+            "duration": 330,
+            "source": "tidal",
+            "source_track_id": "123",
+            "_queue_request_id": "row-1",
+        }
+    )
+    assert track["name"] == "Teardrop"
+    assert track["artists"] == [{"name": "Massive Attack"}]
+    assert track["album"] == "Mezzanine"
+    assert track["duration_ms"] == 330_000
+    assert track["id"] == "123"
+    assert track["_queue_request_id"] == "row-1"
+
+
+def test_provider_identity_is_stable_and_different_sources_do_not_collide():
+    tidal = {"source": "tidal", "source_track_id": "42", "title": "X", "artist": "Y"}
+    spotify = {"source": "spotify", "source_track_id": "42", "title": "X", "artist": "Y"}
+    assert track_identity(tidal) == track_identity(dict(tidal))
+    assert track_identity(tidal) != track_identity(spotify)
+
+
+def test_deduplicates_repeated_queue_entries_but_keeps_all_request_ids():
+    unique, request_ids = deduplicate_prefetch_tracks(
+        [
+            {"title": "Genesis", "artist": "Justice", "album": "Cross", "_queue_request_id": "a"},
+            {"name": "Genesis", "artists": ["Justice"], "album": "Cross", "_queue_request_id": "b"},
+        ]
+    )
+    assert len(unique) == 1
+    key = unique[0]["_playback_queue_key"]
+    assert request_ids[key] == ["a", "b"]
+
+
+def test_rejects_missing_identity_metadata():
+    with pytest.raises(ValueError, match="title and artist"):
+        normalize_prefetch_track({"title": "Untitled"})

--- a/tests/playback/test_prefetch_runtime.py
+++ b/tests/playback/test_prefetch_runtime.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from core.runtime_state import download_batches, download_tasks, tasks_lock
+
+
+_TMP = tempfile.mkdtemp(prefix="soulsync-testdb-playback-prefetch-")
+os.environ.setdefault("DATABASE_PATH", os.path.join(_TMP, "s.db"))
+os.environ.setdefault("SOULSYNC_TEST_DB_READY", "1")
+
+web_server = pytest.importorskip("web_server")
+
+
+@pytest.fixture(autouse=True)
+def clean_runtime_state():
+    with tasks_lock:
+        download_tasks.clear()
+        download_batches.clear()
+    yield
+    with tasks_lock:
+        download_tasks.clear()
+        download_batches.clear()
+
+
+def test_runtime_reuses_owned_files_and_deduplicates_active_downloads(monkeypatch):
+    started = []
+    monitored = []
+    monkeypatch.setattr(
+        web_server,
+        "_resolve_playback_prefetch_local_file",
+        lambda track: "/music/Owned.flac" if track["name"] == "Owned" else None,
+    )
+    monkeypatch.setattr(
+        web_server.download_monitor,
+        "start_monitoring",
+        lambda batch_id: monitored.append(batch_id),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_start_next_batch_of_downloads",
+        lambda batch_id: started.append(batch_id),
+    )
+    monkeypatch.setattr(web_server, "add_activity_item", lambda *args: None)
+
+    request = [
+        {"title": "Owned", "artist": "A", "_queue_request_id": "owned"},
+        {"title": "Missing", "artist": "B", "_queue_request_id": "missing-1"},
+        {"name": "Missing", "artists": ["B"], "_queue_request_id": "missing-2"},
+    ]
+    result = web_server._start_playback_queue_prefetch(request)
+    assert result["queued"] == 1
+    assert len(result["batch_ids"]) == 1
+    assert started == result["batch_ids"]
+    assert monitored == result["batch_ids"]
+    ready = next(item for item in result["items"] if item["state"] == "ready")
+    queued = next(item for item in result["items"] if item["state"] == "queued")
+    assert ready["final_path"] == "/music/Owned.flac"
+    assert queued["request_ids"] == ["missing-1", "missing-2"]
+    assert len(download_tasks) == 1
+    task = download_tasks[queued["task_id"]]
+    assert task["track_info"]["_queue_request_ids"] == ["missing-1", "missing-2"]
+    batch = download_batches[result["batch_ids"][0]]
+    assert batch["max_concurrent"] == 1
+
+    again = web_server._start_playback_queue_prefetch(
+        [{"title": "Missing", "artist": "B", "_queue_request_id": "again"}]
+    )
+    assert again["queued"] == 0
+    assert again["items"][0]["task_id"] == queued["task_id"]
+    assert task["track_info"]["_queue_request_ids"] == [
+        "missing-1",
+        "missing-2",
+        "again",
+    ]
+    assert started == result["batch_ids"]
+
+
+def test_runtime_reuses_one_batch_and_prioritizes_current_queue_order(monkeypatch):
+    started = []
+    monitored = []
+    monkeypatch.setattr(
+        web_server,
+        "_resolve_playback_prefetch_local_file",
+        lambda _track: None,
+    )
+    monkeypatch.setattr(
+        web_server.download_monitor,
+        "start_monitoring",
+        lambda batch_id: monitored.append(batch_id),
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_start_next_batch_of_downloads",
+        lambda batch_id: started.append(batch_id),
+    )
+    monkeypatch.setattr(web_server, "add_activity_item", lambda *args: None)
+
+    initial = web_server._start_playback_queue_prefetch(
+        [
+            {"title": "First", "artist": "A", "_queue_request_id": "first"},
+            {"title": "Second", "artist": "B", "_queue_request_id": "second"},
+        ]
+    )
+    batch_id = initial["batch_ids"][0]
+
+    updated = web_server._start_playback_queue_prefetch(
+        [
+            {"title": "Play Next", "artist": "C", "_queue_request_id": "next"},
+            {"title": "First", "artist": "A", "_queue_request_id": "first"},
+            {"title": "Second", "artist": "B", "_queue_request_id": "second"},
+        ]
+    )
+
+    assert updated["queued"] == 1
+    assert updated["batch_ids"] == [batch_id]
+    assert monitored == [batch_id]
+    assert started == [batch_id, batch_id]
+    batch = download_batches[batch_id]
+    assert batch["max_concurrent"] == 1
+    assert [
+        download_tasks[task_id]["track_info"]["name"] for task_id in batch["queue"]
+    ] == ["Play Next", "First", "Second"]
+
+
+def test_prefetch_routes_dispatch_and_report_status(monkeypatch):
+    starts = []
+    monkeypatch.setattr(web_server, "check_download_permission", lambda: None)
+    monkeypatch.setattr(
+        web_server,
+        "_start_playback_queue_prefetch",
+        lambda tracks: starts.append(tracks) or {
+            "success": True,
+            "queued": 1,
+            "batch_ids": ["batch-1"],
+            "items": [],
+        },
+    )
+    monkeypatch.setattr(
+        web_server,
+        "_playback_queue_prefetch_status",
+        lambda batch_ids: {
+            "success": True,
+            "batch_ids": batch_ids,
+            "batches": {},
+        },
+    )
+
+    client = web_server.app.test_client()
+    response = client.post(
+        "/api/playback/queue/prefetch",
+        json={"tracks": [{"title": "Genesis", "artist": "Justice"}]},
+    )
+    assert response.status_code == 200
+    assert response.get_json()["batch_ids"] == ["batch-1"]
+    assert starts == [[{"title": "Genesis", "artist": "Justice"}]]
+
+    response = client.get(
+        "/api/playback/queue/prefetch/status?batch_ids=batch-1&batch_ids=batch-2"
+    )
+    assert response.status_code == 200
+    assert response.get_json()["batch_ids"] == ["batch-1", "batch-2"]
+
+
+def test_prefetch_route_rejects_empty_track_list(monkeypatch):
+    monkeypatch.setattr(web_server, "check_download_permission", lambda: None)
+    response = web_server.app.test_client().post(
+        "/api/playback/queue/prefetch", json={"tracks": []}
+    )
+    assert response.status_code == 400
+    assert response.get_json()["success"] is False

--- a/tests/playback/test_queue_prefetch_frontend_contract.py
+++ b/tests/playback/test_queue_prefetch_frontend_contract.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_legacy_player_exposes_acquisition_aware_queue_contract():
+    source = (ROOT / "webui/static/media-player.js").read_text(encoding="utf-8")
+
+    assert "'/api/playback/queue/prefetch'" in source
+    assert "`/api/playback/queue/prefetch/status?${query}`" in source
+    assert "await npEnsureQueueTrackReady(track);" in source
+    assert "npQueue = npPrepareQueueTracks(list);" in source
+    assert "info._queue_request_ids" in source
+    assert "npQueuePrefetchReschedule" in source
+    assert "npScheduleQueuePrefetch();" in source
+
+
+def test_queue_auto_download_control_is_present_and_disabled_by_default():
+    source = (ROOT / "webui/index.html").read_text(encoding="utf-8")
+    player_source = (ROOT / "webui/static/media-player.js").read_text(encoding="utf-8")
+
+    assert 'id="np-autodownload-btn"' in source
+    assert 'class="np-autodownload-btn"' in source
+    assert 'aria-pressed="false"' in source
+    assert "let npAutoDownloadQueue = false;" in player_source
+    assert "localStorage.getItem(npAutoDownloadStorageKey()) === '1'" in player_source

--- a/tests/test_sync_history_play_endpoint.py
+++ b/tests/test_sync_history_play_endpoint.py
@@ -1,9 +1,9 @@
 """GET /api/sync/history/<id>/play — the Listen button's resolver.
 
 Stubbed db + resolver (the hermetic pattern from the radio endpoint test):
-this file owns the endpoint's parsing — spotify-shaped cached tracks (name +
-artists as dicts) resolved per track, unmatched ones skipped, `total` honest
-about the playlist's real size — not the matcher, which has its own coverage.
+this file owns the endpoint's parsing — provider-shaped cached tracks resolved
+in one batch, with owned rows playable now and unmatched rows retained for the
+queue's automatic acquisition path.
 """
 
 from __future__ import annotations
@@ -45,7 +45,7 @@ def client():
     return web_server.app.test_client()
 
 
-def test_resolves_matched_tracks_and_skips_the_rest(client, monkeypatch):
+def test_resolves_owned_tracks_and_retains_missing_queue_rows(client, monkeypatch):
     entry = {
         'playlist_name': 'Hot Hits',
         'tracks_json': json.dumps([
@@ -75,7 +75,12 @@ def test_resolves_matched_tracks_and_skips_the_rest(client, monkeypatch):
     assert t == {'id': 't1', 'title': 'Owned Song', 'artist': 'Ado',
                  'album': 'Kyougen', 'file_path': '/m/o.flac',
                  'image_url': None, 'bitrate': 1411, 'duration': 200,
-                 'artist_id': 'ar1', 'album_id': 'al1'}
+                 'artist_id': 'ar1', 'album_id': 'al1', 'is_library': True}
+    assert [row['title'] for row in body['queue_tracks']] == [
+        'Owned Song', 'Missing Song', 'String Artist'
+    ]
+    assert body['queue_tracks'][1]['playback_status'] == 'missing'
+    assert body['queue_tracks'][1]['artists'] == [{'name': 'Nobody'}]
     # ONE batch resolution for the whole playlist (the per-track version
     # full-scanned the tracks table once per song — minutes on a big
     # library), and artists-as-strings parse too (older cached entries).

--- a/web_server.py
+++ b/web_server.py
@@ -5808,6 +5808,277 @@ def get_music_video_status(video_id):
     return jsonify(status)
 
 
+_PLAYBACK_PREFETCH_ACTIVE_STATES = {
+    'pending', 'queued', 'searching', 'downloading', 'post_processing',
+}
+
+
+def _resolve_playback_prefetch_local_file(track):
+    """Return an on-disk library file for a queue row, if one already exists."""
+    raw_path = str(track.get('file_path') or track.get('filename') or '').strip()
+    if raw_path:
+        resolved = _resolve_library_file_path(raw_path)
+        if resolved and os.path.isfile(resolved):
+            return resolved
+
+    title = str(track.get('name') or track.get('title') or '').strip()
+    raw_artists = track.get('artists') if isinstance(track.get('artists'), list) else []
+    artists = []
+    for value in raw_artists:
+        name = value.get('name') if isinstance(value, dict) else value
+        if str(name or '').strip():
+            artists.append(str(name).strip())
+    fallback_artist = str(track.get('artist') or track.get('artist_name') or '').strip()
+    if not artists and fallback_artist:
+        artists.append(fallback_artist)
+    if not title or not artists:
+        return None
+
+    album = track.get('album')
+    if isinstance(album, dict):
+        album = album.get('name') or album.get('title')
+    album = str(album or track.get('album_title') or '').strip() or None
+    database = get_database()
+    active_server = config_manager.get_active_media_server()
+    for artist in artists:
+        matched, confidence = database.check_track_exists(
+            title,
+            artist,
+            confidence_threshold=0.7,
+            server_source=active_server,
+            album=album,
+        )
+        if not matched or confidence < 0.7:
+            continue
+        candidate = _resolve_library_file_path(getattr(matched, 'file_path', '') or '')
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _start_playback_queue_prefetch(raw_tracks):
+    """Add missing player rows to the existing downloader in strict queue order."""
+    from core.playback.prefetch import (
+        PLAYBACK_PREFETCH_MAX_CONCURRENT,
+        deduplicate_prefetch_tracks,
+    )
+
+    tracks, request_ids_by_key = deduplicate_prefetch_tracks(raw_tracks)
+    if not tracks:
+        raise ValueError('No valid missing tracks were provided')
+
+    resolved_paths = {
+        track['_playback_queue_key']: _resolve_playback_prefetch_local_file(track)
+        for track in tracks
+    }
+    items = []
+    new_tracks = []
+    existing_batch_ids = set()
+    requested_rank = {
+        track['_playback_queue_key']: index for index, track in enumerate(tracks)
+    }
+    new_batch_id = ''
+    created_new_batch = False
+
+    with tasks_lock:
+        active_by_key = {}
+        for task_id, task in download_tasks.items():
+            if not isinstance(task, dict) or task.get('playlist_id') != 'playback_queue':
+                continue
+            track_info = task.get('track_info') if isinstance(task.get('track_info'), dict) else {}
+            key = track_info.get('_playback_queue_key')
+            if not key:
+                continue
+            state = str(task.get('status') or '')
+            final_path = str(task.get('final_file_path') or '')
+            if state == 'completed' and final_path and os.path.isfile(final_path):
+                active_by_key[key] = (task_id, task, 'ready', final_path)
+            elif state in _PLAYBACK_PREFETCH_ACTIVE_STATES:
+                active_by_key[key] = (task_id, task, state, '')
+
+        reusable_batches = [
+            (batch_id, batch)
+            for batch_id, batch in download_batches.items()
+            if isinstance(batch, dict)
+            and batch.get('playback_prefetch')
+            and str(batch.get('phase') or '') not in {'complete', 'error', 'cancelled'}
+        ]
+        reusable_batches.sort(key=lambda pair: float(pair[1].get('created_at') or 0))
+        reusable_batch_id = reusable_batches[0][0] if reusable_batches else ''
+
+        for track in tracks:
+            key = track['_playback_queue_key']
+            request_ids = request_ids_by_key.get(key, [])
+            local_path = resolved_paths.get(key)
+            if local_path:
+                items.append({
+                    'queue_key': key,
+                    'request_ids': request_ids,
+                    'state': 'ready',
+                    'final_path': local_path,
+                })
+                continue
+            existing = active_by_key.get(key)
+            if existing:
+                task_id, task, state, final_path = existing
+                track_info = task.get('track_info')
+                if isinstance(track_info, dict):
+                    known_request_ids = list(track_info.get('_queue_request_ids') or [])
+                    legacy_request_id = track_info.get('_queue_request_id')
+                    if legacy_request_id and legacy_request_id not in known_request_ids:
+                        known_request_ids.append(legacy_request_id)
+                    for request_id in request_ids:
+                        if request_id not in known_request_ids:
+                            known_request_ids.append(request_id)
+                    track_info['_queue_request_ids'] = known_request_ids
+                batch_id = str(task.get('batch_id') or '')
+                if batch_id:
+                    existing_batch_ids.add(batch_id)
+                items.append({
+                    'queue_key': key,
+                    'request_ids': request_ids,
+                    'state': state,
+                    'final_path': final_path,
+                    'batch_id': batch_id,
+                    'task_id': task_id,
+                })
+                continue
+            new_tracks.append(track)
+
+        if new_tracks:
+            new_batch_id = reusable_batch_id or str(uuid.uuid4())
+            created_new_batch = not bool(reusable_batch_id)
+            if created_new_batch:
+                download_batches[new_batch_id] = {
+                    'phase': 'downloading',
+                    'playlist_id': 'playback_queue',
+                    'playlist_name': 'Playback Queue',
+                    'queue': [],
+                    'active_count': 0,
+                    # Queue downloads are deliberately sequential. The source,
+                    # matching and post-processing logic remains unchanged; this
+                    # only ensures the next audible gap is filled first.
+                    'max_concurrent': PLAYBACK_PREFETCH_MAX_CONCURRENT,
+                    'queue_index': 0,
+                    'permanently_failed_tracks': [],
+                    'cancelled_tracks': set(),
+                    'profile_id': get_current_profile_id(),
+                    'playback_prefetch': True,
+                    'created_at': time.time(),
+                }
+            batch = download_batches[new_batch_id]
+            batch['max_concurrent'] = PLAYBACK_PREFETCH_MAX_CONCURRENT
+            for track in new_tracks:
+                task_id = str(uuid.uuid4())
+                request_ids = request_ids_by_key.get(track['_playback_queue_key'], [])
+                track['_queue_request_ids'] = request_ids
+                track_index = requested_rank[track['_playback_queue_key']]
+                download_tasks[task_id] = {
+                    'status': 'pending',
+                    'track_info': track,
+                    'playlist_id': 'playback_queue',
+                    'batch_id': new_batch_id,
+                    'track_index': track_index,
+                    'download_id': None,
+                    'username': None,
+                    'filename': None,
+                    'retry_count': 0,
+                    'cached_candidates': [],
+                    'used_sources': set(),
+                    'status_change_time': time.time(),
+                }
+                batch['queue'].append(task_id)
+                items.append({
+                    'queue_key': track['_playback_queue_key'],
+                    'request_ids': request_ids_by_key.get(track['_playback_queue_key'], []),
+                    'state': 'queued',
+                    'final_path': '',
+                    'batch_id': new_batch_id,
+                    'task_id': task_id,
+                })
+
+        # A later "Play next" or drag reorder sends the full missing-track
+        # order again. Reorder only tasks that have not started; an active task
+        # is allowed to finish through the normal download lifecycle.
+        for _batch_id, batch in reusable_batches:
+            batch['max_concurrent'] = PLAYBACK_PREFETCH_MAX_CONCURRENT
+        if new_batch_id and created_new_batch:
+            reusable_batches.append((new_batch_id, download_batches[new_batch_id]))
+        for _batch_id, batch in reusable_batches:
+            queue = batch.get('queue') if isinstance(batch.get('queue'), list) else []
+            queue_index = min(max(int(batch.get('queue_index') or 0), 0), len(queue))
+            pending = queue[queue_index:]
+            original_position = {task_id: index for index, task_id in enumerate(pending)}
+
+            def _pending_rank(task_id, original_position=original_position):
+                task = download_tasks.get(task_id)
+                info = task.get('track_info') if isinstance(task, dict) else {}
+                key = info.get('_playback_queue_key') if isinstance(info, dict) else None
+                if key in requested_rank:
+                    return (0, requested_rank[key])
+                return (1, original_position[task_id])
+
+            queue[queue_index:] = sorted(pending, key=_pending_rank)
+
+    if new_tracks:
+        if created_new_batch:
+            download_monitor.start_monitoring(new_batch_id)
+        _start_next_batch_of_downloads(new_batch_id)
+        add_activity_item(
+            '',
+            'Playback Queue Prefetch',
+            f'{len(new_tracks)} missing track(s) queued',
+            'Now',
+        )
+        existing_batch_ids.add(new_batch_id)
+
+    return {
+        'success': True,
+        'items': items,
+        'batch_ids': sorted(existing_batch_ids),
+        'queued': len(new_tracks),
+    }
+
+
+def _playback_queue_prefetch_status(batch_ids):
+    data = _downloads_status.build_batched_status(batch_ids, _build_status_deps())
+    return {'success': True, **data}
+
+
+@app.route('/api/playback/queue/prefetch', methods=['POST'])
+def playback_queue_prefetch():
+    """Acquire missing queue entries through the existing download pipeline."""
+    permission_error = check_download_permission()
+    if permission_error:
+        return permission_error
+    data = request.get_json(silent=True) or {}
+    tracks = data.get('tracks')
+    if not isinstance(tracks, list) or not tracks:
+        return jsonify({'success': False, 'error': 'tracks list is required'}), 400
+    try:
+        return jsonify(_start_playback_queue_prefetch(tracks))
+    except ValueError as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+    except Exception as exc:
+        logger.exception('Playback queue prefetch failed')
+        return jsonify({'success': False, 'error': str(exc)}), 500
+
+
+@app.route('/api/playback/queue/prefetch/status', methods=['GET'])
+def playback_queue_prefetch_status():
+    batch_ids = [value for value in request.args.getlist('batch_ids') if value]
+    if not batch_ids:
+        return jsonify({
+            'success': False,
+            'error': 'At least one batch_ids value is required',
+        }), 400
+    try:
+        return jsonify(_playback_queue_prefetch_status(batch_ids))
+    except Exception as exc:
+        logger.exception('Playback queue prefetch status failed')
+        return jsonify({'success': False, 'error': str(exc)}), 500
+
+
 @app.route('/api/download', methods=['POST'])
 def start_download():
     """Simple download route"""
@@ -15557,11 +15828,7 @@ def get_sync_history_entry(entry_id):
 
 @app.route('/api/sync/history/<int:entry_id>/play')
 def play_sync_history_entry(entry_id):
-    """The synced playlist as a PLAYABLE library track list. Each cached track
-    resolves against the library with the same title+artist matcher the stats
-    play button uses; tracks that never landed are skipped (total says how
-    many the playlist really has). Same track shape as /api/library/radio so
-    the player maps it with the one helper it already owns."""
+    """Resolve a synced playlist into owned rows plus an acquisition-aware queue."""
     try:
         db = MusicDatabase()
         entry = db.get_sync_history_entry(entry_id, profile_id=get_current_profile_id())
@@ -15574,6 +15841,7 @@ def play_sync_history_entry(entry_id):
         # each call, which read as "the play button does nothing for two
         # minutes" on a 300k-track library.
         wanted = []
+        wanted_rows = []
         for t in cached[:200]:
             if not isinstance(t, dict):
                 continue
@@ -15581,16 +15849,18 @@ def play_sync_history_entry(entry_id):
             artists = t.get('artists') or []
             first = artists[0] if isinstance(artists, list) and artists else None
             artist = (first.get('name') if isinstance(first, dict) else str(first or '')).strip()
-            if title:
+            if title and artist:
                 wanted.append((title, artist))
+                wanted_rows.append((title, artist, t))
         resolved = db.resolve_library_tracks(wanted)
 
         tracks = []
-        for title, artist in wanted:
+        queue_tracks = []
+        for title, artist, source_track in wanted_rows:
             row = resolved.get((title.lower(), artist.lower()))
             if row and row.get('file_path'):
                 thumb = row.get('thumb_url')
-                tracks.append({
+                playable = {
                     'id': row.get('id'),
                     'title': row.get('title'),
                     'artist': row.get('artist_name'),
@@ -15601,11 +15871,29 @@ def play_sync_history_entry(entry_id):
                     'duration': row.get('duration'),
                     'artist_id': row.get('artist_id'),
                     'album_id': row.get('album_id'),
+                    'is_library': True,
+                }
+                tracks.append(playable)
+                queue_tracks.append(dict(playable))
+            else:
+                missing = dict(source_track)
+                missing.update({
+                    'title': title,
+                    'name': title,
+                    'artist': artist,
+                    'artists': source_track.get('artists') or [{'name': artist}],
+                    'album': source_track.get('album') or source_track.get('album_name') or '',
+                    'file_path': '',
+                    'is_library': False,
+                    'playback_status': 'missing',
+                    'source': source_track.get('source') or entry.get('source') or '',
                 })
+                queue_tracks.append(missing)
         return jsonify({"success": True,
                         "name": entry.get('playlist_name') or '',
                         "total": len(cached),
-                        "tracks": tracks})
+                        "tracks": tracks,
+                        "queue_tracks": queue_tracks})
     except Exception as e:
         logger.error(f"Error resolving sync entry {entry_id} for playback: {e}")
         return jsonify({"success": False, "error": str(e)}), 500

--- a/webui/index.html
+++ b/webui/index.html
@@ -7164,6 +7164,10 @@
                         <span class="np-queue-count" id="np-queue-count"></span>
                     </button>
                     <div class="np-queue-header-actions">
+                        <button class="np-autodownload-btn" id="np-autodownload-btn" title="Automatically download missing queue tracks" aria-pressed="false">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
+                            <span>Auto-download</span>
+                        </button>
                         <button class="np-radio-btn" id="np-radio-btn" title="Radio mode - auto-add similar tracks" aria-pressed="false">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h.01"/><path d="M8.5 16.429a5 5 0 0 1 7 0"/><path d="M5 12.859a10 10 0 0 1 14 0"/><path d="M1.5 9.289a15 15 0 0 1 21 0"/></svg>
                             <span class="np-radio-label">Radio</span>

--- a/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
+++ b/webui/src/routes/artist-detail/-artist-detail.enhanced-album.ts
@@ -739,13 +739,22 @@ export function queueTrackPayload(
   album: EnhancedAlbum,
   artist: Record<string, unknown> | undefined,
 ) {
+  const sourceTrack =
+    ((track as unknown as { _sourceTrack?: Record<string, unknown> })._sourceTrack as
+      | Record<string, unknown>
+      | undefined) || {};
+  const filePath = track.file_path || '';
   return {
+    ...sourceTrack,
     title: track.title || 'Unknown Track',
+    name: track.title || 'Unknown Track',
     artist: String(artist?.name || '') || 'Unknown Artist',
+    artists: track.artists || sourceTrack.artists || [{ name: String(artist?.name || '') }],
     album: album.title || 'Unknown Album',
-    file_path: track.file_path,
-    filename: track.file_path,
-    is_library: true,
+    file_path: filePath,
+    filename: filePath,
+    is_library: Boolean(filePath),
+    playback_status: filePath ? 'ready' : 'missing',
     image_url: album.thumb_url || artist?.thumb_url || null,
     id: track.id,
     artist_id: artist?.id ?? null,

--- a/webui/src/routes/artist-detail/-route.test.tsx
+++ b/webui/src/routes/artist-detail/-route.test.tsx
@@ -1,5 +1,5 @@
 import { createMemoryHistory } from '@tanstack/react-router';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRouterProvider, createAppRouter } from '@/app/router';
@@ -63,6 +63,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
   window.SoulSyncWebShellBridge = undefined;
   delete document.body.dataset.artistSource;
+  delete window.playTrackList;
+  delete window.showLoadingOverlay;
+  delete window.hideLoadingOverlay;
 });
 
 describe('artist-detail route', () => {
@@ -115,5 +118,53 @@ describe('artist-detail route', () => {
 
     unmount();
     expect(window.cancelSimilarArtistsLoad).toHaveBeenCalled();
+  });
+
+  it('loads an album tracklist and sends the complete context to the queue', async () => {
+    window.playTrackList = vi.fn();
+    window.showLoadingOverlay = vi.fn();
+    window.hideLoadingOverlay = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input instanceof Request ? input.url : String(input);
+        let body: unknown = { success: false, tracks: [] };
+        if (url.includes('/api/artist-detail/')) {
+          body = {
+            success: true,
+            artist: { id: 42, name: 'Aphex Twin', server_source: 'plex' },
+            discography: {
+              albums: [{ id: 1, title: 'SAW', owned: true, image_url: 'album.jpg' }],
+              source: 'spotify',
+            },
+          };
+        } else if (url.includes('/api/album/1/tracks')) {
+          body = {
+            success: true,
+            tracks: [
+              { id: 'sp-1', name: 'Xtal' },
+              { id: 'sp-2', name: 'Tha' },
+            ],
+          };
+        }
+        return new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }),
+    );
+
+    renderArtistDetailRoute();
+    await screen.findByText('SAW');
+    fireEvent.click(document.querySelector('.release-card-play-btn')!);
+
+    await waitFor(() => expect(window.playTrackList).toHaveBeenCalledTimes(1));
+    expect(window.playTrackList).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ title: 'Xtal', artist: 'Aphex Twin', album: 'SAW' }),
+        expect.objectContaining({ title: 'Tha', artist: 'Aphex Twin', album: 'SAW' }),
+      ],
+      'SAW',
+    );
   });
 });

--- a/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
+++ b/webui/src/routes/artist-detail/-ui/artist-detail-page.tsx
@@ -319,6 +319,51 @@ export function ArtistDetailPage() {
     }
   };
 
+  const playRelease = async (release: DiscographyRelease) => {
+    if (!isReleaseClickable(release)) {
+      window.showToast?.(stillCheckingMessage(release), 'info');
+      return;
+    }
+    if (!payload) return;
+
+    const image = heroImage(payload.artist ?? {}, displayed);
+    const artist = openReleaseArtist(payload, payload.artist?.id, image.primary);
+    if (!artist) {
+      window.showToast?.('Error: No artist information available', 'error');
+      return;
+    }
+
+    window.showLoadingOverlay?.('Loading album...');
+    try {
+      const album = releaseToAlbumData(release);
+      const params = new URLSearchParams(albumTracksParams(release, artist));
+      const response = await fetch(`/api/album/${album.id}/tracks?${params}`);
+      if (!response.ok) throw new Error(`Failed to load album tracks: ${response.status}`);
+
+      const data = await response.json();
+      if (!data.success || !data.tracks?.length)
+        throw new Error('No tracks found for this release');
+
+      const tracks = data.tracks.map((track: Record<string, unknown>) => ({
+        ...track,
+        title: track.title || track.name || 'Unknown Track',
+        name: track.name || track.title || 'Unknown Track',
+        artist: track.artist || track.artist_name || artist.name,
+        artists:
+          Array.isArray(track.artists) && track.artists.length
+            ? track.artists
+            : [{ name: artist.name }],
+        album: track.album || track.album_title || album.name,
+        image_url: track.image_url || album.image_url || artist.image_url,
+      }));
+      window.hideLoadingOverlay?.();
+      await window.playTrackList?.(tracks, String(album.name || 'Album'));
+    } catch (error) {
+      window.hideLoadingOverlay?.();
+      window.showToast?.(`Could not play that album: ${(error as Error).message}`, 'error');
+    }
+  };
+
   // The hero stays hidden on failure — the vanilla kept it hidden rather than
   // showing an empty shell over an error.
   if (failed) {
@@ -406,6 +451,7 @@ export function ArtistDetailPage() {
                   isMusicBrainz={isMusicBrainz}
                   isSourceArtist={sourceOnly}
                   onOpen={openRelease}
+                  onPlay={playRelease}
                 />
               ))}
               <ArtistVideosSection artistName={payload.artist?.name} />

--- a/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.test.tsx
@@ -19,6 +19,7 @@ function renderSection(
       isMusicBrainz={opts.mb ?? false}
       isSourceArtist={false}
       onOpen={vi.fn()}
+      onPlay={vi.fn()}
     />,
   );
 }
@@ -157,6 +158,7 @@ describe('lazy artwork loading', () => {
         isMusicBrainz={false}
         isSourceArtist={false}
         onOpen={vi.fn()}
+        onPlay={vi.fn()}
       />,
     );
 

--- a/webui/src/routes/artist-detail/-ui/discography-section.tsx
+++ b/webui/src/routes/artist-detail/-ui/discography-section.tsx
@@ -25,6 +25,7 @@ interface Props {
   isMusicBrainz: boolean;
   isSourceArtist: boolean;
   onOpen: (release: DiscographyRelease) => void;
+  onPlay: (release: DiscographyRelease) => void | Promise<void>;
 }
 
 /**
@@ -43,6 +44,7 @@ export function DiscographySection({
   isMusicBrainz,
   isSourceArtist,
   onOpen,
+  onPlay,
 }: Props) {
   const counts = sectionCounts(releases, isMusicBrainz, filters);
   if (isSectionHidden(bucket, counts, filters)) return null;
@@ -84,6 +86,7 @@ export function DiscographySection({
             isMusicBrainz={isMusicBrainz}
             isSourceArtist={isSourceArtist}
             onOpen={onOpen}
+            onPlay={onPlay}
           />
         ))}
       </div>

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.test.tsx
@@ -447,6 +447,22 @@ describe('row actions', () => {
     expect(window.addToQueue).toHaveBeenCalled();
   });
 
+  it('queues an expected-missing track for automatic download', () => {
+    renderTable();
+    click('.enhanced-queue-btn', 2);
+    expect(window.addToQueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Ageispolis',
+        artist: 'Aphex Twin',
+        source: 'spotify',
+        track_id: 's3',
+        file_path: '',
+        is_library: false,
+        playback_status: 'missing',
+      }),
+    );
+  });
+
   it('wires each admin action to its own handler', () => {
     // Write-tags is no longer a window bridge: ✎ opens the local tag preview
     // modal (showTagPreview's port), which fetches the diff on mount.

--- a/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-track-table.tsx
@@ -334,7 +334,6 @@ function TrackRow({
     };
 
   const enqueue = (playNext: boolean) => {
-    if (!track.file_path) return;
     const payload = queueTrackPayload(track, album, artist);
     // Play-next falls back to a plain enqueue when the player does not expose
     // it, which is what the vanilla's typeof check did.
@@ -482,17 +481,14 @@ function TrackRow({
         </div>
       </td>
 
-      {/* `!missing` is redundant — normalizeExpectedMissingTrack never sets a
-          file_path, so a missing row cannot reach the truthy branch. Kept
-          because the vanilla wrote it, and it survives mutation for that
-          reason rather than for want of a test. */}
       <td className="col-queue">
-        {!missing && track.file_path ? (
+        {track.file_path ||
+        (missing && (track as { _hasActionableContext?: boolean })._hasActionableContext) ? (
           <>
             <button
               type="button"
               className="enhanced-playnext-btn"
-              title="Play next"
+              title={missing ? 'Download automatically and play next' : 'Play next'}
               onClick={act(() => enqueue(true))}
             >
               ⇥
@@ -500,7 +496,7 @@ function TrackRow({
             <button
               type="button"
               className="enhanced-queue-btn"
-              title="Add to queue"
+              title={missing ? 'Add to queue and download automatically' : 'Add to queue'}
               onClick={act(() => enqueue(false))}
             >
               +

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.test.tsx
@@ -25,6 +25,7 @@ afterEach(() => {
   // lives there, and wiping the body out from under Testing Library's cleanup
   // makes it throw "The node to be removed is not a child of this node".
   cleanup();
+  delete window.playTrackList;
 });
 
 describe('EnhancedView states', () => {
@@ -102,7 +103,9 @@ describe('sections', () => {
       <EnhancedView
         onReload={vi.fn()}
         isAdmin={false}
-        data={{ albums: [{ id: 10, title: 'Greatest Hits', record_type: 'compilation', tracks: [] }] }}
+        data={{
+          albums: [{ id: 10, title: 'Greatest Hits', record_type: 'compilation', tracks: [] }],
+        }}
         status={READY}
       />,
     );
@@ -156,6 +159,43 @@ describe('album rows', () => {
       />,
     );
     expect(document.querySelector('.enhanced-album-title')?.textContent).toBe('Unknown');
+  });
+
+  it('plays every album row in disc and track order without expanding it', () => {
+    window.playTrackList = vi.fn();
+    render(
+      <EnhancedView
+        onReload={vi.fn()}
+        isAdmin={false}
+        data={{
+          artist: { id: 42, name: 'Aphex Twin', thumb_url: 'artist.jpg' },
+          albums: [
+            {
+              id: 1,
+              title: 'SAW 85-92',
+              thumb_url: 'album.jpg',
+              tracks: [
+                { id: 2, title: 'Tha', disc_number: 1, track_number: 2, file_path: 'tha.flac' },
+                { id: 1, title: 'Xtal', disc_number: 1, track_number: 1, file_path: 'xtal.flac' },
+              ],
+            },
+          ],
+        }}
+        status={READY}
+      />,
+    );
+
+    const row = document.getElementById('enhanced-album-row-1') as HTMLElement;
+    fireEvent.click(row.querySelector('.enhanced-album-play-btn')!);
+
+    expect(window.playTrackList).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ title: 'Xtal', file_path: 'xtal.flac', artist: 'Aphex Twin' }),
+        expect.objectContaining({ title: 'Tha', file_path: 'tha.flac', artist: 'Aphex Twin' }),
+      ],
+      'SAW 85-92',
+    );
+    expect(row.className).not.toContain('expanded');
   });
 });
 

--- a/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
+++ b/webui/src/routes/artist-detail/-ui/enhanced-view.tsx
@@ -12,7 +12,7 @@ import {
   sectionCountLabel,
   sectionTrackTotal,
 } from '../-artist-detail.enhanced';
-import { getAlbumTrackRows } from '../-artist-detail.enhanced-album';
+import { getAlbumTrackRows, queueTrackPayload } from '../-artist-detail.enhanced-album';
 import { syncVanillaEnhancedData, syncVanillaSelection } from '../-artist-detail.vanilla-state';
 import { AlbumMetaRow } from './album-meta-row';
 import { ArtistMetaPanel } from './artist-meta-panel';
@@ -270,6 +270,17 @@ function EnhancedAlbumWrapper({
     setAlbum(albumProp);
   }
   const meta = albumRowMeta(album);
+  const rows = getAlbumTrackRows(album);
+  const albumTitle = typeof album.title === 'string' && album.title ? album.title : 'Unknown';
+
+  const playAlbum = () => {
+    if (!rows.length) {
+      window.showToast?.(`No tracks found for ${albumTitle}`, 'info');
+      return;
+    }
+    const tracks = rows.map((track) => queueTrackPayload(track, album, artist));
+    void window.playTrackList?.(tracks, albumTitle);
+  };
 
   return (
     <div
@@ -306,6 +317,19 @@ function EnhancedAlbumWrapper({
           <span className="enhanced-album-meta-line">{meta.metaLine}</span>
         </div>
 
+        <button
+          type="button"
+          className="enhanced-album-play-btn"
+          aria-label={`Play ${albumTitle}`}
+          title={`Play ${albumTitle}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            playAlbum();
+          }}
+        >
+          ▶
+        </button>
+
         <span className={`enhanced-album-type-badge ${(type || 'album').toLowerCase()}`}>
           {type}
         </span>
@@ -325,7 +349,7 @@ function EnhancedAlbumWrapper({
             <>
               <ExpandedAlbumHeader
                 album={album}
-                rows={getAlbumTrackRows(album)}
+                rows={rows}
                 artistId={artist?.id}
                 artistName={String(artist?.name ?? '')}
                 isAdmin={isAdmin}

--- a/webui/src/routes/artist-detail/-ui/release-card.test.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.test.tsx
@@ -10,15 +10,17 @@ function renderCard(
   opts: Partial<{ mb: boolean; source: boolean }> = {},
 ) {
   const onOpen = vi.fn();
+  const onPlay = vi.fn();
   render(
     <ReleaseCard
       release={release}
       isMusicBrainz={opts.mb ?? false}
       isSourceArtist={opts.source ?? false}
       onOpen={onOpen}
+      onPlay={onPlay}
     />,
   );
-  return { onOpen, card: document.querySelector('.release-card') as HTMLElement };
+  return { onOpen, onPlay, card: document.querySelector('.release-card') as HTMLElement };
 }
 
 afterEach(() => {
@@ -123,6 +125,13 @@ describe('ReleaseCard interaction', () => {
     const { onOpen, card } = renderCard({ id: 1, title: 'X', musicbrainz_release_id: 'mbid' });
     fireEvent.click(card.querySelector('.mb-card-icon')!);
     expect(open).toHaveBeenCalledWith('https://musicbrainz.org/release/mbid', '_blank');
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('plays the album without also opening its modal', () => {
+    const { onOpen, onPlay, card } = renderCard({ id: 1, title: 'Kid A', owned: true });
+    fireEvent.click(card.querySelector('.release-card-play-btn')!);
+    expect(onPlay).toHaveBeenCalledWith(expect.objectContaining({ title: 'Kid A' }));
     expect(onOpen).not.toHaveBeenCalled();
   });
 

--- a/webui/src/routes/artist-detail/-ui/release-card.tsx
+++ b/webui/src/routes/artist-detail/-ui/release-card.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import type { DiscographyRelease } from '../-artist-detail.types';
 
 import {
@@ -17,6 +19,8 @@ interface Props {
   isMusicBrainz: boolean;
   isSourceArtist: boolean;
   onOpen: (release: DiscographyRelease) => void;
+  /** Resolve the release tracklist and replace the player queue with it. */
+  onPlay: (release: DiscographyRelease) => void | Promise<void>;
 }
 
 /**
@@ -28,7 +32,8 @@ interface Props {
  * both select on them, and dropping them would change the page's appearance
  * without changing any behaviour a test would notice.
  */
-export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen }: Props) {
+export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen, onPlay }: Props) {
+  const [playPending, setPlayPending] = useState(false);
   const flags = releaseFlags(release, isMusicBrainz);
   const overlay = completionOverlay(release, isSourceArtist);
   const year = releaseYearText(release);
@@ -54,6 +59,26 @@ export function ReleaseCard({ release, isMusicBrainz, isSourceArtist, onOpen }: 
       {/* data-bg-src, not a style: an IntersectionObserver swaps it in, so a
           75-card grid does not fetch 75 images up front. */}
       <div className="album-card-image" data-bg-src={bg ?? undefined} />
+
+      <button
+        type="button"
+        className="release-card-play-btn"
+        aria-label={`Play ${release.title || 'album'}`}
+        title={`Play ${release.title || 'album'}`}
+        disabled={playPending}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (playPending) return;
+          setPlayPending(true);
+          try {
+            void Promise.resolve(onPlay(release)).finally(() => setPlayPending(false));
+          } catch {
+            setPlayPending(false);
+          }
+        }}
+      >
+        {playPending ? '…' : '▶'}
+      </button>
 
       {overlay ? (
         <div className={`completion-overlay ${overlay.className}`}>

--- a/webui/src/routes/dashboard/-ui/sync-band.tsx
+++ b/webui/src/routes/dashboard/-ui/sync-band.tsx
@@ -23,8 +23,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { AutoSyncSeamState } from '../-dash.autosync';
-import type { SyncBandRow } from '../-dash.syncband';
 import type { SyncProgressFrame } from '../-dash.events';
+import type { SyncBandRow } from '../-dash.syncband';
 
 import { fetchDashboardSyncHistory } from '../-dash.api';
 import { autoSyncCardRows } from '../-dash.autosync';
@@ -157,7 +157,9 @@ function useSyncBand() {
         if (live) return live;
       }
       const rowName = normName(row.name);
-      return Object.values(liveSyncs).find((live) => normName(live.playlistName) === rowName) || null;
+      return (
+        Object.values(liveSyncs).find((live) => normName(live.playlistName) === rowName) || null
+      );
     },
     [liveSyncs],
   );
@@ -318,16 +320,18 @@ function useSyncBand() {
         name?: string;
         total?: number;
         tracks?: unknown[];
+        queue_tracks?: unknown[];
       };
       if (!data.success) throw new Error(data.error || 'failed');
-      const tracks = data.tracks || [];
+      const tracks = data.queue_tracks || data.tracks || [];
       if (!tracks.length) {
-        window.showToast?.('None of those tracks are in your library yet', 'info');
+        window.showToast?.('That playlist has no usable track metadata', 'info');
         return;
       }
-      if (data.total && tracks.length < data.total) {
+      const ownedCount = data.tracks?.length || 0;
+      if (data.total && ownedCount < data.total) {
         window.showToast?.(
-          `Playing ${tracks.length} of ${data.total} — the rest aren't in your library`,
+          `Queued ${data.total} tracks — preloading ${data.total - ownedCount} missing`,
           'info',
         );
       }

--- a/webui/src/routes/discover/-discover.playable.test.ts
+++ b/webui/src/routes/discover/-discover.playable.test.ts
@@ -47,6 +47,10 @@ describe('playMixNow', () => {
     stubFetch({
       success: true,
       tracks: [{ id: 1, file_path: '/m/a.flac', title: 'A' }],
+      queue_tracks: [
+        { id: 1, file_path: '/m/a.flac', title: 'A' },
+        { title: 'B', artist: 'X', playback_status: 'missing' },
+      ],
       matched: 1,
       total: 2,
     });
@@ -54,7 +58,8 @@ describe('playMixNow', () => {
     expect(outcome).toBe('played');
     expect(played).toHaveLength(1);
     expect(played[0].name).toBe('Daily Mix 1');
-    expect(toasts[0].msg).toContain('Playing 1 of 2');
+    expect(played[0].tracks).toHaveLength(2);
+    expect(toasts[0].msg).toContain('preloading 1 missing');
   });
 
   it('says all-owned when everything matched', async () => {
@@ -63,18 +68,27 @@ describe('playMixNow', () => {
     expect(toasts[0].msg).toContain('Playing all 1');
   });
 
-  it('nothing owned: honest toast, no playback', async () => {
-    stubFetch({ success: true, tracks: [], matched: 0, total: 5 });
+  it('nothing owned: queues the missing rows for automatic acquisition', async () => {
+    stubFetch({
+      success: true,
+      tracks: [],
+      queue_tracks: [{ title: 'A', artist: 'X', playback_status: 'missing' }],
+      matched: 0,
+      total: 1,
+    });
     const outcome = await playMixNow([{ title: 'A', artist: 'X' }], 'Mix');
-    expect(outcome).toBe('empty');
-    expect(played).toHaveLength(0);
-    expect(toasts[0].msg).toContain('library yet');
+    expect(outcome).toBe('played');
+    expect(played).toHaveLength(1);
+    expect(toasts[0].msg).toContain('preloading 1 missing');
   });
 
   it('a failed resolve never plays and says so', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => {
-      throw new Error('down');
-    }));
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('down');
+      }),
+    );
     const outcome = await playMixNow([{ title: 'A', artist: 'X' }], 'Mix');
     expect(outcome).toBe('failed');
     expect(played).toHaveLength(0);
@@ -86,7 +100,7 @@ describe('resolveMixPlayable', () => {
     const spy = vi.fn();
     vi.stubGlobal('fetch', spy);
     const res = await resolveMixPlayable([]);
-    expect(res).toEqual({ rows: [], matched: 0, total: 0 });
+    expect(res).toEqual({ rows: [], queueRows: [], matched: 0, total: 0 });
     expect(spy).not.toHaveBeenCalled();
   });
 

--- a/webui/src/routes/discover/-discover.playable.ts
+++ b/webui/src/routes/discover/-discover.playable.ts
@@ -13,6 +13,7 @@ import { normalizeTrack } from './-discover.helpers';
 
 export interface PlayableResolution {
   rows: Record<string, unknown>[];
+  queueRows: Record<string, unknown>[];
   matched: number;
   total: number;
 }
@@ -33,7 +34,7 @@ export function toPlayablePairs(tracks: unknown[]): { artist: string; title: str
 
 export async function resolveMixPlayable(tracks: unknown[]): Promise<PlayableResolution | null> {
   const pairs = toPlayablePairs(tracks);
-  if (!pairs.length) return { rows: [], matched: 0, total: 0 };
+  if (!pairs.length) return { rows: [], queueRows: [], matched: 0, total: 0 };
   try {
     const response = await fetch('/api/discover/resolve-playable', {
       method: 'POST',
@@ -43,12 +44,18 @@ export async function resolveMixPlayable(tracks: unknown[]): Promise<PlayableRes
     const data = (await response.json()) as {
       success?: boolean;
       tracks?: Record<string, unknown>[];
+      queue_tracks?: Record<string, unknown>[];
       matched?: number;
       total?: number;
     };
     if (!data?.success) return null;
     return {
       rows: Array.isArray(data.tracks) ? data.tracks : [],
+      queueRows: Array.isArray(data.queue_tracks)
+        ? data.queue_tracks
+        : Array.isArray(data.tracks)
+          ? data.tracks
+          : [],
       matched: data.matched ?? 0,
       total: data.total ?? 0,
     };
@@ -70,15 +77,16 @@ export async function playMixNow(
     window.showToast?.('Could not check your library right now', 'error');
     return 'failed';
   }
-  if (res.matched === 0) {
-    window.showToast?.('None of these tracks are in your library yet — download them first', 'info');
+  if (res.queueRows.length === 0) {
+    window.showToast?.('This mix has no playable track metadata', 'info');
     return 'empty';
   }
-  void window.playTrackList?.(res.rows as never, contextName);
+  void window.playTrackList?.(res.queueRows as never, contextName);
+  const missing = Math.max(0, res.total - res.matched);
   window.showToast?.(
     res.matched === res.total
       ? `Playing all ${res.matched} tracks`
-      : `Playing ${res.matched} of ${res.total} — the rest are a download away`,
+      : `Queued ${res.total} tracks — preloading ${missing} missing`,
     'success',
   );
   return 'played';

--- a/webui/src/routes/library/-ui/library-artist-card.test.tsx
+++ b/webui/src/routes/library/-ui/library-artist-card.test.tsx
@@ -220,3 +220,50 @@ describe('LibraryArtistCard link', () => {
     expect(document.querySelector('.library-artist-stat')).toBeNull();
   });
 });
+
+describe('LibraryArtistCard play action', () => {
+  it('plays top tracks without following the artist link', () => {
+    const onPlay = vi.fn();
+    render(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin' }}
+        index={0}
+        href="/artist-detail/library/1"
+        onPlay={onPlay}
+      />,
+    );
+
+    const button = document.querySelector('.library-artist-play-btn') as HTMLElement;
+    expect(button.getAttribute('aria-label')).toBe('Play top tracks by Aphex Twin');
+    expect(fireEvent.click(button)).toBe(false);
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it('is keyboard accessible and inert while the list is loading', () => {
+    const onPlay = vi.fn();
+    const { rerender } = render(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin' }}
+        index={0}
+        href="/artist-detail/library/1"
+        onPlay={onPlay}
+      />,
+    );
+    fireEvent.keyDown(document.querySelector('.library-artist-play-btn')!, { key: 'Enter' });
+    expect(onPlay).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <LibraryArtistCard
+        artist={{ id: 1, name: 'Aphex Twin' }}
+        index={0}
+        href="/artist-detail/library/1"
+        onPlay={onPlay}
+        playPending
+      />,
+    );
+    const button = document.querySelector('.library-artist-play-btn') as HTMLElement;
+    expect(button.textContent).toBe('…');
+    fireEvent.click(button);
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+});

--- a/webui/src/routes/library/-ui/library-artist-card.tsx
+++ b/webui/src/routes/library/-ui/library-artist-card.tsx
@@ -22,6 +22,10 @@ interface Props {
   onToggleWatch?: () => void;
   /** True while that toggle is in flight — the badge label shows "…". */
   watchPending?: boolean;
+  /** Replace the player queue with this artist's ranked top tracks. */
+  onPlay?: () => void;
+  /** True while the top-tracks list is being resolved. */
+  playPending?: boolean;
 }
 
 /**
@@ -119,6 +123,8 @@ export function LibraryArtistCard({
   href,
   onToggleWatch,
   watchPending,
+  onPlay,
+  playPending,
 }: Props) {
   const badges = buildArtistBadges(artist);
   const { primary, overflow, needsOverflow } = splitBadgeColumns(badges);
@@ -127,6 +133,7 @@ export function LibraryArtistCard({
   const tracks = trackCountLabel(artist.track_count);
   const hasImage = Boolean(artist.image_url && artist.image_url.trim() !== '');
   const onWatchClick = badgeClickHandler(watchPending ? undefined : onToggleWatch);
+  const onPlayClick = badgeClickHandler(playPending ? undefined : onPlay);
 
   // Only the UNWATCHED badge acts: the vanilla handler gated the toggle on
   // `badge.dataset.unwatched`, so a "Watching" badge swallowed its click and
@@ -199,6 +206,24 @@ export function LibraryArtistCard({
       <div className="library-artist-image">
         <ArtistImage artist={artist} hasImage={hasImage} />
       </div>
+
+      <span
+        className="library-artist-play-btn"
+        role="button"
+        tabIndex={0}
+        aria-label={`Play top tracks by ${artist.name}`}
+        aria-disabled={playPending || undefined}
+        title={`Play ${artist.name}'s top tracks`}
+        onClick={onPlayClick}
+        onKeyDown={(e) => {
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+          e.preventDefault();
+          e.stopPropagation();
+          if (!playPending) onPlay?.();
+        }}
+      >
+        {playPending ? '…' : '▶'}
+      </span>
 
       <div className="library-artist-info">
         <h3 className="library-artist-name" title={artist.name}>

--- a/webui/src/routes/library/-ui/library-page.test.tsx
+++ b/webui/src/routes/library/-ui/library-page.test.tsx
@@ -48,20 +48,30 @@ function stubFetch(artists: LibraryArtist[], total = artists.length, pages = 1) 
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      const body = url.includes('/api/library/artists')
-        ? {
-            success: true,
-            artists,
-            pagination: {
-              page: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1),
-              limit: 75,
-              total_count: total,
-              total_pages: pages,
-              has_prev: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) > 1,
-              has_next: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) < pages,
-            },
-          }
-        : {};
+      const body =
+        url.includes('/api/artist/') && url.includes('/top-tracks')
+          ? {
+              success: true,
+              source: 'spotify',
+              tracks: [
+                { id: 'sp-1', name: 'Xtal', artists: [{ name: 'Aphex Twin' }] },
+                { id: 'sp-2', name: 'Tha', artists: [{ name: 'Aphex Twin' }] },
+              ],
+            }
+          : url.includes('/api/library/artists')
+            ? {
+                success: true,
+                artists,
+                pagination: {
+                  page: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1),
+                  limit: 75,
+                  total_count: total,
+                  total_pages: pages,
+                  has_prev: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) > 1,
+                  has_next: Number(new URL(url, 'http://x').searchParams.get('page') ?? 1) < pages,
+                },
+              }
+            : {};
       return new Response(JSON.stringify(body), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -96,6 +106,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   delete window.SoulSyncWebShellBridge;
   delete window.showLibraryDownloadsSection;
+  delete window.playTrackList;
 });
 
 describe('LibraryPage rendering', () => {
@@ -130,6 +141,23 @@ describe('LibraryPage rendering', () => {
     fireEvent.click(document.querySelector('.library-radio-btn')!);
     expect(window.startLibraryRadio).toHaveBeenCalled();
     delete window.startLibraryRadio;
+  });
+
+  it("plays an artist's ranked top tracks in provider order", async () => {
+    window.playTrackList = vi.fn();
+    renderPage();
+    await screen.findByText('Aphex Twin');
+
+    fireEvent.click(document.querySelector('.library-artist-play-btn')!);
+
+    await waitFor(() => expect(window.playTrackList).toHaveBeenCalledTimes(1));
+    expect(window.playTrackList).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ title: 'Xtal', artist: 'Aphex Twin' }),
+        expect.objectContaining({ title: 'Tha', artist: 'Aphex Twin' }),
+      ],
+      'Aphex Twin — Top Tracks',
+    );
   });
 });
 

--- a/webui/src/routes/library/-ui/library-page.tsx
+++ b/webui/src/routes/library/-ui/library-page.tsx
@@ -9,6 +9,7 @@ import type { LibraryArtist, LibraryArtistsResponse } from '../-library.types';
 import { libraryArtistsQueryOptions, setArtistWatchlisted } from '../-library.api';
 import { readArtistsResponse, watchlistArtistId } from '../-library.helpers';
 import { useLibraryChanged } from '../-library.live';
+import { loadTopTracks, trackArtistLabel } from '../../artist-detail/-artist-detail.top-tracks';
 import { Route } from '../route';
 import { ExportArtistsModal } from './export-modal';
 import { LibraryArtistCard } from './library-artist-card';
@@ -54,6 +55,7 @@ export function LibraryPage() {
 
   const [exporting, setExporting] = useState(false);
   const [watchingAll, setWatchingAll] = useState(false);
+  const [playing, setPlaying] = useState<ReadonlySet<string>>(new Set());
 
   // The input is local so typing stays responsive; the URL only catches up
   // after the debounce, exactly as the vanilla 300ms timer did.
@@ -153,6 +155,44 @@ export function LibraryPage() {
 
   const setSearch = (patch: Partial<typeof search>) =>
     void navigate({ search: (prev) => ({ ...prev, ...patch, page: patch.page ?? 1 }) });
+
+  /**
+   * Load the same popularity-ranked list as the artist hero and hand the whole
+   * context to the acquisition-aware player. Its queue preflight resolves
+   * owned files first, so a provider/Last.fm row cannot duplicate a track that
+   * is already in the library; genuine misses enter the normal download flow.
+   */
+  const playArtistTopTracks = async (artist: LibraryArtist) => {
+    const key = String(artist.id);
+    if (playing.has(key)) return;
+    setPlaying((current) => new Set(current).add(key));
+    try {
+      const state = await loadTopTracks(artist.id, artist.name);
+      if (!state.tracks.length) {
+        window.showToast?.(`No top tracks found for ${artist.name}`, 'info');
+        return;
+      }
+      const tracks = state.tracks.map((track) => {
+        const artistName = trackArtistLabel(track, artist.name);
+        return {
+          ...track,
+          title: track.title || track.name || 'Unknown Track',
+          name: track.name || track.title || 'Unknown Track',
+          artist: artistName,
+          artists: track.artists?.length ? track.artists : [{ name: artistName }],
+        };
+      });
+      await window.playTrackList?.(tracks, `${artist.name} — Top Tracks`);
+    } catch {
+      window.showToast?.(`Could not play ${artist.name}'s top tracks`, 'error');
+    } finally {
+      setPlaying((current) => {
+        const next = new Set(current);
+        next.delete(key);
+        return next;
+      });
+    }
+  };
 
   // TRAP 0 — showLibraryDownloadsSection (shared-helpers.js) inserts a
   // #library-downloads-section node as a SIBLING before #library-artists-grid,
@@ -320,6 +360,8 @@ export function LibraryPage() {
               href={`/artist-detail/library/${artist.id}`}
               onToggleWatch={() => watchArtist.mutate(artist)}
               watchPending={watching.has(String(artist.id))}
+              onPlay={() => void playArtistTopTracks(artist)}
+              playPending={playing.has(String(artist.id))}
             />
           ))}
         </div>

--- a/webui/static/media-player.js
+++ b/webui/static/media-player.js
@@ -73,6 +73,10 @@ function initializeMediaPlayer() {
     if (miniShuffleBtn) miniShuffleBtn.addEventListener('click', (e) => { e.stopPropagation(); handleNpShuffle(); });
     if (miniRepeatBtn) miniRepeatBtn.addEventListener('click', (e) => { e.stopPropagation(); handleNpRepeat(); });
 
+    // Auto-download is off by default and profile-scoped. A user must enable it
+    // from the queue header before SoulSync starts background acquisitions.
+    try { npAutoDownloadQueue = localStorage.getItem(npAutoDownloadStorageKey()) === '1'; } catch (_) {}
+
     // Restore a previously-saved queue (does not auto-play)
     npRestoreQueue();
 }
@@ -1409,6 +1413,243 @@ let npVizInitialized = false;
 let npCrossfadeOn = false;
 let npSleepMinutes = 0;       // 0 = off
 let npSleepTimerId = null;
+let npAutoDownloadQueue = false;
+let npQueueRequestCounter = 0;
+let npQueuePrefetchRequest = null;
+let npQueuePrefetchReschedule = false;
+let npQueuePrefetchTimer = null;
+let npQueuePrefetchPoller = null;
+const npQueuePrefetchBatchIds = new Set();
+const NP_QUEUE_PREFETCH_TERMINAL = new Set(['failed', 'not_found', 'cancelled', 'quarantined']);
+
+function npQueueIdentity(track) {
+    const source = String(track?.source || track?.metadata_source || '').trim().toLowerCase();
+    const sourceId = String(track?.source_track_id || track?.spotify_track_id || track?.tidal_track_id ||
+        track?.deezer_id || track?.itunes_track_id || track?.musicbrainz_recording_id || track?.track_id || '').trim();
+    if (source && sourceId) return `source:${source}:${sourceId}`;
+    const title = String(track?.title || track?.name || '').trim().toLowerCase();
+    const artistValues = Array.isArray(track?.artists) ? track.artists : [];
+    const artists = artistValues.map(value => String(typeof value === 'object' ? value?.name : value || '').trim().toLowerCase()).filter(Boolean);
+    if (!artists.length) artists.push(String(track?.artist || track?.artist_name || '').trim().toLowerCase());
+    const rawAlbum = track?.album;
+    const album = String(typeof rawAlbum === 'object' ? (rawAlbum?.name || rawAlbum?.title || '') :
+        (rawAlbum || track?.album_title || '')).trim().toLowerCase();
+    return `metadata:${title}|${artists.join('|')}|${album}`;
+}
+
+function npPrepareQueueTrack(rawTrack) {
+    const track = { ...(rawTrack || {}) };
+    track.title = track.title || track.name || 'Unknown Track';
+    track.name = track.name || track.title;
+    if (!track.artist) {
+        const first = Array.isArray(track.artists) ? track.artists[0] : null;
+        track.artist = typeof first === 'object' ? first?.name : first;
+    }
+    track.artist = track.artist || track.artist_name || 'Unknown Artist';
+    if (!Array.isArray(track.artists) || !track.artists.length) track.artists = [{ name: track.artist }];
+    if (typeof track.album === 'object') track.album = track.album?.name || track.album?.title || '';
+    track.album = track.album || track.album_title || 'Unknown Album';
+    track.file_path = track.file_path || track.filename || '';
+    track.filename = track.file_path;
+    track.is_library = Boolean(track.file_path);
+    track.playback_status = track.file_path ? 'ready' : (track.playback_status || 'missing');
+    track._queue_identity = npQueueIdentity(track);
+    if (!track._queue_request_id) {
+        const existing = npQueue.find(item => item?._queue_identity === track._queue_identity && item?._queue_request_id);
+        track._queue_request_id = existing?._queue_request_id ||
+            `npq-${Date.now().toString(36)}-${(++npQueueRequestCounter).toString(36)}`;
+    }
+    return track;
+}
+
+function npPrepareQueueTracks(rawTracks) {
+    const requestIdByIdentity = new Map();
+    return (rawTracks || []).map(rawTrack => {
+        const track = npPrepareQueueTrack(rawTrack);
+        const sharedRequestId = requestIdByIdentity.get(track._queue_identity);
+        if (sharedRequestId) {
+            track._queue_request_id = sharedRequestId;
+        } else {
+            requestIdByIdentity.set(track._queue_identity, track._queue_request_id);
+        }
+        return track;
+    });
+}
+
+function npQueueTrackNeedsDownload(track) {
+    return Boolean(track && !track.file_path && track.title && track.artist &&
+        !NP_QUEUE_PREFETCH_TERMINAL.has(track.playback_status));
+}
+
+function npAutoDownloadStorageKey() {
+    const profile = String(window._currentProfileName || 'default');
+    return `soulsync-queue-auto-download:${profile}`;
+}
+
+function npQueueStatusLabel(track) {
+    switch (track?.playback_status) {
+        case 'requesting': return 'Preparing…';
+        case 'pending':
+        case 'queued': return 'Queued';
+        case 'searching': return 'Searching…';
+        case 'downloading': return track.download_progress > 0 ? `Downloading ${Math.round(track.download_progress)}%` : 'Downloading…';
+        case 'post_processing': return 'Verifying…';
+        case 'ready': return 'Ready';
+        case 'failed': return 'Download failed';
+        case 'not_found': return 'Not found';
+        case 'cancelled': return 'Cancelled';
+        case 'quarantined': return 'Quarantined';
+        default: return track?.file_path ? '' : 'Missing';
+    }
+}
+
+function npApplyQueuePrefetchState(requestIds, state, finalPath = '', progress = 0, error = '') {
+    const ids = new Set((requestIds || []).map(String));
+    let changed = false;
+    npQueue.forEach(track => {
+        if (!ids.has(String(track?._queue_request_id || ''))) return;
+        if (finalPath) {
+            track.file_path = finalPath;
+            track.filename = finalPath;
+            track.is_library = true;
+            track.playback_status = 'ready';
+            track.playback_error = '';
+        } else {
+            track.playback_status = state || track.playback_status;
+            track.download_progress = Number(progress || 0);
+            track.playback_error = error || '';
+        }
+        changed = true;
+    });
+    return changed;
+}
+
+function npStartQueuePrefetchPolling() {
+    if (npQueuePrefetchPoller || npQueuePrefetchBatchIds.size === 0) return;
+    npQueuePrefetchPoller = setInterval(npPollQueuePrefetch, 2000);
+    npPollQueuePrefetch();
+}
+
+function npStopQueuePrefetchPolling() {
+    if (npQueuePrefetchPoller) clearInterval(npQueuePrefetchPoller);
+    npQueuePrefetchPoller = null;
+}
+
+async function npPollQueuePrefetch() {
+    if (npQueuePrefetchBatchIds.size === 0) {
+        npStopQueuePrefetchPolling();
+        return;
+    }
+    const query = [...npQueuePrefetchBatchIds].map(id => `batch_ids=${encodeURIComponent(id)}`).join('&');
+    try {
+        const response = await fetch(`/api/playback/queue/prefetch/status?${query}`, { cache: 'no-store' });
+        const data = await response.json();
+        if (!response.ok || !data.success) throw new Error(data.error || 'Queue download status unavailable');
+        let changed = false;
+        Object.entries(data.batches || {}).forEach(([batchId, batch]) => {
+            const tasks = Array.isArray(batch?.tasks) ? batch.tasks : [];
+            tasks.forEach(task => {
+                const info = task.track_info || {};
+                const requestIds = Array.isArray(info._queue_request_ids) && info._queue_request_ids.length
+                    ? info._queue_request_ids
+                    : [info._queue_request_id].filter(Boolean);
+                if (!requestIds.length) return;
+                const state = task.quarantine_entry_id ? 'quarantined' : String(task.status || 'queued');
+                const finalPath = state === 'completed' ? String(task.final_file_path || '') : '';
+                changed = npApplyQueuePrefetchState(
+                    requestIds,
+                    finalPath ? 'ready' : state,
+                    finalPath,
+                    task.progress,
+                    task.error_message,
+                ) || changed;
+            });
+            const terminal = ['complete', 'error', 'cancelled'].includes(batch?.phase) &&
+                tasks.every(task => ['completed', 'failed', 'not_found', 'cancelled'].includes(task.status));
+            if (terminal) npQueuePrefetchBatchIds.delete(batchId);
+        });
+        if (changed) renderNpQueue();
+        if (npQueuePrefetchBatchIds.size === 0) npStopQueuePrefetchPolling();
+    } catch (error) {
+        console.warn('Queue prefetch status failed:', error.message);
+    }
+}
+
+async function npPrefetchMissingQueueTracks() {
+    if (!npAutoDownloadQueue) return;
+    if (npQueuePrefetchRequest) return npQueuePrefetchRequest;
+    const missing = npQueue.filter(npQueueTrackNeedsDownload);
+    if (!missing.length) return;
+    missing.forEach(track => { track.playback_status = 'requesting'; });
+    renderNpQueue();
+    npQueuePrefetchRequest = (async () => {
+        try {
+            const response = await fetch('/api/playback/queue/prefetch', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tracks: missing }),
+            });
+            const data = await response.json();
+            if (!response.ok || !data.success) throw new Error(data.error || 'Could not prefetch queue');
+            (data.items || []).forEach(item => {
+                npApplyQueuePrefetchState(
+                    item.request_ids || [],
+                    item.state || 'queued',
+                    item.final_path || '',
+                );
+            });
+            (data.batch_ids || []).forEach(id => npQueuePrefetchBatchIds.add(String(id)));
+            if (data.queued > 0) showToast(`Preloading ${data.queued} missing queue track${data.queued === 1 ? '' : 's'}`, 'info');
+            renderNpQueue();
+            npStartQueuePrefetchPolling();
+        } catch (error) {
+            missing.forEach(track => {
+                if (track.playback_status === 'requesting') {
+                    track.playback_status = 'failed';
+                    track.playback_error = error.message;
+                }
+            });
+            renderNpQueue();
+            showToast(`Queue prefetch failed: ${error.message}`, 'error');
+        } finally {
+            npQueuePrefetchRequest = null;
+            if (npQueuePrefetchReschedule) {
+                npQueuePrefetchReschedule = false;
+                npScheduleQueuePrefetch();
+            }
+        }
+    })();
+    return npQueuePrefetchRequest;
+}
+
+function npScheduleQueuePrefetch() {
+    if (!npAutoDownloadQueue) return;
+    if (npQueuePrefetchRequest) {
+        npQueuePrefetchReschedule = true;
+        return;
+    }
+    if (npQueuePrefetchTimer) clearTimeout(npQueuePrefetchTimer);
+    npQueuePrefetchTimer = setTimeout(() => {
+        npQueuePrefetchTimer = null;
+        npPrefetchMissingQueueTracks();
+    }, 80);
+}
+
+async function npEnsureQueueTrackReady(track) {
+    if (track?.file_path) return track;
+    if (!npAutoDownloadQueue) throw new Error('Auto-download is disabled for missing queue tracks');
+    await npPrefetchMissingQueueTracks();
+    const deadline = Date.now() + 45 * 60 * 1000;
+    while (!track.file_path && Date.now() < deadline) {
+        if (NP_QUEUE_PREFETCH_TERMINAL.has(track.playback_status)) {
+            throw new Error(track.playback_error || npQueueStatusLabel(track));
+        }
+        await new Promise(resolve => setTimeout(resolve, 1500));
+        await npPollQueuePrefetch();
+    }
+    if (!track.file_path) throw new Error('Download timed out after 45 minutes');
+    return track;
+}
 
 function npQueueHasNext() {
     if (npQueue.length === 0) return false;
@@ -1590,6 +1831,20 @@ function initExpandedPlayer() {
     }
     const queueClearBtn = document.getElementById('np-queue-clear');
     if (queueClearBtn) queueClearBtn.addEventListener('click', () => { clearQueue(); });
+
+    const autoDownloadBtn = document.getElementById('np-autodownload-btn');
+    if (autoDownloadBtn) {
+        autoDownloadBtn.classList.toggle('active', npAutoDownloadQueue);
+        autoDownloadBtn.setAttribute('aria-pressed', npAutoDownloadQueue ? 'true' : 'false');
+        autoDownloadBtn.addEventListener('click', () => {
+            npAutoDownloadQueue = !npAutoDownloadQueue;
+            autoDownloadBtn.classList.toggle('active', npAutoDownloadQueue);
+            autoDownloadBtn.setAttribute('aria-pressed', npAutoDownloadQueue ? 'true' : 'false');
+            try { localStorage.setItem(npAutoDownloadStorageKey(), npAutoDownloadQueue ? '1' : '0'); } catch (_) {}
+            showToast(npAutoDownloadQueue ? 'Queue auto-download enabled' : 'Queue auto-download disabled', 'info');
+            if (npAutoDownloadQueue) npScheduleQueuePrefetch();
+        });
+    }
 
     // Radio mode button
     const radioBtn = document.getElementById('np-radio-btn');
@@ -2159,10 +2414,11 @@ function npSetPlayContext(text) {
 }
 
 function addToQueue(track) {
-    npQueue.push(track);
+    npQueue.push(npPrepareQueueTrack(track));
     showToast('Added to queue', 'success');
     renderNpQueue();
     updateNpPrevNextButtons();
+    npScheduleQueuePrefetch();
     // If nothing is currently playing, auto-play the first queued track
     if (!currentTrack) {
         playQueueItem(npQueue.length - 1);
@@ -2176,10 +2432,11 @@ function playNext(track) {
         addToQueue(track);
         return;
     }
-    npQueue.splice(npQueueIndex + 1, 0, track);
+    npQueue.splice(npQueueIndex + 1, 0, npPrepareQueueTrack(track));
     showToast('Playing next', 'success');
     renderNpQueue();
     updateNpPrevNextButtons();
+    npScheduleQueuePrefetch();
 }
 
 function removeFromQueue(index) {
@@ -2201,12 +2458,16 @@ function removeFromQueue(index) {
         playQueueItem(npQueueIndex);
     }
     renderNpQueue();
+    npScheduleQueuePrefetch();
     updateNpPrevNextButtons();
+    if (!npQueue.some(track => !track.file_path)) npStopQueuePrefetchPolling();
 }
 
 function clearQueue() {
     npQueue = [];
     npQueueIndex = -1;
+    npQueuePrefetchBatchIds.clear();
+    npStopQueuePrefetchPolling();
     renderNpQueue();
     updateNpPrevNextButtons();
 }
@@ -2282,6 +2543,24 @@ async function playQueueItem(index) {
     const track = npQueue[index];
 
     try {
+        if (!track.file_path) {
+            setTrackInfo({
+                title: track.title,
+                artist: track.artist,
+                album: track.album || 'Waiting for download',
+                filename: '',
+                is_library: false,
+                image_url: track.image_url,
+                download_pending: true,
+            });
+            showLoadingAnimation();
+            const loadingText = document.querySelector('.loading-text');
+            if (loadingText) loadingText.textContent = 'Downloading queued track…';
+            renderNpQueue();
+            await npEnsureQueueTrackReady(track);
+            track.is_library = true;
+            if (loadingText) loadingText.textContent = 'Loading track…';
+        }
         if (track.is_library) {
             // Library track playback flow
             await stopStream();
@@ -2412,8 +2691,16 @@ function renderNpQueue() {
         info.appendChild(artist);
         item.appendChild(info);
 
-        // Active row → equalizer animation; others → duration
-        if (i === npQueueIndex) {
+        // Missing rows expose acquisition progress; ready rows keep the normal
+        // equalizer/duration affordance.
+        const queueStatus = npQueueStatusLabel(track);
+        if (!track.file_path || (track.playback_status && track.playback_status !== 'ready')) {
+            const status = document.createElement('span');
+            status.className = `np-queue-item-status ${track.playback_status || 'missing'}`;
+            status.textContent = queueStatus || 'Missing';
+            if (track.playback_error) status.title = track.playback_error;
+            item.appendChild(status);
+        } else if (i === npQueueIndex) {
             const eq = document.createElement('div');
             eq.className = 'np-queue-item-eq';
             eq.innerHTML = '<i></i><i></i><i></i>';
@@ -2464,11 +2751,20 @@ function npRestoreQueue() {
         if (!raw) return;
         const data = JSON.parse(raw);
         if (data && Array.isArray(data.queue) && data.queue.length) {
-            npQueue = data.queue;
+            npQueue = npPrepareQueueTracks(data.queue).map(track => {
+                const restored = track;
+                if (!restored.file_path) {
+                    restored.playback_status = 'missing';
+                    restored.playback_error = '';
+                    restored.download_progress = 0;
+                }
+                return restored;
+            });
             // Don't claim a track is "playing" on a fresh load — nothing is.
             npQueueIndex = -1;
             renderNpQueue();
             updateNpPrevNextButtons();
+            npScheduleQueuePrefetch();
         }
     } catch (e) { /* corrupt entry — ignore */ }
 }
@@ -2521,6 +2817,7 @@ function npReorderQueue(from, to) {
     }
     renderNpQueue();
     updateNpPrevNextButtons();
+    npScheduleQueuePrefetch();
 }
 
 // Up-next peek: show the track that plays after the current one.
@@ -3156,24 +3453,30 @@ async function startLibraryRadio() {
 }
 window.startLibraryRadio = startLibraryRadio;
 
-// Play a resolved LIBRARY track list as the queue (a synced playlist, a mix —
-// anything already shaped like /api/library/radio rows). Replaces the queue,
-// plays from the top, labels the "Playing from" context. Radio mode is left
-// OFF: a playlist has an end, and auto-queueing similar tracks after it is
-// the radio button's call, not this one's.
+// Play an acquisition-aware track list. Owned rows start immediately; missing
+// rows enter the same queue and are downloaded, verified and imported ahead of
+// playback. Radio mode stays off because a playlist still has a fixed end.
 async function playTrackList(tracks, contextName) {
-    var list = (tracks || []).filter(function (t) { return t && t.file_path; });
+    var list = (tracks || []).filter(function (t) {
+        if (!t) return false;
+        if (t.file_path) return true;
+        const title = t.title || t.name;
+        const firstArtist = Array.isArray(t.artists) ? t.artists[0] : null;
+        const artist = t.artist || t.artist_name || (typeof firstArtist === 'object' ? firstArtist?.name : firstArtist);
+        return Boolean(title && artist);
+    });
     if (!list.length) {
-        showToast('None of these tracks are in your library yet', 'info');
+        showToast('This list has no usable track metadata', 'info');
         return;
     }
     npCancelCrossfade();
     npRadioMode = false;
     clearQueue();
     if (audioPlayer && !audioPlayer.paused) audioPlayer.pause();
-    npQueue = list.map(npMapRadioTrack);
+    npQueue = npPrepareQueueTracks(list);
     renderNpQueue();
     npSetPlayContext(contextName || 'Playlist');
+    npScheduleQueuePrefetch();
     await playQueueItem(0);
 }
 window.playTrackList = playTrackList;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -54413,6 +54413,28 @@ textarea.enhanced-meta-field-input {
     gap: 4px;
     transition: all 0.15s ease;
 }
+.np-autodownload-btn {
+    background: none;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.35);
+    font-size: 11px;
+    padding: 3px 8px;
+    border-radius: 6px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.15s ease;
+}
+.np-autodownload-btn:hover {
+    color: rgba(255, 255, 255, 0.7);
+    border-color: rgba(255, 255, 255, 0.2);
+}
+.np-autodownload-btn.active {
+    color: rgb(var(--accent-rgb));
+    border-color: rgba(var(--accent-rgb), 0.3);
+    background: rgba(var(--accent-rgb), 0.08);
+}
 .np-radio-btn:hover {
     color: rgba(255, 255, 255, 0.7);
     border-color: rgba(255, 255, 255, 0.2);
@@ -54880,6 +54902,15 @@ textarea.enhanced-meta-field-input {
 .np-queue-item-title { font-size: 14px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .np-queue-item-artist { font-size: 12px; color: rgba(255,255,255,0.4); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .np-queue-item-duration { font-size: 12px; font-variant-numeric: tabular-nums; color: rgba(255,255,255,0.38); }
+.np-queue-item-status { font-size: 11px; white-space: nowrap; color: rgba(255,255,255,0.5); }
+.np-queue-item-status.downloading,
+.np-queue-item-status.searching,
+.np-queue-item-status.post_processing,
+.np-queue-item-status.requesting { color: rgb(var(--accent-light-rgb)); }
+.np-queue-item-status.failed,
+.np-queue-item-status.not_found,
+.np-queue-item-status.cancelled,
+.np-queue-item-status.quarantined { color: #ff7777; }
 .np-queue-item-eq { display: inline-flex; align-items: flex-end; gap: 2px; height: 14px; }
 .np-queue-item-eq i { width: 3px; border-radius: 2px; background: rgb(var(--accent-light-rgb)); animation: npQueueEq 0.9s ease-in-out infinite; }
 .np-queue-item-eq i:nth-child(2) { animation-delay: 0.2s; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -29894,6 +29894,43 @@ body:has(.download-missing-modal[style*="display: flex"]) #helper-float-btn {
             transparent 65%);
 }
 
+.library-artist-play-btn {
+    position: absolute;
+    right: 14px;
+    bottom: 58px;
+    z-index: 3;
+    width: 42px;
+    height: 42px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgb(var(--accent-rgb));
+    color: #fff;
+    font-size: 16px;
+    line-height: 1;
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.42);
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(8px) scale(0.94);
+    transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
+}
+
+.library-artist-card:hover .library-artist-play-btn,
+.library-artist-play-btn:focus-visible {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.library-artist-play-btn:hover {
+    filter: brightness(1.12);
+}
+
+.library-artist-play-btn[aria-disabled="true"] {
+    cursor: wait;
+}
+
 /* Artist Info — pinned to bottom over the gradient */
 .library-artist-info {
     position: absolute;
@@ -52048,6 +52085,25 @@ textarea.enhanced-meta-field-input {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+.enhanced-album-play-btn {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border-radius: 50%;
+    border: 1px solid rgba(var(--accent-rgb), 0.34);
+    background: rgba(var(--accent-rgb), 0.18);
+    color: rgb(var(--accent-light-rgb));
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+.enhanced-album-play-btn:hover,
+.enhanced-album-play-btn:focus-visible {
+    background: rgba(var(--accent-rgb), 0.34);
+    transform: scale(1.06);
+}
 .enhanced-album-year {
     font-size: 12px;
     color: rgba(255,255,255,0.4);
@@ -70130,6 +70186,54 @@ body[data-artist-source="source"] .artist-detail-page #library-artist-enhance-bt
 
 .artist-detail-page .release-card.album-card .mb-card-icon:hover {
     opacity: 1;
+}
+
+.artist-detail-page .release-card-play-btn {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    z-index: 4;
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgb(var(--accent-rgb));
+    color: #fff;
+    font-size: 18px;
+    line-height: 1;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.48);
+    cursor: pointer;
+    opacity: 0;
+    transform: translate(-50%, -40%) scale(0.9);
+    transition: opacity 0.2s ease, transform 0.2s ease, filter 0.2s ease;
+}
+
+.artist-detail-page .release-card.album-card:hover .release-card-play-btn,
+.artist-detail-page .release-card-play-btn:focus-visible {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+}
+
+.artist-detail-page .release-card-play-btn:hover {
+    filter: brightness(1.12);
+}
+
+.artist-detail-page .release-card-play-btn:disabled {
+    cursor: wait;
+}
+
+@media (hover: none) {
+    .library-artist-play-btn {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+    .artist-detail-page .release-card-play-btn {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+    }
 }
 
 /* ── HiFi API instances list (drag and drop) ── */


### PR DESCRIPTION
## Summary

This PR aims to add 2 new related features:
* [feat(playback): auto-download missing queue tracks](https://github.com/Nezreka/SoulSync/pull/1195/changes/2d56f85b84fd671b0e97088894a9891d0fb0f7db)
  - Automatically acquire missing playback-queue tracks through SoulSync's existing enabled download sources.
  - Preserve queue order with one active queue download so the next unavailable track is prepared first.
  - Reconcile completed downloads with their imported library files so queue entries become playable instead of remaining `Missing`.
* [feat(library): add artist and album play actions](https://github.com/Nezreka/SoulSync/pull/1195/changes/84c9871cb4fcbe2108409642b2d80028fefb4e59)
  - Add Play actions for artists in Library that adds top tracks to the player's queue (and download missing tracks with auto-download enabled)
  - For albums on artist pages, add a play button that adds all tracks to the queue and start playing the albums (and download missing tracks with auto-download enabled)

## Behavior

- Queue auto-download is disabled by default and stored per profile.
- Existing library files and active or completed queue downloads are reused.
- Missing tracks expose queued, searching, downloading, verifying, and error states.
- The first unavailable queue track waits for its verified import while later missing tracks remain ordered behind it.
- Downloads use SoulSync's existing source-selection, matching, download, verification, and import pipeline.
- Artist Play queues the artist's top tracks; album Play queues its tracks in album order.

## Testing

- `python -m ruff check --output-format=github .`
- `python -m compileall api core database services scripts web_server.py wsgi.py beatport_unified_scraper.py`
- Targeted Python tests: 103 passed.
- Full Python suite: 15,133 passed; three unrelated failures were reproduced unchanged on `dev`.
- Targeted WebUI tests: 153 passed.
- Full WebUI suite: 8,032 passed.
- WebUI production build completed successfully.
- Changed WebUI sources pass formatting and type-aware lint with no errors.
- The repository-wide WebUI format check is already failing on `dev` (36 pre-existing files); this branch reduces that count and introduces no formatting failure in its changed sources.

## Screenshots

### Library artist Play action

<img width="2810" height="1154" alt="Library artist Play action" src="https://github.com/user-attachments/assets/5d8c4028-7318-4c9b-bc7e-2e426466118a" />

### Artist-page album Play action

<img width="2802" height="732" alt="Artist-page album Play action" src="https://github.com/user-attachments/assets/a177b3dd-3259-4d09-b5ef-8d740f10f437" />

### Ordered queue auto-download states

<img width="1942" height="1186" alt="Ordered queue auto-download states" src="https://github.com/user-attachments/assets/05942b7e-7d13-4678-bfde-84364068f2bf" />


