### PR TITLE
fix(sync): show YouTube Music in the add-playlist account list

### DIFF
--- a/webui/src/routes/sync/-ui/add-playlist-sheet.tsx
+++ b/webui/src/routes/sync/-ui/add-playlist-sheet.tsx
@@ -38,6 +38,7 @@ export const ADD_PLAYLIST_ACCOUNTS: readonly { tab: string; label: string; glyph
   { tab: 'tidal', label: 'Tidal', glyph: '🌊' },
   { tab: 'qobuz', label: 'Qobuz', glyph: '♫' },
   { tab: 'deezer', label: 'Deezer', glyph: '🎧' },
+  { tab: 'ytmusic', label: 'YouTube Music', glyph: '▶️' },
   { tab: 'listenbrainz-sync', label: 'ListenBrainz', glyph: '🧠' },
   { tab: 'lastfm-sync', label: 'Last.fm', glyph: '📻' },
   { tab: 'soulsync-discovery-sync', label: 'SoulSync Discovery', glyph: '✨' },


### PR DESCRIPTION
I don't know how I made my rebase but this has been dropped unfortunately.... Follow-up of https://github.com/Nezreka/SoulSync/pull/1193