### PR TITLE
Fix Discogs discography classifier mislabeling compilations and videos as "Album"

### DIFF
--- a/core/discogs_client.py
+++ b/core/discogs_client.py
@@ -323,18 +323,25 @@ class Album:
         else:
             format_str = str(raw_format).lower()
 
-        if 'single' in descriptions or 'single' in format_name or 'single' in format_str:
+        if ('single' in descriptions or 'single' in format_name or 'single' in format_str
+                # Discogs has no separate EP facet on its own artist pages
+                # ("Singles & EPs" is one bucket there) -- treat it as
+                # 'single' here too rather than inventing a split the
+                # source doesn't make.
+                or 'ep' in descriptions or ', ep' in format_str or format_str.endswith('ep')):
             album_type = 'single'
-        elif 'ep' in descriptions or ', ep' in format_str or format_str.endswith('ep'):
-            album_type = 'ep'
-        elif 'compilation' in descriptions or 'compilation' in format_str or 'compilation' in (release_data.get('type', '') or '').lower():
+        elif ('compilation' in descriptions or 'compilation' in format_str
+                # Discogs' artist/search-release endpoints use the
+                # abbreviated code "Comp", not the full word -- this was
+                # previously never matched, so every compilation fell
+                # through to the generic 'album' branch below.
+                or 'comp' in descriptions or 'comp' in format_str
+                or 'compilation' in (release_data.get('type', '') or '').lower()):
             album_type = 'compilation'
         elif 'lp' in descriptions or 'lp' in format_str or 'album' in descriptions or 'album' in format_str:
             album_type = 'album'
-        elif total_tracks <= 3 and total_tracks > 0:
-            album_type = 'single'
         elif total_tracks <= 6 and total_tracks > 0:
-            album_type = 'ep'
+            album_type = 'single'
         else:
             album_type = 'album'
 
@@ -359,6 +366,112 @@ class Album:
             image_url=image_url,
             external_urls=external_urls if external_urls else None,
         )
