### PR TITLE
Protect same-run album/artist inserts from the orphan-cleanup sweep

### DIFF
--- a/core/database_update_worker.py
+++ b/core/database_update_worker.py
@@ -48,6 +48,13 @@ class DatabaseUpdateWorker:
         # Spotify/MusicBrainz/etc. ids without a manual backfill.
         self._new_track_ids = set()
 
+        # Artist/album ids this run wrote a row for (insert OR update), passed
+        # to cleanup_orphaned_records() as an exclude-list — protects against
+        # deleting a row this same run just created before its tracks landed
+        # (see cleanup_orphaned_records' docstring for why).
+        self._touched_artist_ids = set()
+        self._touched_album_ids = set()
+
         # Optional callback(worker) run as the FINAL scan phase, immediately
         # before the 'finished' signal — so the auto-reconcile is inside the
         # scan's running window (automations/UI treat it as a normal phase and
@@ -274,7 +281,10 @@ class DatabaseUpdateWorker:
             # Cleanup orphaned records after incremental updates (catches fixed matches)
             if not self.full_refresh and self.database:
                 try:
-                    cleanup_results = self.database.cleanup_orphaned_records()
+                    cleanup_results = self.database.cleanup_orphaned_records(
+                        exclude_artist_ids=self._touched_artist_ids,
+                        exclude_album_ids=self._touched_album_ids,
+                    )
                     orphaned_artists = cleanup_results.get('orphaned_artists_removed', 0)
                     orphaned_albums = cleanup_results.get('orphaned_albums_removed', 0)
 
@@ -416,7 +426,10 @@ class DatabaseUpdateWorker:
             # Phase 4: Cleanup
             self._emit_signal('phase_changed', "Deep scan: Cleaning up orphaned records...")
             try:
-                cleanup_results = self.database.cleanup_orphaned_records()
+                cleanup_results = self.database.cleanup_orphaned_records(
+                    exclude_artist_ids=self._touched_artist_ids,
+                    exclude_album_ids=self._touched_album_ids,
+                )
                 orphaned_artists = cleanup_results.get('orphaned_artists_removed', 0)
                 orphaned_albums = cleanup_results.get('orphaned_albums_removed', 0)
                 if orphaned_artists > 0 or orphaned_albums > 0:
@@ -1005,7 +1018,8 @@ class DatabaseUpdateWorker:
                     artist_success = self.database.insert_or_update_media_artist(artist, server_source=self.server_type)
                     if artist_success:
                         total_processed_artists += 1
-                    
+                        self._touched_artist_ids.add(artist_id)
+
                     # Process albums for this artist  
                     artist_album_ids = albums_by_artist.get(artist_id, set())
                     for album_id in artist_album_ids:
@@ -1022,7 +1036,8 @@ class DatabaseUpdateWorker:
                                     album_success = self.database.insert_or_update_media_album(album, artist_id, server_source=self.server_type)
                                     if album_success:
                                         total_processed_albums += 1
-                                    
+                                        self._touched_album_ids.add(str(album_id))
+
                                     # Process all tracks in this album
                                     for track in album_tracks:
                                         if self.should_stop:
@@ -1505,6 +1520,7 @@ class DatabaseUpdateWorker:
                 return False, "Failed to update artist data", 0, 0
 
             artist_id = str(media_artist.ratingKey)
+            self._touched_artist_ids.add(artist_id)
 
             # 2. Get all albums for this artist (cached from aggressive pre-population)
             try:
@@ -1535,6 +1551,7 @@ class DatabaseUpdateWorker:
                         if album_success:
                             album_count += 1
                             album_id = str(album.ratingKey)
+                            self._touched_album_ids.add(album_id)
 
                             # 4. Process tracks in this album (cached from aggressive pre-population)
                             try:

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -7550,49 +7550,82 @@ class MusicDatabase:
                 logger.error(f"Error clearing {server_source} database data: {e}")
                 raise
     
