### PR TITLE
feat(settings): move YouTube auth into Connections

### DIFF
--- a/api/source_playlists.py
+++ b/api/source_playlists.py
@@ -4657,7 +4657,7 @@ def get_ytmusic_playlists():
     from core.ytmusic_library import fetch_library_playlists, fetch_liked_music_row, library_playlists_to_rows
     auth = _ytmusic_auth_headers()
     if not auth:
-        return jsonify({"error": "YouTube Music not authenticated. Settings → Downloads → Download Source: YouTube Only → Paste cookies.txt → Save."}), 401
+        return jsonify({"error": "YouTube Music not authenticated. Settings → Connections → YouTube → Paste cookies.txt → Save."}), 401
     try:
         rows = library_playlists_to_rows(fetch_library_playlists(auth))
         liked_row = fetch_liked_music_row(auth)

--- a/core/connection_test.py
+++ b/core/connection_test.py
@@ -108,6 +108,24 @@ def run_service_test(service, test_config):
                 return True, f"Tidal connection successful! Connected as: {username}"
             else:
                 return False, "Tidal authentication failed. Please use the 'Authenticate' button and complete the flow in your browser."
+        elif service == "youtube":
+            from core.youtube_cookies import PASTE_MODE, ytmusic_auth_from_cookiefile
+            mode = str(config_manager.get('youtube.cookies_browser', '') or '').strip()
+            if not mode:
+                return False, "No YouTube cookies configured, SoulSync will only have access to public playlists"
+            if mode != PASTE_MODE:
+                return True, f"Browser cookie source '{mode}' configured. Only verifiable on a machine where that browser is installed and signed in — not checkable from the server."
+            auth = ytmusic_auth_from_cookiefile(config_manager.get('youtube.cookies_file', ''))
+            if not auth:
+                return False, "cookies.txt is missing, unreadable, or has no usable auth cookies. Re-paste it."
+            try:
+                from ytmusicapi import YTMusic
+                YTMusic(auth).get_library_playlists(limit=1)
+                return True, "YouTube Music cookies are valid — library is reachable."
+            except ImportError:
+                return False, "ytmusicapi is not installed on the server."
+            except Exception as e:
+                return False, f"YouTube Music cookies rejected: {e}"
         elif service == "plex":
             temp_client = PlexClient()
             if temp_client.is_connected():

--- a/tests/downloads/test_youtube_audio_quality.py
+++ b/tests/downloads/test_youtube_audio_quality.py
@@ -1799,17 +1799,16 @@ def test_docs_mention_youtube_reencode_default():
     assert 'Re-encode YouTube audio' in youtube_docs
     assert 'MP3 320' in youtube_docs
     assert 'Re-encode to MP3 320 (on by default)' in youtube_help
-    assert 'Netscape cookies.txt' in youtube_help
     assert 'Premium audio' in youtube_help
-    assert 'Paste cookies.txt' in youtube_docs
-    assert 'Netscape' in youtube_docs
+    assert 'Netscape/Mozilla' in index and 'cookies.txt' in index
+    assert 'Netscape' in docs and 'cookies.txt' in docs
     assert 'Premium audio qualities' in index
     assert 'Opus or AAC' in transcode_help
     assert 'quality list' in transcode_help
     assert 'minimum confidence threshold' not in youtube_docs.lower()
-    search_yt = _slice_between(docs, 'YouTube settings', 'Downloading Music')
+    search_yt = _slice_between(docs, 'Youtube cookies', 'Downloading Music')
     assert 'minimum confidence threshold' not in search_yt.lower()
-    assert 'Re-encode' in search_yt or 'MP3 320' in search_yt
+    assert 'Premium audio' in search_yt or 'bot detection' in search_yt
 
 
 def test_quality_profile_help_covers_youtube():