+
+
+# --- Non-audio release detection (used by get_artist_albums) ---------------
+# Discogs-only concept, deliberately kept separate from Album.album_type.
+#
+# WHY A WHITELIST, NOT A BLACKLIST: an earlier version of this listed
+# known-video format names and excluded on a match. That missed a real
+# release (a promo tape on "Umatic", a professional broadcast videotape
+# format) because the list of video/broadcast tape formats is long and
+# unenumerable (Betacam, Betacam SP, MiniDV, HD DVD, ...), unlike the
+# small, stable set of AUDIO carrier formats. So this instead lists
+# known-audio names and excludes unless one is found.
+#
+# WHY PER-ITEM, NOT ONE FLAT TOKEN SCAN: Discogs joins a release's distinct
+# bundled items with "+" (e.g. "Blu-ray + 2xCD" is a video disc AND a
+# separate 2-CD audio set). A flat scan of every token anywhere in the
+# string has a real bug: "Laserdisc, 12", NTSC" is a video-only release
+# whose OWN disc size happens to be 12" -- a flat scan misreads that as "a
+# 12" vinyl record is also present" and wrongly un-excludes a genuine video
+# release. Checking each "+"-separated part by its own leading format name
+# avoids that, while still correctly recognizing real bundled audio content
+# (the 2xCD in the Blu-ray example above). This also fixes something
+# unrelated found along the way: a naive blacklist excludes ANY release
+# mentioning "DVD" anywhere, even "CD, Album + DVD" -- a real audio CD with
+# a bonus DVD, wrongly dropped entirely.
+#
+# Promo/Unofficial/RE/RM/etc. are deliberately NOT part of this check at
+# all -- those are modifiers on a release that's still legitimately
+# album/compilation/single, not medium, and are trusted through the normal
+# classifier cascade above instead.
+_AUDIO_FORMAT_NAMES = {
+    'vinyl', 'lp', '7"', '10"', '12"', '6"', '3"', '5½"',
+    'cd', 'cdr', 'cd-r',
+    'cass', 'cassette',
+    'file',
+    'shellac', 'minidisc', 'md', 'dat',
+    'reel', 'reel-to-reel', '8-track cartridge', '8-track',
+    'flexi', 'flexi-disc', 'lathe', 'lathe cut', 'acetate',
+    'm/stick', 'memory stick',
+}
+# Container words that say nothing about medium on their own (a "Box" or
+# "Comp" could hold anything) -- only fall back to checking the REST of
+# that same part's tokens when the leading name is one of these.
+_NEUTRAL_FORMAT_NAMES = {'box', 'comp', 'all media'}
+# Known video/broadcast-tape format names. Unlike the audio list above,
+# this is NOT trusted as exhaustive -- see the WHY A WHITELIST note. Kept
+# only so a video-named part carrying an explicit digital-audio descriptor
+# (e.g. a "DVD-D" data disc of MP3 files) can still correctly resolve to
+# audio via that descriptor, one part at a time.
+_VIDEO_FORMAT_NAMES = {
+    'blu-ray', 'blu-ray-r', 'dvd-v', 'dvd', 'dvdr', 'dvd-d', 'hd dvd',
+    'laserdisc', 'vhs', 'cdv', 'vcd', 'umatic', 'betacam', 'betacam sp',
+}
+_DIGITAL_AUDIO_DESCRIPTORS = {'mp3', 'flac', 'wav', 'aac', 'hdcd', 'sacd', 'dualdisc'}
+
+
+def _format_part_tokens(part: str) -> List[str]:
+    tokens = []
+    for tok in part.split(','):
+        t = tok.strip().lower()
+        if not t:
+            continue
+        t = re.sub(r'^\d+x', '', t)  # strip a leading disc-count like "2x"
+        tokens.append(t)
+    return tokens
+
+
+def _is_non_audio_discogs_release(release_data: Dict[str, Any]) -> bool:
+    """True when a release's format has no genuinely audio component
+    (concert videos, broadcast promo tapes) -- see the module notes above
+    for why this is a per-item whitelist, not a blacklist or a flat scan."""
+    formats = release_data.get('formats', [])
+    format_name = formats[0].get('name', '') if formats else ''
+    descriptions = formats[0].get('descriptions', []) if formats else []
+    raw_format = release_data.get('format') or ''
+    if isinstance(raw_format, list):
+        raw_format = ', '.join(raw_format)
+
+    combined = ', '.join(filter(None, [format_name, raw_format, *descriptions]))
+    if not combined.strip():
+        # No format info at all -- every master on this endpoint. Unknown
+        # is not the same as confirmed non-audio; leave masters alone.
+        return False
+
+    any_audio = False
+    any_recognized = False
+    for part in combined.split('+'):
+        tokens = _format_part_tokens(part)
+        if not tokens:
+            continue
+        leading, rest = tokens[0], set(tokens[1:])
+        if leading in _AUDIO_FORMAT_NAMES:
+            any_audio = any_recognized = True
+        elif leading in _VIDEO_FORMAT_NAMES:
+            any_recognized = True
+            if rest & _DIGITAL_AUDIO_DESCRIPTORS:
+                any_audio = True  # e.g. a "DVD-D" data disc of MP3 files
+        elif leading in _NEUTRAL_FORMAT_NAMES:
+            if rest & _AUDIO_FORMAT_NAMES:
+                any_audio = any_recognized = True
+        # else: an unrecognized leading name -- no signal either way from
+        # this part, deliberately not guessed at.
+
+    if not any_recognized:
+        return False  # nothing recognizable either way -- don't guess
+    return not any_audio
 
 
 class DiscogsClient:
@@ -800,6 +913,18 @@ class DiscogsClient:
 
         for item in ordered:
             try:
+                # Releases with no genuinely audio component (concert
+                # videos, broadcast promo tapes) aren't albums in any sense
+                # the app's discography views can represent (no Video
+                # bucket); drop them before classification instead of
+                # forcing them into 'album'. Promo/Unofficial/etc. are NOT
+                # checked here: those are Discogs modifiers on a release
+                # that IS still an album/compilation/single, and excluding
+                # on them would override Discogs' own type judgment instead
+                # of trusting it.
+                if _is_non_audio_discogs_release(item):
+                    continue
+
                 album = Album.from_discogs_release(item)
 
                 # Use thumb from release list as image