-    def cleanup_orphaned_records(self) -> Dict[str, int]:
-        """Remove artists and albums that have no associated tracks"""
+    def cleanup_orphaned_records(self, exclude_artist_ids: Optional[set] = None,
+                                  exclude_album_ids: Optional[set] = None) -> Dict[str, int]:
+        """Remove artists and albums that have no associated tracks.
+
+        ``exclude_artist_ids``/``exclude_album_ids`` protect rows the CURRENT
+        scan run itself just wrote an artist/album for, from a same-run
+        insert-then-immediately-orphaned race: if the media server's API call
+        for an artist's albums (or an album's tracks) comes back incomplete
+        or empty on one call within a run, an album (or a brand-new,
+        single-album artist) can be inserted with zero tracks and then get
+        swept by this SAME run's cleanup before it ever has a track — and
+        because the row briefly existed, the media server no longer reports
+        it as "recently added/updated" on future incremental scans either,
+        so it silently never comes back (see the
+        soulsync_navidrome_compilation_id_instability_TODO investigation —
+        Rare Funk & Disco 24 on redhome). Excluding rows this run touched
+        costs nothing (a genuinely orphaned row from a PRIOR run is still
+        caught next cleanup) and closes off that permanent-loss path."""
         try:
+            exclude_artist_ids = exclude_artist_ids or set()
+            exclude_album_ids = exclude_album_ids or set()
+
             with self._get_connection() as conn:
                 cursor = conn.cursor()
-                
+
+                artist_exclude_sql = ""
+                artist_params: list = []
+                if exclude_artist_ids:
+                    placeholders = ",".join("?" for _ in exclude_artist_ids)
+                    artist_exclude_sql = f" AND id NOT IN ({placeholders})"
+                    artist_params = list(exclude_artist_ids)
+
+                album_exclude_sql = ""
+                album_params: list = []
+                if exclude_album_ids:
+                    placeholders = ",".join("?" for _ in exclude_album_ids)
+                    album_exclude_sql = f" AND id NOT IN ({placeholders})"
+                    album_params = list(exclude_album_ids)
+
                 # Find orphaned artists (no tracks)
-                cursor.execute("""
-                    SELECT COUNT(*) FROM artists 
-                    WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks WHERE artist_id IS NOT NULL)
-                """)
+                cursor.execute(f"""
+                    SELECT COUNT(*) FROM artists
+                    WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks WHERE artist_id IS NOT NULL){artist_exclude_sql}
+                """, artist_params)
                 orphaned_artists_count = cursor.fetchone()[0]
-                
+
                 # Find orphaned albums (no tracks)
-                cursor.execute("""
-                    SELECT COUNT(*) FROM albums 
-                    WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)
-                """)
+                cursor.execute(f"""
+                    SELECT COUNT(*) FROM albums
+                    WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL){album_exclude_sql}
+                """, album_params)
                 orphaned_albums_count = cursor.fetchone()[0]
-                
+
                 # Delete orphaned artists
                 if orphaned_artists_count > 0:
-                    cursor.execute("""
-                        DELETE FROM artists 
-                        WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks WHERE artist_id IS NOT NULL)
-                    """)
+                    cursor.execute(f"""
+                        DELETE FROM artists
+                        WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks WHERE artist_id IS NOT NULL){artist_exclude_sql}
+                    """, artist_params)
                     logger.info(f"Removed {orphaned_artists_count} orphaned artists")
-                
-                # Delete orphaned albums  
+
+                # Delete orphaned albums
                 if orphaned_albums_count > 0:
-                    cursor.execute("""
-                        DELETE FROM albums 
-                        WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)
-                    """)
+                    cursor.execute(f"""
+                        DELETE FROM albums
+                        WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL){album_exclude_sql}
+                    """, album_params)
                     logger.info(f"Removed {orphaned_albums_count} orphaned albums")
-                
+
                 conn.commit()