--- a/web_server.py
+++ b/web_server.py
@@ -2400,6 +2400,7 @@ SERVICE_CONFIG_REGISTRY = {
     'bandcamp':     {'always': True},   # public search + release-page scrape, no credentials
     'discogs':      {'required': ['token']},
     'tidal':        {'custom': lambda _svc: _tidal_has_auth_token()},
+    'youtube':      {'custom': lambda _svc: _youtube_cookies_configured()},
     # Qobuz login (M&E mode) stores its credentials NESTED under
     # qobuz.session = {app_id, app_secret, user_auth_token} — the top-level
     # keys this registry used to check are never written, so a fully
@@ -2424,6 +2425,23 @@ def _tidal_has_auth_token() -> bool:
     """Check if Tidal has a cached OAuth token. Tidal uses a token file, not config fields."""
     try:
         return bool(tidal_client and tidal_client.is_authenticated())
+    except Exception:
+        return False
+
+
+def _youtube_cookies_configured() -> bool:
+    """Check if YouTube cookies are configured — a browser name, or a pasted
+    cookies.txt that actually exists on disk. Mirrors the same check
+    ``_youtube_cookie_opts()`` does before building yt-dlp's cookie opts."""
+    from core.youtube_cookies import PASTE_MODE
+    try:
+        mode = str(config_manager.get('youtube.cookies_browser', '') or '').strip()
+        if not mode:
+            return False
+        if mode == PASTE_MODE:
+            path = config_manager.get('youtube.cookies_file', '')
+            return bool(path) and os.path.exists(path)
+        return True
     except Exception:
         return False
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -2790,6 +2790,51 @@
                                     </div>
                                 </div>
 
+                                <!-- YouTube Auth -->
+                                <div class="api-service-frame stg-service" data-service="youtube">
+                                    <div class="stg-service-header" onclick="toggleStgService(this)">
+                                        <span class="stg-service-dot" style="color: #FF0000;"></span>
+                                        <h4 class="service-title">YouTube</h4>
+                                        <span class="stg-service-chevron">›</span>
+                                    </div>
+                                    <div class="stg-service-body">
+                                        <div class="form-group">
+                                            <label>YouTube cookies:</label>
+                                            <select id="youtube-cookies-browser" class="form-select">
+                                                <option value="">None (public unauthenticated)</option>
+                                                <option value="chrome">From local Chrome</option>
+                                                <option value="firefox">From local Firefox</option>
+                                                <option value="edge">From local Edge</option>
+                                                <option value="brave">From local Brave</option>
+                                                <option value="opera">From local Opera</option>
+                                                <option value="safari">From local Safari</option>
+                                                <option value="custom">Paste cookies.txt (server / Docker)</option>
+                                            </select>
+                                            <div class="setting-help-text">
+                                                If YouTube shows "Sign in to confirm you're not a bot", select your browser here.
+                                                SoulSync will use your browser's YouTube cookies to authenticate. Cookies are also
+                                                used for Premium audio qualities and to sync your YouTube Music playlists and
+                                                library. Reading a browser only works when that browser is on the same machine
+                                                as SoulSync &mdash; on a server/Docker box, choose <strong>Paste cookies.txt</strong> instead.
+                                            </div>
+                                        </div>
+                                        <div class="form-group" id="youtube-cookies-paste-group" style="display:none;">
+                                            <label>Paste cookies.txt:</label>
+                                            <textarea id="youtube-cookies-paste" class="form-input" rows="6"
+                                                      style="width: 100%; font-family: monospace; font-size: 12px;"
+                                                      placeholder="# Netscape HTTP Cookie File&#10;#HttpOnly_.youtube.com&#9;TRUE&#9;/&#9;TRUE&#9;1809994081&#9;__Secure-YEC&#9;xxx&#10;#HttpOnly_.youtube.com&#9;TRUE&#9;/&#9;TRUE&#9;1820933112&#9;__Secure-3PSID&#9;g.yyy&#10;.youtube.com&#9;TRUE&#9;/&#9;FALSE&#9;1819892806&#9;SIDCC&#9;xxxx&#10;..."></textarea>
+                                            <div class="setting-help-text">
+                                                For server/Docker installs with no local browser. Paste a Netscape/Mozilla
+                                                <code>cookies.txt</code>. Export with a
+                                                "Get cookies.txt LOCALLY" extension and paste the whole file &mdash; the
+                                                <code># Netscape HTTP Cookie File</code> header alone is not enough.
+                                                Required for private playlists like your <strong>Liked Music</strong>, and for
+                                                Premium audio itags. Cookies expire periodically &mdash; re-paste if YouTube stops working.
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
                                 <!-- Last.fm Settings -->
                                 <div class="api-service-frame stg-service" data-service="lastfm">
                                     <div class="stg-service-header" onclick="toggleStgService(this)">
@@ -4312,36 +4357,8 @@
                                 <!-- YouTube Settings (shown when youtube or hybrid mode) -->
                                 <div id="youtube-settings-container" style="display: none;">
                                     <div class="form-group">
-                                        <label>YouTube Browser Cookies:</label>
-                                        <select id="youtube-cookies-browser" class="form-select">
-                                            <option value="">None (No cookies)</option>
-                                            <option value="chrome">Chrome</option>
-                                            <option value="firefox">Firefox</option>
-                                            <option value="edge">Edge</option>
-                                            <option value="brave">Brave</option>
-                                            <option value="opera">Opera</option>
-                                            <option value="safari">Safari</option>
-                                            <option value="custom">Paste cookies.txt (server / Docker)</option>
-                                        </select>
-                                        <div class="setting-help-text">
-                                            If YouTube shows "Sign in to confirm you're not a bot", select your browser here.
-                                            SoulSync will use your browser's YouTube cookies to authenticate. Cookies are also
-                                            used for Premium audio qualities. Reading a browser only works when that browser is
-                                            on the same machine as SoulSync &mdash; on a server/Docker box, choose
-                                            <strong>Paste cookies.txt</strong> instead.
-                                        </div>
-                                    </div>
-                                    <div class="form-group" id="youtube-cookies-paste-group" style="display:none;">
-                                        <label>Paste cookies.txt:</label>
-                                        <textarea id="youtube-cookies-paste" class="form-input" rows="6"
-                                                  placeholder="# Netscape HTTP Cookie File&#10;.youtube.com&#9;TRUE&#9;/&#9;TRUE&#9;...&#9;NAME&#9;VALUE"></textarea>
-                                        <div class="setting-help-text">
-                                            For server/Docker installs with no local browser. Paste a Netscape/Mozilla
-                                            <code>cookies.txt</code>. Export with a
-                                            "Get cookies.txt LOCALLY" extension and paste the whole file &mdash; the
-                                            <code># Netscape HTTP Cookie File</code> header alone is not enough.
-                                            Required for private playlists like your <strong>Liked Music</strong>, and for
-                                            Premium audio itags. Cookies expire periodically &mdash; re-paste if YouTube stops working.
+                                        <div class="setting-help-text" style="padding: 12px 14px; background: rgba(var(--accent-rgb), 0.06); border: 1px solid rgba(var(--accent-rgb), 0.2); border-radius: 10px;">
+                                            📡 YouTube sign-in (cookies) now lives in <strong>Settings → Connections → YouTube</strong> &mdash; downloads still use it, connect it there.
                                         </div>
                                     </div>
                                     <div class="form-group">

--- a/webui/static/docs.js
+++ b/webui/static/docs.js
@@ -77,7 +77,7 @@ const DOCS_SECTIONS = [
                         <tr><td><strong>Spotify</strong></td><td>Primary metadata source (artists, albums, tracks, cover art, genres)</td><td>OAuth &mdash; Client ID + Secret</td></tr>
                         <tr><td><strong>iTunes / Apple Music</strong></td><td>Fallback metadata source, always free, no auth needed</td><td>None</td></tr>
                         <tr><td><strong>Soulseek (slskd)</strong></td><td>Download source &mdash; P2P network, best for lossless and rare music</td><td>URL + API key</td></tr>
-                        <tr><td><strong>YouTube</strong></td><td>Download source &mdash; audio extraction via yt-dlp</td><td>Optional: local cookies browser, or Netscape cookies.txt paste (Docker)</td></tr>
+                        <tr><td><strong>YouTube</strong></td><td>Download source (yt-dlp) &mdash; playlist, supports YouTube Music library sync</td><td>Optional: local cookies browser or Netscape cookies.txt dump</td></tr>
                         <tr><td><strong>Tidal</strong></td><td>Download source + playlist import + enrichment</td><td>OAuth &mdash; Client ID + Secret</td></tr>
                         <tr><td><strong>Qobuz</strong></td><td>Download source + enrichment</td><td>Username + Password, or Auth Token (from browser DevTools)</td></tr>
                         <tr><td><strong>HiFi</strong></td><td>Download source &mdash; free lossless via community API</td><td>None</td></tr>
@@ -814,7 +814,7 @@ const DOCS_SECTIONS = [
                     </tbody>
                 </table>
                 <div class="docs-callout tip"><span class="docs-callout-icon">&#x1F4A1;</span><div><strong>Hybrid mode</strong> is recommended for most users. It tries your primary source first, then falls back through your configured priority order. All six sources (Soulseek, YouTube, Tidal, Qobuz, HiFi, Deezer) can be ordered via drag-and-drop in Settings.</div></div>
-                <p class="docs-text"><strong>YouTube settings</strong> include cookies (bot detection bypass, and Premium audio if your account has it), download delay (seconds between requests), and <em>Re-encode YouTube audio</em> (MP3 320 by default). On Docker, use <strong>Paste cookies.txt</strong>: Netscape/Mozilla format only (tab-separated rows). Paste the whole file from a "Get cookies.txt LOCALLY" extension &mdash; the header line alone is not enough.</p>
+                <div class="docs-callout tip"><span class="docs-callout-icon">&#x1F4A1;</span><div><strong>Youtube cookies</strong>: Make sure to setup some YouTube cookies in the Connection section in order to access Premium audio, sync your YouTube Music library and bypass bot detection.</div></div>
             </div>
             <div class="docs-subsection" id="search-downloading">
                 <h3 class="docs-subsection-title">Downloading Music</h3>
@@ -1399,6 +1399,7 @@ const DOCS_SECTIONS = [
                     <li><strong>Qobuz</strong> &mdash; Username + Password (app ID auto-fetched), or paste an Auth Token from browser DevTools if login fails due to CAPTCHA</li>
                     <li><strong>HiFi</strong> &mdash; No credentials needed, uses community-run API instances. Test Connection to verify.</li>
                     <li><strong>Deezer</strong> &mdash; ARL cookie token from your browser (log into deezer.com &rarr; DevTools &rarr; Cookies &rarr; copy <code>arl</code>). Used for downloads AND user playlist access.</li>
+                    <li><strong>YouTube</strong> &mdash; Browser cookies, or a Netscape <code>cookies.txt</code> dump for Docker/server installs. Used for yt-dlp downloads (bot-detection bypass, Premium audio) AND to sync your YouTube Music playlists and library.</li>
                     <li><strong>Discogs</strong> &mdash; Personal Access Token from discogs.com/settings/developers (free, no app registration needed). Provides genres, styles, labels, catalog numbers, and community ratings.</li>
                     <li><strong>AcoustID</strong> &mdash; API key from acoustid.org (enables fingerprint verification of downloaded files)</li>
                     <li><strong>ListenBrainz</strong> &mdash; Base URL + token for listening history, scrobbling, and playlist import</li>
@@ -1455,7 +1456,7 @@ const DOCS_SECTIONS = [
             <div class="docs-subsection" id="set-other">
                 <h3 class="docs-subsection-title">Other Settings</h3>
                 <ul class="docs-list">
-                    <li><strong>YouTube Configuration</strong> &mdash; Cookies for bot detection bypass and Premium audio if your account has it: pick a local browser, or on Docker/server use <strong>Paste cookies.txt</strong> (Netscape/Mozilla tab-separated file only &mdash; not JSON, not a <code>Cookie:</code> header). Set download delay (seconds between requests). <em>Re-encode YouTube audio</em> is on by default (MP3 320).</li>
+                    <li><strong>YouTube Configuration</strong> &mdash; Download delay (seconds between requests) and whether to re-encode audio (<em>Re-encode YouTube audio</em>, on by default, MP3 320).</li>
                     <li><strong>UI Appearance</strong> &mdash; Custom accent colors with persistent preference. Changes apply immediately across the entire interface. Choose from different <strong>sidebar visualizer types</strong> for the media player audio visualization.</li>
                     <li><strong>API Keys</strong> &mdash; Generate and manage API keys for the REST API. Keys use a <code>sk_</code> prefix and are shown once at creation &mdash; only a SHA-256 hash is stored for security.</li>
                     <li><strong>Path Templates</strong> &mdash; Configure how files are organized in your library. The default template is <code>Artist/Album/TrackNum - Title.ext</code></li>

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -1804,7 +1804,7 @@ const HELPER_CONTENT = {
     },
     '#youtube-settings-container': {
         title: 'YouTube Settings',
-        description: 'Cookies for bot detection bypass and Premium audio: a local browser, or on Docker a pasted Netscape cookies.txt. Download delay and Re-encode to MP3 320 (on by default).',
+        description: 'Download delay and Re-encode to MP3 320 (on by default). Cookies (bot detection bypass, Premium audio, YouTube Music sync) are configured in Connections section.',
     },
 
     // Quality Profile

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1677,7 +1677,7 @@ async function loadSettingsData() {
                 _ytPasteGroup.style.display = _ytCookieSel.value === 'custom' ? '' : 'none';
             };
             if (_ytPasteBox && settings.youtube?.cookies_file) {
-                _ytPasteBox.placeholder = 'A cookies.txt is saved. Paste again to replace it, or leave blank to keep it.';
+                _ytPasteBox.placeholder = '<saved cookies.txt not shown for security reasons>\n\nEdit this field to overwrite.';
             }
             _toggleYtPaste();
             if (!_ytCookieSel.dataset.pasteToggleBound) {


### PR DESCRIPTION
## Summary

YouTube Music polling and yt-dlp downloads share the same cookie auth, but the cookie fields only rendered when YouTube was the active download source. 

That basically means the user has to change it's download source to "YouTube only", paste the cookies, and then revert to the previous download source. 

This PR changes this by moving the youtube auth part in the "Connection" tab of the settings

Before 👇 

<img width="1220" height="1248" alt="Screenshot 2026-09-02 at 15 50 40" src="https://github.com/user-attachments/assets/919caeaa-765d-4cbe-b8d6-d36b414906f0" />

After 👇 

<img width="1686" height="1220" alt="Screenshot 2026-09-02 at 17 23 45" src="https://github.com/user-attachments/assets/576963a8-f630-424c-a8b7-4c47c6b485c9" />

<img width="1380" height="1004" alt="Screenshot 2026-09-02 at 16 53 44" src="https://github.com/user-attachments/assets/d7c608c7-cb1f-469d-8bcf-4109afe7f483" />