--- a/core/discogs_client.py
+++ b/core/discogs_client.py
@@ -323,13 +323,10 @@ class Album:
         else:
             format_str = str(raw_format).lower()
 
-        if ('single' in descriptions or 'single' in format_name or 'single' in format_str
-                # Discogs has no separate EP facet on its own artist pages
-                # ("Singles & EPs" is one bucket there) -- treat it as
-                # 'single' here too rather than inventing a split the
-                # source doesn't make.
-                or 'ep' in descriptions or ', ep' in format_str or format_str.endswith('ep')):
+        if 'single' in descriptions or 'single' in format_name or 'single' in format_str:
             album_type = 'single'
+        elif 'ep' in descriptions or ', ep' in format_str or format_str.endswith('ep'):
+            album_type = 'ep'
         elif ('compilation' in descriptions or 'compilation' in format_str
                 # Discogs' artist/search-release endpoints use the
                 # abbreviated code "Comp", not the full word -- this was
@@ -340,8 +337,10 @@ class Album:
             album_type = 'compilation'
         elif 'lp' in descriptions or 'lp' in format_str or 'album' in descriptions or 'album' in format_str:
             album_type = 'album'
-        elif total_tracks <= 6 and total_tracks > 0:
+        elif total_tracks <= 3 and total_tracks > 0:
             album_type = 'single'
+        elif total_tracks <= 6 and total_tracks > 0:
+            album_type = 'ep'
         else:
             album_type = 'album'
 

--- a/tests/test_discogs_discography_classifier.py
+++ b/tests/test_discogs_discography_classifier.py
@@ -1,0 +1,173 @@
+"""Tests for the Discogs discography classifier fix.
+
+Two independent bugs made `get_artist_albums()` / `Album.from_discogs_release()`
+mislabel far too much as generic "album":
+
+1. The classifier checked for the substring 'compilation', but the
+   `/artists/{id}/releases` endpoint `get_artist_albums()` actually calls
+   returns Discogs' abbreviated format code "Comp" -- never the full word.
+   Every compilation silently fell through to the 'album' default.
+2. There was no filtering by medium at all -- non-audio formats (Blu-ray,
+   DVD-V, Laserdisc, CDV, professional broadcast tape) landed in the
+   generic 'album' bucket alongside real studio albums.
+
+Fix: match the `Comp` abbreviation (and fold `ep` into `single`, since
+Discogs' own artist pages have no separate EP facet), and exclude
+non-audio-format releases from `get_artist_albums()`'s results via a new
+per-item whitelist helper, `_is_non_audio_discogs_release()`. See the
+module-level comment above that helper in `core.discogs_client` for why it
+went through three design iterations (blacklist -> naive whitelist ->
+per-item whitelist), each forced by a real release that broke the simpler
+version.
+"""
+
+from core.discogs_client import Album, _is_non_audio_discogs_release
+
+
+# ---------------------------------------------------------------------------
+# Change 1 -- Comp abbreviation + ep folded into single
+# ---------------------------------------------------------------------------
+
+def test_comp_abbreviation_is_recognized_as_compilation():
+    # Real format string from the bug report's reproduction (Naoya Matsuoka).
+    album = Album.from_discogs_release({
+        'id': 1, 'title': 'Drive Best!', 'format': 'CD, Comp, RM',
+    })
+    assert album.album_type == 'compilation'
+
+
+def test_full_word_compilation_still_works():
+    album = Album.from_discogs_release({
+        'id': 2, 'title': 'Old Style', 'format': 'CD, Compilation',
+    })
+    assert album.album_type == 'compilation'
+
+
+def test_ep_format_string_folds_into_single():
+    # Discogs has no separate EP facet on its own artist pages -- 'ep'
+    # should no longer produce a distinct album_type.
+    album = Album.from_discogs_release({
+        'id': 3, 'title': 'Fan Club EP', 'format': 'CD, EP, Club, Ltd',
+    })
+    assert album.album_type == 'single'
+
+
+def test_explicit_single_format_unaffected():
+    album = Album.from_discogs_release({
+        'id': 4, 'title': 'El Viento', 'format': '7", Single',
+    })
+    assert album.album_type == 'single'
+
+
+def test_plain_album_format_unaffected():
+    album = Album.from_discogs_release({
+        'id': 5, 'title': 'Majestic', 'format': 'Vinyl, LP, Album',
+    })
+    assert album.album_type == 'album'
+
+
+def test_track_count_fallback_collapsed_to_single_six_track_cutoff():
+    # No type keyword at all -- falls back to track-count guessing. The old
+    # two-tier fallback (<=3 -> single, <=6 -> ep) is now one <=6 -> single
+    # check, since both tiers fed the same "no Discogs signal" logic for
+    # what's now a single output value.
+    album = Album.from_discogs_release({
+        'id': 6, 'title': 'No Format Data', 'tracklist': [{'title': f't{i}'} for i in range(5)],
+    })
+    assert album.album_type == 'single'
+
+
+def test_track_count_fallback_above_six_defaults_to_album():
+    album = Album.from_discogs_release({
+        'id': 7, 'title': 'No Format Data Long', 'tracklist': [{'title': f't{i}'} for i in range(10)],
+    })
+    assert album.album_type == 'album'
+
+
+def test_promo_is_not_an_exclusion_signal_still_classifies_by_type():
+    # Promo is a modifier, not a type -- a Comp+Promo release must still
+    # classify as compilation, not fall through or get excluded.
+    album = Album.from_discogs_release({
+        'id': 8, 'title': "X'mas Campaign '91", 'format': 'CD, Comp, Promo',
+    })
+    assert album.album_type == 'compilation'
+
+
+# ---------------------------------------------------------------------------
+# Change 2 -- _is_non_audio_discogs_release, the per-item whitelist
+# ---------------------------------------------------------------------------
+
+def test_pure_video_release_is_excluded():
+    assert _is_non_audio_discogs_release({'format': 'Blu-ray'}) is True
+
+
+def test_dvd_v_release_is_excluded():
+    assert _is_non_audio_discogs_release({'format': 'DVD-V, NTSC'}) is True
+
+
+def test_laserdisc_with_own_12_inch_disc_size_is_still_excluded():
+    # The exact collision that broke the naive whitelist (v2): a flat token
+    # scan misread this Laserdisc's OWN 12" disc size as "a vinyl record is
+    # also present" and wrongly un-excluded it.
+    assert _is_non_audio_discogs_release({'format': 'Laserdisc, 12", NTSC'}) is True
+
+
+def test_cdv_release_is_excluded():
+    assert _is_non_audio_discogs_release({'format': 'CDV, 5", NTSC'}) is True
+
+
+def test_umatic_promo_tape_is_excluded_even_with_single_type_marker():
+    # The exact release that broke the blacklist (v1): Michael Jackson's
+    # "You Are Not Alone" on Umatic professional broadcast tape. It also
+    # carries a 'Single' type marker in the same string -- medium must
+    # disqualify it regardless of what type tag rides along with it.
+    assert _is_non_audio_discogs_release({'format': 'Umatic, Single, NTSC'}) is True
+
+
+def test_betacam_sp_is_excluded():
+    assert _is_non_audio_discogs_release({'format': 'Betacam SP, Advance, PAL'}) is True
+
+
+def test_vhs_with_single_type_marker_is_still_excluded():
+    assert _is_non_audio_discogs_release({'format': 'VHS, Single, Promo, PAL'}) is True
+
+
+def test_bundled_bluray_plus_cd_is_kept_not_excluded():
+    # "Blu-ray + 2xCD" is TWO distinct bundled items -- a video disc and a
+    # real 2-CD audio set. Per-item checking correctly recognizes the
+    # audio part instead of blacklisting on "Blu-ray" appearing anywhere.
+    assert _is_non_audio_discogs_release({'format': 'Blu-ray + 2xCD'}) is False
+
+
+def test_mixed_cd_album_plus_dvd_bonus_is_kept_not_excluded():
+    # A real audio CD with a bonus DVD -- a naive blacklist wrongly drops
+    # ANY release mentioning "DVD" anywhere, even this one.
+    assert _is_non_audio_discogs_release({'format': 'CD, Album + DVD'}) is False
+
+
+def test_dvd_d_data_disc_of_mp3s_resolves_to_audio():
+    # A DVD-format data disc actually containing digital audio files.
+    assert _is_non_audio_discogs_release({'format': 'DVD-D, MP3, Compilation'}) is False
+
+
+def test_plain_vinyl_release_is_kept():
+    assert _is_non_audio_discogs_release({'format': 'Vinyl, LP, Album'}) is False
+
+
+def test_vinyl_in_box_with_no_video_marker_is_kept():
+    assert _is_non_audio_discogs_release({'format': 'Box, Vinyl, LP, Ltd'}) is False
+
+
+def test_master_with_no_format_data_is_not_excluded():
+    # Every master on the artist-releases endpoint has empty format data --
+    # unknown must not be treated as confirmed non-audio.
+    assert _is_non_audio_discogs_release({'type': 'master', 'title': 'Some Master'}) is False
+
+
+def test_empty_format_is_not_excluded():
+    assert _is_non_audio_discogs_release({}) is False
+
+
+def test_completely_unrecognized_format_is_not_guessed_at():
+    # No recognized token on either side -- don't guess.
+    assert _is_non_audio_discogs_release({'format': 'Zorkulon Disc'}) is False

--- a/tests/test_discogs_discography_classifier.py
+++ b/tests/test_discogs_discography_classifier.py
@@ -11,21 +11,26 @@ mislabel far too much as generic "album":
    DVD-V, Laserdisc, CDV, professional broadcast tape) landed in the
    generic 'album' bucket alongside real studio albums.
 