-                
+
                 return {
                     'orphaned_artists_removed': orphaned_artists_count,
                     'orphaned_albums_removed': orphaned_albums_count
                 }
-                
+
         except Exception as e:
             logger.error(f"Error cleaning up orphaned records: {e}")
             return {'orphaned_artists_removed': 0, 'orphaned_albums_removed': 0}

--- a/tests/database/test_cleanup_orphaned_records_exclusion.py
+++ b/tests/database/test_cleanup_orphaned_records_exclusion.py
@@ -1,0 +1,112 @@
+"""cleanup_orphaned_records() must not delete a row the CURRENT scan run
+just wrote, even though it has no tracks yet (see
+soulsync_navidrome_compilation_id_instability_TODO memory / redhome's
+"Rare Funk & Disco 24" — an album inserted this run, then swept by this
+same run's cleanup before its tracks landed, never came back because the
+media server stopped reporting it as "recently added" once the row had
+briefly existed)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from database.music_database import MusicDatabase
+
+
+class _InMemoryDB(MusicDatabase):
+    def __init__(self):
+        self._conn = sqlite3.connect(":memory:")
+        self._conn.row_factory = sqlite3.Row
+
+    def _get_connection(self):
+        return _NonClosingConn(self._conn)
+
+
+class _NonClosingConn:
+    def __init__(self, real):
+        self._real = real
+
+    def cursor(self):
+        return self._real.cursor()
+
+    def commit(self):
+        return self._real.commit()
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def _seed(db):
+    cur = db._conn.cursor()
+    cur.execute("CREATE TABLE artists (id TEXT PRIMARY KEY, name TEXT)")
+    cur.execute("CREATE TABLE albums (id TEXT PRIMARY KEY, artist_id TEXT, title TEXT)")
+    cur.execute("""
+        CREATE TABLE tracks (id TEXT PRIMARY KEY, album_id TEXT, artist_id TEXT, title TEXT)
+    """)
+    # A normal artist/album with a track — never at risk, sanity baseline.
+    cur.execute("INSERT INTO artists VALUES ('artist-ok', 'Has Tracks')")
+    cur.execute("INSERT INTO albums VALUES ('album-ok', 'artist-ok', 'Real Album')")
+    cur.execute("INSERT INTO tracks VALUES ('track-1', 'album-ok', 'artist-ok', 'Song')")
+    # A genuinely stale artist/album from a PRIOR run — no tracks, not touched
+    # this run. Cleanup must still remove these (regression guard).
+    cur.execute("INSERT INTO artists VALUES ('artist-stale', 'Old Orphan')")
+    cur.execute("INSERT INTO albums VALUES ('album-stale', 'artist-stale', 'Old Orphan Album')")
+    # This run's freshly-inserted, still-trackless artist/album — the race.
+    cur.execute("INSERT INTO artists VALUES ('artist-fresh', 'Various Artists')")
+    cur.execute("INSERT INTO albums VALUES ('album-fresh', 'artist-fresh', 'Rare Funk & Disco 24')")
+    db._conn.commit()
+
+
+def test_excluded_trackless_album_and_artist_survive_cleanup():
+    db = _InMemoryDB()
+    _seed(db)
+
+    result = db.cleanup_orphaned_records(
+        exclude_artist_ids={'artist-fresh'},
+        exclude_album_ids={'album-fresh'},
+    )
+
+    remaining_albums = {r['id'] for r in db._conn.execute("SELECT id FROM albums")}
+    remaining_artists = {r['id'] for r in db._conn.execute("SELECT id FROM artists")}
+
+    assert 'album-fresh' in remaining_albums, "excluded (this-run) album must not be deleted"
+    assert 'artist-fresh' in remaining_artists, "excluded (this-run) artist must not be deleted"
+    # The genuinely stale, non-excluded rows are still cleaned up.
+    assert 'album-stale' not in remaining_albums
+    assert 'artist-stale' not in remaining_artists
+    assert result['orphaned_albums_removed'] == 1
+    assert result['orphaned_artists_removed'] == 1
+
+
+def test_no_exclusions_behaves_like_before():
+    db = _InMemoryDB()
+    _seed(db)
+
+    result = db.cleanup_orphaned_records()
+
+    remaining_albums = {r['id'] for r in db._conn.execute("SELECT id FROM albums")}
+    remaining_artists = {r['id'] for r in db._conn.execute("SELECT id FROM artists")}
+
+    # Without an exclude list every trackless row is swept, including the
+    # this-run one — this is the OLD (buggy) behavior, pinned so a future
+    # change can't silently widen the default to "always exclude everything".
+    assert remaining_albums == {'album-ok'}
+    assert remaining_artists == {'artist-ok'}
+    assert result['orphaned_albums_removed'] == 2
+    assert result['orphaned_artists_removed'] == 2
+
+
+def test_album_with_tracks_never_removed_regardless_of_exclusion():
+    db = _InMemoryDB()
+    _seed(db)
+
+    db.cleanup_orphaned_records(exclude_artist_ids=set(), exclude_album_ids=set())
+
+    row = db._conn.execute("SELECT id FROM albums WHERE id = 'album-ok'").fetchone()
+    assert row is not None

--- a/tests/database/test_orphan_cleanup_same_run_integration.py
+++ b/tests/database/test_orphan_cleanup_same_run_integration.py
@@ -1,0 +1,167 @@
+"""End-to-end check for the same-run orphan-cleanup fix (Nezreka/SoulSync#1216,
+PR #1217) — exercises the REAL DatabaseUpdateWorker code path
+(_process_artist_with_content) against a real on-disk MusicDatabase schema,
+not just cleanup_orphaned_records() in isolation
+(see tests/database/test_cleanup_orphaned_records_exclusion.py for that).
+
+Reproduces the exact failure shape traced live on Rare Funk & Disco 24: an
+artist whose album fetch comes back with the album but an EMPTY track list
+on one run (simulating an incomplete upstream response), then a full track
+list on a later run once the fetch behaves.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.database_update_worker import DatabaseUpdateWorker
+from database.music_database import MusicDatabase
+
+
+class _Track:
+    def __init__(self, rating_key, title, track_number):
+        self.ratingKey = rating_key
+        self.title = title
+        self.trackNumber = track_number
+
+
+class _Album:
+    def __init__(self, rating_key, title, tracks):
+        self.ratingKey = rating_key
+        self.title = title
+        self._tracks = tracks
+
+    def tracks(self):
+        return self._tracks
+
+
+class _Artist:
+    def __init__(self, rating_key, title, albums):
+        self.ratingKey = rating_key
+        self.title = title
+        self._albums = albums
+
+    def albums(self):
+        return self._albums
+
+
+@pytest.fixture()
+def dbpath(tmp_path):
+    return str(tmp_path / "music.db")
+
+
+def _worker(dbpath):
+    worker = DatabaseUpdateWorker(
+        media_client=None,  # unused directly by _process_artist_with_content
+        database_path=dbpath,
+        server_type="navidrome",
+        full_refresh=False,
+        force_sequential=True,
+    )
+    # run() normally sets this via get_database(); _process_artist_with_content
+    # is called directly here (bypassing run()), so wire it the same way
+    # the real web-server call site does (api/database_admin.py:
+    # ``worker.database = database``).
+    worker.database = MusicDatabase(dbpath)
+    return worker
+
+
+def test_incomplete_fetch_survives_same_run_cleanup_then_completes_next_run(dbpath):
+    album_id = "album-rare-funk"
+    artist_id = "artist-various"
+
+    # ── Run 1: the album is inserted, but its own track fetch came back
+    # empty on this call (the exact condition that used to be fatal) ──
+    empty_album = _Album(album_id, "Rare Funk & Disco 24", tracks=[])
+    artist_run1 = _Artist(artist_id, "Various Artists", albums=[empty_album])
+
+    worker1 = _worker(dbpath)
+    success, details, album_count, track_count = worker1._process_artist_with_content(artist_run1)
+    assert success is True
+    assert album_count == 1
+    assert track_count == 0
+    assert album_id in worker1._touched_album_ids
+    assert artist_id in worker1._touched_artist_ids
+
+    # Simulate the real end-of-run cleanup call, passing this run's touched ids
+    # exactly like run() does.
+    cleanup1 = worker1.database.cleanup_orphaned_records(
+        exclude_artist_ids=worker1._touched_artist_ids,
+        exclude_album_ids=worker1._touched_album_ids,
+    )
+    assert cleanup1["orphaned_albums_removed"] == 0
+    assert cleanup1["orphaned_artists_removed"] == 0
+
+    row = worker1.database._get_connection().execute(
+        "SELECT id FROM albums WHERE id = ?", (album_id,)
+    ).fetchone()
+    assert row is not None, "album must survive the same run's cleanup despite having 0 tracks"
+
+    track_row_count = worker1.database._get_connection().execute(
+        "SELECT COUNT(*) FROM tracks WHERE album_id = ?", (album_id,)
+    ).fetchone()[0]
+    assert track_row_count == 0
+
+    # ── Run 2 (fresh worker — new process/scan, like the real hourly
+    # automation instantiating a new DatabaseUpdateWorker each time): the
+    # upstream fetch now behaves and returns all 16 tracks. Confirm the
+    # surviving album row gets completed, not treated as a duplicate/stuck. ──
+    full_tracks = [_Track(f"track-{i}", f"Song {i}", i) for i in range(1, 17)]
+    full_album = _Album(album_id, "Rare Funk & Disco 24", tracks=full_tracks)
+    artist_run2 = _Artist(artist_id, "Various Artists", albums=[full_album])
+
+    worker2 = _worker(dbpath)
+    success2, _, album_count2, track_count2 = worker2._process_artist_with_content(artist_run2)
+    assert success2 is True
+    assert album_count2 == 1
+    assert track_count2 == 16
+
+    cleanup2 = worker2.database.cleanup_orphaned_records(
+        exclude_artist_ids=worker2._touched_artist_ids,
+        exclude_album_ids=worker2._touched_album_ids,
+    )
+    assert cleanup2["orphaned_albums_removed"] == 0
+
+    final_track_count = worker2.database._get_connection().execute(
+        "SELECT COUNT(*) FROM tracks WHERE album_id = ?", (album_id,)
+    ).fetchone()[0]
+    assert final_track_count == 16
+
+
+def test_album_still_trackless_after_a_later_untouched_run_is_genuinely_cleaned(dbpath):
+    """The fix protects a row for the run that touched it — it must NOT
+    become permanently immune. If a later run doesn't touch this artist at
+    all (e.g. it dropped out of the incremental scan's recent-albums window)
+    and the album is still trackless, that run's cleanup should remove it
+    like any other real orphan."""
+    album_id = "album-stuck-forever"
+    artist_id = "artist-stuck"
+
+    empty_album = _Album(album_id, "Never Gets Tracks", tracks=[])
+    artist = _Artist(artist_id, "Some Artist", albums=[empty_album])
+
+    worker1 = _worker(dbpath)
+    worker1._process_artist_with_content(artist)
+    worker1.database.cleanup_orphaned_records(
+        exclude_artist_ids=worker1._touched_artist_ids,
+        exclude_album_ids=worker1._touched_album_ids,
+    )
+    still_there = worker1.database._get_connection().execute(
+        "SELECT id FROM albums WHERE id = ?", (album_id,)
+    ).fetchone()
+    assert still_there is not None
+
+    # A later run's cleanup, with nothing touched this time (this artist
+    # wasn't in scope for this scan at all) — must remove the still-trackless row.
+    worker2 = _worker(dbpath)
+    cleanup2 = worker2.database.cleanup_orphaned_records(
+        exclude_artist_ids=worker2._touched_artist_ids,  # empty
+        exclude_album_ids=worker2._touched_album_ids,    # empty
+    )
+    assert cleanup2["orphaned_albums_removed"] == 1
+    assert cleanup2["orphaned_artists_removed"] == 1
+
+    gone = worker2.database._get_connection().execute(
+        "SELECT id FROM albums WHERE id = ?", (album_id,)
+    ).fetchone()
+    assert gone is None


### PR DESCRIPTION
Fixes #1216

## Problem

`cleanup_orphaned_records()` runs at the end of every incremental scan and
deep scan, and unconditionally deletes any artist/album with zero attached
tracks:

```python
cursor.execute("""
    DELETE FROM albums
    WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks WHERE album_id IS NOT NULL)
""")
```

That's correct for a row genuinely left behind from a prior run, but it
doesn't distinguish that from a row the **current** run itself just
inserted moments earlier in the same pass, whose track-insert step hasn't
completed yet — e.g. the album insert succeeded but the follow-up
`album.tracks()` / per-track insert calls came back short for that one
album on that one call. If that happens, the album is deleted before it
ever gets tracks, and since the row briefly existed, the media server no
longer reports it as "recently added/updated" — so no future incremental
scan re-discovers it as new either. The album is gone for good with no
error logged anywhere.

I wasn't able to pin down why an individual artist/album fetch is
occasionally short within an otherwise-successful run (traced one instance
live with debug logging — every read/write on that particular run
succeeded cleanly, so it's evidently intermittent and upstream of this
code), so this fix doesn't attempt to fix *that*. It closes the resulting
permanent-data-loss path instead: whatever the cause, an album this run
already knows it touched should never be a candidate for this run's own
cleanup.

## Fix

`cleanup_orphaned_records()` gains two optional parameters,
`exclude_artist_ids` and `exclude_album_ids`, appended as
`AND id NOT IN (...)` to both the orphan `SELECT COUNT` and the `DELETE`
for artists and albums respectively. `DatabaseUpdateWorker` gains
`self._touched_artist_ids` / `self._touched_album_ids`, populated at every
place the worker successfully inserts-or-updates an artist or album row
(covers the Navidrome/Plex/deep-scan shared path in
`_process_artist_with_content()` and the separate Jellyfin fast-processing
path), and passes them at both `cleanup_orphaned_records()` call sites
(incremental scan and deep scan).

No behavior change for a normal run: only rows this exact run wrote to are
ever excluded, so a row that's genuinely been orphaned since a prior scan
is still caught and removed on schedule.

## Testing

`tests/database/test_cleanup_orphaned_records_exclusion.py` (3 tests, unit
level): an excluded, still-trackless artist/album survives cleanup while a
non-excluded stale one is still removed in the same call (regression
guard against accidentally widening exclusion to everything); no
exclusion args behaves exactly like the old unconditional-delete behavior
(pins the default); an album with real tracks is never touched either way.

`tests/database/test_orphan_cleanup_same_run_integration.py` (2 tests,
end-to-end against the real `_process_artist_with_content()` path, not
the isolated method): reproduces the traced failure shape directly — an
artist whose album fetch returns the album but an *empty* track list on
one run survives that run's cleanup with 0 tracks, then a later run
(fresh `DatabaseUpdateWorker`, same DB) with a full track list completes
it normally; separately, an album that's *still* trackless on a later run
that didn't touch it at all is correctly swept as a genuine orphan — the
fix protects a row for the run that touched it, not permanently.

Confirmed these two are exercising the real bug and not a tautology: reverted
`database/music_database.py` and `core/database_update_worker.py` to their
pre-fix state and re-ran — both new tests fail (`AttributeError` on the
missing `_touched_*_ids`) — then restored and confirmed green again.

Full existing suite still green, no regressions. `ruff check` clean.