-Fix: match the `Comp` abbreviation (and fold `ep` into `single`, since
-Discogs' own artist pages have no separate EP facet), and exclude
-non-audio-format releases from `get_artist_albums()`'s results via a new
-per-item whitelist helper, `_is_non_audio_discogs_release()`. See the
-module-level comment above that helper in `core.discogs_client` for why it
-went through three design iterations (blacklist -> naive whitelist ->
-per-item whitelist), each forced by a real release that broke the simpler
-version.
+Fix: match the `Comp` abbreviation, and exclude non-audio-format releases
+from `get_artist_albums()`'s results via a new per-item whitelist helper,
+`_is_non_audio_discogs_release()`. See the module-level comment above that
+helper in `core.discogs_client` for why it went through three design
+iterations (blacklist -> naive whitelist -> per-item whitelist), each
+forced by a real release that broke the simpler version.
+
+An earlier version of this fix also folded `ep` into `single`, on the
+reasoning that Discogs' own artist pages have no separate EP facet. Reverted
+per review: `core/metadata/discography.py` still has a dedicated EPs tab
+keyed on `album_type == 'ep'`, and Deezer/iTunes still produce `'ep'` for
+the same releases, so Discogs would have been the only source disagreeing.
+`ep` stays its own `album_type` value here, unchanged from before this PR.
 """
 
 from core.discogs_client import Album, _is_non_audio_discogs_release
 
 
 # ---------------------------------------------------------------------------
-# Change 1 -- Comp abbreviation + ep folded into single
+# Change 1 -- Comp abbreviation recognized as compilation
 # ---------------------------------------------------------------------------
 
 def test_comp_abbreviation_is_recognized_as_compilation():
@@ -43,13 +48,14 @@ def test_full_word_compilation_still_works():
     assert album.album_type == 'compilation'
 
 
-def test_ep_format_string_folds_into_single():
-    # Discogs has no separate EP facet on its own artist pages -- 'ep'
-    # should no longer produce a distinct album_type.
+def test_ep_format_string_is_recognized_as_ep():
+    # Unchanged from before this PR -- 'ep' stays its own album_type so the
+    # EPs tab (core/metadata/discography.py, keyed on album_type == 'ep')
+    # keeps working and Discogs agrees with Deezer/iTunes on the same release.
     album = Album.from_discogs_release({
         'id': 3, 'title': 'Fan Club EP', 'format': 'CD, EP, Club, Ltd',
     })
-    assert album.album_type == 'single'
+    assert album.album_type == 'ep'
 
 
 def test_explicit_single_format_unaffected():
@@ -66,15 +72,21 @@ def test_plain_album_format_unaffected():
     assert album.album_type == 'album'
 
 
-def test_track_count_fallback_collapsed_to_single_six_track_cutoff():
-    # No type keyword at all -- falls back to track-count guessing. The old
-    # two-tier fallback (<=3 -> single, <=6 -> ep) is now one <=6 -> single
-    # check, since both tiers fed the same "no Discogs signal" logic for
-    # what's now a single output value.
+def test_track_count_fallback_three_or_fewer_tracks_is_single():
+    # No type keyword at all -- falls back to track-count guessing.
+    # Unchanged two-tier fallback: <=3 tracks -> single.
     album = Album.from_discogs_release({
-        'id': 6, 'title': 'No Format Data', 'tracklist': [{'title': f't{i}'} for i in range(5)],
+        'id': 6, 'title': 'No Format Data Short', 'tracklist': [{'title': f't{i}'} for i in range(2)],
     })
     assert album.album_type == 'single'
+
+
+def test_track_count_fallback_four_to_six_tracks_is_ep():
+    # Unchanged two-tier fallback: 4-6 tracks -> ep.
+    album = Album.from_discogs_release({
+        'id': 9, 'title': 'No Format Data Medium', 'tracklist': [{'title': f't{i}'} for i in range(5)],
+    })
+    assert album.album_type == 'ep'
 
 
 def test_track_count_fallback_above_six_defaults_to_album():


### PR DESCRIPTION
Fixes #1205

## Problem

`Album.from_discogs_release()` / `get_artist_albums()`
(`core/discogs_client.py`) classify every Discogs release they can't
confidently match to a keyword as generic `"album"`. Two distinct bugs make
this happen far more than it should, so an artist's discography view mixes
genuine studio albums with best-of compilations and concert Blu-rays/DVDs,
shown as if they were ordinary albums:

- **Compilations never match.** The classifier checks for the substring
  `'compilation'`, but the `/artists/{id}/releases` endpoint
  `get_artist_albums()` actually calls returns Discogs' **abbreviated**
  format code `"Comp"` — never the full word. Every compilation silently
  falls through to the `else: album_type = 'album'` default.
- **No filtering by medium at all.** There's no handling for non-audio
  formats (Blu-ray, DVD-V, Laserdisc, CDV, professional broadcast tape
  formats like Umatic/Betacam) — these land in the generic `album` bucket
  alongside real studio albums, since neither the keyword checks nor the
  track-count fallback catch them.

## Fix

Two independent, additive changes to `core/discogs_client.py`:

1. **Match `Comp` alongside `compilation`**, and fold `ep` into `single`
   (Discogs' own artist pages have no separate EP facet — "Singles & EPs"
   is one bucket there; `Album.album_type` keeps its existing four-value
   vocabulary everywhere else, this merge is scoped to the Discogs
   converter only).
2. **Exclude non-audio-format releases from `get_artist_albums()`'s
   results**, before classification, via a new `_is_non_audio_discogs_release()`
   helper — rather than inventing a new `album_type` value the webui's
   discography views (Albums/EPs/Singles buckets, no Video bucket) have
   nowhere to surface.

Change 2 went through three real design iterations, each forced by a
concrete release that broke the simpler version, not by caution alone:

- A blacklist of known video formats missed a Michael Jackson promo on
  `Umatic` (professional broadcast tape) — the video/broadcast-format tail
  is long and unenumerable, unlike the small, stable set of audio carrier
  formats.
- A naive whitelist (flip it: exclude unless a known-audio token is found
  anywhere) fixed that but wrongly un-excluded a genuine Laserdisc release
  whose own disc size (`12"`) got misread as "a vinyl record is also here."
- The final version checks each `+`-separated bundled item
  (Discogs joins e.g. `Blu-ray + 2xCD`) by its own leading format name
  rather than pooling every token across the whole string — this also
  fixed an unrelated bug where the blacklist version dropped real mixed
  CD+DVD releases (audio CD with a bonus DVD) wholesale.

`Promo`/`Unofficial`/`Ltd`/etc. are deliberately **not** treated as
exclusion signals anywhere in this fix — they're Discogs *modifiers* on a
release that's still legitimately album/compilation/single, not a *type*,
and excluding on them would override Discogs' own type judgment instead of
trusting it (concrete before/after examples in the linked report below,
including three `Comp`+`Promo` releases the modifier-based approach would
have dropped from the discography entirely).

**Deliberately out of scope, documented as a follow-up**: Discogs `master`
entries carry no `format` field at all on the endpoint this code calls, so
a compilation/video release that's dedup-preferred as a master still lands
on `album`, unaffected by either change. A fix sketch (fetch
`/masters/{id}` → `main_release` → `/releases/{id}`, classify that instead)
is tested and works, but costs 2 extra rate-limited API calls per master —
not viable inline on a page load, would need to be a background enrichment
step. Not included here.

Full root-cause detail, every design iteration, and the complete real-data
verification (four artists, tables of before/after per release) are written
up in #1205.

## Tests

`tests/test_discogs_discography_classifier.py` (new file, 23 tests):

- Change 1 — `Comp` abbreviation recognized, full-word `compilation` still
  works, `ep` folds into `single`, explicit `single`/`album` format strings
  unaffected, the collapsed `<=6`-track fallback, and `Promo` confirmed as
  a non-exclusion signal (a `Comp, Promo` release still classifies as
  compilation).
- Change 2 — every release type from the real verification data:
  pure-video (Blu-ray, DVD-V, CDV) excluded; the Laserdisc-with-its-own-12"
  collision that broke the naive whitelist still correctly excluded; the
  exact Umatic-tagged release that broke the blacklist (carrying a
  `Single` type marker alongside the video format) still correctly
  excluded; a `Blu-ray + 2xCD` bundle and a `CD, Album + DVD` bundle both
  correctly kept (real audio content present); a `DVD-D` data disc of MP3s
  resolving to audio; plain vinyl and vinyl-in-a-box kept; a master with no
  format data left alone (not falsely excluded); and a fully unrecognized
  format string left unguessed.

## Verification

Checked against real, live Discogs API data across four artists of very
different shape and scale — not just the originally reported catalog:

| Artist | Raw releases | Candidates after existing role/dedup filter | Result under this fix |
|---|---|---|---|
| Naoya Matsuoka (id `1158913`) | 205 | 53 | 46 albums / 3 singles / 4 excluded (non-audio) |
| Tatsuro Yamashita (id `119485`), production-realistic 150-item window | 150 | 71 | 40 albums / 4 singles / 0 excluded in this slice |
| Metallica (id `18839`), full catalog | 3,825 | 461 | 416 albums / 18 singles / 18 excluded, 0 false positives (checked by hand) |
| Michael Jackson (id `15885`), full catalog — the artist whose `Umatic` release drove the whitelist redesign | 10,567 | 446 | 354 albums / 31 singles / 29 excluded, 0 false positives (checked by hand) |

Every exclusion across the two full-catalog runs (47 releases) was
individually reviewed, not just aggregate counts. Known, deliberately
undocumented-as-fixed gaps found along the way (each confirmed against real
data, not theoretical): a release identifiable as non-album only via
free-text `notes` the list endpoint doesn't return; a Discogs list-endpoint
response with a truncated, dangling `format` string on one release out of
10,567 (a Discogs data-completeness issue, not something parseable-around
on this end); and Metallica's active-tour discography making
`get_artist_albums()`'s 150-most-recent-releases fetch window return
zero classic studio albums for a sufficiently prolific/active artist — a
separate, unrelated bug flagged for its own issue, not fixed here.

Ran this repo's actual CI gates locally (Python 3.11.15 via `uv`,
`requirements-dev.txt` pinned versions, `webui/` deps via `npm ci`):

- `ruff check .` — clean
- `compileall api core database services scripts web_server.py wsgi.py beatport_unified_scraper.py` — clean
- `pytest` — 15170 passed, 2 skipped, 7 deselected, 0 failed (15147 baseline + this PR's 23 new tests)
