### PR TITLE
Dev

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,9 +9,9 @@ on:
   workflow_dispatch:
     inputs:
       version_tag:
-        description: 'Version tag (e.g. 3.4.0)'
+        description: 'Version tag (e.g. 3.4.1)'
         required: true
-        default: '3.4.0'
+        default: '3.4.1'
 
 jobs:
   build-and-push:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ logs/*.log.*
 
 # Auto-downloaded binaries
 bin/
+tools/ffmpeg*
+tools/ffprobe*
 
 # Development compose/config files
 *.dev.yml

--- a/RELEASE_3.4.1_discord.md
+++ b/RELEASE_3.4.1_discord.md
@@ -1,0 +1,13 @@
+**SoulSync 3.4.1**
+
+This update focuses on long waits, clearer pages and more reliable audiobook handling.
+
+**Speed and reliability.** Lyrics requests now time out, manual imports run in the background with progress updates, and download recovery no longer blocks status updates. Metadata searches have bounded waits and worker capacity. Offline Plex connections are cached, with shorter interactive checks and refreshed scan status. These address the blocking paths reported in #1245.
+
+**Discover, Watchlist and Settings.** Refreshed layouts and controls across all three pages. Discover adds Deezer editorial playlists, all 28 genres and playlist search. Watchlist shows source-matching progress and lets you cancel during a long artist match (#1240). Music and video share Folders and Organization cards.
+
+**Audiobooks.** Scan books already on disk, browse the rebuilt library and review catalogue edition matches. Downloads report actual client progress, cancellation persists, Soulseek transfer matching is corrected, and wishlist rows move beyond “sent to downloads.”
+
+**Also fixed.** SoundCloud import and tagging (#1239), Last.fm username corrections (#1241), Deezer track identity, and Soulseek chat connection checks with unsent drafts preserved. Podcast fetching is hardened and watchlists respect profiles. Video libraries can span additional paths across drives.
+
+Thanks to everyone who sent reports and logs.

--- a/api/audiobooks.py
+++ b/api/audiobooks.py
@@ -48,7 +48,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 import requests
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, jsonify, request, send_file, url_for
 
 from core.audiobook_client import (
     SEARCH_TYPES,
@@ -68,6 +68,26 @@ logger = get_logger("audiobooks.api")
 
 _MAX_LIMIT = 50   # Audible 400s above this; clamped rather than forwarded
 _DEFAULT_LIMIT = 25
+
+
+def _library_cover(row):
+    """Only serve known image names inside the configured, indexed book folder."""
+    from pathlib import Path
+    from core.audiobook_organizer import library_root
+    try:
+        root = Path(library_root()).resolve()
+        path = Path(row.get("path") or "").resolve()
+        if path == root or not path.is_relative_to(root):
+            return None
+        candidates = [path / name for name in ("cover.jpg", "cover.jpeg", "cover.png", "cover.webp", "folder.jpg")]
+        if path.is_file():
+            candidates = [path.with_suffix(ext) for ext in (".jpg", ".png", ".webp")]
+        for candidate in candidates:
+            if candidate.is_file() and candidate.resolve().is_relative_to(root):
+                return candidate.resolve()
+    except OSError:
+        pass
+    return None
 
 
 def _limit(default: int = _DEFAULT_LIMIT) -> int:
@@ -816,31 +836,64 @@ def create_audiobooks_blueprint() -> Blueprint:
 
     @bp.route("/library", methods=["GET"])
     def library():
-        """Everything imported, newest first."""
-        rows = get_audiobook_db().get_library()
+        """Indexed local books and the most recent folder scan."""
+        from core.audiobook_library_scan import scan_status
+        from core.audiobook_organizer import library_root
+
+        db = get_audiobook_db()
+        rows = db.get_library()
+        for row in rows:
+            if not row.get("cover_url"):
+                row["cover_url"] = url_for("audiobooks_api.library_cover", asin=row["asin"])
         return jsonify({
-            "success": True,
-            "books": rows,
+            "success": True, "books": rows,
             "total_bytes": sum(int(r.get("size_bytes") or 0) for r in rows),
+            "root": library_root(), "scan": scan_status(db),
         })
+
+    @bp.route("/library/<asin>/cover", methods=["GET"])
+    def library_cover(asin: str):
+        row = get_audiobook_db().get_library_entry(asin)
+        cover = _library_cover(row) if row else None
+        if cover is not None:
+            return send_file(cover, conditional=True, max_age=3600)
+        if row:
+            from io import BytesIO
+            from pathlib import Path
+            from core.audiobook_organizer import library_root
+            from core.audiobook_library_metadata import embedded_cover
+            root = Path(library_root()).resolve()
+            path = Path(row.get("path") or "").resolve()
+            if path != root and path.is_relative_to(root):
+                art = embedded_cover(path)
+                if art:
+                    return send_file(BytesIO(art[0]), mimetype=art[1], max_age=3600)
+        return jsonify({"success": False, "error": "No local cover"}), 404
 
     @bp.route("/library/<asin>", methods=["DELETE"])
     def library_delete(asin: str):
         """Remove one book from disk and from the record.
 
         The folder goes to the recycle bin rather than being unlinked, so a
-        mistake is recoverable for as long as the keep window allows. The row
-        is dropped either way: leaving it would put an Owned badge on a book
-        that is no longer there.
+        mistake is recoverable for as long as the keep window allows. Ownership
+        is removed only after the disk operation succeeds.
         """
         db = get_audiobook_db()
-        row = next((r for r in db.get_library() if r.get("asin") == asin), None)
+        row = db.get_library_entry(asin)
         if row is None:
             return jsonify({"success": False, "error": "Not in your library"}), 404
 
         from core.audiobook_recycle import discard
 
-        outcome = discard(str(row.get("path") or ""), reason="deleted from the library")
+        from pathlib import Path
+        from core.audiobook_organizer import library_root
+        root = Path(library_root()).resolve()
+        path = Path(str(row.get("path") or "")).resolve()
+        if path == root or not path.is_relative_to(root):
+            return jsonify({"success": False, "error": "This book is outside the configured audiobook folder."}), 400
+        outcome = discard(str(path), reason="deleted from the library")
+        if not outcome.get("ok"):
+            return jsonify({"success": False, "error": outcome.get("error") or "Could not delete this book."}), 400
         db.remove_from_library(asin)
         return jsonify({
             "success": True,

--- a/api/audiobooks.py
+++ b/api/audiobooks.py
@@ -842,7 +842,12 @@ def create_audiobooks_blueprint() -> Blueprint:
 
         db = get_audiobook_db()
         rows = db.get_library()
+        history = db.library_download_history()
         for row in rows:
+            row["download"] = history.get(row.get("download_id"))
+            matched_cover = (row.get("catalog_book") or {}).get("cover_url")
+            if matched_cover and not row.get("cover_url"):
+                row["cover_url"] = matched_cover
             if not row.get("cover_url"):
                 row["cover_url"] = url_for("audiobooks_api.library_cover", asin=row["asin"])
         return jsonify({
@@ -850,6 +855,67 @@ def create_audiobooks_blueprint() -> Blueprint:
             "total_bytes": sum(int(r.get("size_bytes") or 0) for r in rows),
             "root": library_root(), "scan": scan_status(db),
         })
+
+    @bp.route("/library/<asin>/matches", methods=["GET"])
+    def library_matches(asin: str):
+        from core.audiobook_library_matching import candidates_for, score_candidate
+        from core.audiobook_library_metadata import ASIN_RE
+        row = get_audiobook_db().get_library_entry(asin)
+        if row is None:
+            return jsonify({"success": False, "error": "Book not found"}), 404
+        query = str(request.args.get("q") or "").strip()[:300]
+        try:
+            client = get_audiobook_client()
+            if ASIN_RE.fullmatch(query):
+                book = client.get_book(query.upper())
+                candidates = [score_candidate(row.get("metadata_json") or row, book)] if book else []
+            else:
+                candidates = candidates_for(row, client, query=query or None)
+            return jsonify({"success": True, "candidates": candidates,
+                            "scan_signature": row.get("scan_signature", ""),
+                            "match_revision": row.get("match_revision", 0)})
+        except Exception as exc:
+            return jsonify({"success": False, "error": str(exc)}), 503
+
+    @bp.route("/library/<asin>/match", methods=["PATCH"])
+    def library_match(asin: str):
+        from core.audiobook_library_matching import compact
+        from core.audiobook_library_metadata import ASIN_RE
+        db = get_audiobook_db()
+        row = db.get_library_entry(asin)
+        if row is None:
+            return jsonify({"success": False, "error": "Book not found"}), 404
+        data = request.get_json(silent=True) or {}
+        if not isinstance(data, dict):
+            return jsonify({"success": False, "error": "Invalid match request"}), 400
+        action = data.get("action")
+        if action not in ("confirm", "ignore", "retry"):
+            return jsonify({"success": False, "error": "Choose confirm, ignore or retry"}), 400
+        if data.get("scan_signature") != row.get("scan_signature") or data.get("match_revision") != row.get("match_revision"):
+            return jsonify({"success": False, "error": "This book changed. Refresh its matches before saving."}), 409
+        selected = str(data.get("catalog_asin") or "").strip().upper()
+        book = {}
+        if action == "confirm":
+            if not ASIN_RE.fullmatch(selected):
+                return jsonify({"success": False, "error": "A valid Audible ASIN is required"}), 400
+            try:
+                result = get_audiobook_client().get_book(selected)
+            except Exception:
+                result = None
+            if result is None:
+                return jsonify({"success": False, "error": "Could not verify that catalogue edition. Try again later."}), 503
+            book = compact(result)
+            if book.get("asin") != selected or book.get("source") not in (None, "audible"):
+                return jsonify({"success": False, "error": "The catalogue returned a different edition"}), 400
+        ok = db.apply_library_match(asin, signature=data["scan_signature"], revision=data["match_revision"],
+            status="confirmed" if action == "confirm" else "ignored" if action == "ignore" else "unmatched",
+            catalog_asin=selected if action == "confirm" else "", book=book, manual=True,
+            evidence=["Edition confirmed by you" if action == "confirm" else "Kept unmatched by you" if action == "ignore" else "Automatic matching requested"])
+        if not ok:
+            return jsonify({"success": False, "error": "The book changed while saving. Refresh and try again."}), 409
+        if action == "retry":
+            db.update_library_entry(asin, match_checked_at=0)
+        return jsonify({"success": True, "book": db.get_library_entry(asin)})
 
     @bp.route("/library/<asin>/cover", methods=["GET"])
     def library_cover(asin: str):
@@ -891,9 +957,18 @@ def create_audiobooks_blueprint() -> Blueprint:
         path = Path(str(row.get("path") or "")).resolve()
         if path == root or not path.is_relative_to(root):
             return jsonify({"success": False, "error": "This book is outside the configured audiobook folder."}), 400
-        outcome = discard(str(path), reason="deleted from the library")
-        if not outcome.get("ok"):
-            return jsonify({"success": False, "error": outcome.get("error") or "Could not delete this book."}), 400
+        targets = [path]
+        if row.get("file_scope") == "files":
+            targets = [Path(p).resolve() for p in row.get("file_paths") or [str(path)]]
+            if any(p == root or not p.is_relative_to(root) or p.is_dir() for p in targets):
+                return jsonify({"success": False, "error": "The selected audio files are outside this library."}), 400
+        outcomes = []
+        for target in targets:
+            outcome = discard(str(target), reason="deleted from the library")
+            outcomes.append(outcome)
+            if not outcome.get("ok"):
+                return jsonify({"success": False, "error": (outcome.get("error") or "Could not delete this book.") + " Some files may already be in the recycle bin; scan to refresh."}), 400
+        outcome = {"ok": True, "permanent": any(o.get("permanent") for o in outcomes)}
         db.remove_from_library(asin)
         return jsonify({
             "success": True,

--- a/api/chat.py
+++ b/api/chat.py
@@ -408,6 +408,33 @@ def _oembed_fetch(video_id):
 def create_blueprint() -> Blueprint:
     bp = Blueprint("chat_api", __name__)
 
+    def connection_state(client):
+        probe = getattr(client, "get_chat_connection_state", None)
+        if not callable(probe):
+            return {"connected": True}  # compatibility with injected chat adapters
+        try:
+            return _run_async(probe(), timeout=5)
+        except Exception:
+            return {"connected": False, "code": "slskd_unavailable",
+                    "error": "Cannot reach slskd. Check its connection before sending. Your draft is preserved."}
+
+    @bp.before_request
+    def require_soulseek_connection():
+        path = request.path
+        sends = request.method == "POST" and (path in (
+            "/api/chat/room/message", "/api/chat/room/protocol", "/api/chat/room/react",
+            "/api/chat/rooms/join") or path.startswith("/api/chat/conversations/"))
+        reads = request.method == "GET" and (path == "/api/chat/room" or path.startswith("/api/chat/conversations/"))
+        if not (sends or reads) or (sends and not _can_send()):
+            return None
+        client = _client()
+        if client is None:
+            return None  # route retains its existing not-configured response
+        state = connection_state(client)
+        if not state.get("connected"):
+            return jsonify({**state, "can_send": False}), 503
+        return None
+
     # ── Arcade bank (play money) ─────────────────────────────────────────
     # Per profile, local, refilled every local midnight. It is NOT authoritative
     # for anything between players and is not meant to be: a balance only your
@@ -991,10 +1018,12 @@ def create_blueprint() -> Blueprint:
     def chat_status():
         """Cheap page hydrate: is chat usable, which room, may I send."""
         client = _client()
+        connection = connection_state(client) if client is not None else {"connected": False}
         return jsonify({
+            **connection,
             "configured": client is not None,
             "room": _room_name(),
-            "can_send": _can_send(),
+            "can_send": _can_send() and connection.get("connected", False),
             "is_admin": bool(getattr(g, "is_admin", True)),   # shows the settings cog
             # our slskd account name — the page needs it for @mention highlights
             "username": _self_username(client) if client is not None else "",

--- a/api/discover_routes.py
+++ b/api/discover_routes.py
@@ -2807,7 +2807,10 @@ def image_proxy():
     try:
         from core.image_cache import get_image_cache
 
-        cached = get_image_cache().get_url(url)
+        cache = get_image_cache()
+        cached = cache.get_url(url)
+        if request.args.get('v') == 'rail':
+            cached = cache.get_variant_of(cached.key, 'rail')
         response = send_file(cached.path, mimetype=cached.mime_type, conditional=True)
         max_age = int(config_manager.get("image_cache.ttl_seconds", 2592000))
         response.headers['Cache-Control'] = f'private, max-age={max_age}'
@@ -2874,7 +2877,9 @@ def serve_cached_image(cache_key):
         # nothing keeps getting the original.
         variant = (request.args.get('v') or '').strip()
         cache = get_image_cache()
-        if variant and thumbnails_enabled():
+        # Compact dashboard artwork is always bounded; other variants retain
+        # the existing opt-in setting for library/detail pages.
+        if variant == 'rail' or (variant and thumbnails_enabled()):
             cached = cache.get_variant_of(cache_key, variant)
         else:
             cached = cache.get(cache_key)

--- a/api/import_routes.py
+++ b/api/import_routes.py
@@ -8,7 +8,7 @@ attribute). bodies byte-identical; only the decorator changed and
 dev_mode_enabled / hydrabase_worker became getters.
 """
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 
 from core.imports.album import build_album_import_match_payload
 from core.imports.routes import ImportRouteRuntime as _ImportRouteRuntime
@@ -208,10 +208,41 @@ def import_album_match():
     return jsonify(payload), status
 
 
+def _process_import(kind, data):
+    runtime = _build_import_route_runtime()
+    def operation():
+        if kind == 'album':
+            return _import_album_process(runtime, data)
+        return _import_singles_process(runtime, data.get('files', []))
+    if request.headers.get('Prefer') != 'respond-async':
+        payload, status = operation()
+    else:
+        from core.imports.jobs import import_jobs
+        key = request.headers.get('Idempotency-Key', '')
+        if not key or len(key) > 128:
+            return jsonify(success=False, error='A valid Idempotency-Key is required'), 400
+        app = current_app._get_current_object()
+        def background():
+            with app.app_context():
+                return operation()
+        payload, status = import_jobs.submit(get_current_profile_id(), key, kind, data, background)
+    return jsonify(payload), status
+
+
+@bp.route('/api/import/jobs/<job_id>', methods=['GET'])
+def import_job_status(job_id):
+    from core.imports.jobs import import_jobs
+    payload, status = import_jobs.get(get_current_profile_id(), job_id)
+    if payload.get('state') == 'complete' and (payload.get('status') or 200) >= 400:
+        # Preserve HTTPError/error_code semantics (notably disconnected media
+        # servers) used by the browser to stop the rest of an import batch.
+        return jsonify(payload['result']), payload['status']
+    return jsonify(payload), status
+
+
 @bp.route('/api/import/album/process', methods=['POST'])
 def import_album_process():
-    payload, status = _import_album_process(_build_import_route_runtime(), request.get_json() or {})
-    return jsonify(payload), status
+    return _process_import('album', request.get_json() or {})
 
 
 @bp.route('/api/import/search/tracks', methods=['GET'])
@@ -231,8 +262,7 @@ def _process_single_import_file(file_info):
 @bp.route('/api/import/singles/process', methods=['POST'])
 def import_singles_process():
     data = request.get_json() or {}
-    payload, status = _import_singles_process(_build_import_route_runtime(), data.get('files', []))
-    return jsonify(payload), status
+    return _process_import('singles', data)
 
 
 # Auto-Import Worker

--- a/api/podcasts.py
+++ b/api/podcasts.py
@@ -23,6 +23,15 @@ from datetime import datetime, timezone
 from email.utils import format_datetime
 from typing import Any, Dict, List, Optional
 import xml.etree.ElementTree as ET
+from urllib.parse import urljoin
+
+from core.podcast_ingest_guard import (
+    MAX_OPML_BYTES,
+    MAX_REDIRECTS,
+    check_url,
+    has_fetchable_scheme,
+    parse_xml_safely,
+)
 
 import requests
 from flask import Blueprint, Response, jsonify, request
@@ -132,6 +141,39 @@ def show_to_dict(show: PodcastShow, include_episodes: bool = True) -> Dict[str, 
 
 
 # ---------------------------------------------------------------------------
+# Proxy helper
+# ---------------------------------------------------------------------------
+
+def _proxy_get_following_checked_redirects(url: str, headers: dict):
+    """GET a checked url for streaming, re-checking every redirect hop.
+
+    fetch_guarded in the ingest guard buffers its body, which is right for a
+    feed and wrong here: this proxy forwards Range requests so seeking inside
+    an episode works, and that means handing back the live response. Same rule
+    though - requests would follow a 302 to anywhere, so the hops are walked by
+    hand and each one goes back through check_url.
+
+    Returns the response, or None when a hop is refused or the chain is too long.
+    """
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        ok, reason = check_url(current)
+        if not ok:
+            logger.warning("audio-proxy refused a redirect hop: %s (%s)", current[:120], reason)
+            return None
+        resp = requests.get(current, headers=headers, stream=True,
+                            timeout=15, allow_redirects=False)
+        if resp.status_code not in (301, 302, 303, 307, 308):
+            return resp
+        location = resp.headers.get("Location") or ""
+        resp.close()
+        if not location:
+            return None
+        current = urljoin(current, location)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # OPML Helpers
 # ---------------------------------------------------------------------------
 
@@ -150,7 +192,11 @@ def parse_opml_content(content: str | bytes) -> List[Dict[str, str]]:
         else:
             content_bytes = content
 
-        root = ET.fromstring(content_bytes)
+        # an opml file is uploaded, so it is untrusted the same way a feed is.
+        # parse_xml_safely refuses a DOCTYPE, which is the whole billion-laughs
+        # family - stdlib ElementTree will not fetch an external entity but it
+        # expands internal ones happily.
+        root = parse_xml_safely(content_bytes)
     except Exception as exc:
         logger.warning("Failed to parse OPML XML: %s", exc)
         return []
@@ -193,6 +239,14 @@ def parse_opml_content(content: str | bytes) -> List[Dict[str, str]]:
         ).strip()
         description = (outline.get("description") or "").strip()
         html_url = (outline.get("htmlUrl") or outline.get("htmlurl") or "").strip()
+
+        # an opml file is a list of urls somebody else wrote, so a scheme we do
+        # not fetch is dropped here rather than stored and retried on a timer
+        # forever. only the scheme: whether a HOST is private is a dns question,
+        # and check_url asks it at fetch time, where the answer is still true.
+        if not has_fetchable_scheme(xml_url):
+            logger.warning("OPML import skipped a feed URL we cannot fetch: %s", xml_url[:120])
+            continue
 
         feeds.append({
             "title": title or xml_url,
@@ -748,6 +802,18 @@ def create_podcasts_blueprint() -> Blueprint:
         if not target_url:
             return jsonify({"error": "Missing url parameter"}), 400
 
+        # this endpoint takes a url from the query string and fetches it from
+        # the server, which is an open relay into whatever network soulsync is
+        # running on unless it is checked. the audiobook sample proxy says the
+        # same thing about itself and solves it with an allowlist; podcast audio
+        # comes from thousands of cdns so there is no list, and the check is on
+        # the address instead. login is off by default, so anyone who can reach
+        # the web ui could otherwise read internal http services through this.
+        ok, reason = check_url(target_url)
+        if not ok:
+            logger.warning("audio-proxy refused a URL: %s (%s)", target_url[:120], reason)
+            return jsonify({"error": reason}), 400
+
         headers = {}
         if "Range" in request.headers:
             headers["Range"] = request.headers["Range"]
@@ -758,7 +824,12 @@ def create_podcasts_blueprint() -> Blueprint:
         )
 
         try:
-            req = requests.get(target_url, headers=headers, stream=True, timeout=15)
+            # redirects are NOT followed: the check above applies to the url we
+            # were handed, and a 302 could point anywhere. real enclosure hosts
+            # do redirect, so a hop is re-checked and followed by hand.
+            req = _proxy_get_following_checked_redirects(target_url, headers)
+            if req is None:
+                return jsonify({"error": "That host redirected somewhere SoulSync will not fetch"}), 502
             forward_headers = {}
             for h in ("Content-Type", "Content-Length", "Content-Range", "Accept-Ranges"):
                 if h in req.headers:
@@ -811,7 +882,8 @@ def create_podcasts_blueprint() -> Blueprint:
             return jsonify({"success": True, "is_watching": False, "podcast": None})
 
         try:
-            pod = db.get_watchlist_podcast(feed_url=feed_url or None, itunes_id=itunes_id)
+            pod = db.get_watchlist_podcast(feed_url=feed_url or None, itunes_id=itunes_id,
+                                          profile_id=_profile())
             is_watching = pod is not None
             return jsonify({"success": True, "is_watching": is_watching, "podcast": pod})
         except Exception as exc:
@@ -875,7 +947,7 @@ def create_podcasts_blueprint() -> Blueprint:
                 episode_count=episode_count,
                 profile_id=profile_id,
             )
-            pod = db.get_watchlist_podcast(feed_url=feed_url)
+            pod = db.get_watchlist_podcast(feed_url=feed_url, profile_id=profile_id)
             return jsonify({"success": bool(ok), "is_watching": True, "podcast": pod})
         except Exception as exc:
             logger.exception("podcasts_watchlist_add failed for %s: %s", title, exc)
@@ -900,7 +972,8 @@ def create_podcasts_blueprint() -> Blueprint:
             return jsonify({"success": False, "error": "database unavailable"}), 500
 
         try:
-            ok = db.remove_watchlist_podcast(feed_url=feed_url or None, itunes_id=itunes_id)
+            ok = db.remove_watchlist_podcast(feed_url=feed_url or None, itunes_id=itunes_id,
+                                            profile_id=_profile())
             return jsonify({"success": bool(ok), "is_watching": False})
         except Exception as exc:
             logger.exception("podcasts_watchlist_remove failed: %s", exc)
@@ -934,8 +1007,9 @@ def create_podcasts_blueprint() -> Blueprint:
                 feed_url,
                 auto_download=auto_download,
                 retention_days=retention_days,
+                profile_id=_profile(),
             )
-            pod = db.get_watchlist_podcast(feed_url=feed_url)
+            pod = db.get_watchlist_podcast(feed_url=feed_url, profile_id=_profile())
             return jsonify({"success": bool(ok), "podcast": pod})
         except Exception as exc:
             logger.exception("podcasts_watchlist_settings failed for %s: %s", feed_url, exc)
@@ -946,7 +1020,8 @@ def create_podcasts_blueprint() -> Blueprint:
         """Trigger an immediate scan of all watchlisted podcast feeds."""
         try:
             from core.podcast_automation import scan_and_auto_download_podcasts
-            res = scan_and_auto_download_podcasts()
+            # a person pressing Scan Now means their own shows, not profile 1's
+            res = scan_and_auto_download_podcasts(profile_id=_profile())
             return jsonify(res), 200
         except Exception as exc:
             logger.exception("Failed to run podcast scan: %s", exc)
@@ -1009,10 +1084,22 @@ def create_podcasts_blueprint() -> Blueprint:
             action = "subscribe"
         elif "file" in request.files:
             uploaded = request.files["file"]
-            raw_content = uploaded.read()
+            # read one byte past the cap so a file that is exactly at the limit
+            # still imports and anything larger is refused rather than truncated
+            raw_content = uploaded.read(MAX_OPML_BYTES + 1)
+            if len(raw_content) > MAX_OPML_BYTES:
+                return jsonify({
+                    "success": False,
+                    "error": f"That OPML file is larger than {MAX_OPML_BYTES // (1024 * 1024)}MB",
+                }), 413
             feeds = parse_opml_content(raw_content)
         else:
             content = body_json.get("opml_text") or body_json.get("xml") or ""
+            if len(content) > MAX_OPML_BYTES:
+                return jsonify({
+                    "success": False,
+                    "error": f"That OPML document is larger than {MAX_OPML_BYTES // (1024 * 1024)}MB",
+                }), 413
             if content:
                 feeds = parse_opml_content(content)
             else:

--- a/api/source_playlists.py
+++ b/api/source_playlists.py
@@ -2352,6 +2352,70 @@ def get_deezer_arl_playlist_tracks(playlist_id):
         return jsonify({'error': str(e)}), 500
 
 
+@bp.route('/api/discover/deezer/editorial', methods=['GET'])
+def get_deezer_editorial_playlists():
+    """Deezer's own curated playlists, for a Discover shelf.
+
+    The browse half of a pipeline that already exists. Everything after picking
+    a card - loading the playlist, matching its tracks, syncing the result - is
+    /api/deezer/playlist/<id> and the /api/deezer/discovery/* family, unchanged.
+    The only thing missing was a way to FIND a playlist without pasting a url,
+    which is what ListenBrainz's created-for shelf does for its own source.
+
+    No auth. These endpoints are public, so the shelf works for everyone, not
+    only for users who have linked a Deezer account.
+
+    ?genre= a genre id from /api/discover/deezer/genres (0, the everything
+    chart, is the default and is deliberately small - the per-genre charts are
+    where the content is).
+    ?q= searches playlists by name instead, editorial and user mixed.
+    """
+    try:
+        client = _get_deezer_client()
+        if client is None:
+            return jsonify({"success": True, "playlists": [], "count": 0,
+                            "error": "Deezer client unavailable"})
+
+        query = (request.args.get('q') or '').strip()
+        try:
+            limit = int(request.args.get('limit') or 25)
+        except (TypeError, ValueError):
+            limit = 25
+
+        if query:
+            playlists = client.search_playlists(query, limit=limit)
+            scope = {'kind': 'search', 'query': query}
+        else:
+            genre_id = request.args.get('genre') or 0
+            playlists = client.get_editorial_playlists(genre_id, limit=limit)
+            scope = {'kind': 'genre', 'genre': str(genre_id)}
+
+        return jsonify({
+            "success": True,
+            "playlists": playlists,
+            "count": len(playlists),
+            "scope": scope,
+            "source": "deezer",
+        })
+    except Exception as e:
+        logger.error(f"Error getting Deezer editorial playlists: {e}")
+        # a browse row that fails is an empty row, not a broken page
+        return jsonify({"success": True, "playlists": [], "count": 0, "error": str(e)})
+
+
+@bp.route('/api/discover/deezer/genres', methods=['GET'])
+def get_deezer_editorial_genres():
+    """The genre chips the editorial shelf offers."""
+    try:
+        client = _get_deezer_client()
+        if client is None:
+            return jsonify({"success": True, "genres": []})
+        return jsonify({"success": True, "genres": client.get_editorial_genres()})
+    except Exception as e:
+        logger.error(f"Error getting Deezer editorial genres: {e}")
+        return jsonify({"success": True, "genres": []})
+
+
 @bp.route('/api/deezer/playlist/<playlist_id>', methods=['GET'])
 def get_deezer_playlist(playlist_id):
     """Fetch a Deezer playlist by ID or URL"""

--- a/api/stats.py
+++ b/api/stats.py
@@ -445,9 +445,9 @@ def lastfm_listening_import_status():
             'enabled': bool(config_manager.get('lastfm.listening_sync_enabled', False)),
             'api_key_configured': bool(config_manager.get('lastfm.api_key', '')),
             'authenticated_user_available': can_use_auth_user,
-            'username': username,
             'next_run_in_seconds': next_run,
             **status,
+            'username': username,
         })
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)}), 500

--- a/api/video/downloads.py
+++ b/api/video/downloads.py
@@ -379,6 +379,8 @@ def register_routes(bp):
         if not out["movies_path"]:        # migrate the legacy single transfer folder → Movies
             out["movies_path"] = db.get_setting("transfer_path") or ""
         out["download_path"] = config_manager.get(_SHARED_DOWNLOAD_KEY, "") or ""   # shared w/ music
+        from core.video.library_roots import ADDITIONAL_KEYS, additional_paths
+        out.update({key: additional_paths(db, key) for key in ADDITIONAL_KEYS})
         out.update(load_source(db))   # download_mode + hybrid_order
         return jsonify(out)
 
@@ -388,6 +390,14 @@ def register_routes(bp):
         from core.video.download_config import save as save_source
         db = get_video_db()
         body = request.get_json(silent=True) or {}
+        from core.video.library_roots import ADDITIONAL_KEYS, normalize_paths
+        import json
+        try:
+            extras = {key: normalize_paths(body[key]) for key in ADDITIONAL_KEYS if key in body}
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+        for key, paths in extras.items():
+            db.set_setting(key, json.dumps(paths))
         for key in _PATH_KEYS:
             if key in body:
                 db.set_setting(key, (str(body.get(key) or "")).strip())

--- a/api/video/libraries.py
+++ b/api/video/libraries.py
@@ -177,12 +177,13 @@ def register_routes(bp):
             return jsonify({"success": False, "error": "bad server"}), 400
         try:
             if which == "plex":
-                from core.video.sources import video_plex_config, PLEX_SCAN_TIMEOUT
+                from core.video.sources import video_plex_config, PLEX_CONNECT_TIMEOUT, invalidate_video_source_cache
                 cfg = video_plex_config()
                 if not cfg.get("base_url") or not cfg.get("token"):
                     return jsonify({"success": False, "error": "Plex URL/token not set"})
                 from plexapi.server import PlexServer
-                srv = PlexServer(cfg["base_url"], cfg["token"], timeout=PLEX_SCAN_TIMEOUT)
+                srv = PlexServer(cfg["base_url"], cfg["token"], timeout=PLEX_CONNECT_TIMEOUT)
+                invalidate_video_source_cache()
                 return jsonify({"success": True, "message": "Connected to " + (srv.friendlyName or "Plex")})
             from core.video.sources import video_jellyfin_config, video_jellyfin_test
             ok, message = video_jellyfin_test(video_jellyfin_config())

--- a/core/audiobook_client.py
+++ b/core/audiobook_client.py
@@ -1256,6 +1256,7 @@ class AudiobookClient:
         marketplace: str = _DEFAULT_MARKETPLACE,
         page: int = 1,
         sort: Optional[str] = None,
+        strict: bool = False,
     ) -> List[AudiobookItem]:
         """Search the Audible catalog.
 
@@ -1283,6 +1284,8 @@ class AudiobookClient:
         data = self._get_catalog(
             marketplace, "", params, _SEARCH_TTL, "Audible search",
         )
+        if data is None and strict:
+            raise RuntimeError("The audiobook catalogue is unavailable. Try again later.")
         items = self._products(data)
         logger.debug("search(%r, type=%s) -> %d results", query, param, len(items))
         return items

--- a/core/audiobook_database.py
+++ b/core/audiobook_database.py
@@ -40,7 +40,9 @@ STATUS_GRABBED = "grabbed"      # handed to a download client, not yet imported
 STATUS_DONE = "done"            # imported into the library
 STATUS_FAILED = "failed"        # last attempt failed; retried on a later pass
 
-_STATUSES = (STATUS_WANTED, STATUS_SEARCHING, STATUS_GRABBED, STATUS_DONE, STATUS_FAILED)
+STATUS_CANCELLED = "cancelled"  # explicitly stopped; never automatically retried
+
+_STATUSES = (STATUS_WANTED, STATUS_SEARCHING, STATUS_GRABBED, STATUS_DONE, STATUS_FAILED, STATUS_CANCELLED)
 
 # Whether a wishlisted book must be downloaded in the narrator's reading it was
 # wished for. On Audible the narrator is baked into the ASIN, so picking a book
@@ -435,7 +437,9 @@ class AudiobookDatabase:
 
     def get_wishlist(self, profile_id: int = 1, status: Optional[str] = None) -> List[Dict[str, Any]]:
         conn = self._connect()
-        sql = "SELECT * FROM audiobook_wishlist WHERE profile_id = ?"
+        sql = """SELECT *, (SELECT d.status FROM audiobook_downloads d
+                 WHERE d.asin = audiobook_wishlist.asin ORDER BY d.created_at DESC, d.rowid DESC LIMIT 1) AS download_status
+                 FROM audiobook_wishlist WHERE profile_id = ?"""
         params: List[Any] = [int(profile_id)]
         if status:
             sql += " AND status = ?"
@@ -961,9 +965,24 @@ class AudiobookDatabase:
             # 'staged' is active on purpose: a book held back for missing
             # chapters must keep being re-checked, because the usual reason is a
             # torrent that has not finished yet.
-            sql += " WHERE status IN ('queued', 'downloading', 'importing', 'staged')"
+            sql += " WHERE status IN ('queued', 'downloading', 'importing', 'staged', 'paused', 'unavailable')"
         sql += " ORDER BY created_at DESC"
         return [dict(row) for row in conn.execute(sql)]
+
+    def cancel_active_downloads(self, task_ids=None):
+        """Persist cancellation before runtime cleanup can erase its signal."""
+        conn = self._connect()
+        with conn:
+            conn.execute("BEGIN IMMEDIATE")
+            rows = self.get_downloads(active_only=True)
+            if task_ids is not None:
+                rows = [r for r in rows if r['download_id'] in task_ids]
+            for row in rows:
+                conn.execute("UPDATE audiobook_downloads SET status='cancelled', error='Cancelled by you', updated_at=? WHERE download_id=?",
+                             (_now(), row['download_id']))
+                conn.execute("UPDATE audiobook_wishlist SET status='cancelled', last_error='', status_changed_at=? WHERE asin=? AND status='grabbed' AND NOT EXISTS (SELECT 1 FROM audiobook_downloads d WHERE d.asin=audiobook_wishlist.asin AND d.status IN ('queued', 'downloading', 'importing', 'staged', 'paused', 'unavailable'))",
+                             (_now(), row['asin']))
+        return rows
 
     def update_download(
         self,
@@ -1001,7 +1020,7 @@ class AudiobookDatabase:
         conn = self._connect()
         try:
             cursor = conn.execute(
-                f"UPDATE audiobook_downloads SET {', '.join(fields)} WHERE download_id = ?",
+                f"UPDATE audiobook_downloads SET {', '.join(fields)} WHERE download_id = ?" + ("" if status == "cancelled" else " AND status != 'cancelled'"),
                 params,
             )
             conn.commit()
@@ -1197,6 +1216,7 @@ class AudiobookDatabase:
             "release_date": row["release_date"],
             "language": row["language"],
             "status": row["status"],
+            "download_status": (row["download_status"] if "download_status" in row.keys() else None),
             # Older rows predate the column; "exact" is the safe reading of a
             # book wished for before the choice existed.
             "narrator_mode": (

--- a/core/audiobook_database.py
+++ b/core/audiobook_database.py
@@ -54,6 +54,11 @@ _NARRATOR_MODES = (NARRATOR_EXACT, NARRATOR_ANY)
 # appears for anyone already running.
 _COLUMN_MIGRATIONS = (
     ("audiobook_wishlist", "narrator_mode", f"TEXT DEFAULT '{NARRATOR_EXACT}'"),
+    # When the row last CHANGED STATE, which is not when it was last attempted:
+    # last_attempt_at only moves when count_attempt is passed, and a user action
+    # deliberately does not count as an attempt. Freeing a row stuck on
+    # "grabbed" needs to know how long it has been grabbed, so it needs this.
+    ("audiobook_wishlist", "status_changed_at", "REAL DEFAULT 0"),
     # Why a download is staged rather than imported, in the user's words.
     ("audiobook_downloads", "completeness", "TEXT DEFAULT ''"),
     # The whole book as the catalogue described it AT GRAB TIME. Importing needs
@@ -454,6 +459,55 @@ class AudiobookDatabase:
             logger.warning("Could not free stale searching rows: %s", exc)
             return 0
 
+    def reset_stale_grabbed(self, older_than_seconds: float = 21600.0,
+                            profile_id: int = 1) -> int:
+        """Free rows handed to a download client that nothing is following.
+
+        A row goes to "grabbed" the moment a client accepts the release, and it
+        is the download MONITOR that moves it off again — to done when the book
+        imports, to failed when the client gives up. The monitor only looks at
+        rows with an ACTIVE download, so if that download row never arrives, or
+        is cleared, or the monitor itself stops running, the wishlist row sits
+        on "grabbed" forever. The user sees "sent to downloads" against a book
+        with nothing downloading, and no pass ever picks it up again because the
+        retry query only takes "wanted" and "failed".
+
+        Same shape as reset_stale_searching, and the same reasoning: a state
+        that only something ELSE can clear needs a way back when that something
+        does not run.
+
+        A row is only freed when it has no live download to explain it, so a
+        book genuinely sitting in a slow torrent is left alone however long it
+        takes. The age gate is generous for the same reason — a large audiobook
+        on a thin swarm is normal.
+        """
+        cutoff = _now() - max(0.0, float(older_than_seconds))
+        conn = self._connect()
+        try:
+            cursor = conn.execute("""
+                UPDATE audiobook_wishlist
+                SET status = ?,
+                    last_error = 'Sent to downloads, but nothing was tracking it'
+                WHERE profile_id = ?
+                  AND status = ?
+                  AND status_changed_at > 0
+                  AND status_changed_at <= ?
+                  AND asin NOT IN (
+                      SELECT asin FROM audiobook_downloads
+                      WHERE status NOT IN ('completed', 'failed', 'cancelled')
+                  )
+            """, (STATUS_WANTED, int(profile_id), STATUS_GRABBED, cutoff))
+            conn.commit()
+            if cursor.rowcount:
+                logger.info(
+                    "Freed %d audiobook wishlist rows stuck on grabbed with no live download",
+                    cursor.rowcount,
+                )
+            return cursor.rowcount
+        except sqlite3.Error as exc:
+            logger.warning("Could not free stale grabbed rows: %s", exc)
+            return 0
+
     def mark_wishlist_status(
         self,
         asin: str,
@@ -476,15 +530,18 @@ class AudiobookDatabase:
                 cursor = conn.execute("""
                     UPDATE audiobook_wishlist
                     SET status = ?, last_error = ?, last_attempt_at = ?,
+                        status_changed_at = ?,
                         attempt_count = attempt_count + 1
                     WHERE asin = ? AND profile_id = ?
-                """, (status, str(error or ""), _now(), str(asin or "").strip(), int(profile_id)))
+                """, (status, str(error or ""), _now(), _now(),
+                      str(asin or "").strip(), int(profile_id)))
             else:
                 cursor = conn.execute("""
                     UPDATE audiobook_wishlist
-                    SET status = ?, last_error = ?
+                    SET status = ?, last_error = ?, status_changed_at = ?
                     WHERE asin = ? AND profile_id = ?
-                """, (status, str(error or ""), str(asin or "").strip(), int(profile_id)))
+                """, (status, str(error or ""), _now(),
+                      str(asin or "").strip(), int(profile_id)))
             conn.commit()
             return cursor.rowcount > 0
         except sqlite3.Error as exc:

--- a/core/audiobook_database.py
+++ b/core/audiobook_database.py
@@ -9,7 +9,8 @@ solved this by living in database/video_library.db, and audiobooks follow the
 same rule: a new file, a new connection, nothing shared. A bug in here cannot
 corrupt, lock, or migrate anything the music side reads.
 
-ASIN is the identity throughout, the same key the catalog client uses.
+Catalogue entries use ASINs. Unidentified library files use local: keys,
+which are excluded from catalogue ownership checks.
 
 Schema changes ride _COLUMN_MIGRATIONS rather than being edited into the CREATE
 TABLE statements, because an existing install has already run the CREATE and
@@ -53,6 +54,9 @@ _NARRATOR_MODES = (NARRATOR_EXACT, NARRATOR_ANY)
 # added only to CREATE TABLE arrives for fresh installs and silently never
 # appears for anyone already running.
 _COLUMN_MIGRATIONS = (
+    ("audiobook_library", "cover_url", "TEXT DEFAULT ''"),
+    ("audiobook_library", "source", "TEXT DEFAULT 'download'"),
+    ("audiobook_library", "scan_signature", "TEXT DEFAULT ''"),
     ("audiobook_wishlist", "narrator_mode", f"TEXT DEFAULT '{NARRATOR_EXACT}'"),
     # When the row last CHANGED STATE, which is not when it was last attempted:
     # last_attempt_at only moves when count_attempt is passed, and a user action
@@ -301,6 +305,12 @@ class AudiobookDatabase:
                 "ON audiobook_blocklist (asin)"
             )
 
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS audiobook_library_scan_state (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    payload TEXT NOT NULL
+                )
+            """)
             self._apply_column_migrations(cursor)
             conn.commit()
             self._initialized = True
@@ -972,7 +982,7 @@ class AudiobookDatabase:
             return False
 
     def add_to_library(self, book: Dict[str, Any], path: str, **extra: Any) -> bool:
-        """Record an imported book so the UI can say "you already have this"."""
+        """Record a downloaded or scanned book; local: keys identify unmatched files."""
         asin = str(book.get("asin") or "").strip()
         if not asin or not path:
             return False
@@ -984,8 +994,9 @@ class AudiobookDatabase:
             conn.execute("""
                 INSERT OR REPLACE INTO audiobook_library
                     (asin, title, author, narrator, series_title, series_sequence,
-                     path, file_count, size_bytes, audio_format, runtime_minutes, imported_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     path, file_count, size_bytes, audio_format, runtime_minutes, imported_at,
+                     cover_url, source, scan_signature)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 asin, str(book.get("title") or ""),
                 str(authors[0]) if authors else "",
@@ -994,6 +1005,8 @@ class AudiobookDatabase:
                 str(path), int(extra.get("file_count") or 0),
                 int(extra.get("size_bytes") or 0), str(extra.get("audio_format") or ""),
                 int(book.get("runtime_minutes") or 0), _now(),
+                str(book.get("cover_url") or ""), str(extra.get("source") or "download"),
+                str(extra.get("scan_signature") or ""),
             ))
             conn.commit()
             return True
@@ -1001,12 +1014,28 @@ class AudiobookDatabase:
             logger.warning("Could not record %s in the audiobook library: %s", asin, exc)
             return False
 
+    def get_library_scan_state(self) -> Dict[str, Any]:
+        row = self._connect().execute(
+            "SELECT payload FROM audiobook_library_scan_state WHERE id = 1").fetchone()
+        return json.loads(row[0]) if row else {"status": "never"}
+
+    def set_library_scan_state(self, state: Dict[str, Any]) -> None:
+        conn = self._connect()
+        conn.execute("INSERT OR REPLACE INTO audiobook_library_scan_state (id, payload) VALUES (1, ?)",
+                     (json.dumps(state),))
+        conn.commit()
+
     def is_owned(self, asin: str) -> bool:
         conn = self._connect()
         row = conn.execute(
             "SELECT 1 FROM audiobook_library WHERE asin = ?", (str(asin or "").strip(),),
         ).fetchone()
         return row is not None
+
+    def get_library_entry(self, asin: str) -> Optional[Dict[str, Any]]:
+        row = self._connect().execute(
+            "SELECT * FROM audiobook_library WHERE asin = ?", (asin,)).fetchone()
+        return dict(row) if row else None
 
     def get_library(self) -> List[Dict[str, Any]]:
         conn = self._connect()
@@ -1022,7 +1051,7 @@ class AudiobookDatabase:
         conn = self._connect()
         return {
             str(row[0]) for row in conn.execute("SELECT asin FROM audiobook_library")
-            if row[0]
+            if row[0] and not str(row[0]).startswith("local:")
         }
 
     def remove_from_library(self, asin: str) -> bool:
@@ -1049,7 +1078,9 @@ class AudiobookDatabase:
     def update_library_entry(self, asin: str, **fields: Any) -> bool:
         """Refresh what the scan measured on disk: path, file count, size."""
         asin = str(asin or "").strip()
-        allowed = {"path", "file_count", "size_bytes", "audio_format"}
+        allowed = {"path", "file_count", "size_bytes", "audio_format", "scan_signature",
+                   "title", "author", "narrator", "series_title", "series_sequence",
+                   "runtime_minutes", "cover_url"}
         updates = {k: v for k, v in fields.items() if k in allowed}
         if not asin or not updates:
             return False

--- a/core/audiobook_database.py
+++ b/core/audiobook_database.py
@@ -54,6 +54,23 @@ _NARRATOR_MODES = (NARRATOR_EXACT, NARRATOR_ANY)
 # added only to CREATE TABLE arrives for fresh installs and silently never
 # appears for anyone already running.
 _COLUMN_MIGRATIONS = (
+    ("audiobook_downloads", "imported_path", "TEXT DEFAULT ''"),
+    ("audiobook_library", "catalog_asin", "TEXT DEFAULT ''"),
+    ("audiobook_library", "match_status", "TEXT DEFAULT 'unmatched'"),
+    ("audiobook_library", "match_score", "REAL DEFAULT 0"),
+    ("audiobook_library", "match_candidates", "TEXT DEFAULT '[]'"),
+    ("audiobook_library", "match_evidence", "TEXT DEFAULT '[]'"),
+    ("audiobook_library", "catalog_book", "TEXT DEFAULT '{}'"),
+    ("audiobook_library", "match_checked_at", "REAL DEFAULT 0"),
+    ("audiobook_library", "match_revision", "INTEGER DEFAULT 0"),
+    ("audiobook_library", "origin", "TEXT DEFAULT 'unknown'"),
+    ("audiobook_library", "download_id", "TEXT DEFAULT ''"),
+    ("audiobook_library", "file_paths", "TEXT DEFAULT '[]'"),
+    ("audiobook_library", "file_scope", "TEXT DEFAULT 'folder'"),
+    ("audiobook_library", "fingerprint", "TEXT DEFAULT ''"),
+    ("audiobook_library", "metadata_json", "TEXT DEFAULT '{}'"),
+    ("audiobook_library", "grouping", "TEXT DEFAULT ''"),
+
     ("audiobook_library", "cover_url", "TEXT DEFAULT ''"),
     ("audiobook_library", "source", "TEXT DEFAULT 'download'"),
     ("audiobook_library", "scan_signature", "TEXT DEFAULT ''"),
@@ -311,6 +328,9 @@ class AudiobookDatabase:
                     payload TEXT NOT NULL
                 )
             """)
+            cursor.execute("""CREATE TABLE IF NOT EXISTS audiobook_library_file_cache (
+                path TEXT PRIMARY KEY, size INTEGER NOT NULL, mtime INTEGER NOT NULL,
+                payload TEXT NOT NULL)""")
             self._apply_column_migrations(cursor)
             conn.commit()
             self._initialized = True
@@ -327,6 +347,14 @@ class AudiobookDatabase:
                 existing = {row["name"] for row in cursor.execute(f"PRAGMA table_info({table})")}
                 if column not in existing:
                     cursor.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
+                    if table == "audiobook_library" and column == "catalog_asin":
+                        cursor.execute("UPDATE audiobook_library SET catalog_asin = asin WHERE asin NOT LIKE 'local:%'")
+                    if table == "audiobook_library" and column == "match_status":
+                        cursor.execute("UPDATE audiobook_library SET match_status = 'identifier' WHERE catalog_asin != ''")
+                    if table == "audiobook_library" and column == "origin" and "source" in {
+                        r["name"] for r in cursor.execute("PRAGMA table_info(audiobook_library)")
+                    }:
+                        cursor.execute("UPDATE audiobook_library SET origin = 'disk' WHERE source = 'scan'")
                     logger.info("Added %s.%s to the audiobook database", table, column)
             except sqlite3.Error as exc:
                 logger.warning("Audiobook column migration %s.%s failed: %s", table, column, exc)
@@ -947,6 +975,7 @@ class AudiobookDatabase:
         save_path: Optional[str] = None,
         error: Optional[str] = None,
         completeness: Optional[str] = None,
+        imported_path: Optional[str] = None,
     ) -> bool:
         """Patch whatever changed. Only the fields given are written.
 
@@ -959,7 +988,7 @@ class AudiobookDatabase:
         for column, value in (
             ("status", status), ("progress", progress), ("bytes_done", bytes_done),
             ("bytes_total", bytes_total), ("save_path", save_path), ("error", error),
-            ("completeness", completeness),
+            ("completeness", completeness), ("imported_path", imported_path),
         ):
             if value is not None:
                 fields.append(f"{column} = ?")
@@ -1008,11 +1037,62 @@ class AudiobookDatabase:
                 str(book.get("cover_url") or ""), str(extra.get("source") or "download"),
                 str(extra.get("scan_signature") or ""),
             ))
+            catalog_asin = str(extra.get("catalog_asin") or (asin if not asin.startswith("local:") else ""))
+            conn.execute("""UPDATE audiobook_library SET catalog_asin=?, match_status=?,
+                origin=?, download_id=?, file_paths=?, file_scope=?, fingerprint=?, metadata_json=?, grouping=? WHERE asin=?""",
+                (catalog_asin, "identifier" if catalog_asin else "unmatched",
+                 extra.get("origin") or ("soulsync" if extra.get("download_id") else "disk" if extra.get("source") == "scan" else "unknown"),
+                 extra.get("download_id") or "", json.dumps(extra.get("file_paths") or []),
+                 extra.get("file_scope") or "folder", extra.get("fingerprint") or "",
+                 json.dumps(extra.get("metadata_json") or {}), extra.get("grouping") or "", asin))
             conn.commit()
             return True
         except sqlite3.Error as exc:
             logger.warning("Could not record %s in the audiobook library: %s", asin, exc)
             return False
+
+    @staticmethod
+    def _library_row(row) -> Dict[str, Any]:
+        data = dict(row)
+        for key, fallback in (("file_paths", []), ("match_candidates", []),
+                              ("match_evidence", []), ("metadata_json", {}), ("catalog_book", {})):
+            try:
+                data[key] = json.loads(data.get(key) or json.dumps(fallback))
+            except (ValueError, TypeError):
+                data[key] = fallback
+        return data
+
+    def cached_library_file(self, path: str, size: int, mtime: int):
+        row = self._connect().execute(
+            "SELECT payload FROM audiobook_library_file_cache WHERE path=? AND size=? AND mtime=?",
+            (path, size, mtime)).fetchone()
+        return json.loads(row[0]) if row else None
+
+    def cache_library_file(self, path: str, size: int, mtime: int, payload: dict):
+        conn = self._connect()
+        conn.execute("INSERT OR REPLACE INTO audiobook_library_file_cache VALUES (?, ?, ?, ?)",
+                     (path, size, mtime, json.dumps(payload)))
+        conn.commit()
+
+    def apply_library_match(self, key: str, *, signature: str, revision: int,
+                            status: str, catalog_asin: str = "", score: float = 0,
+                            evidence=None, candidates=None, book=None, manual=False) -> bool:
+        """Compare-and-set: a slow catalogue response cannot overwrite a newer decision."""
+        conn = self._connect()
+        guard = "" if manual else " AND match_status NOT IN ('confirmed', 'ignored', 'changed')"
+        cursor = conn.execute("""UPDATE audiobook_library SET catalog_asin=?, match_status=?,
+            match_score=?, match_evidence=?, match_candidates=?, catalog_book=?, match_checked_at=?,
+            match_revision=match_revision+1 WHERE asin=? AND scan_signature=? AND match_revision=?""" + guard,
+            (catalog_asin, status, score, json.dumps(evidence or []), json.dumps(candidates or []),
+             json.dumps(book or {}), _now(), key, signature, revision))
+        conn.commit()
+        return cursor.rowcount > 0
+
+    def library_download_history(self):
+        return {row["download_id"]: dict(row) for row in self._connect().execute("""
+            SELECT download_id, source, indexer, release_title, created_at, completed_at
+            FROM audiobook_downloads WHERE download_id IN
+            (SELECT download_id FROM audiobook_library WHERE download_id != '')""")}
 
     def get_library_scan_state(self) -> Dict[str, Any]:
         row = self._connect().execute(
@@ -1028,18 +1108,18 @@ class AudiobookDatabase:
     def is_owned(self, asin: str) -> bool:
         conn = self._connect()
         row = conn.execute(
-            "SELECT 1 FROM audiobook_library WHERE asin = ?", (str(asin or "").strip(),),
+            "SELECT 1 FROM audiobook_library WHERE catalog_asin = ? AND match_status IN ('identifier', 'automatic', 'confirmed')", (str(asin or "").strip(),),
         ).fetchone()
         return row is not None
 
     def get_library_entry(self, asin: str) -> Optional[Dict[str, Any]]:
         row = self._connect().execute(
             "SELECT * FROM audiobook_library WHERE asin = ?", (asin,)).fetchone()
-        return dict(row) if row else None
+        return self._library_row(row) if row else None
 
     def get_library(self) -> List[Dict[str, Any]]:
         conn = self._connect()
-        return [dict(row) for row in conn.execute(
+        return [self._library_row(row) for row in conn.execute(
             "SELECT * FROM audiobook_library ORDER BY imported_at DESC")]
 
     def owned_asins(self) -> Set[str]:
@@ -1050,7 +1130,7 @@ class AudiobookDatabase:
         """
         conn = self._connect()
         return {
-            str(row[0]) for row in conn.execute("SELECT asin FROM audiobook_library")
+            str(row[0]) for row in conn.execute("SELECT catalog_asin FROM audiobook_library WHERE match_status IN ('identifier', 'automatic', 'confirmed')")
             if row[0] and not str(row[0]).startswith("local:")
         }
 
@@ -1080,8 +1160,12 @@ class AudiobookDatabase:
         asin = str(asin or "").strip()
         allowed = {"path", "file_count", "size_bytes", "audio_format", "scan_signature",
                    "title", "author", "narrator", "series_title", "series_sequence",
-                   "runtime_minutes", "cover_url"}
-        updates = {k: v for k, v in fields.items() if k in allowed}
+                   "runtime_minutes", "cover_url", "catalog_asin", "match_status", "match_score",
+                   "match_candidates", "match_evidence", "catalog_book", "match_checked_at",
+                   "origin", "download_id", "file_paths", "file_scope", "fingerprint",
+                   "metadata_json", "grouping"}
+        updates = {k: json.dumps(v) if isinstance(v, (dict, list)) else v
+                   for k, v in fields.items() if k in allowed}
         if not asin or not updates:
             return False
         clause = ", ".join(f"{key} = ?" for key in updates)

--- a/core/audiobook_download_monitor.py
+++ b/core/audiobook_download_monitor.py
@@ -96,6 +96,10 @@ def process_download(
         except (TypeError, ValueError):
             pass
 
+    speed = getattr(status, "download_speed", None)
+    if speed is not None:
+        patch["speed"] = max(0, float(speed or 0))
+
     state = normalize_state(status)
     if state == "failed":
         patch["status"] = "failed"
@@ -179,11 +183,11 @@ class _SoulseekStatus:
     """
 
     def __init__(self, rolled: Dict[str, Any]) -> None:
-        self.state = rolled["state"]
-        self.progress = rolled["progress"]
+        self.state = "completed" if rolled["state"] == "done" else rolled["state"]
+        self.progress = rolled["progress"] / 100.0
         self.size = rolled["size"]
-        self.transferred = rolled["transferred"]
-        self.speed = 0
+        self.downloaded = rolled["transferred"]
+        self.download_speed = rolled.get("speed", 0)
         self.save_path = rolled.get("save_path", "")
         self.files = rolled["total"]
         self.files_done = rolled["finished"]
@@ -351,6 +355,7 @@ def tick(db: Any = None) -> Dict[str, int]:
 
     from core.audiobook_download_state import (
         forget,
+        register_download,
         is_cancelled,
         mark_status,
         update_progress,
@@ -358,6 +363,11 @@ def tick(db: Any = None) -> Dict[str, int]:
 
     for row in active:
         summary["checked"] += 1
+        # Runtime cards disappear on restart; the durable job and client refs
+        # remain. Reattach without replacing existing progress/cancellation.
+        register_download(row["download_id"], row.get("title") or "Audiobook",
+                          author=row.get("author") or "", protocol=row.get("source") or "",
+                          size_bytes=row.get("bytes_total") or 0, only_if_missing=True)
 
         # Cancelling a card used to remove it from the page while the torrent
         # carried on downloading. The client is told, then the row is closed.
@@ -376,6 +386,7 @@ def tick(db: Any = None) -> Dict[str, int]:
             continue
 
         imported_path = patch.pop("imported_path", "")
+        speed = patch.pop("speed", None)
         database.update_download(row["download_id"], imported_path=imported_path or None, **patch)
 
         # Same numbers onto the Downloads page card.
@@ -384,7 +395,11 @@ def tick(db: Any = None) -> Dict[str, int]:
             percent=patch.get("progress"),
             bytes_done=patch.get("bytes_done"),
             bytes_total=patch.get("bytes_total"),
+            speed=speed,
         )
+
+        if patch.get("status") == "downloading":
+            mark_status(row["download_id"], "downloading")
 
         asin = str(row.get("asin") or "")
         if patch.get("status") == "completed":

--- a/core/audiobook_download_monitor.py
+++ b/core/audiobook_download_monitor.py
@@ -376,7 +376,7 @@ def tick(db: Any = None) -> Dict[str, int]:
             continue
 
         imported_path = patch.pop("imported_path", "")
-        database.update_download(row["download_id"], **patch)
+        database.update_download(row["download_id"], imported_path=imported_path or None, **patch)
 
         # Same numbers onto the Downloads page card.
         update_progress(
@@ -397,6 +397,7 @@ def tick(db: Any = None) -> Dict[str, int]:
                 database.mark_wishlist_status(asin, STATUS_DONE)
                 database.add_to_library(
                     _book_for(row), imported_path or patch.get("save_path", ""),
+                    download_id=row["download_id"], origin="soulsync",
                 )
             logger.info("Audiobook imported: %s -> %s", row.get("title"), imported_path)
         elif patch.get("status") == "staged":

--- a/core/audiobook_download_monitor.py
+++ b/core/audiobook_download_monitor.py
@@ -76,7 +76,7 @@ def process_download(
 
     status = get_status(source, ref)
     if status is None:
-        return {}
+        return {"status": "unavailable", "error": "Waiting for the download client to report this job"}
 
     patch: Dict[str, Any] = {}
     for key, attr in (("bytes_done", "downloaded"), ("bytes_total", "size")):
@@ -107,7 +107,14 @@ def process_download(
         return patch
 
     if state != "completed":
-        patch["status"] = "downloading"
+        raw_state = str(getattr(status, "state", "")).lower()
+        if raw_state in ("queued", "waiting", "stalled", "missing"):
+            patch["status"] = "queued"
+        elif raw_state in ("paused", "unavailable"):
+            patch["status"] = raw_state
+        else:
+            patch["status"] = "downloading"
+        patch["error"] = "Waiting for the download client to report this job" if raw_state == "unavailable" else ""
         return patch
 
     # content_path FIRST. It is the client's absolute path to THIS torrent's
@@ -370,11 +377,9 @@ def tick(db: Any = None) -> Dict[str, int]:
                           size_bytes=row.get("bytes_total") or 0, only_if_missing=True)
 
         # Cancelling a card used to remove it from the page while the torrent
-        # carried on downloading. The client is told, then the row is closed.
+        # carried on downloading. Persist cancellation before runtime cleanup.
         if is_cancelled(row["download_id"]):
-            _cancel_at_client(row)
-            database.update_download(row["download_id"], status="cancelled",
-                                     error="Cancelled")
+            cancel_downloads([row["download_id"]], db=database)
             forget(row["download_id"])
             summary["cancelled"] += 1
             continue
@@ -387,7 +392,9 @@ def tick(db: Any = None) -> Dict[str, int]:
 
         imported_path = patch.pop("imported_path", "")
         speed = patch.pop("speed", None)
-        database.update_download(row["download_id"], imported_path=imported_path or None, **patch)
+        if not database.update_download(row["download_id"], imported_path=imported_path or None, **patch):
+            forget(row["download_id"])
+            continue
 
         # Same numbers onto the Downloads page card.
         update_progress(
@@ -398,8 +405,9 @@ def tick(db: Any = None) -> Dict[str, int]:
             speed=speed,
         )
 
-        if patch.get("status") == "downloading":
-            mark_status(row["download_id"], "downloading")
+        if patch.get("status") in ("downloading", "queued", "paused", "unavailable"):
+            mark_status(row["download_id"], "downloading" if patch["status"] == "downloading" else "queued",
+                        error=patch.get("error") or ("Paused in download client" if patch["status"] == "paused" else ""))
 
         asin = str(row.get("asin") or "")
         if patch.get("status") == "completed":
@@ -433,6 +441,17 @@ def tick(db: Any = None) -> Dict[str, int]:
                     asin, STATUS_FAILED, error=str(patch.get("error") or ""),
                 )
     return summary
+
+
+def cancel_downloads(task_ids=None, db=None):
+    from core.audiobook_database import get_audiobook_db
+    from core.audiobook_download_state import forget
+    database = db if db is not None else get_audiobook_db()
+    rows = database.cancel_active_downloads(task_ids)
+    for row in rows:
+        _cancel_at_client(row)
+        forget(row['download_id'])
+    return len(rows)
 
 
 def _cancel_at_client(row: Dict[str, Any]) -> None:

--- a/core/audiobook_download_state.py
+++ b/core/audiobook_download_state.py
@@ -97,7 +97,7 @@ def register_download(
         batch["phase"] = "downloading"
 
         download_tasks[task_id] = {
-            "status": "downloading",
+            "status": "queued",
             "track_info": {
                 "title": title,
                 "name": title,
@@ -173,7 +173,7 @@ def mark_status(
         if task["status"] != status:
             task["status_change_time"] = time.time()
         task["status"] = status
-        if status == "downloading":
+        if status in ("downloading", "queued"):
             task["error_message"] = None
         if status == "completed":
             task["progress"] = 100.0

--- a/core/audiobook_download_state.py
+++ b/core/audiobook_download_state.py
@@ -73,6 +73,7 @@ def register_download(
     artwork_url: str = "",
     protocol: str = "",
     size_bytes: int = 0,
+    only_if_missing: bool = False,
 ) -> bool:
     """Put one grabbed audiobook on the Downloads page.
 
@@ -88,6 +89,8 @@ def register_download(
         return False
 
     with tasks_lock:
+        if only_if_missing and task_id in download_tasks:
+            return False
         batch = _ensure_batch()
         if task_id not in batch["queue"]:
             batch["queue"].append(task_id)
@@ -127,6 +130,7 @@ def update_progress(
     percent: Optional[float] = None,
     bytes_done: Optional[int] = None,
     bytes_total: Optional[int] = None,
+    speed: Optional[float] = None,
 ) -> None:
     """Push a poll result onto the card. Missing values are left alone."""
     task_id = str(task_id or "").strip()
@@ -136,6 +140,8 @@ def update_progress(
         task = download_tasks.get(task_id)
         if not task:
             return
+        if speed is not None:
+            task["speed"] = max(0.0, float(speed))
         if percent is not None:
             task["progress"] = max(0.0, min(100.0, float(percent)))
         if bytes_done is not None:
@@ -164,8 +170,11 @@ def mark_status(
         task = download_tasks.get(task_id)
         if not task:
             return
+        if task["status"] != status:
+            task["status_change_time"] = time.time()
         task["status"] = status
-        task["status_change_time"] = time.time()
+        if status == "downloading":
+            task["error_message"] = None
         if status == "completed":
             task["progress"] = 100.0
         if error:

--- a/core/audiobook_library_inventory.py
+++ b/core/audiobook_library_inventory.py
@@ -1,0 +1,130 @@
+"""Metadata-aware file grouping, cached probes, and move fingerprints."""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.audiobook_library_metadata import read_metadata
+from core.audiobook_organizer import AUDIO_EXTENSIONS, natural_key
+
+DISC = re.compile(r'^(?:cd|disc|disk|part)\s*[-_ ]*\d+$', re.I)
+CHAPTER = re.compile(r'^(?:(.*?)\s*[-_ .]*\b(?:chapter|track|part|disc|cd)\s*\d+.*|\d{1,4}\s*[-_. ]+.*)$', re.I)
+MIN_BYTES = 1024 * 1024
+
+
+def canonical(path):
+    return os.path.normcase(str(Path(path).resolve()))
+
+
+def folded(value):
+    return re.sub(r'\W+', ' ', str(value or '').casefold()).strip()
+
+
+@dataclass
+class BookGroup:
+    path: Path
+    files: list[Path]
+    probes: list[dict]
+    scope: str
+    grouping: str
+    fingerprint: str
+    signature: str
+
+
+def probe_file(path, db):
+    stat = path.stat()
+    key = canonical(path)
+    cached = db.cached_library_file(key, stat.st_size, stat.st_mtime_ns)
+    if isinstance(cached, dict):
+        return cached
+    facts = read_metadata(path, [path], include_sidecars=False)
+    digest = hashlib.sha256(str(stat.st_size).encode())
+    # Sampling supports move detection without hashing gigabytes on each scan.
+    with path.open('rb') as stream:
+        for offset in sorted({0, max(0, stat.st_size // 2 - 32768), max(0, stat.st_size - 65536)}):
+            stream.seek(offset)
+            digest.update(stream.read(65536))
+    facts['fingerprint'] = digest.hexdigest()
+    facts['size'] = stat.st_size
+    facts['mtime'] = stat.st_mtime_ns
+    db.cache_library_file(key, stat.st_size, stat.st_mtime_ns, facts)
+    return facts
+
+
+def discover(root: Path, db, error, max_depth=32):
+    containers = defaultdict(list)
+    stack = [(root, 0)]
+    while stack:
+        folder, depth = stack.pop()
+        if depth > max_depth:
+            error(folder, 'Folder nesting exceeds the scan limit')
+            continue
+        try:
+            entries = sorted(folder.iterdir())
+            audio = [p for p in entries if not p.is_symlink() and p.is_file()
+                     and not p.name.startswith('.') and p.suffix.lower() in AUDIO_EXTENSIONS]
+            container = folder.parent if DISC.fullmatch(folder.name) and folder.parent != root else folder
+            for file in audio:
+                containers[container].append((file, probe_file(file, db)))
+            for child in entries:
+                if child.is_symlink() or child.name.startswith('.') or not child.is_dir():
+                    continue
+                if audio and child.name.casefold() in {'extras', 'samples', 'sample', 'bonus'}:
+                    continue
+                stack.append((child, depth + 1))
+        except OSError as exc:
+            error(folder, str(exc))
+
+    groups = []
+    for container, entries in containers.items():
+        grouped = defaultdict(list)
+        sidecar = read_metadata(container, [], probes=[])
+        for file, facts in entries:
+            if facts.get('title_source') == 'metadata':
+                # Different narrators, authors or explicit IDs remain separate editions.
+                title = facts['title']
+                if DISC.fullmatch(file.parent.name):
+                    title = re.sub(r'\s*[\[(]?(?:disc|cd)\s*\d+(?:\s*(?:of|/)\s*\d+)?[\])]?$', '', title, flags=re.I)
+                peers = [f for _, f in entries if folded(f.get('title')) == folded(facts['title'])]
+                def consistent(field):
+                    values = {f.get(field) for f in peers if f.get(field)}
+                    return facts.get(field) or (next(iter(values)) if len(values) == 1 else '') or sidecar.get(field) or ''
+                identity = ('book', folded(title), folded(consistent('author')),
+                            folded(consistent('narrator')), consistent('asin'))
+                reason = 'Grouped by book title, author, narrator and identifier in file metadata'
+            elif sidecar.get('title_source') == 'metadata':
+                identity = ('book', folded(sidecar['title']), folded(sidecar['author']), folded(sidecar['narrator']), sidecar.get('asin', ''))
+                reason = 'Grouped by folder sidecar metadata'
+            else:
+                chapter = CHAPTER.match(file.stem)
+                if chapter and (container != root or chapter.group(1)):
+                    identity = ('chapters', folded(chapter.group(1) or container.name))
+                    reason = 'Numbered chapter sequence; catalogue identity still needs evidence'
+                else:
+                    identity = ('file', file.name)
+                    reason = 'Standalone file; no reliable chapter grouping metadata'
+            grouped[identity].append((file, facts, reason))
+        for items in grouped.values():
+            files = sorted((item[0] for item in items), key=lambda p: natural_key(str(p)))
+            if sum(p.stat().st_size for p in files) < MIN_BYTES:
+                continue
+            probes = [next(item[1] for item in items if item[0] == file) for file in files]
+            # Never own a shared parent: deleting one group must not delete its neighbours.
+            owns_folder = len(grouped) == 1 and container != root and not any(
+                other != container and other.is_relative_to(container) for other in containers)
+            path = container if owns_folder else files[0]
+            fingerprint = hashlib.sha256('\n'.join(sorted(p['fingerprint'] for p in probes)).encode()).hexdigest()
+            signature_parts = [f'{p}:{facts["size"]}:{facts["mtime"]}' for p, facts in zip(files, probes)]
+            for sidecar_path in ([container / name for name in ('metadata.opf', 'book.nfo', 'metadata.json')]
+                                 + [files[0].with_suffix('.opf'), files[0].with_suffix('.nfo')]):
+                if sidecar_path.exists():
+                    stat = sidecar_path.stat()
+                    signature_parts.append(f'{sidecar_path}:{stat.st_size}:{stat.st_mtime_ns}')
+            signature = hashlib.sha256('\n'.join(signature_parts).encode()).hexdigest()
+            groups.append(BookGroup(path, files, probes, 'folder' if owns_folder else 'files',
+                                    items[0][2], fingerprint, signature))
+    return groups

--- a/core/audiobook_library_inventory.py
+++ b/core/audiobook_library_inventory.py
@@ -90,7 +90,7 @@ def discover(root: Path, db, error, max_depth=32):
                 if DISC.fullmatch(file.parent.name):
                     title = re.sub(r'\s*[\[(]?(?:disc|cd)\s*\d+(?:\s*(?:of|/)\s*\d+)?[\])]?$', '', title, flags=re.I)
                 peers = [f for _, f in entries if folded(f.get('title')) == folded(facts['title'])]
-                def consistent(field):
+                def consistent(field, peers=peers, facts=facts, sidecar=sidecar):
                     values = {f.get(field) for f in peers if f.get(field)}
                     return facts.get(field) or (next(iter(values)) if len(values) == 1 else '') or sidecar.get(field) or ''
                 identity = ('book', folded(title), folded(consistent('author')),
@@ -118,7 +118,7 @@ def discover(root: Path, db, error, max_depth=32):
                 other != container and other.is_relative_to(container) for other in containers)
             path = container if owns_folder else files[0]
             fingerprint = hashlib.sha256('\n'.join(sorted(p['fingerprint'] for p in probes)).encode()).hexdigest()
-            signature_parts = [f'{p}:{facts["size"]}:{facts["mtime"]}' for p, facts in zip(files, probes)]
+            signature_parts = [f'{p}:{facts["size"]}:{facts["mtime"]}' for p, facts in zip(files, probes, strict=True)]
             for sidecar_path in ([container / name for name in ('metadata.opf', 'book.nfo', 'metadata.json')]
                                  + [files[0].with_suffix('.opf'), files[0].with_suffix('.nfo')]):
                 if sidecar_path.exists():

--- a/core/audiobook_library_matching.py
+++ b/core/audiobook_library_matching.py
@@ -1,0 +1,135 @@
+"""Conservative catalogue matching with explicit evidence and durable review decisions."""
+from __future__ import annotations
+
+import re
+import time
+import unicodedata
+from difflib import SequenceMatcher
+
+from core.audiobook_library_metadata import ASIN_RE
+
+MATCH_VERSION = 1
+
+
+def normalize(value):
+    text = unicodedata.normalize('NFKD', str(value or '')).casefold()
+    return ' '.join(re.findall(r'\w+', ''.join(c for c in text if not unicodedata.combining(c))))
+
+
+def title_key(value):
+    return normalize(re.sub(r'\b(?:unabridged|abridged|audiobook)\b', '', str(value or ''), flags=re.I))
+
+
+def similarity(left, right):
+    left, right = normalize(left), normalize(right)
+    if not left or not right:
+        return 0.0
+    return SequenceMatcher(None, left, right).ratio()
+
+
+def people_score(local, names):
+    if not local or not names:
+        return 0.0
+    # Sorting handles "surname, first name" without discarding any name tokens.
+    key = ' '.join(sorted(normalize(local).split()))
+    return max(similarity(key, ' '.join(sorted(normalize(name).split()))) for name in names)
+
+
+def compact(book):
+    data = book.to_dict() if hasattr(book, 'to_dict') else dict(book)
+    return {key: data.get(key) for key in ('asin', 'title', 'subtitle', 'author_names',
+            'narrator_names', 'runtime_minutes', 'language', 'format_type', 'cover_url', 'series', 'source')}
+
+
+def score_candidate(local, book):
+    book = compact(book)
+    title = similarity(title_key(local.get('title')), title_key(book.get('title')))
+    author = people_score(local.get('author'), book.get('author_names') or [])
+    narrator = people_score(local.get('narrator'), book.get('narrator_names') or [])
+    local_time = float(local.get('runtime_minutes') or 0)
+    book_time = float(book.get('runtime_minutes') or 0)
+    delta = abs(local_time - book_time) / book_time if local_time and book_time else None
+    duration = max(0, 1 - delta * 3) if delta is not None else 0
+    reasons, conflicts = [], []
+    for label, score in (('Title', title), ('Author', author), ('Narrator', narrator)):
+        reasons.append(f'{label}: ' + ('strong agreement' if score >= .94 else 'partial agreement' if score >= .70 else 'missing or different'))
+    reasons.append(f'Runtime: {abs(local_time-book_time):.0f} minutes difference' if delta is not None else 'Runtime: not available for comparison')
+    if re.findall(r'\d+', title_key(local.get('title'))) != re.findall(r'\d+', title_key(book.get('title'))):
+        conflicts.append('Different volume or edition numbers')
+    if local.get('author') and book.get('author_names') and author < .75:
+        conflicts.append('Different author')
+    if local.get('narrator') and book.get('narrator_names') and narrator < .80:
+        conflicts.append('Different narrator or recording')
+    if delta is not None and delta > .10:
+        conflicts.append('Runtime differs by more than 10%')
+    language = {'eng':'english', 'en':'english', 'en us':'english', 'en gb':'english', 'de':'german', 'deu':'german', 'ger':'german', 'fr':'french', 'fra':'french', 'fre':'french', 'es':'spanish', 'spa':'spanish'}
+    a, b = normalize(local.get('language')), normalize(book.get('language'))
+    if a and b and language.get(a,a) != language.get(b,b):
+        conflicts.append('Different language')
+    a, b = normalize(local.get('format_type')), normalize(book.get('format_type'))
+    if a and b and a != b:
+        conflicts.append('Abridged and unabridged editions differ')
+    if local.get('metadata_conflicts'):
+        conflicts.extend(local['metadata_conflicts'])
+    score = round((title*.45 + author*.25 + narrator*.20 + duration*.10)*100, 1)
+    strong = (title >= .96 and author >= .94 and narrator >= .94 and delta is not None
+              and delta <= .03 and not conflicts and local.get('title_source') == 'metadata')
+    return {'book': book, 'score': score, 'evidence': reasons, 'conflicts': conflicts,
+            'automatic_eligible': strong, 'match_version': MATCH_VERSION}
+
+
+def candidates_for(row, client, query=None):
+    local = row.get('metadata_json') or row
+    query = (query or f"{local.get('title', row.get('title', ''))} {local.get('author', row.get('author', ''))}").strip()
+    if not query:
+        return []
+    books = client.search(query, limit=20, strict=True)
+    distinct = {}
+    for book in books:
+        data = compact(book)
+        if data.get('source') not in (None, 'audible') or not ASIN_RE.fullmatch(str(data.get('asin') or '')):
+            continue
+        distinct[data['asin']] = score_candidate(local, data)
+    return sorted(distinct.values(), key=lambda c: c['score'], reverse=True)[:8]
+
+
+def match_one(db, row, client):
+    candidates = candidates_for(row, client)
+    best = candidates[0] if candidates else None
+    margin = best['score'] - candidates[1]['score'] if len(candidates) > 1 else 100
+    automatic = bool(best and best['automatic_eligible'] and best['score'] >= 96 and margin >= 8)
+    status = 'automatic' if automatic else 'suggested' if candidates else 'unmatched'
+    evidence = list(best['evidence']) if best else ['No catalogue candidates found; will retry later']
+    if best and margin < 8:
+        evidence.append('Several editions are similarly plausible; review required')
+    applied = db.apply_library_match(row['asin'], signature=row.get('scan_signature',''),
+        revision=row.get('match_revision',0), status=status,
+        catalog_asin=best['book']['asin'] if automatic else '',
+        score=best['score'] if best else 0, evidence=evidence, candidates=candidates,
+        book=best['book'] if automatic else {})
+    return status if applied else 'unchanged'
+
+
+def match_library(db, client=None, limit=25, progress=None):
+    from core.audiobook_client import get_audiobook_client
+    client = client or get_audiobook_client()
+    counts = {'matched':0, 'review':0, 'match_errors':0, 'match_checked':0, 'match_pending':0}
+    now = time.time()
+    due = [r for r in db.get_library() if r.get('match_status') in ('unmatched','suggested','error')
+           and now - float(r.get('match_checked_at') or 0) >= (3600 if r.get('match_status') == 'error' else 7*86400)]
+    due.sort(key=lambda r: float(r.get('match_checked_at') or 0))
+    batch = due[:max(0, min(int(limit),100))]
+    counts['match_pending'] = max(0,len(due)-len(batch))
+    for row in batch:
+        try:
+            status = match_one(db,row,client)
+            counts['matched'] += int(status == 'automatic')
+            counts['review'] += int(status == 'suggested')
+        except Exception as exc:
+            counts['match_errors'] += 1
+            db.apply_library_match(row['asin'], signature=row.get('scan_signature',''),
+                revision=row.get('match_revision',0), status='error', evidence=[str(exc)])
+        counts['match_checked'] += 1
+        if progress:
+            progress(counts, row['title'])
+    return counts

--- a/core/audiobook_library_metadata.py
+++ b/core/audiobook_library_metadata.py
@@ -1,0 +1,145 @@
+"""Read existing audiobook metadata without changing files or querying a catalogue."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+ASIN_RE = re.compile(r"^[A-Z0-9]{10}$", re.I)
+
+
+def _text(value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else ""
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    return str(value or "").strip()
+
+
+def read_metadata(path: Path, files: list[Path]) -> dict:
+    """Prefer sidecars, then embedded album tags, then the name on disk.
+
+    A local identity is assigned by the scanner when no explicit ASIN exists.
+    Titles and authors never imply ownership of a particular catalogue edition.
+    """
+    folder = path if path.is_dir() else path.parent
+    facts = {"title": "", "author": "", "narrator": "", "asin": "",
+             "series_title": "", "series_sequence": "", "runtime_minutes": 0}
+
+    def put(key, value):
+        text = _text(value)
+        if text and not facts.get(key):
+            facts[key] = text
+
+    # A loose file must not inherit another book's directory sidecar.
+    sidecars = [folder / n for n in ("metadata.opf", "book.nfo", "metadata.json")] \
+        if path.is_dir() else [path.with_suffix(".opf"), path.with_suffix(".nfo")]
+    for sidecar in sidecars:
+        try:
+            if sidecar.stat().st_size > 2 * 1024 * 1024:
+                continue
+            text = sidecar.read_text(encoding="utf-8-sig")
+            if sidecar.suffix == ".json":
+                data = json.loads(text)
+                if not isinstance(data, dict):
+                    continue
+                for key, field in (("title", "title"), ("author", "authors"),
+                                   ("narrator", "narrators"), ("asin", "asin")):
+                    put(key, data.get(field))
+                series = data.get("series") or []
+                if series and isinstance(series[0], str):
+                    put("series_title", series[0])
+                continue
+            # Do not expand externally supplied entities in library sidecars.
+            if "<!DOCTYPE" in text.upper() or "<!ENTITY" in text.upper():
+                continue
+            tree = ET.fromstring(text)
+            for element in tree.iter():
+                tag = element.tag.rsplit("}", 1)[-1].lower()
+                attrs = {k.rsplit("}", 1)[-1].lower(): v for k, v in element.attrib.items()}
+                value = element.text or ""
+                if tag == "title":
+                    put("title", value)
+                elif tag == "creator":
+                    put("narrator" if attrs.get("role") == "nrt" else "author", value)
+                elif tag in ("author", "narrator", "asin"):
+                    put(tag, value)
+                elif tag in ("identifier", "uniqueid") and \
+                        (attrs.get("scheme", "").lower() == "asin" or attrs.get("type") == "asin"):
+                    put("asin", value)
+                elif tag == "meta":
+                    key = {"calibre:series": "series_title", "calibre:series_index": "series_sequence"}.get(attrs.get("name"))
+                    if key:
+                        put(key, attrs.get("content"))
+        except (OSError, ValueError, ET.ParseError, TypeError):
+            continue
+
+    duration = 0.0
+    for file in files:
+        try:
+            import mutagen
+            audio = mutagen.File(file)
+            if audio is None:
+                continue
+            duration += float(getattr(audio.info, "length", 0) or 0)
+            tags = audio.tags or {}
+            for key, names in {
+                "title": ("TALB", "album", "\xa9alb"),
+                "author": ("TPE2", "albumartist", "aART", "TPE1", "artist", "\xa9ART"),
+                "narrator": ("TCOM", "composer", "\xa9wrt"),
+                "asin": ("TXXX:ASIN", "asin", "ASIN", "----:com.apple.iTunes:ASIN"),
+                "series_title": ("TXXX:SERIES", "series", "----:com.apple.iTunes:SERIES"),
+                "series_sequence": ("TXXX:SERIES-PART", "series-part"),
+            }.items():
+                for name in names:
+                    if name in tags:
+                        put(key, tags[name])
+        except (ImportError, OSError, ValueError, TypeError, AttributeError):
+            continue
+        except Exception:  # malformed media is still visible by its filename
+            continue
+    facts["runtime_minutes"] = round(duration / 60)
+    if not ASIN_RE.fullmatch(str(facts["asin"])):
+        facts["asin"] = ""
+    else:
+        facts["asin"] = str(facts["asin"]).upper()
+    facts["title"] = facts["title"] or (path.name if path.is_dir() else path.stem)
+    return facts
+
+
+def embedded_cover(path: Path):
+    """Read one embedded cover on demand; never create artwork beside the book."""
+    from core.audiobook_organizer import AUDIO_EXTENSIONS
+    try:
+        if path.is_file():
+            files = [path]
+        else:
+            files = sorted(p for p in path.iterdir() if p.is_file()
+                           and not p.is_symlink() and p.suffix.lower() in AUDIO_EXTENSIONS)
+        for file in files[:3]:
+            try:
+                import mutagen
+                audio = mutagen.File(file)
+                if audio is None:
+                    continue
+                data = None
+                tags = audio.tags or {}
+                if tags.get('covr'):
+                    data = bytes(tags['covr'][0])
+                elif hasattr(tags, 'getall') and tags.getall('APIC'):
+                    data = tags.getall('APIC')[0].data
+                elif getattr(audio, 'pictures', None):
+                    data = audio.pictures[0].data
+                if not data or len(data) > 10 * 1024 * 1024:
+                    continue
+                if data.startswith(b'\xff\xd8\xff'):
+                    return data, 'image/jpeg'
+                if data.startswith(b'\x89PNG\r\n\x1a\n'):
+                    return data, 'image/png'
+            except Exception:
+                continue
+    except OSError:
+        pass
+    return None

--- a/core/audiobook_library_metadata.py
+++ b/core/audiobook_library_metadata.py
@@ -18,7 +18,7 @@ def _text(value: Any) -> str:
     return str(value or "").strip()
 
 
-def read_metadata(path: Path, files: list[Path]) -> dict:
+def read_metadata(path: Path, files: list[Path], probes=None, include_sidecars=True) -> dict:
     """Prefer sidecars, then embedded album tags, then the name on disk.
 
     A local identity is assigned by the scanner when no explicit ASIN exists.
@@ -26,7 +26,8 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
     """
     folder = path if path.is_dir() else path.parent
     facts = {"title": "", "author": "", "narrator": "", "asin": "",
-             "series_title": "", "series_sequence": "", "runtime_minutes": 0}
+             "series_title": "", "series_sequence": "", "runtime_minutes": 0,
+             "language": "", "format_type": ""}
 
     def put(key, value):
         text = _text(value)
@@ -36,7 +37,7 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
     # A loose file must not inherit another book's directory sidecar.
     sidecars = [folder / n for n in ("metadata.opf", "book.nfo", "metadata.json")] \
         if path.is_dir() else [path.with_suffix(".opf"), path.with_suffix(".nfo")]
-    for sidecar in sidecars:
+    for sidecar in sidecars if include_sidecars else []:
         try:
             if sidecar.stat().st_size > 2 * 1024 * 1024:
                 continue
@@ -64,7 +65,7 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
                     put("title", value)
                 elif tag == "creator":
                     put("narrator" if attrs.get("role") == "nrt" else "author", value)
-                elif tag in ("author", "narrator", "asin"):
+                elif tag in ("author", "narrator", "asin", "language"):
                     put(tag, value)
                 elif tag in ("identifier", "uniqueid") and \
                         (attrs.get("scheme", "").lower() == "asin" or attrs.get("type") == "asin"):
@@ -77,7 +78,7 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
             continue
 
     duration = 0.0
-    for file in files:
+    for file in files if probes is None else []:
         try:
             import mutagen
             audio = mutagen.File(file)
@@ -92,6 +93,7 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
                 "asin": ("TXXX:ASIN", "asin", "ASIN", "----:com.apple.iTunes:ASIN"),
                 "series_title": ("TXXX:SERIES", "series", "----:com.apple.iTunes:SERIES"),
                 "series_sequence": ("TXXX:SERIES-PART", "series-part"),
+                "language": ("TLAN", "language", "LANGUAGE"),
             }.items():
                 for name in names:
                     if name in tags:
@@ -100,7 +102,21 @@ def read_metadata(path: Path, files: list[Path]) -> dict:
             continue
         except Exception:  # malformed media is still visible by its filename
             continue
+    if probes is not None:
+        for probe in probes:
+            for key in ("title", "author", "narrator", "asin", "series_title", "series_sequence", "language", "format_type"):
+                if key == "title" and probe.get("title_source") == "filename":
+                    continue
+                put(key, probe.get(key))
+            duration += probe.get("duration_seconds", 0)
+    facts["duration_seconds"] = duration
     facts["runtime_minutes"] = round(duration / 60)
+    facts["title_source"] = "metadata" if facts["title"] else "filename"
+    text_title = str(facts["title"]).lower()
+    if "unabridged" in text_title:
+        facts["format_type"] = "unabridged"
+    elif "abridged" in text_title:
+        facts["format_type"] = "abridged"
     if not ASIN_RE.fullmatch(str(facts["asin"])):
         facts["asin"] = ""
     else:

--- a/core/audiobook_library_scan.py
+++ b/core/audiobook_library_scan.py
@@ -1,29 +1,14 @@
-"""Audiobook library scan — keeps the "you own this" record honest.
+"""Index the configured audiobook folder, including books acquired elsewhere.
 
-SoulSync records a book in ``audiobook_library`` at import, and that record is
-what puts an Owned badge on a search result and what stops the grab route
-downloading something twice. Records go stale the moment the user touches the
-folder themselves, which they do: books get deleted after listening, moved to
-a NAS, or restored from a backup taken before an import.
-
-This is the reconciliation. It does two things and no more:
-
-  * Forgets rows whose folder is gone, so an Owned badge never lies.
-  * Adopts folders on disk that the database does not know about, by reading
-    the asin back out of the sidecars the post-processor wrote.
-
-It never deletes, moves or rewrites a file. The disk is the truth here and the
-database is the copy, so the only thing that changes is the database.
-
-Adoption is deliberately limited to folders carrying a sidecar. Matching an
-arbitrary folder name back to a catalogue entry is a guess, and a wrong guess
-here is worse than no guess at all: it silently marks a book owned that the
-user does not have, and the wishlist then refuses to fetch it.
+The scan reads audio and sidecars; it never moves, tags, renames or deletes files.
+Unidentified books receive local keys, never guessed catalogue ownership.
 """
-
 from __future__ import annotations
 
+import hashlib
 import os
+import re
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -31,14 +16,10 @@ from typing import Any, Dict, List, Optional
 from utils.logging_config import get_logger
 
 logger = get_logger("audiobook_library_scan")
-
-# How deep to walk below the library root before giving up. The default
-# template is author/series/title, so three is the shape; four gives room for
-# an install that shelves by first letter on top of that.
-MAX_DEPTH = 4
-
-# A folder holding fewer bytes than this is not a book, it is leftovers.
+MAX_DEPTH = 32
 MIN_BOOK_BYTES = 1024 * 1024
+_SCAN_LOCK = threading.Lock()
+_DISC = re.compile(r"^(?:cd|disc|disk|part)\s*[-_ ]*\d+$", re.I)
 
 
 def _audio_extensions() -> frozenset:
@@ -46,224 +27,228 @@ def _audio_extensions() -> frozenset:
     return AUDIO_EXTENSIONS
 
 
+def _stats(files: list[Path]) -> dict:
+    return {"file_count": len(files), "size_bytes": sum(p.stat().st_size for p in files),
+            "audio_format": "/".join(sorted({p.suffix.lower().lstrip('.') for p in files}))}
+
+
 def folder_stats(folder: Path) -> Dict[str, Any]:
-    """Count and measure the audio directly inside a folder.
-
-    Not recursive on purpose. A book folder holds its own chapters, and
-    counting a subfolder's files into it would make a series folder look like
-    one enormous book.
-    """
-    extensions = _audio_extensions()
-    count = 0
-    size = 0
-    formats: List[str] = []
-
+    """Measure direct audio children; retained for organizer callers."""
     try:
-        entries = list(Path(folder).iterdir())
+        files = [p for p in Path(folder).iterdir()
+                 if not p.is_symlink() and p.is_file() and p.suffix.lower() in _audio_extensions()]
+        return _stats(files)
     except OSError:
         return {"file_count": 0, "size_bytes": 0, "audio_format": ""}
 
-    for entry in entries:
-        try:
-            if not entry.is_file():
-                continue
-            suffix = entry.suffix.lower()
-            if suffix not in extensions:
-                continue
-            count += 1
-            size += entry.stat().st_size
-            token = suffix.lstrip(".")
-            if token not in formats:
-                formats.append(token)
-        except OSError:
-            continue
-
-    return {
-        "file_count": count,
-        "size_bytes": size,
-        # Sorted so a mixed folder reports the same string every scan and does
-        # not churn the row on every pass.
-        "audio_format": "/".join(sorted(formats)),
-    }
-
 
 def is_book_folder(folder: Path) -> bool:
-    """True when this folder looks like it holds one book's audio."""
     stats = folder_stats(folder)
     return stats["file_count"] > 0 and stats["size_bytes"] >= MIN_BOOK_BYTES
 
 
 def iter_book_folders(root: Path, max_depth: int = MAX_DEPTH):
-    """Every folder under root that holds audio, without descending into it.
-
-    Stops at the first folder on a branch that holds audio: a book's own
-    chapters are the leaves, and anything below them belongs to that book.
-    """
-    root = Path(root)
-    if not root.is_dir():
+    """Compatibility iterator for book directories (never the library root)."""
+    if not Path(root).is_dir():
         return
+    for path, _ in _inventory(Path(root), max_depth, lambda *_: None):
+        if path.is_dir():
+            yield path
 
+
+def _inventory(root: Path, max_depth: int, error):
     stack = [(root, 0)]
     while stack:
         folder, depth = stack.pop()
         if depth > max_depth:
+            error(folder, "Folder nesting exceeds the scan limit")
             continue
-
-        if depth > 0 and is_book_folder(folder):
-            yield folder
-            continue
-
         try:
-            children = [
-                child for child in folder.iterdir()
-                # Hidden folders are somebody's business, not the library's.
-                # The recycle bin is the one that matters: without this, a book
-                # deleted yesterday is found in .deleted, read from its own
-                # sidecar, and adopted straight back into the library — the
-                # delete would silently undo itself on the next daily scan.
-                if child.is_dir() and not child.name.startswith(".")
-            ]
+            entries = sorted(folder.iterdir())
+            visible = [p for p in entries if not p.name.startswith('.') and not p.is_symlink()]
+            files = [p for p in visible if p.is_file() and p.suffix.lower() in _audio_extensions()]
+            children = [p for p in visible if p.is_dir()]
+            # CD1/CD2 are parts of a book, not independent titles.
+            discs = [p for p in children if _DISC.fullmatch(p.name)]
+            if folder != root and discs and len(discs) == len(children):
+                for disc in discs:
+                    files.extend(p for p in sorted(disc.iterdir())
+                                 if p.is_file() and not p.is_symlink()
+                                 and p.suffix.lower() in _audio_extensions())
+                children = []
+            if files and _stats(files)["size_bytes"] >= MIN_BOOK_BYTES:
+                if folder == root or (len(files) > 1 and all(p.suffix.lower() == ".m4b" for p in files)
+                                      and not (folder / "metadata.opf").exists()
+                                      and not (folder / "book.nfo").exists()):
+                    # A flat library is many files, never one deletable root directory.
+                    for file in files:
+                        if file.stat().st_size >= MIN_BOOK_BYTES:
+                            yield file, [file]
+                else:
+                    yield folder, files
+                    continue
+            stack.extend((p, depth + 1) for p in reversed(children))
         except OSError as exc:
-            logger.debug("Could not list %s: %s", folder, exc)
-            continue
-
-        for child in children:
-            stack.append((child, depth + 1))
+            error(folder, str(exc))
 
 
-def _book_from_sidecar(folder: Path, asin: str) -> Dict[str, Any]:
-    """The minimum a library row needs, read off disk.
+def _key(path: Path) -> str:
+    return os.path.normcase(str(path.resolve()))
 
-    Only reached for a folder the database has never seen, so there is nothing
-    better to fall back on. The catalogue is not consulted: a scan that fires
-    one Audible request per unknown folder would hammer them on the first run
-    over an existing library, and every field it would fill is cosmetic.
-    """
-    from core.audiobook_post_processor import NFO_NAME, OPF_NAME
 
-    title = ""
-    author = ""
-    narrator = ""
+def _local_id(path: Path) -> str:
+    return "local:" + hashlib.sha256(_key(path).encode()).hexdigest()[:24]
 
-    for name, opening, closing in (
-        (OPF_NAME, "<dc:title>", "</dc:title>"),
-        (NFO_NAME, "<title>", "</title>"),
-    ):
+
+def _signature(path: Path, files: list[Path]) -> str:
+    sidecars = [path / name for name in ("metadata.opf", "book.nfo", "metadata.json")] \
+        if path.is_dir() else [path.with_suffix('.opf'), path.with_suffix('.nfo')]
+    parts = []
+    for file in files + sidecars:
         try:
-            text = (folder / name).read_text(encoding="utf-8", errors="ignore")
-        except OSError:
+            stat = file.stat()
+        except FileNotFoundError:
             continue
-        if opening in text:
-            title = text.split(opening, 1)[1].split(closing, 1)[0].strip()
-        if not author and 'opf:role="aut"' in text:
-            author = text.split('opf:role="aut"', 1)[1].split(">", 1)[1] \
-                .split("<", 1)[0].strip()
-        if not narrator and 'opf:role="nrt"' in text:
-            narrator = text.split('opf:role="nrt"', 1)[1].split(">", 1)[1] \
-                .split("<", 1)[0].strip()
-        if title:
-            break
-
-    return {
-        "asin": asin,
-        # The folder name is the honest fallback: it is what the user sees.
-        "title": title or folder.name,
-        "author_names": [author] if author else [],
-        "narrator_names": [narrator] if narrator else [],
-        "series": [],
-    }
+        parts.append(f"{file}:{stat.st_size}:{stat.st_mtime_ns}")
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
 
-def scan(root: Optional[str] = None, db: Any = None) -> Dict[str, Any]:
-    """Reconcile the library table against the folder on disk.
+def scan_status(db=None) -> dict:
+    from core.audiobook_database import get_audiobook_db
+    database = db if db is not None else get_audiobook_db()
+    state = database.get_library_scan_state()
+    if state.get("status") == "running" and not _SCAN_LOCK.locked():
+        state = {**state, "status": "interrupted", "error": "The previous scan was interrupted. Run it again."}
+    return state
 
-    Returns ``{checked, removed, adopted, updated, missing_root}``. Never
-    raises: this runs from the automation engine, and a scan that throws would
-    take the whole run down with it.
+
+def scan(root: Optional[str] = None, db: Any = None, progress=None) -> Dict[str, Any]:
+    """One shared, non-overlapping pass for the library automation.
+
+    Missing roots and incomplete walks never prune records. Local rows are
+    promoted to a catalogue identity only when an explicit ASIN is discovered.
     """
-    summary = {"checked": 0, "removed": 0, "adopted": 0, "updated": 0,
-               "missing_root": False, "started_at": time.time()}
-
+    if not _SCAN_LOCK.acquire(blocking=False):
+        return {"status": "skipped", "skipped": "An audiobook library scan is already running"}
     from core.audiobook_database import get_audiobook_db
     from core.audiobook_organizer import library_root
-
-    database = db if db is not None else get_audiobook_db()
-    library_path = Path(str(root or library_root()))
-
-    try:
-        rows = database.get_library()
-    except Exception as exc:                                # noqa: BLE001
-        logger.warning("Could not read the audiobook library: %s", exc)
-        return summary
-
-    if not library_path.is_dir():
-        # A missing root is almost always an unmounted share or a container
-        # started without its volume. Forgetting the whole library over that
-        # would be catastrophic and unrecoverable, so nothing is touched.
-        summary["missing_root"] = True
-        logger.warning("Audiobook library root %s is not there; skipping the scan",
-                       library_path)
-        return summary
-
-    known_paths = set()
-
-    for row in rows:
-        summary["checked"] += 1
-        asin = str(row.get("asin") or "")
-        path = Path(str(row.get("path") or ""))
-
-        if not asin:
-            continue
-
-        if not path.is_dir() or not is_book_folder(path):
-            try:
-                if database.remove_from_library(asin):
-                    summary["removed"] += 1
-                    logger.info("Forgot %s: %s is gone", asin, path)
-            except Exception as exc:                        # noqa: BLE001
-                logger.warning("Could not forget %s: %s", asin, exc)
-            continue
-
-        known_paths.add(os.path.normcase(str(path.resolve())))
-
-        stats = folder_stats(path)
-        if (stats["file_count"] != int(row.get("file_count") or 0)
-                or stats["size_bytes"] != int(row.get("size_bytes") or 0)):
-            try:
-                if database.update_library_entry(asin, **stats):
-                    summary["updated"] += 1
-            except Exception as exc:                        # noqa: BLE001
-                logger.debug("Could not refresh %s: %s", asin, exc)
-
+    from core.audiobook_library_metadata import read_metadata
     from core.audiobook_post_processor import read_asin_from_folder
 
-    for folder in iter_book_folders(library_path):
+    summary = {"status": "running", "checked": 0, "removed": 0, "adopted": 0,
+               "updated": 0, "local": 0, "errors": 0, "missing_root": False,
+               "started_at": time.time(), "error": ""}
+    database = None
+
+    def report():
+        if database is not None:
+            database.set_library_scan_state(summary)
+        if progress:
+            progress(dict(summary))
+
+    def error(path, detail):
+        summary["errors"] += 1
+        summary["error"] = f"Could not fully scan {path}: {detail}"
+        logger.warning(summary["error"])
+
+    try:
+        library_path = Path(str(root or library_root())).resolve()
+        summary["root"] = str(library_path)
+        database = db if db is not None else get_audiobook_db()
+        report()
+        if not library_path.is_dir():
+            summary.update(missing_root=True, status="error", error="The audiobook folder is not reachable. Check its setting and mount.")
+            return summary
+        rows = database.get_library()
+        by_path = {_key(Path(row["path"])): row for row in rows if row.get("path")}
+        ids = {row["asin"] for row in rows}
+        seen = set()
+        adopted_ids = set()
+        # Inventory first. An unreadable branch must not look like deleted books.
+        candidates = list(_inventory(library_path, MAX_DEPTH, error))
+        summary["found"] = len(candidates)
+        for index, (path, files) in enumerate(candidates):
+            summary["checked"] += 1
+            summary["current"] = path.name
+            seen.add(_key(path))
+            try:
+                previous = by_path.get(_key(path))
+                stats = _stats(files)
+                signature = _signature(path, files)
+                if previous and previous.get("scan_signature") == signature:
+                    summary["local"] += int(previous["asin"].startswith("local:"))
+                    continue
+                facts = read_metadata(path, files)
+                asin = facts["asin"]
+                if not asin and path.is_dir():
+                    asin = read_asin_from_folder(path)
+                if previous and not previous["asin"].startswith("local:"):
+                    asin = previous["asin"]
+                # Keep multiple physical copies visible without overwriting an owned copy.
+                if asin in ids and (not previous or previous["asin"] != asin):
+                    old = next((r for r in rows if r["asin"] == asin), None)
+                    if old is None or Path(old["path"]).exists():
+                        asin = ""
+                asin = asin or _local_id(path)
+                summary["local"] += int(asin.startswith("local:"))
+                if previous and previous["asin"] == asin:
+                    fields = {**stats, "scan_signature": signature}
+                    if previous.get("source") == "scan":
+                        fields.update({k: facts[k] for k in ("title", "author", "narrator", "series_title", "series_sequence", "runtime_minutes")})
+                    if not database.update_library_entry(asin, **fields):
+                        raise RuntimeError("Could not update the library record")
+                    summary["updated"] += 1
+                else:
+                    book = {"asin": asin, "title": facts["title"],
+                            "author_names": [facts["author"]] if facts["author"] else [],
+                            "narrator_names": [facts["narrator"]] if facts["narrator"] else [],
+                            "series": [{"title": facts["series_title"], "sequence": facts["series_sequence"]}],
+                            "runtime_minutes": facts["runtime_minutes"]}
+                    if not database.add_to_library(book, str(path), source="scan", scan_signature=signature, **stats):
+                        raise RuntimeError("Could not save the library record")
+                    ids.add(asin)
+                    adopted_ids.add(asin)
+                    if previous:
+                        database.remove_from_library(previous["asin"])
+                    summary["adopted"] += 1
+            except Exception as exc:
+                error(path, str(exc))
+            finally:
+                if index % 10 == 0:
+                    report()
+        # A mount disappearing during enumeration is also an incomplete scan.
+        if not library_path.is_dir():
+            error(library_path, "Folder became unavailable during the scan")
+        if not summary["errors"]:
+            for row in rows:
+                if row["asin"] in adopted_ids:
+                    continue
+                path = Path(str(row.get("path") or ""))
+                if not row.get("path") or not path.resolve().is_relative_to(library_path):
+                    continue
+                if _key(path) in seen:
+                    continue
+                try:
+                    # Permission errors and existing audio outside the inventory are
+                    # preserved; only demonstrably missing/empty paths are forgotten.
+                    if path.exists() and (path.is_file() or is_book_folder(path)):
+                        continue
+                    if database.remove_from_library(row["asin"]):
+                        summary["removed"] += 1
+                except Exception as exc:
+                    error(path, str(exc))
+        summary["status"] = "error" if summary["errors"] else "completed"
+        return summary
+    except Exception as exc:
+        summary.update(status="error", error=str(exc))
+        summary["errors"] += 1
+        logger.exception("Audiobook library scan failed")
+        return summary
+    finally:
+        summary["finished_at"] = time.time()
+        summary["duration"] = round(time.time() - summary["started_at"], 2)
+        summary.pop("current", None)
         try:
-            resolved = os.path.normcase(str(folder.resolve()))
-        except OSError:
-            continue
-        if resolved in known_paths:
-            continue
-
-        asin = read_asin_from_folder(folder)
-        if not asin:
-            # No sidecar, so no reliable identity. Left alone rather than
-            # guessed at, because a wrong Owned badge blocks a download the
-            # user actually wants.
-            continue
-
-        try:
-            if database.is_owned(asin):
-                continue
-            if database.add_to_library(_book_from_sidecar(folder, asin),
-                                       str(folder), **folder_stats(folder)):
-                summary["adopted"] += 1
-                logger.info("Adopted %s from %s", asin, folder)
-        except Exception as exc:                            # noqa: BLE001
-            logger.warning("Could not adopt %s: %s", folder, exc)
-
-    summary["duration"] = round(time.time() - summary["started_at"], 2)
-    logger.info("Audiobook library scan: %d checked, %d removed, %d adopted, %d updated",
-                summary["checked"], summary["removed"], summary["adopted"],
-                summary["updated"])
-    return summary
+            report()
+        finally:
+            _SCAN_LOCK.release()

--- a/core/audiobook_library_scan.py
+++ b/core/audiobook_library_scan.py
@@ -48,48 +48,14 @@ def is_book_folder(folder: Path) -> bool:
 
 
 def iter_book_folders(root: Path, max_depth: int = MAX_DEPTH):
-    """Compatibility iterator for book directories (never the library root)."""
-    if not Path(root).is_dir():
-        return
-    for path, _ in _inventory(Path(root), max_depth, lambda *_: None):
-        if path.is_dir():
-            yield path
-
-
-def _inventory(root: Path, max_depth: int, error):
-    stack = [(root, 0)]
-    while stack:
-        folder, depth = stack.pop()
-        if depth > max_depth:
-            error(folder, "Folder nesting exceeds the scan limit")
-            continue
-        try:
-            entries = sorted(folder.iterdir())
-            visible = [p for p in entries if not p.name.startswith('.') and not p.is_symlink()]
-            files = [p for p in visible if p.is_file() and p.suffix.lower() in _audio_extensions()]
-            children = [p for p in visible if p.is_dir()]
-            # CD1/CD2 are parts of a book, not independent titles.
-            discs = [p for p in children if _DISC.fullmatch(p.name)]
-            if folder != root and discs and len(discs) == len(children):
-                for disc in discs:
-                    files.extend(p for p in sorted(disc.iterdir())
-                                 if p.is_file() and not p.is_symlink()
-                                 and p.suffix.lower() in _audio_extensions())
-                children = []
-            if files and _stats(files)["size_bytes"] >= MIN_BOOK_BYTES:
-                if folder == root or (len(files) > 1 and all(p.suffix.lower() == ".m4b" for p in files)
-                                      and not (folder / "metadata.opf").exists()
-                                      and not (folder / "book.nfo").exists()):
-                    # A flat library is many files, never one deletable root directory.
-                    for file in files:
-                        if file.stat().st_size >= MIN_BOOK_BYTES:
-                            yield file, [file]
-                else:
-                    yield folder, files
-                    continue
-            stack.extend((p, depth + 1) for p in reversed(children))
-        except OSError as exc:
-            error(folder, str(exc))
+    from core.audiobook_library_inventory import discover
+    class MemoryCache:
+        def cached_library_file(self, *args): return None
+        def cache_library_file(self, *args): pass
+    if Path(root).is_dir():
+        for group in discover(Path(root), MemoryCache(), lambda *_: None, max_depth):
+            if group.scope == "folder":
+                yield group.path
 
 
 def _key(path: Path) -> str:
@@ -122,132 +88,166 @@ def scan_status(db=None) -> dict:
     return state
 
 
-def scan(root: Optional[str] = None, db: Any = None, progress=None) -> Dict[str, Any]:
-    """One shared, non-overlapping pass for the library automation.
+def _provenance(group, facts, previous, downloads):
+    if previous and previous.get("origin") == "soulsync":
+        return "soulsync", previous.get("download_id", "")
+    marker = ""
+    if group.scope == "folder":
+        try:
+            marker = (group.path / ".soulsync-release").read_text(encoding="utf-8").strip()
+        except OSError:
+            pass
+    for download in downloads:
+        if download.get("status") != "completed":
+            continue
+        exact_path = download.get("imported_path") and _key(Path(download["imported_path"])) == _key(group.path)
+        marked = marker and marker in (download.get("release_title"), download.get("download_id"))
+        if exact_path or (marked and download.get("asin") == facts.get("asin")):
+            return "soulsync", download["download_id"]
+    if marker:
+        return "soulsync", ""
+    return (previous.get("origin", "unknown") if previous else "disk"), ""
 
-    Missing roots and incomplete walks never prune records. Local rows are
-    promoted to a catalogue identity only when an explicit ASIN is discovered.
-    """
-    if not _SCAN_LOCK.acquire(blocking=False):
-        return {"status": "skipped", "skipped": "An audiobook library scan is already running"}
+
+def scan(root: Optional[str] = None, db: Any = None, progress=None,
+         match_catalog: bool = False, match_limit: int = 25, client=None) -> Dict[str, Any]:
+    """Read files, reconcile inventory, then optionally match a bounded catalogue batch."""
     from core.audiobook_database import get_audiobook_db
     from core.audiobook_organizer import library_root
     from core.audiobook_library_metadata import read_metadata
-    from core.audiobook_post_processor import read_asin_from_folder
-
-    summary = {"status": "running", "checked": 0, "removed": 0, "adopted": 0,
-               "updated": 0, "local": 0, "errors": 0, "missing_root": False,
-               "started_at": time.time(), "error": ""}
+    from core.audiobook_library_inventory import discover
+    if not _SCAN_LOCK.acquire(blocking=False):
+        return {"status": "skipped", "skipped": "An audiobook library scan is already running"}
+    summary = {"status": "running", "phase": "scanning", "checked": 0, "removed": 0,
+               "adopted": 0, "updated": 0, "moved": 0, "local": 0, "errors": 0,
+               "missing_root": False, "started_at": time.time(), "error": ""}
     database = None
-
     def report():
         if database is not None:
             database.set_library_scan_state(summary)
         if progress:
             progress(dict(summary))
-
     def error(path, detail):
         summary["errors"] += 1
         summary["error"] = f"Could not fully scan {path}: {detail}"
         logger.warning(summary["error"])
-
     try:
-        library_path = Path(str(root or library_root())).resolve()
-        summary["root"] = str(library_path)
+        root_path = Path(str(root or library_root())).resolve()
+        summary["root"] = str(root_path)
         database = db if db is not None else get_audiobook_db()
         report()
-        if not library_path.is_dir():
+        if not root_path.is_dir():
             summary.update(missing_root=True, status="error", error="The audiobook folder is not reachable. Check its setting and mount.")
             return summary
         rows = database.get_library()
-        by_path = {_key(Path(row["path"])): row for row in rows if row.get("path")}
-        ids = {row["asin"] for row in rows}
-        seen = set()
-        adopted_ids = set()
-        # Inventory first. An unreadable branch must not look like deleted books.
-        candidates = list(_inventory(library_path, MAX_DEPTH, error))
-        summary["found"] = len(candidates)
-        for index, (path, files) in enumerate(candidates):
+        downloads = database.get_downloads()
+        by_path = {_key(Path(r["path"])): r for r in rows if r.get("path")}
+        ids = {r["asin"] for r in rows}
+        groups = discover(root_path, database, error)
+        summary["found"] = len(groups)
+        seen_ids, seen_files = set(), set()
+        for index, group in enumerate(groups):
             summary["checked"] += 1
-            summary["current"] = path.name
-            seen.add(_key(path))
+            summary["current"] = group.path.name
             try:
-                previous = by_path.get(_key(path))
-                stats = _stats(files)
-                signature = _signature(path, files)
-                if previous and previous.get("scan_signature") == signature:
-                    summary["local"] += int(previous["asin"].startswith("local:"))
-                    continue
-                facts = read_metadata(path, files)
-                asin = facts["asin"]
-                if not asin and path.is_dir():
-                    asin = read_asin_from_folder(path)
-                if previous and not previous["asin"].startswith("local:"):
-                    asin = previous["asin"]
-                # Keep multiple physical copies visible without overwriting an owned copy.
-                if asin in ids and (not previous or previous["asin"] != asin):
-                    old = next((r for r in rows if r["asin"] == asin), None)
-                    if old is None or Path(old["path"]).exists():
-                        asin = ""
-                asin = asin or _local_id(path)
-                summary["local"] += int(asin.startswith("local:"))
-                if previous and previous["asin"] == asin:
-                    fields = {**stats, "scan_signature": signature}
+                previous = by_path.get(_key(group.path))
+                if previous is None:
+                    possible = [r for r in rows if r.get("fingerprint") == group.fingerprint
+                                and r["asin"] not in seen_ids and not Path(r["path"]).exists()]
+                    if len(possible) == 1:
+                        previous = possible[0]
+                        summary["moved"] += 1
+                paths = [str(p) for p in group.files]
+                seen_files.update(_key(p) for p in group.files)
+                facts = (previous.get("metadata_json") if previous and previous.get("scan_signature") == group.signature
+                         else None)
+                if not facts:
+                    facts = read_metadata(group.path, group.files, probes=group.probes)
+                explicit_ids = {p.get("asin") for p in group.probes if p.get("asin")}
+                if facts.get("asin"):
+                    explicit_ids.add(facts["asin"])
+                facts["metadata_conflicts"] = ["Conflicting identifiers in the sidecar and audio files"] if len(explicit_ids)>1 else []
+                if facts["metadata_conflicts"]:
+                    facts["asin"] = ""
+                catalog_asin = facts.get("asin") or ""
+                key = previous["asin"] if previous else catalog_asin if catalog_asin and catalog_asin not in ids else _local_id(group.path)
+                origin, download_id = _provenance(group, facts, previous, downloads)
+                stats = _stats(group.files)
+                fields = {**stats, "path": str(group.path), "file_paths": paths,
+                          "file_scope": group.scope, "fingerprint": group.fingerprint,
+                          "scan_signature": group.signature, "metadata_json": facts,
+                          "grouping": group.grouping, "origin": origin, "download_id": download_id}
+                if previous:
+                    changed = previous.get("scan_signature") != group.signature
+                    # A previous manual decision is never silently replaced by a search.
+                    pinned = previous.get("match_status") in ("confirmed", "ignored", "changed")
+                    if changed and pinned and previous.get("match_status") != "ignored" and previous.get("fingerprint") and previous["fingerprint"] != group.fingerprint:
+                        fields.update(match_status="changed", match_evidence=["Files changed since confirmation; please review the saved match"])
+                    elif not pinned and (changed or previous.get("match_status") == "identifier"):
+                        preserve_import = (previous.get("origin") == "soulsync" or previous.get("match_status") == "identifier") and not facts["metadata_conflicts"] and not catalog_asin and (not previous.get("fingerprint") or previous["fingerprint"] == group.fingerprint)
+                        catalog_asin = catalog_asin or (previous.get("catalog_asin", "") if preserve_import else "")
+                        fields.update(catalog_asin=catalog_asin, match_status="identifier" if catalog_asin else "unmatched",
+                                      match_checked_at=0, match_candidates=[], catalog_book={})
                     if previous.get("source") == "scan":
-                        fields.update({k: facts[k] for k in ("title", "author", "narrator", "series_title", "series_sequence", "runtime_minutes")})
-                    if not database.update_library_entry(asin, **fields):
-                        raise RuntimeError("Could not update the library record")
-                    summary["updated"] += 1
+                        fields.update({k:facts[k] for k in ("title","author","narrator","series_title","series_sequence","runtime_minutes")})
+                    # No repeated DB writes or tag probes for an unchanged entry.
+                    if any(previous.get(k) != v for k,v in fields.items()):
+                        if not database.update_library_entry(key, **fields):
+                            raise RuntimeError("Could not update the library record")
+                        summary["updated"] += 1
                 else:
-                    book = {"asin": asin, "title": facts["title"],
-                            "author_names": [facts["author"]] if facts["author"] else [],
-                            "narrator_names": [facts["narrator"]] if facts["narrator"] else [],
-                            "series": [{"title": facts["series_title"], "sequence": facts["series_sequence"]}],
-                            "runtime_minutes": facts["runtime_minutes"]}
-                    if not database.add_to_library(book, str(path), source="scan", scan_signature=signature, **stats):
+                    book = {"asin":key, "title":facts["title"], "author_names":[facts["author"]] if facts["author"] else [],
+                            "narrator_names":[facts["narrator"]] if facts["narrator"] else [],
+                            "runtime_minutes":facts["runtime_minutes"],
+                            "series":[{"title":facts["series_title"],"sequence":facts["series_sequence"]}]}
+                    if not database.add_to_library(book,str(group.path),source="scan", catalog_asin=catalog_asin, **{k:v for k,v in fields.items() if k!='path'}):
                         raise RuntimeError("Could not save the library record")
-                    ids.add(asin)
-                    adopted_ids.add(asin)
-                    if previous:
-                        database.remove_from_library(previous["asin"])
                     summary["adopted"] += 1
+                seen_ids.add(key)
+                ids.add(key)
+                summary["local"] += int(not catalog_asin)
             except Exception as exc:
-                error(path, str(exc))
+                error(group.path, str(exc))
             finally:
                 if index % 10 == 0:
                     report()
-        # A mount disappearing during enumeration is also an incomplete scan.
-        if not library_path.is_dir():
-            error(library_path, "Folder became unavailable during the scan")
+        if not root_path.is_dir():
+            error(root_path,"Folder became unavailable during the scan")
         if not summary["errors"]:
             for row in rows:
-                if row["asin"] in adopted_ids:
+                if row["asin"] in seen_ids or not row.get("path"):
                     continue
-                path = Path(str(row.get("path") or ""))
-                if not row.get("path") or not path.resolve().is_relative_to(library_path):
-                    continue
-                if _key(path) in seen:
+                path = Path(row["path"])
+                if not path.resolve().is_relative_to(root_path):
                     continue
                 try:
-                    # Permission errors and existing audio outside the inventory are
-                    # preserved; only demonstrably missing/empty paths are forgotten.
-                    if path.exists() and (path.is_file() or is_book_folder(path)):
+                    old_files = row.get("file_paths") or []
+                    regrouped = old_files and all(_key(Path(p)) in seen_files for p in old_files)
+                    if not regrouped and path.exists() and (path.is_file() or is_book_folder(path)):
                         continue
                     if database.remove_from_library(row["asin"]):
                         summary["removed"] += 1
                 except Exception as exc:
-                    error(path, str(exc))
+                    error(path,str(exc))
+        if match_catalog:
+            from core.audiobook_library_matching import match_library
+            summary["phase"] = "matching"
+            report()
+            def matching_progress(counts,title):
+                summary.update(counts, current=title)
+                report()
+            summary.update(match_library(database,client=client,limit=match_limit,progress=matching_progress))
         summary["status"] = "error" if summary["errors"] else "completed"
         return summary
     except Exception as exc:
-        summary.update(status="error", error=str(exc))
+        summary.update(status="error",error=str(exc))
         summary["errors"] += 1
-        logger.exception("Audiobook library scan failed")
+        logger.exception("Audiobook scan failed")
         return summary
     finally:
         summary["finished_at"] = time.time()
-        summary["duration"] = round(time.time() - summary["started_at"], 2)
-        summary.pop("current", None)
+        summary["duration"] = round(time.time()-summary["started_at"],2)
+        summary.pop("current",None)
         try:
             report()
         finally:

--- a/core/audiobook_recycle.py
+++ b/core/audiobook_recycle.py
@@ -145,9 +145,8 @@ def entry_age_seconds(name: str, now: Optional[float] = None) -> Optional[float]
 def discard(path: str, reason: str = "") -> Dict[str, Any]:
     """Move one book folder to the bin. ``{ok, moved_to, permanent, error}``.
 
-    With the bin turned off, or when the folder cannot be moved into it, the
-    book is deleted outright — refusing to delete would leave the caller's
-    "removed" bookkeeping lying and fill the disk.
+    With the bin turned off, the selected book is deleted outright. A failed
+    recycle move leaves the book in place and reports an error to the caller.
     """
     source = Path(str(path or ""))
     result: Dict[str, Any] = {"ok": False, "moved_to": "", "permanent": False, "error": ""}
@@ -204,7 +203,7 @@ def discard(path: str, reason: str = "") -> Dict[str, Any]:
 
 def _delete_outright(source: Path, result: Dict[str, Any]) -> Dict[str, Any]:
     try:
-        shutil.rmtree(str(source))
+        shutil.rmtree(str(source)) if source.is_dir() else source.unlink()
         result.update(ok=True, permanent=True)
         logger.info("Deleted %s permanently", source.name)
     except OSError as exc:

--- a/core/audiobook_soulseek.py
+++ b/core/audiobook_soulseek.py
@@ -412,8 +412,13 @@ def aggregate(statuses: Sequence[Any], expected: int = 0) -> Dict[str, Any]:
         state = "failed"
     elif settled >= expected:
         state = "done"
-    else:
+    elif any(_state_of(s) == "running" and any(
+        token in str(getattr(s, "state", "")).lower()
+        for token in ("inprogress", "downloading", "transferring")
+    ) for s in statuses):
         state = "downloading"
+    else:
+        state = "queued"
 
     progress = (transferred / total_size * 100.0) if total_size else (
         finished / expected * 100.0 if expected else 0.0
@@ -457,6 +462,8 @@ def status_for(client_id: Any, client: Any = None) -> Optional[Dict[str, Any]]:
     mine = [status for status in (everything or [])
             if str(getattr(status, "id", "")) in wanted]
     rolled = aggregate(mine, expected=len(wanted))
+    if not mine:
+        rolled["state"] = "unavailable"
     rolled["save_path"] = landing_path(unpacked["folder"], client)
     return rolled
 

--- a/core/audiobook_soulseek.py
+++ b/core/audiobook_soulseek.py
@@ -423,6 +423,7 @@ def aggregate(statuses: Sequence[Any], expected: int = 0) -> Dict[str, Any]:
         "state": state,
         "progress": round(min(progress, 100.0), 2),
         "transferred": transferred,
+        "speed": sum(max(0, float(getattr(s, "speed", 0) or 0)) for s in statuses if _state_of(s) not in ("done", "failed")),
         "size": total_size,
         "finished": finished,
         "failed": failed,

--- a/core/audiobook_soulseek.py
+++ b/core/audiobook_soulseek.py
@@ -459,8 +459,18 @@ def status_for(client_id: Any, client: Any = None) -> Optional[Dict[str, Any]]:
         logger.debug("Soulseek status poll failed: %s", exc)
         return None
 
-    mine = [status for status in (everything or [])
-            if str(getattr(status, "id", "")) in wanted]
+    # slskd can acknowledge enqueue without returning a transfer ID. The
+    # shared client then returns the full remote filename. Match that fallback
+    # only within the submitting peer, never by basename or folder alone.
+    filenames = {ref.replace("\\", "/") for ref in wanted if "\\" in ref or "/" in ref}
+    peer = unpacked["username"]
+    mine = []
+    for status in everything or []:
+        transfer_id = str(getattr(status, "id", ""))
+        filename = str(getattr(status, "filename", "")).replace("\\", "/")
+        username = str(getattr(status, "username", ""))
+        if transfer_id in wanted or (peer and username == peer and filename in filenames):
+            mine.append(status)
     rolled = aggregate(mine, expected=len(wanted))
     if not mine:
         rolled["state"] = "unavailable"

--- a/core/audiobook_soulseek.py
+++ b/core/audiobook_soulseek.py
@@ -70,6 +70,18 @@ def is_enabled() -> bool:
         return False
 
 
+def _shared_client():
+    """The process-wide Soulseek client.
+
+    Deliberately NOT cached here, and deliberately reading no config here: the
+    audiobook side must never consult music's soulseek settings to decide
+    anything (tests/test_audiobooks_isolation.py holds that line). The cache and
+    the config read both live in core/soulseek_client.py, which owns them.
+    """
+    from core.soulseek_client import get_shared_soulseek_client
+    return get_shared_soulseek_client()
+
+
 def is_available() -> bool:
     """Whether Soulseek can actually answer: wanted by the chain AND configured.
 
@@ -80,8 +92,7 @@ def is_available() -> bool:
     if not is_enabled():
         return False
     try:
-        from core.soulseek_client import SoulseekClient
-        return bool(str(getattr(SoulseekClient(), "base_url", "") or ""))
+        return bool(str(getattr(_shared_client(), "base_url", "") or ""))
     except Exception as exc:                                # noqa: BLE001
         logger.debug("Could not check whether slskd is configured: %s", exc)
         return False
@@ -212,8 +223,7 @@ def search(
 
     if client is None:
         try:
-            from core.soulseek_client import SoulseekClient
-            client = SoulseekClient()
+            client = _shared_client()
         except Exception as exc:                            # noqa: BLE001
             logger.warning("Could not build a Soulseek client: %s", exc)
             return []
@@ -269,8 +279,7 @@ def grab(release: Any, save_path: Optional[str] = None, client: Any = None) -> D
 
     if client is None:
         try:
-            from core.soulseek_client import SoulseekClient
-            client = SoulseekClient()
+            client = _shared_client()
         except Exception as exc:                            # noqa: BLE001
             return {"ok": False, "error": f"Soulseek is not reachable: {exc}",
                     "refs": [], "username": username}
@@ -342,8 +351,7 @@ def landing_path(folder: str, client: Any = None) -> str:
         return ""
     try:
         if client is None:
-            from core.soulseek_client import SoulseekClient
-            client = SoulseekClient()
+            client = _shared_client()
         root = str(getattr(client, "download_path", "") or "")
     except Exception as exc:                                # noqa: BLE001
         logger.debug("Could not read the Soulseek download path: %s", exc)
@@ -432,8 +440,7 @@ def status_for(client_id: Any, client: Any = None) -> Optional[Dict[str, Any]]:
 
     if client is None:
         try:
-            from core.soulseek_client import SoulseekClient
-            client = SoulseekClient()
+            client = _shared_client()
         except Exception as exc:                            # noqa: BLE001
             logger.debug("Could not build a Soulseek client to poll: %s", exc)
             return None
@@ -461,8 +468,7 @@ def cancel(client_id: Any, client: Any = None) -> bool:
 
     if client is None:
         try:
-            from core.soulseek_client import SoulseekClient
-            client = SoulseekClient()
+            client = _shared_client()
         except Exception as exc:                            # noqa: BLE001
             logger.debug("Could not build a Soulseek client to cancel: %s", exc)
             return False

--- a/core/audiobook_wishlist_worker.py
+++ b/core/audiobook_wishlist_worker.py
@@ -209,6 +209,22 @@ def process_one(row: Dict[str, Any], db: Any = None, auto_grab: bool = True) -> 
                 # nothing has to be asked of the catalogue again later.
                 book=book,
             )
+        if not ref:
+            # "grabbed" hands the row to the download monitor. With no ref there
+            # is no download to follow, so claiming it strands the row on "sent
+            # to downloads" with nothing behind it - the state reset_stale_grabbed
+            # exists to clean up. Fail it and let the next pass try again.
+            database.mark_wishlist_status(
+                asin, STATUS_FAILED,
+                error="The client accepted the release but returned no handle",
+                count_attempt=True,
+            )
+            logger.warning(
+                "Audiobook grab for %s reported success with no ref; not marking it grabbed",
+                asin,
+            )
+            return outcome
+
         database.mark_wishlist_status(asin, STATUS_GRABBED, count_attempt=True)
         outcome["grabbed"] = True
         logger.info("Audiobook wishlist grabbed %s for %s", best.title, asin)
@@ -228,7 +244,8 @@ def run_pass(db: Any = None, limit: Optional[int] = None) -> Dict[str, Any]:
     from core.audiobook_database import get_audiobook_db
 
     database = db if db is not None else get_audiobook_db()
-    summary = {"checked": 0, "found": 0, "grabbed": 0, "errors": 0, "freed": 0}
+    summary = {"checked": 0, "found": 0, "grabbed": 0, "errors": 0,
+               "freed": 0, "unstuck": 0}
 
     # Self-healing, at the start of every pass rather than only at boot: a pass
     # that died mid-search leaves rows claimed as "searching", and the retry
@@ -238,6 +255,16 @@ def run_pass(db: Any = None, limit: Optional[int] = None) -> Dict[str, Any]:
         summary["freed"] = database.reset_stale_searching()
     except Exception as exc:                                # noqa: BLE001
         logger.debug("Could not free stale searching rows: %s", exc)
+
+    # A row handed to a download client is moved off "grabbed" by the download
+    # MONITOR, which only watches live downloads. If that download never
+    # registered, was cleared, or the monitor stopped running, the row sits on
+    # "sent to downloads" forever and no pass looks at it again. Same recovery
+    # as above, for the same reason.
+    try:
+        summary["unstuck"] = database.reset_stale_grabbed()
+    except Exception as exc:                                # noqa: BLE001
+        logger.debug("Could not free stale grabbed rows: %s", exc)
 
     # Every profile, not just the first. There is no request behind a timed
     # pass, so the profile has to come from the rows — and sweeping only

--- a/core/automation/blocks.py
+++ b/core/automation/blocks.py
@@ -239,7 +239,10 @@ ACTIONS: list[dict] = [
     {"type": "scan_watchlist_podcasts", "label": "Scan Watchlist Podcasts", "icon": "mic", "description": "Check watchlisted podcasts for new episodes and prune expired", "available": True},
     {"type": "audiobook_scan_library", "label": "Scan Audiobook Library", "icon": "headphones",
      "description": "Scan the audiobook folder set in Settings, including books added outside SoulSync. Read tags and sidecars, index local books, and reconcile missing files without changing files on disk.",
-     "available": True},
+     "available": True, "config_fields": [
+         {"key": "match_catalog", "type": "checkbox", "label": "Find catalogue matches after scanning", "default": True},
+         {"key": "match_batch_size", "type": "number", "label": "Books to match per run", "default": 25, "min": 1, "max": 100},
+     ]},
     {"type": "scan_library", "label": "Scan Library", "icon": "refresh", "description": "Trigger media server library scan", "available": True},
     {"type": "refresh_mirrored", "label": "Refresh Mirrored Playlist", "icon": "copy", "description": "Re-fetch playlist from source and update mirror", "available": True,
      "config_fields": [

--- a/core/automation/blocks.py
+++ b/core/automation/blocks.py
@@ -237,6 +237,9 @@ ACTIONS: list[dict] = [
      "config_fields": [{"key": "category", "type": "select", "label": "Category", "options": [{"value": "all", "label": "All"}, {"value": "albums", "label": "Albums"}, {"value": "singles", "label": "Singles"}], "default": "all"}]},
     {"type": "scan_watchlist", "label": "Scan Watchlist", "icon": "eye", "description": "Check watched artists AND followed labels for new releases", "available": True},
     {"type": "scan_watchlist_podcasts", "label": "Scan Watchlist Podcasts", "icon": "mic", "description": "Check watchlisted podcasts for new episodes and prune expired", "available": True},
+    {"type": "audiobook_scan_library", "label": "Scan Audiobook Library", "icon": "headphones",
+     "description": "Scan the audiobook folder set in Settings, including books added outside SoulSync. Read tags and sidecars, index local books, and reconcile missing files without changing files on disk.",
+     "available": True},
     {"type": "scan_library", "label": "Scan Library", "icon": "refresh", "description": "Trigger media server library scan", "available": True},
     {"type": "refresh_mirrored", "label": "Refresh Mirrored Playlist", "icon": "copy", "description": "Re-fetch playlist from source and update mirror", "available": True,
      "config_fields": [

--- a/core/automation/handlers/audiobook_scan_library.py
+++ b/core/automation/handlers/audiobook_scan_library.py
@@ -1,53 +1,39 @@
-"""Automation handler: ``audiobook_scan_library`` action.
-
-Reconciles the audiobook library table against the folder on disk, so an Owned
-badge never outlives the book it describes. Daily, in the quiet hours after the
-other audio automations have had their turn.
-
-The music side's ``scan_library`` reads a whole music library and enriches it;
-this is much smaller on purpose. Audiobooks have no library page to populate,
-so the only thing the record is for is answering "do I already have this", and
-the only way it goes wrong is the user moving or deleting a folder.
-
-Deliberately NOT tagged owned_by, matching the other audio automations.
-"""
-
+"""Scan existing audiobook files through the shared automation engine."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict
 
 from core.automation.deps import AutomationDeps
 
 
 def auto_scan_audiobook_library(config: Dict[str, Any], deps: AutomationDeps) -> Dict[str, Any]:
-    """Forget books that are gone and adopt folders that turned up.
+    from core.audiobook_organizer import library_root
+    from core.audiobook_database import subsystem_in_use
+    from core.audiobook_library_scan import scan
 
-    Skips quietly on an install that has never used audiobooks: seeding an
-    automation must not be what creates the subsystem's database.
-    """
+    automation_id = config.get("_automation_id")
+    root = str(config.get("root") or library_root())
+    # A configured folder is enough to discover an existing library on first use.
+    if not subsystem_in_use() and not Path(root).is_dir():
+        return {"status": "completed", "skipped": "No audiobook folder available yet"}
+
+    def progress(state):
+        running = state["status"] == "running"
+        failed = state["status"] == "error"
+        total = max(1, state.get("found", 0))
+        phase = (f"Reading {state.get('current', 'audiobook folders')}" if running else
+                 state.get("error") if failed else
+                 f"Library updated: {state['adopted']} added, {state['updated']} refreshed, {state['removed']} missing")
+        deps.update_progress(
+            automation_id, status="running" if running else "error" if failed else "finished",
+            progress=min(95, int(state["checked"] / total * 95)) if running else 100,
+            phase=phase, log_line=phase, log_type="error" if failed else "info")
+
     try:
-        from core.audiobook_database import subsystem_in_use
-
-        if not subsystem_in_use():
-            return {"status": "completed", "skipped": "no audiobooks yet"}
-
-        from core.audiobook_library_scan import scan
-
-        summary = scan(root=config.get("root") or None)
-
-        if summary.get("missing_root"):
-            # An unmounted share, almost always. Reported rather than treated
-            # as an empty library, because forgetting everything over it would
-            # be unrecoverable.
-            return {"status": "completed",
-                    "skipped": "the audiobook folder is not reachable"}
-
-        return {
-            "status": "completed",
-            "checked": summary.get("checked", 0),
-            "removed": summary.get("removed", 0),
-            "adopted": summary.get("adopted", 0),
-            "updated": summary.get("updated", 0),
-        }
-    except Exception as exc:                                # noqa: BLE001
-        return {"status": "error", "error": str(exc)}
+        result = scan(root=root, progress=progress)
+        return {**result, "_manages_own_progress": result.get("status") != "skipped"}
+    except Exception as exc:
+        deps.update_progress(automation_id, status="error", phase="Scan failed",
+                             log_line=str(exc), log_type="error")
+        return {"status": "error", "error": str(exc), "_manages_own_progress": True}

--- a/core/automation/handlers/audiobook_scan_library.py
+++ b/core/automation/handlers/audiobook_scan_library.py
@@ -22,7 +22,7 @@ def auto_scan_audiobook_library(config: Dict[str, Any], deps: AutomationDeps) ->
         running = state["status"] == "running"
         failed = state["status"] == "error"
         total = max(1, state.get("found", 0))
-        phase = (f"Reading {state.get('current', 'audiobook folders')}" if running else
+        phase = (f"{'Matching' if state.get('phase') == 'matching' else 'Reading'} {state.get('current', 'audiobook folders')}" if running else
                  state.get("error") if failed else
                  f"Library updated: {state['adopted']} added, {state['updated']} refreshed, {state['removed']} missing")
         deps.update_progress(
@@ -31,7 +31,8 @@ def auto_scan_audiobook_library(config: Dict[str, Any], deps: AutomationDeps) ->
             phase=phase, log_line=phase, log_type="error" if failed else "info")
 
     try:
-        result = scan(root=root, progress=progress)
+        result = scan(root=root, progress=progress, match_catalog=bool(config.get("match_catalog", True)),
+                      match_limit=max(1,min(int(config.get("match_batch_size",25)),100)))
         return {**result, "_manages_own_progress": result.get("status") != "skipped"}
     except Exception as exc:
         deps.update_progress(automation_id, status="error", phase="Scan failed",

--- a/core/automation/handlers/database_update.py
+++ b/core/automation/handlers/database_update.py
@@ -116,6 +116,7 @@ def _run_with_progress(
             'status': 'running', 'phase': initial_phase,
             'progress': 0, 'current_item': '', 'processed': 0, 'total': 0,
             'error_message': '',
+            'last_progress_at': time.time(),
         })
     deps.db_update_executor.submit(task, *task_args)
 

--- a/core/automation_engine.py
+++ b/core/automation_engine.py
@@ -117,9 +117,6 @@ SYSTEM_AUTOMATIONS = [
         'action_type': 'audiobook_scan_watchlist',
         'initial_delay': 420,  # 7 minutes after startup
     },
-    # Keeps the "you own this" record honest. Daily and cheap: it reads the
-    # audiobook folder and touches nothing on disk, so the only cost of being
-    # wrong is an Owned badge that outlives the book.
     # Empties the audiobook recycle bin. The schedule is what matters: the
     # opportunistic pass only fires when something else is deleted, so on a
     # library nobody prunes the bin would never expire.
@@ -130,6 +127,8 @@ SYSTEM_AUTOMATIONS = [
         'action_type': 'audiobook_purge_recycle',
         'initial_delay': 780,  # 13 minutes after startup
     },
+    # Index existing audiobook folders and loose files, including external books.
+    # Reuse this system job so existing user schedules and history are preserved.
     {
         'name': 'Auto-Scan Audiobook Library',
         'trigger_type': 'schedule',

--- a/core/deezer_client.py
+++ b/core/deezer_client.py
@@ -403,15 +403,23 @@ class DeezerClient:
         """Reload configuration — refresh OAuth token from config."""
         self._load_token()
 
-    def _api_get(self, endpoint: str, params: dict = None, timeout: int = 15) -> Optional[Dict[str, Any]]:
+    def _api_get(self, endpoint: str, params: dict = None, timeout: int = 15,
+                 use_token: bool = True) -> Optional[Dict[str, Any]]:
         """Generic GET request to Deezer API with error handling.
-        Includes OAuth access_token when available for user-level endpoints."""
+        Includes OAuth access_token when available for user-level endpoints.
+
+        use_token=False for the PUBLIC endpoints - charts, editorial, search.
+        They need no auth, and sending a stale token does not get ignored: the
+        api answers `{"error": {"type": "OAuthException"}}` and the call fails
+        outright. So a user with an expired Deezer link lost the browse rows
+        that never needed their account in the first place.
+        """
         try:
             url = f"{self.BASE_URL}/{endpoint.lstrip('/')}"
             if params is None:
                 params = {}
             # Include access token for authenticated requests
-            if self._access_token and 'access_token' not in params:
+            if use_token and self._access_token and 'access_token' not in params:
                 params['access_token'] = self._access_token
             response = self.session.get(url, params=params, timeout=timeout)
 
@@ -690,7 +698,7 @@ class DeezerClient:
             genre_id = 0
         limit = max(1, min(int(limit or 25), 100))
 
-        data = self._api_get(f'chart/{genre_id}/playlists', {'limit': limit})
+        data = self._api_get(f'chart/{genre_id}/playlists', {'limit': limit}, use_token=False)
         items = (data or {}).get('data') or []
         if not items:
             logger.debug("No Deezer editorial playlists for genre %s", genre_id)
@@ -714,7 +722,7 @@ class DeezerClient:
         if not query:
             return []
         limit = max(1, min(int(limit or 25), 100))
-        data = self._api_get('search/playlist', {'q': query, 'limit': limit})
+        data = self._api_get('search/playlist', {'q': query, 'limit': limit}, use_token=False)
         items = (data or {}).get('data') or []
         out = []
         for item in items:

--- a/core/deezer_client.py
+++ b/core/deezer_client.py
@@ -662,10 +662,10 @@ class DeezerClient:
     # Nothing here needs a token, so it works for every user whether or not they
     # have linked a Deezer account.
 
-    # A genre's own chart, keyed by the ids `GET /genre` returns. Kept as a
-    # tuple rather than fetched so a browse does not spend a request working out
-    # what to ask for, and so the order on screen is a decision rather than
-    # whatever the api felt like returning.
+    # The fallback genre set, used only when `GET /genre` cannot be reached.
+    # The live list is asked for instead (see get_editorial_genres): this used
+    # to BE the list, and shipping twelve of Deezer's twenty-eight quietly hid
+    # Metal, Country, Blues, Folk, Soul & Funk and every regional category.
     EDITORIAL_GENRES = (
         (0, 'Top'),
         (132, 'Pop'),
@@ -682,8 +682,33 @@ class DeezerClient:
     )
 
     def get_editorial_genres(self) -> List[Dict[str, Any]]:
-        """The genres a browse can ask for, as [{id, name}]."""
-        return [{'id': gid, 'name': name} for gid, name in self.EDITORIAL_GENRES]
+        """The genres a browse can ask for, as [{id, name}].
+
+        Asked for rather than hardcoded. The first version shipped twelve names
+        as a constant to save a request, which cost sixteen genres - Metal,
+        Country, Blues, Soul & Funk, Folk and every regional category among
+        them. One cached call is worth more than that.
+
+        EDITORIAL_GENRES stays as the fallback, so the chips still appear when
+        Deezer is unreachable, and 'All' is kept at the front because it is the
+        row the shelf opens on.
+        """
+        data = self._api_get('genre', use_token=False)
+        rows = (data or {}).get('data') or []
+        out = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            gid = row.get('id')
+            name = str(row.get('name') or '').strip()
+            if gid is None or not name:
+                continue
+            out.append({'id': int(gid), 'name': name})
+        if not out:
+            logger.debug("Deezer genre list unavailable; using the built-in set")
+            return [{'id': gid, 'name': name} for gid, name in self.EDITORIAL_GENRES]
+        out.sort(key=lambda g: (g['id'] != 0, g['name'].lower()))
+        return out
 
     def get_editorial_playlists(self, genre_id: int = 0, limit: int = 25) -> List[Dict[str, Any]]:
         """Deezer's curated playlists for one genre.

--- a/core/deezer_client.py
+++ b/core/deezer_client.py
@@ -640,6 +640,118 @@ class DeezerClient:
 
         return albums[:limit]
 
+    # ── Editorial playlists ──────────────────────────────────────
+    #
+    # Deezer's own editors publish playlists per genre, and the public API
+    # serves them with no key and no auth. These are the "top stuff" rows: the
+    # same thing the Deezer app opens on.
+    #
+    # `chart/{genre}/playlists` is the curated selection. Genre 0 is the
+    # everything chart and is deliberately tiny (four entries), so a browse that
+    # only asked for 0 would look broken; the per-genre charts are where the
+    # content is (Rock 50, Dance 40, Rap 35 when this was written).
+    #
+    # Nothing here needs a token, so it works for every user whether or not they
+    # have linked a Deezer account.
+
+    # A genre's own chart, keyed by the ids `GET /genre` returns. Kept as a
+    # tuple rather than fetched so a browse does not spend a request working out
+    # what to ask for, and so the order on screen is a decision rather than
+    # whatever the api felt like returning.
+    EDITORIAL_GENRES = (
+        (0, 'Top'),
+        (132, 'Pop'),
+        (116, 'Rap / Hip Hop'),
+        (152, 'Rock'),
+        (113, 'Dance'),
+        (106, 'Electro'),
+        (165, 'R&B'),
+        (85, 'Alternative'),
+        (144, 'Reggae'),
+        (129, 'Jazz'),
+        (98, 'Classical'),
+        (173, 'Films / Games'),
+    )
+
+    def get_editorial_genres(self) -> List[Dict[str, Any]]:
+        """The genres a browse can ask for, as [{id, name}]."""
+        return [{'id': gid, 'name': name} for gid, name in self.EDITORIAL_GENRES]
+
+    def get_editorial_playlists(self, genre_id: int = 0, limit: int = 25) -> List[Dict[str, Any]]:
+        """Deezer's curated playlists for one genre.
+
+        Returns the normalised shape the discover shelf reads, or [] on any
+        failure - a browse row that cannot load is an empty row, never an error
+        the page has to handle.
+        """
+        try:
+            genre_id = int(genre_id)
+        except (TypeError, ValueError):
+            genre_id = 0
+        limit = max(1, min(int(limit or 25), 100))
+
+        data = self._api_get(f'chart/{genre_id}/playlists', {'limit': limit})
+        items = (data or {}).get('data') or []
+        if not items:
+            logger.debug("No Deezer editorial playlists for genre %s", genre_id)
+            return []
+
+        out = []
+        for item in items:
+            playlist = self._editorial_playlist_to_dict(item)
+            if playlist:
+                out.append(playlist)
+        logger.info("Deezer editorial: %s playlists for genre %s", len(out), genre_id)
+        return out
+
+    def search_playlists(self, query: str, limit: int = 25) -> List[Dict[str, Any]]:
+        """Search Deezer playlists by name. Editorial and user playlists mixed.
+
+        Same normalised shape as get_editorial_playlists, so a shelf can render
+        either without caring which it asked for.
+        """
+        query = (query or '').strip()
+        if not query:
+            return []
+        limit = max(1, min(int(limit or 25), 100))
+        data = self._api_get('search/playlist', {'q': query, 'limit': limit})
+        items = (data or {}).get('data') or []
+        out = []
+        for item in items:
+            playlist = self._editorial_playlist_to_dict(item)
+            if playlist:
+                out.append(playlist)
+        return out
+
+    @staticmethod
+    def _editorial_playlist_to_dict(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """One api playlist row -> the shape the shelf and the loader share.
+
+        `id` is what matters: it is the same id /api/deezer/playlist/<id> already
+        takes, so a card picked here goes through the pipeline that already
+        exists rather than a second one built for browsing.
+        """
+        if not isinstance(item, dict):
+            return None
+        playlist_id = str(item.get('id') or '').strip()
+        title = str(item.get('title') or '').strip()
+        if not playlist_id or not title:
+            return None
+        user = item.get('user') if isinstance(item.get('user'), dict) else {}
+        # picture_xl is 1000x1000; the shelf wants art that survives a retina
+        # tile, and the smaller keys are the same image scaled down
+        image = (item.get('picture_xl') or item.get('picture_big')
+                 or item.get('picture_medium') or item.get('picture') or '')
+        return {
+            'id': playlist_id,
+            'title': title,
+            'creator': str(user.get('name') or 'Deezer').strip() or 'Deezer',
+            'track_count': int(item.get('nb_tracks') or 0),
+            'image_url': image,
+            'link': str(item.get('link') or ''),
+            'source': 'deezer',
+        }
+
     def get_track_details(self, track_id: str) -> Optional[Dict[str, Any]]:
         """Get detailed track info — returns Spotify-compatible dict (metadata source interface)"""
         cache = get_metadata_cache()

--- a/core/deezer_download_client.py
+++ b/core/deezer_download_client.py
@@ -744,6 +744,19 @@ class DeezerDownloadClient(DownloadSourcePlugin):
                     title=title,
                     album=album,
                     track_number=item.get('track_position'),
+                    # the ids of the exact track the user is choosing.
+                    # enrichment used to text-search deezer afterwards to
+                    # work out which deezer track this was - a track we had
+                    # just downloaded from deezer BY id. a remix suffix or a
+                    # differently credited artist made that fuzzy match miss,
+                    # and then no deezer id was embedded at all. tidal and
+                    # hifi already carry theirs through this way.
+                    _source_metadata={
+                        'source': 'deezer',
+                        'track_id': track_id,
+                        'artist_id': str(item.get('artist', {}).get('id') or '') or None,
+                        'album_id': str(item.get('album', {}).get('id') or '') or None,
+                    },
                 )
                 # Stamp CD-quality FLAC (16/44.1) so lossless ranks correctly.
                 tr.set_quality(quality_from_deezer(requested_quality))

--- a/core/downloads/file_finder.py
+++ b/core/downloads/file_finder.py
@@ -91,6 +91,33 @@ def _normalize_for_finding(text: str) -> str:
     return ' '.join(text.split()).strip()
 
 
+def _encoded_display_name(api_filename: str) -> Optional[str]:
+    """The display name out of an ``id||...||name`` dispatch key, else None.
+
+    These are NOT filesystem paths. A source encodes what its worker needs to
+    start the download, and the finder only wants the human-readable tail so it
+    can match the file that landed on disk.
+
+    Most sources encode two parts, ``id||name``. SoundCloud encodes THREE,
+    ``id||url||name``, because its worker needs the permalink to download at all
+    (core/soundcloud_client.py splits with maxsplit=2). Reading everything after
+    the FIRST separator therefore made the search target
+    ``https://soundcloud.com/...||SSIO - Alles oder Nix``, and nothing on disk is
+    called that - so the file was never found, never imported and never tagged.
+    The download looked finished and the file just sat in the completed folder
+    (#1239).
+
+    The three-part shape is recognised by its url rather than by counting, so a
+    title that happens to contain ``||`` keeps reading exactly as it did before.
+    """
+    if not api_filename or '||' not in api_filename:
+        return None
+    parts = api_filename.split('||')
+    if len(parts) > 2 and parts[1].startswith(('http://', 'https://')):
+        return parts[-1]
+    return api_filename.split('||', 1)[1]
+
+
 def _extract_basename(api_filename: str) -> str:
     """Cross-platform rightmost-separator split for a real remote PATH.
 
@@ -100,9 +127,9 @@ def _extract_basename(api_filename: str) -> str:
     must NOT be split on (issue #835)."""
     if not api_filename:
         return ""
-    if '||' in api_filename:
-        _id, title = api_filename.split('||', 1)
-        return title
+    encoded = _encoded_display_name(api_filename)
+    if encoded is not None:
+        return encoded
     last_slash = max(api_filename.rfind('/'), api_filename.rfind('\\'))
     return api_filename[last_slash + 1:] if last_slash != -1 else api_filename
 
@@ -254,9 +281,7 @@ def find_completed_audio_file(
     # truncated the search target to ``T:T`` and the real file was never found,
     # quarantining valid downloads (issue #835). Real remote paths (Soulseek)
     # still get basename + dir-component extraction.
-    encoded_title = None
-    if api_filename and '||' in api_filename:
-        _id, encoded_title = api_filename.split('||', 1)
+    encoded_title = _encoded_display_name(api_filename)
     if encoded_title is not None:
         target_basename = encoded_title
         api_dirs = []

--- a/core/downloads/status.py
+++ b/core/downloads/status.py
@@ -96,7 +96,7 @@ def _recovery_identity(task):
 
 def _schedule_file_recovery(task_id, batch_id, task, deps):
     """Called under tasks_lock. Revalidate the attempt after slow I/O."""
-    if task_id in _recovery_pending or not _recovery_slots.acquire(blocking=False):
+    if task.get('cancel_requested') or task_id in _recovery_pending or not _recovery_slots.acquire(blocking=False):
         return
     identity = _recovery_identity(task)
     _recovery_pending[task_id] = task
@@ -113,6 +113,7 @@ def _schedule_file_recovery(task_id, batch_id, task, deps):
                 if found:
                     current['status'] = 'post_processing'
                     current['status_change_time'] = time.time()
+                    processing_identity = _recovery_identity(current)
                 else:
                     current['status'] = 'failed'
                     current['error_message'] = 'Task stuck in downloading state; completed file not found'
@@ -123,7 +124,7 @@ def _schedule_file_recovery(task_id, batch_id, task, deps):
                     # A rejected submission must not strand a download in
                     # Processing with no worker. Preserve any newer transition.
                     with tasks_lock:
-                        if download_tasks.get(task_id) is task and task.get('status') == 'post_processing':
+                        if download_tasks.get(task_id) is task and _recovery_identity(task) == processing_identity:
                             task['status'] = identity[0]
                             task['status_change_time'] = identity[1]
                     raise

--- a/core/downloads/status.py
+++ b/core/downloads/status.py
@@ -352,7 +352,7 @@ def build_batch_status_data(batch_id: str, batch: dict, live_transfers_lookup: d
 
             # If task has been running too long, check if file completed
             _dl_timeout = deps.config_manager.get('soulseek.download_timeout', 600) or 600
-            if task_age > _dl_timeout and task['status'] in ['downloading', 'queued', 'searching']:
+            if not batch.get("managed_externally") and task_age > _dl_timeout and task['status'] in ['downloading', 'queued', 'searching']:
                 stuck_state = task['status']
                 task_filename = task.get('filename') or (task.get('track_info') or {}).get('filename')
 
@@ -387,7 +387,7 @@ def build_batch_status_data(batch_id: str, batch: dict, live_transfers_lookup: d
                 'track_index': task['track_index'],
                 'status': task['status'],
                 'track_info': task['track_info'],
-                'progress': 0,
+                'progress': task.get('progress', 0),
                 # V2 SYSTEM: Add persistent state information
                 'cancel_requested': task.get('cancel_requested', False),
                 'cancel_timestamp': task.get('cancel_timestamp'),
@@ -411,6 +411,12 @@ def build_batch_status_data(batch_id: str, batch: dict, live_transfers_lookup: d
                 'retry_info': task.get('retry_info'),
                 'retry_trigger': task.get('retry_trigger'),
             }
+            # A book/release is monitored as a multi-file job by its own client
+            # monitor. Music's single-file timeout/recovery must not mutate it.
+            if batch.get('managed_externally'):
+                _attach_live_detail(task_status, task, None)
+                batch_tasks.append(task_status)
+                continue
             _ti = task.get('track_info') if isinstance(task.get('track_info'), dict) else {}
             task_filename = task.get('filename') or _ti.get('filename')
             task_username = task.get('username') or _ti.get('username')

--- a/core/downloads/status.py
+++ b/core/downloads/status.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Optional
@@ -76,6 +77,72 @@ def _schedule_completion_callback(deps, batch_id: str, task_id: str, success: bo
         name=f"on-completed-{task_id[:8]}",
         daemon=True,
     ).start()
+
+
+# Recovery must not turn a progress poll into a recursive NAS scan. Bound
+# both running work and submissions, and allow only one probe per task.
+_recovery_pool = ThreadPoolExecutor(max_workers=2, thread_name_prefix="DownloadRecovery")
+_recovery_slots = threading.BoundedSemaphore(2)
+_recovery_pending = {}
+
+
+def _recovery_identity(task):
+    ti = task.get('track_info') or {}
+    return (task.get('status'), task.get('status_change_time'), task.get('download_id'),
+            task.get('filename') or ti.get('filename'),
+            task.get('username') or ti.get('username'),
+            task.get('cancel_requested'), task.get('cancel_timestamp'))
+
+
+def _schedule_file_recovery(task_id, batch_id, task, deps):
+    """Called under tasks_lock. Revalidate the attempt after slow I/O."""
+    if task_id in _recovery_pending or not _recovery_slots.acquire(blocking=False):
+        return
+    identity = _recovery_identity(task)
+    _recovery_pending[task_id] = task
+
+    def run():
+        try:
+            download_dir = deps.docker_resolve_path(deps.config_manager.get('soulseek.download_path', './downloads'))
+            transfer_dir = deps.docker_resolve_path(deps.config_manager.get('soulseek.transfer_path', './Transfer'))
+            found, _ = deps.find_completed_file(download_dir, identity[3], transfer_dir)
+            with tasks_lock:
+                current = download_tasks.get(task_id)
+                if current is not task or _recovery_identity(current) != identity:
+                    return  # cancelled, retried, removed, or completed during I/O
+                if found:
+                    current['status'] = 'post_processing'
+                    current['status_change_time'] = time.time()
+                else:
+                    current['status'] = 'failed'
+                    current['error_message'] = 'Task stuck in downloading state; completed file not found'
+            if found:
+                try:
+                    deps.submit_post_processing(task_id, batch_id)
+                except Exception:
+                    # A rejected submission must not strand a download in
+                    # Processing with no worker. Preserve any newer transition.
+                    with tasks_lock:
+                        if download_tasks.get(task_id) is task and task.get('status') == 'post_processing':
+                            task['status'] = identity[0]
+                            task['status_change_time'] = identity[1]
+                    raise
+            elif deps.on_download_completed:
+                deps.on_download_completed(batch_id, task_id, False)
+        except Exception as exc:
+            # A transient mount error is not proof that a download failed.
+            logger.warning("[Safety Valve] File recovery failed for %s: %s", task_id, exc)
+        finally:
+            with tasks_lock:
+                _recovery_pending.pop(task_id, None)
+            _recovery_slots.release()
+
+    try:
+        _recovery_pool.submit(run)
+    except Exception:
+        _recovery_pending.pop(task_id, None)
+        _recovery_slots.release()
+        raise
 
 
 @dataclass
@@ -356,21 +423,11 @@ def build_batch_status_data(batch_id: str, batch: dict, live_transfers_lookup: d
                 stuck_state = task['status']
                 task_filename = task.get('filename') or (task.get('track_info') or {}).get('filename')
 
-                # Before failing, check if the file actually downloaded successfully
-                recovered = False
-                if task_filename and stuck_state == 'downloading':
-                    try:
-                        download_dir = deps.docker_resolve_path(deps.config_manager.get('soulseek.download_path', './downloads'))
-                        transfer_dir = deps.docker_resolve_path(deps.config_manager.get('soulseek.transfer_path', './Transfer'))
-                        found_file, file_location = deps.find_completed_file(download_dir, task_filename, transfer_dir)
-                        if found_file:
-                            logger.info(f"[Safety Valve] Task {task_id} stuck but file found in {file_location} — routing to post-processing")
-                            task['status'] = 'post_processing'
-                            task['status_change_time'] = current_time
-                            deps.submit_post_processing(task_id, batch_id)
-                            recovered = True
-                    except Exception as e:
-                        logger.error(f"[Safety Valve] Error checking for completed file: {e}")
+                # Leave this attempt live while recovery checks storage outside
+                # the request thread and the global task lock.
+                recovered = bool(task_filename and stuck_state == 'downloading')
+                if recovered:
+                    _schedule_file_recovery(task_id, batch_id, task, deps)
 
                 if not recovered:
                     if stuck_state == 'searching':

--- a/core/image_cache.py
+++ b/core/image_cache.py
@@ -116,6 +116,7 @@ class ImageCache:
         self.fetcher = fetcher or requests.get
         self.db_path = self.cache_dir / "image_cache.sqlite3"
         self._db_lock = threading.RLock()
+        self._registrations: dict[str, float] = {}
         self._key_locks: dict[str, threading.RLock] = {}
         self._key_locks_lock = threading.Lock()
         self.cache_dir.mkdir(parents=True, exist_ok=True)
@@ -135,6 +136,11 @@ class ImageCache:
         key = self.key_for_url(str(url), variant)
         now = time.time()
         with self._db_lock:
+            # Coalesce repeat page registrations, with bounded memory. Serving
+            # still touches LRU timestamps; registration refreshes once/minute.
+            registered = self._registrations.get(key)
+            if registered is not None and 0 <= now - registered < 60:
+                return f"/api/image-cache/{key}"
             with self._connect() as conn:
                 conn.execute(
                     """
@@ -148,6 +154,9 @@ class ImageCache:
                     """,
                     (key, str(url), now, now, now, variant),
                 )
+            if len(self._registrations) >= 4096:
+                self._registrations.pop(next(iter(self._registrations)))
+            self._registrations[key] = now
         return f"/api/image-cache/{key}"
 
     def get(self, key: str) -> CachedImage:
@@ -231,6 +240,7 @@ class ImageCache:
         that nothing will ever clean up."""
         removed = 0
         for key in keys:
+            self._registrations.pop(key, None)
             row = conn.execute("SELECT file_path FROM image_cache WHERE key = ?", (key,)).fetchone()
             path = (row["file_path"] if row else "") or ""
             if path:

--- a/core/image_cache.py
+++ b/core/image_cache.py
@@ -46,6 +46,7 @@ DEFAULT_FETCH_TIMEOUT = 10.0
 # covers are square but artist photos and backdrops are not, so forcing a box
 # would letterbox or crop them.
 DEFAULT_VARIANT_MAX_WIDTH = {
+    "rail": 320,     # compact dashboard covers, including high-density screens
     "grid": 240,     # library/discover tiles
     "card": 480,     # shelf cards, search results
     "hero": 1200,    # detail-page headers

--- a/core/imports/jobs.py
+++ b/core/imports/jobs.py
@@ -1,0 +1,78 @@
+"""Bounded in-process manual import jobs, owned by the submitting profile.
+
+Synchronous API callers remain supported. The browser opts into jobs so a
+slow metadata provider never occupies its HTTP request for the whole import.
+"""
+from concurrent.futures import ThreadPoolExecutor
+import hashlib
+import json
+import threading
+import time
+import uuid
+
+from core.profile_context import set_background_profile, reset_background_profile
+
+
+class ImportJobs:
+    def __init__(self, workers=2, capacity=16):
+        self.pool = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="ManualImport")
+        self.capacity = capacity
+        self.lock = threading.Lock()
+        self.jobs = {}
+        self.keys = {}
+
+    def submit(self, owner, key, kind, data, operation):
+        fingerprint = hashlib.sha256(json.dumps([kind, data], sort_keys=True).encode()).hexdigest()
+        with self.lock:
+            now = time.monotonic()
+            for job_id, job in list(self.jobs.items()):
+                if job['finished'] is not None and now - job['finished'] > 3600:
+                    self.jobs.pop(job_id)
+                    self.keys.pop((job['owner'], job['key']), None)
+            existing = self.keys.get((owner, key))
+            if existing:
+                job = self.jobs[existing]
+                if job['fingerprint'] != fingerprint:
+                    return {'success': False, 'error': 'Idempotency key already used for a different import'}, 409
+                return {'success': True, 'job_id': existing}, 202
+            if sum(j['finished'] is None for j in self.jobs.values()) >= self.capacity or len(self.jobs) >= 1024:
+                return {'success': False, 'error': 'Import queue is full; try again later'}, 429
+            job_id = uuid.uuid4().hex
+            job = dict(owner=owner, key=key, fingerprint=fingerprint,
+                       state='queued', finished=None, result=None, status=None)
+            self.jobs[job_id] = job
+            self.keys[(owner, key)] = job_id
+
+        def run():
+            token = set_background_profile(owner)
+            try:
+                with self.lock:
+                    job['state'] = 'running'
+                result, status = operation()
+            except Exception:
+                import logging
+                logging.getLogger(__name__).exception('Manual import job failed')
+                result, status = {'success': False, 'error': 'Import processing failed; check server logs'}, 500
+            finally:
+                reset_background_profile(token)
+            with self.lock:
+                job.update(state='complete', result=result, status=status, finished=time.monotonic())
+        try:
+            self.pool.submit(run)
+        except Exception:
+            with self.lock:
+                self.jobs.pop(job_id, None)
+                self.keys.pop((owner, key), None)
+            raise
+        return {'success': True, 'job_id': job_id}, 202
+
+    def get(self, owner, job_id):
+        with self.lock:
+            job = self.jobs.get(job_id)
+            if not job or job['owner'] != owner:
+                return {'success': False, 'error': 'Import job unavailable; check imported files before resubmitting'}, 404
+            return {'success': True, 'job_id': job_id, 'state': job['state'],
+                    'result': job['result'], 'status': job['status']}, 200
+
+
+import_jobs = ImportJobs()

--- a/core/listening_import/lastfm.py
+++ b/core/listening_import/lastfm.py
@@ -121,6 +121,9 @@ class LastFMListeningImportWorker:
     def _run(self, username: str, full: bool) -> None:
         start_ts = time.time()
         previous = self._load_state()
+        if previous.get("username") and str(previous["username"]).casefold() != username.casefold():
+            previous = {}
+            self._state = {}
         previous_page = _int(previous.get("page"))
         previous_total_pages = _int(previous.get("total_pages"))
         previous_complete_is_suspect = _is_incomplete_backfill_state(previous)

--- a/core/lyrics_client.py
+++ b/core/lyrics_client.py
@@ -1,9 +1,28 @@
 #!/usr/bin/env python3
 
 import os
+import requests
 from utils.logging_config import get_logger
 
 logger = get_logger("lyrics_client")
+
+# Transport timeout: (connect_timeout, read_timeout)
+# Connect: 3.05s (slightly more than standard 3s SYN retry).
+# Read: 10.0s (LRClib is fast; gives a 30x safety margin without holding threads).
+DEFAULT_LRCLIB_TIMEOUT = (3.05, 10.0)
+
+
+class TimeoutSession(requests.Session):
+    """requests.Session that injects default transport timeouts if not specified."""
+
+    def __init__(self, timeout=DEFAULT_LRCLIB_TIMEOUT):
+        super().__init__()
+        self.default_timeout = timeout
+
+    def request(self, method, url, **kwargs):
+        kwargs.setdefault("timeout", self.default_timeout)
+        return super().request(method, url, **kwargs)
+
 
 class LyricsClient:
     """
@@ -16,11 +35,12 @@ class LyricsClient:
         self._init_api()
 
     def _init_api(self):
-        """Initialize LRClib API with graceful fallback"""
+        """Initialize LRClib API with graceful fallback and transport timeouts."""
         try:
             from lrclib import LrcLibAPI
-            self.api = LrcLibAPI(user_agent="SoulSync/1.0 (WebUI)")
-            logger.debug("LRClib API client initialized")
+            session = TimeoutSession()
+            self.api = LrcLibAPI(user_agent="SoulSync/1.0 (WebUI)", session=session)
+            logger.debug("LRClib API client initialized with transport timeouts")
         except ImportError:
             logger.warning("LRClib API not available - lyrics functionality disabled")
             self.api = None

--- a/core/metadata/multi_source_search.py
+++ b/core/metadata/multi_source_search.py
@@ -25,7 +25,7 @@ contract is shared.
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional, Tuple
@@ -33,6 +33,10 @@ from typing import Any, Dict, List, Optional, Tuple
 from utils.logging_config import get_logger
 
 logger = get_logger('metadata.multi_source_search')
+
+# Cap multi-source search to prevent slow or offline external metadata APIs
+# from monopolizing web-server worker threads.
+DEFAULT_SEARCH_TIMEOUT_SECONDS = 12.0
 
 
 @dataclass
@@ -183,7 +187,8 @@ def _search_one_source(source_name: str, client: Any,
 def search_all_sources(query: TrackQuery,
                        sources: List[Tuple[str, Any]],
                        clean_title: Optional[str] = None,
-                       max_workers: int = 3) -> MultiSourceResult:
+                       max_workers: int = 3,
+                       timeout_seconds: Optional[float] = DEFAULT_SEARCH_TIMEOUT_SECONDS) -> MultiSourceResult:
     """Run a parallel metadata search across every source in ``sources``.
 
     Args:
@@ -201,6 +206,10 @@ def search_all_sources(query: TrackQuery,
             the redownload endpoint's pre-extraction default — bumping
             higher rate-limits on slower sources without speeding up
             the slowest source's response.
+        timeout_seconds: Maximum seconds to wait for all sources before
+            returning completed results (default 12.0s). Prevents slow or
+            failing external metadata providers from holding the HTTP
+            worker indefinitely.
 
     Returns:
         MultiSourceResult with per-source results + cross-source best match.
@@ -213,15 +222,31 @@ def search_all_sources(query: TrackQuery,
 
     metadata_results: Dict[str, List[dict]] = {}
     raw_tracks: Dict[str, List[Any]] = {}
-    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+    pool = ThreadPoolExecutor(max_workers=max_workers)
+    try:
         futures = {
             pool.submit(_search_one_source, name, client, query, clean_title): name
             for name, client in sources
         }
-        for future in as_completed(futures):
-            source_name, results, raws = future.result()
-            metadata_results[source_name] = results
-            raw_tracks[source_name] = raws
+        try:
+            for future in as_completed(futures, timeout=timeout_seconds):
+                source_name, results, raws = future.result()
+                metadata_results[source_name] = results
+                raw_tracks[source_name] = raws
+        except TimeoutError:
+            pending = [name for f, name in futures.items() if not f.done()]
+            logger.warning(
+                f"[MultiSourceSearch] Search timed out after {timeout_seconds}s for '{query.title}'; "
+                f"omitted slow sources: {pending}"
+            )
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    # Ensure all requested sources exist in result dicts, even if timed out
+    for name, _ in sources:
+        if name not in metadata_results:
+            metadata_results[name] = []
+            raw_tracks[name] = []
 
     best_match: Optional[dict] = None
     for source, results in metadata_results.items():

--- a/core/metadata/multi_source_search.py
+++ b/core/metadata/multi_source_search.py
@@ -25,7 +25,9 @@ contract is shared.
 
 from __future__ import annotations
 
-from concurrent.futures import ThreadPoolExecutor, TimeoutError, as_completed
+from concurrent.futures import ThreadPoolExecutor, FIRST_COMPLETED, wait
+import threading
+import time
 from dataclasses import dataclass, field
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional, Tuple
@@ -37,6 +39,10 @@ logger = get_logger('metadata.multi_source_search')
 # Cap multi-source search to prevent slow or offline external metadata APIs
 # from monopolizing web-server worker threads.
 DEFAULT_SEARCH_TIMEOUT_SECONDS = 12.0
+# Timed-out calls can still be inside a provider. Reuse a bounded pool across
+# requests, and bound queued work too; never allocate another pool per timeout.
+_search_pool = ThreadPoolExecutor(max_workers=8, thread_name_prefix="MetadataSearch")
+_search_slots = threading.BoundedSemaphore(24)
 
 
 @dataclass
@@ -122,7 +128,7 @@ def _build_source_query(source_name: str, query: TrackQuery, clean_title: str) -
 
 
 def _search_one_source(source_name: str, client: Any,
-                       query: TrackQuery, clean_title: str
+                       query: TrackQuery, clean_title: str, deadline: Optional[float] = None
                        ) -> Tuple[str, List[dict], List[Any]]:
     """Run one source's search with three-tier query fallback.
 
@@ -143,10 +149,12 @@ def _search_one_source(source_name: str, client: Any,
         title_q = clean_title
 
         logger.info(f"[MultiSourceSearch] Searching {source_name} for: {primary_q}")
+        if deadline is not None and time.monotonic() >= deadline:
+            return source_name, [], []
         track_objs = client.search_tracks(primary_q, limit=10)
-        if not track_objs and primary_q != plain_q:
+        if not track_objs and primary_q != plain_q and (deadline is None or time.monotonic() < deadline):
             track_objs = client.search_tracks(plain_q, limit=10)
-        if not track_objs and clean_title != plain_q:
+        if not track_objs and clean_title != plain_q and (deadline is None or time.monotonic() < deadline):
             track_objs = client.search_tracks(title_q, limit=10)
         logger.info(f"[MultiSourceSearch] {source_name} returned {len(track_objs)} results")
 
@@ -202,7 +210,7 @@ def search_all_sources(query: TrackQuery,
         clean_title: Optional pre-cleaned track title (e.g. with
             "(Remastered)" / "(Single Version)" suffixes stripped).
             Defaults to ``query.title`` if not supplied.
-        max_workers: ThreadPoolExecutor pool size. Default 3 matches
+        max_workers: Per-request concurrency in the shared bounded pool. Default 3 matches
             the redownload endpoint's pre-extraction default — bumping
             higher rate-limits on slower sources without speeding up
             the slowest source's response.
@@ -222,25 +230,50 @@ def search_all_sources(query: TrackQuery,
 
     metadata_results: Dict[str, List[dict]] = {}
     raw_tracks: Dict[str, List[Any]] = {}
-    pool = ThreadPoolExecutor(max_workers=max_workers)
+    if max_workers < 1:
+        raise ValueError('max_workers must be positive')
+    deadline = None if timeout_seconds is None else time.monotonic() + max(0, timeout_seconds)
+    remaining_sources = iter(sources)
+    futures = {}
     try:
-        futures = {
-            pool.submit(_search_one_source, name, client, query, clean_title): name
-            for name, client in sources
-        }
-        try:
-            for future in as_completed(futures, timeout=timeout_seconds):
+        exhausted = False
+        while True:
+            while not exhausted and len(futures) < max_workers:
+                if deadline is not None and time.monotonic() >= deadline:
+                    break
+                try:
+                    name, client = next(remaining_sources)
+                except StopIteration:
+                    exhausted = True
+                    break
+                if not _search_slots.acquire(blocking=False):
+                    continue  # Saturated by slow requests; do not grow a queue.
+                try:
+                    future = _search_pool.submit(_search_one_source, name, client, query, clean_title, deadline)
+                except Exception:
+                    _search_slots.release()
+                    raise
+                future.add_done_callback(lambda _f: _search_slots.release())
+                futures[future] = name
+            if not futures:
+                break
+            remaining = None if deadline is None else max(0, deadline - time.monotonic())
+            done, _ = wait(futures, timeout=remaining, return_when=FIRST_COMPLETED)
+            if not done:
+                break
+            for future in done:
+                futures.pop(future)
                 source_name, results, raws = future.result()
                 metadata_results[source_name] = results
                 raw_tracks[source_name] = raws
-        except TimeoutError:
-            pending = [name for f, name in futures.items() if not f.done()]
-            logger.warning(
-                f"[MultiSourceSearch] Search timed out after {timeout_seconds}s for '{query.title}'; "
-                f"omitted slow sources: {pending}"
-            )
+            if deadline is not None and time.monotonic() >= deadline:
+                break
     finally:
-        pool.shutdown(wait=False, cancel_futures=True)
+        for future in futures:
+            future.cancel()  # Running providers retain their slot until they finish.
+    omitted = [name for name, _ in sources if name not in metadata_results]
+    if omitted:
+        logger.warning("[MultiSourceSearch] Deadline or capacity reached; omitted sources: %s", omitted)
 
     # Ensure all requested sources exist in result dicts, even if timed out
     for name, _ in sources:

--- a/core/metadata/source.py
+++ b/core/metadata/source.py
@@ -433,36 +433,87 @@ def _process_musicbrainz_source(pp: dict, metadata: dict, cfg, runtime, track_ti
             ]
 
 
-def _process_deezer_source(pp: dict, metadata: dict, cfg, runtime, track_title: str, artist_name: str) -> None:
+def _deezer_provenance_id(provenance) -> str:
+    """The deezer track id of the item the user actually picked, or "".
+
+    Only when the download CAME from deezer. A tidal download carries a tidal
+    id, and using it to ask deezer about a track would be worse than the text
+    search it replaces.
+    """
+    if not isinstance(provenance, dict):
+        return ""
+    if (provenance.get("source") or "").strip().lower() != "deezer":
+        return ""
+    return str(provenance.get("track_id") or "").strip()
+
+
+def _process_deezer_source(pp: dict, metadata: dict, cfg, runtime, track_title: str,
+                           artist_name: str, provenance=None) -> None:
     if cfg.get("deezer.embed_tags", True) is False:
-        return
-    if not track_title or not artist_name:
         return
 
     deezer_worker = getattr(runtime, "deezer_worker", None)
     dz_client = deezer_worker.client if deezer_worker else None
     if not dz_client:
         return
-    dz_result = _call_source_lookup("Deezer track", dz_client.search_track, artist_name, track_title)
-    if dz_result and _names_match(dz_result.get("title", ""), track_title) and _names_match(dz_result.get("artist", {}).get("name", ""), artist_name):
+
+    # If the download came from deezer we already know exactly which track this
+    # is - it is the one the user picked, and its id rode along on the search
+    # result. Asking deezer to find it again by artist and title is guesswork
+    # over a fact: search_track takes the first hit of a text query and both
+    # names then have to clear _names_match, which a remix suffix or a
+    # differently credited artist can fail. When that happened no deezer id was
+    # embedded at all, for a track downloaded from deezer.
+    #
+    # This is the same trade tidal and hifi already make, one step short: their
+    # download response carries the whole tag set so they skip the api entirely,
+    # while deezer's carries only ids, so the details call still happens. It
+    # just asks about a known id instead of a guessed one.
+    dz_track_id = _deezer_provenance_id(provenance)
+    dz_result = None
+
+    if not dz_track_id:
+        if not track_title or not artist_name:
+            return
+        dz_result = _call_source_lookup("Deezer track", dz_client.search_track, artist_name, track_title)
+        if not (dz_result
+                and _names_match(dz_result.get("title", ""), track_title)
+                and _names_match(dz_result.get("artist", {}).get("name", ""), artist_name)):
+            return
         dz_track_id = dz_result["id"]
-        pp["id_tags"]["DEEZER_TRACK_ID"] = str(dz_track_id)
+
+    pp["id_tags"]["DEEZER_TRACK_ID"] = str(dz_track_id)
+
+    dz_artist_id = None
+    if dz_result is not None:
         dz_artist_id = dz_result.get("artist", {}).get("id")
-        if dz_artist_id:
-            pp["id_tags"]["DEEZER_ARTIST_ID"] = str(dz_artist_id)
-        dz_details = _call_source_lookup("Deezer track details", dz_client.get_track_details, dz_track_id)
-        if dz_details:
-            bpm_val = dz_details.get("bpm")
-            if bpm_val and bpm_val > 0:
-                pp["deezer_bpm"] = bpm_val
-            dz_isrc = dz_details.get("isrc")
-            if dz_isrc:
-                pp["deezer_isrc"] = dz_isrc
-        if not pp["release_year"]:
+    elif isinstance(provenance, dict):
+        dz_artist_id = provenance.get("artist_id")
+    if dz_artist_id:
+        pp["id_tags"]["DEEZER_ARTIST_ID"] = str(dz_artist_id)
+
+    dz_details = _call_source_lookup("Deezer track details", dz_client.get_track_details, dz_track_id)
+    if dz_details:
+        bpm_val = dz_details.get("bpm")
+        if bpm_val and bpm_val > 0:
+            pp["deezer_bpm"] = bpm_val
+        dz_isrc = dz_details.get("isrc")
+        if dz_isrc:
+            pp["deezer_isrc"] = dz_isrc
+
+    if not pp["release_year"]:
+        # The search path reads the album off the search result, exactly as it
+        # always did. The details call is consulted ONLY on the provenance path,
+        # where there is no search result to read - deliberately not used as an
+        # extra fallback for the search path, so that path stays byte for byte
+        # what it was before provenance existed.
+        if dz_result is not None:
             dz_album = dz_result.get("album", {})
-            dz_release = (dz_album.get("release_date", "") if isinstance(dz_album, dict) else "") or ""
-            if len(dz_release) >= 4 and dz_release[:4].isdigit():
-                pp["release_year"] = dz_release[:4]
+        else:
+            dz_album = (dz_details or {}).get("album", {})
+        dz_release = (dz_album.get("release_date", "") if isinstance(dz_album, dict) else "") or ""
+        if len(dz_release) >= 4 and dz_release[:4].isdigit():
+            pp["release_year"] = dz_release[:4]
 
 
 def _process_jiosaavn_source(pp: dict, metadata: dict, cfg, runtime, track_title: str, artist_name: str) -> None:
@@ -752,11 +803,11 @@ def _process_bandcamp_source(pp: dict, metadata: dict, cfg, runtime, track_title
             pp["bandcamp_label"] = bc_label
 
 
-def _process_source_enrichment(source_name: str, pp: dict, metadata: dict, cfg, runtime, track_title: str, artist_name: str) -> None:
+def _process_source_enrichment(source_name: str, pp: dict, metadata: dict, cfg, runtime, track_title: str, artist_name: str, provenance=None) -> None:
     if source_name == "musicbrainz":
         _process_musicbrainz_source(pp, metadata, cfg, runtime, track_title, artist_name)
     elif source_name == "deezer":
-        _process_deezer_source(pp, metadata, cfg, runtime, track_title, artist_name)
+        _process_deezer_source(pp, metadata, cfg, runtime, track_title, artist_name, provenance=provenance)
     elif source_name == "audiodb":
         _process_audiodb_source(pp, metadata, cfg, runtime, track_title, artist_name)
     elif source_name == "jiosaavn":
@@ -1395,7 +1446,8 @@ def embed_source_ids(audio_file, metadata: dict, context: dict = None, runtime=N
         db = get_database()
 
         for source_name in source_order:
-            _process_source_enrichment(source_name, pp, metadata, cfg, runtime, track_title, artist_name)
+            _process_source_enrichment(source_name, pp, metadata, cfg, runtime, track_title, artist_name,
+                                       provenance=cached_meta)
 
         if not pp["id_tags"] and not pp["deezer_bpm"] and not pp["deezer_isrc"] and not pp["tidal_bpm"] and not pp["hifi_bpm"] and not pp["hifi_copyright"] and not pp["audiodb_mood"] and not pp["audiodb_style"] and not pp["bandcamp_url"] and not pp["bandcamp_tags"]:
             return

--- a/core/podcast_automation.py
+++ b/core/podcast_automation.py
@@ -22,10 +22,7 @@ from utils.logging_config import get_logger
 
 logger = get_logger("podcasts.automation")
 
-_automation_thread: Optional[threading.Thread] = None
-_automation_running = False
 _automation_lock = threading.Lock()
-_stop_event = threading.Event()
 
 # Last scan summary state for observability
 _last_scan_status: Dict[str, Any] = {
@@ -47,17 +44,81 @@ def _get_db():
         return None
 
 
+def _as_utc(value: Any) -> Optional[datetime]:
+    """Best effort parse of a timestamp into an aware UTC datetime, else None.
+
+    date_added comes back from sqlite as a naive string in UTC, while an
+    episode's pub_date is already aware. Comparing those two directly raises,
+    so both ends go through here first.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        try:
+            dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
 def get_scan_status() -> Dict[str, Any]:
     """Return the status and stats of the podcast automation service."""
     with _automation_lock:
         return dict(_last_scan_status)
 
 
-def scan_and_auto_download_podcasts(profile_id: int = 1) -> Dict[str, Any]:
-    """Scan all watchlisted podcasts, auto-download new episodes, and prune expired ones.
+# How many missing episodes one show may claim in a single pass.
+#
+# The scan used to take the newest episode and nothing else, which loses the
+# backlog silently: a show that posts three between two passes had two of them
+# skipped forever, because the next pass looks at the newest again, finds it
+# already downloaded, and never looks further back. Nobody sees an error - the
+# episodes simply never arrive.
+#
+# It is a cap rather than "everything missing" because the first scan after
+# somebody follows a show with 800 episodes should not queue 800 downloads.
+# Each pass takes a bite and the backlog drains over a few of them.
+MAX_BACKLOG_PER_SHOW_PER_PASS = 5
 
-    Can be triggered periodically by the background worker or manually via API.
+
+def scan_and_auto_download_podcasts(profile_id: Optional[int] = None) -> Dict[str, Any]:
+    """Scan watchlisted podcasts, auto-download new episodes, and prune expired ones.
+
+    profile_id None means every profile that follows anything, which is what a
+    timed pass needs: a system automation runs as profile 1, so scoping to the
+    caller meant a second person's shows were never scanned at all. Pass an
+    explicit profile to scan just that one, which is what a person clicking
+    Scan Now wants.
     """
+    if profile_id is None:
+        db = _get_db()
+        if not db:
+            return {"success": False, "error": "Database unavailable"}
+        try:
+            profiles = [int(p) for p in (db.profiles_with_podcast_rows() or [])]
+        except Exception as exc:                             # noqa: BLE001
+            # a database that hands back something unusable must not stop the
+            # scan, it just means we fall back to the one profile that has
+            # always been scanned
+            logger.debug("Could not list podcast profiles: %s", exc)
+            profiles = [1]
+        if not profiles:
+            profiles = [1]
+        totals = {"success": True, "podcasts_checked": 0, "episodes_queued": 0,
+                  "episodes_pruned": 0, "errors": []}
+        for pid in profiles:
+            one = scan_and_auto_download_podcasts(profile_id=pid)
+            totals["podcasts_checked"] += one.get("podcasts_checked", 0)
+            totals["episodes_queued"] += one.get("episodes_queued", 0)
+            totals["episodes_pruned"] += one.get("episodes_pruned", 0)
+            totals["errors"].extend(one.get("errors", []))
+        totals["success"] = not totals["errors"]
+        totals["profiles_scanned"] = len(profiles)
+        return totals
     global _last_scan_status
     with _automation_lock:
         if _last_scan_status["in_progress"]:
@@ -119,48 +180,79 @@ def scan_and_auto_download_podcasts(profile_id: int = 1) -> Dict[str, Any]:
                     else:
                         sorted_episodes = list(show.episodes)
 
-                    latest_ep = sorted_episodes[0]
-                    enclosure_url = (latest_ep.enclosure_url or "").strip()
-                    guid = (latest_ep.guid or enclosure_url).strip()
-                    title = (latest_ep.title or "Episode").strip()
+                    # What counts as new is "published since you followed the
+                    # show", not "the newest one". This used to take
+                    # sorted_episodes[0] and stop, which does protect against a
+                    # first sync grabbing an 800 episode back catalogue - but it
+                    # threw away the ordinary case with it: three episodes
+                    # posted between two passes meant two of them silently never
+                    # arrived, because the next pass looks at the newest again,
+                    # finds it downloaded, and never looks further back.
+                    #
+                    # A follow date settles both. Nothing older than the day you
+                    # followed is ever claimed, and everything since is, capped
+                    # per pass so even a long gap drains over a few runs rather
+                    # than in one flood.
+                    #
+                    # No usable follow date means an older row, so it keeps
+                    # exactly the behaviour it has always had: newest only.
+                    followed_at = _as_utc(pod.get("date_added"))
+                    if followed_at is None:
+                        sorted_episodes = sorted_episodes[:1]
 
-                    if enclosure_url and not db.is_podcast_episode_downloaded(
-                        feed_url=feed_url,
-                        enclosure_url=enclosure_url,
-                        guid=guid,
-                        title=title,
-                    ):
-                        dl_payload = {
-                            "enclosure_url": enclosure_url,
-                            "title": title,
-                            "guid": guid,
-                            "show_title": show.title or show_title,
-                            "author": show.author or author,
-                            "pub_date": latest_ep.pub_date.isoformat() if latest_ep.pub_date else None,
-                            "artwork_url": latest_ep.artwork_url or show.artwork_url or pod.get("artwork_url") or "",
-                            "show_artwork_url": show.artwork_url or pod.get("artwork_url") or "",
-                            "show_description": show.description or pod.get("description") or "",
-                            "description": latest_ep.description or "",
-                            "show_notes": latest_ep.show_notes or latest_ep.description or "",
-                            "duration_seconds": latest_ep.duration_seconds,
-                            "enclosure_type": latest_ep.enclosure_type or "audio/mpeg",
-                            "enclosure_length": latest_ep.enclosure_length,
-                            "feed_url": feed_url,
-                            "season": latest_ep.season,
-                            "episode_number": latest_ep.episode_number,
-                            "episode_type": latest_ep.episode_type,
-                            "itunes_id": show.itunes_id or pod.get("itunes_id"),
-                            "website": show.website or pod.get("website") or "",
-                            "categories": show.categories or [],
-                        }
-                        res = queue_podcast_download(dl_payload)
-                        if res.get("success"):
-                            episodes_queued += 1
-                            logger.info(
-                                "Auto-download queued for latest episode of '%s': '%s'",
-                                show_title,
-                                title,
-                            )
+                    claimed = 0
+                    for latest_ep in sorted_episodes:
+                        if claimed >= MAX_BACKLOG_PER_SHOW_PER_PASS:
+                            break
+                        if followed_at is not None:
+                            published = _as_utc(getattr(latest_ep, "pub_date", None))
+                            # an episode with no date at all is treated as new:
+                            # a feed that omits pub_date would otherwise never
+                            # auto-download anything
+                            if published is not None and published < followed_at:
+                                break
+                        enclosure_url = (latest_ep.enclosure_url or "").strip()
+                        guid = (latest_ep.guid or enclosure_url).strip()
+                        title = (latest_ep.title or "Episode").strip()
+
+                        if enclosure_url and not db.is_podcast_episode_downloaded(
+                            feed_url=feed_url,
+                            enclosure_url=enclosure_url,
+                            guid=guid,
+                            title=title,
+                        ):
+                            dl_payload = {
+                                "enclosure_url": enclosure_url,
+                                "title": title,
+                                "guid": guid,
+                                "show_title": show.title or show_title,
+                                "author": show.author or author,
+                                "pub_date": latest_ep.pub_date.isoformat() if latest_ep.pub_date else None,
+                                "artwork_url": latest_ep.artwork_url or show.artwork_url or pod.get("artwork_url") or "",
+                                "show_artwork_url": show.artwork_url or pod.get("artwork_url") or "",
+                                "show_description": show.description or pod.get("description") or "",
+                                "description": latest_ep.description or "",
+                                "show_notes": latest_ep.show_notes or latest_ep.description or "",
+                                "duration_seconds": latest_ep.duration_seconds,
+                                "enclosure_type": latest_ep.enclosure_type or "audio/mpeg",
+                                "enclosure_length": latest_ep.enclosure_length,
+                                "feed_url": feed_url,
+                                "season": latest_ep.season,
+                                "episode_number": latest_ep.episode_number,
+                                "episode_type": latest_ep.episode_type,
+                                "itunes_id": show.itunes_id or pod.get("itunes_id"),
+                                "website": show.website or pod.get("website") or "",
+                                "categories": show.categories or [],
+                            }
+                            res = queue_podcast_download(dl_payload)
+                            if res.get("success"):
+                                episodes_queued += 1
+                                claimed += 1
+                                logger.info(
+                                    "Auto-download queued for '%s': '%s'",
+                                    show_title,
+                                    title,
+                                )
 
                 # 4. Prune expired episodes if retention_days is configured (> 0)
                 if retention_days and int(retention_days) > 0:
@@ -231,55 +323,13 @@ def scan_and_auto_download_podcasts(profile_id: int = 1) -> Dict[str, Any]:
     }
 
 
-def _automation_loop():
-    """Background worker loop that triggers scans at the configured interval."""
-    logger.info("Podcast automation loop started")
-    # Small initial delay to let server boot completely
-    if _stop_event.wait(15):
-        return
-
-    while not _stop_event.is_set():
-        try:
-            scan_and_auto_download_podcasts()
-        except Exception as e:
-            logger.error("Unexpected error in podcast automation loop: %s", e)
-
-        # Determine interval (default 30 minutes = 1800 seconds)
-        interval_seconds = 1800
-        try:
-            from core.settings import config_manager
-            if config_manager:
-                mins = config_manager.get("podcasts.auto_download_interval_minutes", 30)
-                interval_seconds = max(60, int(mins) * 60)
-        except Exception as cfg_err:
-            logger.debug("Could not read podcast interval config, using default: %s", cfg_err)
-
-        if _stop_event.wait(interval_seconds):
-            break
-
-    logger.info("Podcast automation loop stopped")
-
-
-def start_podcast_automation() -> None:
-    """Start the podcast automation background thread if not already running."""
-    global _automation_thread, _automation_running
-    with _automation_lock:
-        if _automation_running:
-            return
-        _stop_event.clear()
-        _automation_thread = threading.Thread(
-            target=_automation_loop,
-            daemon=True,
-            name="podcast-automation-worker",
-        )
-        _automation_running = True
-        _automation_thread.start()
-        logger.info("Podcast automation background service started")
-
-
-def stop_podcast_automation() -> None:
-    """Signal the podcast automation worker to stop."""
-    global _automation_running
-    with _automation_lock:
-        _stop_event.set()
-        _automation_running = False
+# The scan is scheduled by the shared automation engine as the
+# ``scan_watchlist_podcasts`` system automation, the same way audiobooks drain
+# through ``audiobook_process_wishlist`` and artists through ``scan_watchlist``.
+#
+# There used to be a private daemon thread and a timer here as well. It was
+# never started outside a test, so it scheduled nothing, but it is worth saying
+# why it is gone rather than leaving it for somebody to wire up: an automation
+# shows on the Automations page, can be paused, rescheduled or run by hand, and
+# obeys the master switch. A private thread is none of those, and a user who
+# wanted it to stop would have had nowhere to say so.

--- a/core/podcast_client.py
+++ b/core/podcast_client.py
@@ -25,6 +25,12 @@ from typing import Dict, List, Optional
 
 import requests
 
+from core.podcast_ingest_guard import (
+    MAX_FEED_BYTES,
+    UnsafeXmlError,
+    fetch_guarded,
+    parse_xml_safely,
+)
 from utils.logging_config import get_logger
 
 logger = get_logger("podcast_client")
@@ -345,19 +351,24 @@ class PodcastClient:
         especially artwork, where the feed-level image is always higher-res
         than the iTunes API thumbnail.
         """
-        try:
-            resp = self._session.get(feed_url, timeout=_FETCH_TIMEOUT)
-            resp.raise_for_status()
-        except Exception as exc:
-            logger.warning("Failed to fetch feed %r: %s", feed_url, exc)
+        # a feed url comes from a person pasting one, or from an opml file
+        # somebody else exported, so it is fetched through the guard: checked
+        # scheme and address, redirects followed by hand so each hop is checked
+        # too, and a cap on how much we will read. see core/podcast_ingest_guard.
+        body, error = fetch_guarded(
+            self._session, feed_url,
+            timeout=_FETCH_TIMEOUT, limit=MAX_FEED_BYTES,
+        )
+        if body is None:
+            logger.warning("Failed to fetch feed %r: %s", feed_url, error)
             return None
 
         try:
             # Parse from bytes so ElementTree honours the XML encoding
             # declaration — parsing from text after decode can mis-handle
             # non-UTF-8 feeds.
-            root = ET.fromstring(resp.content)
-        except ET.ParseError as exc:
+            root = parse_xml_safely(body)
+        except (UnsafeXmlError, ET.ParseError) as exc:
             logger.warning("RSS parse error for %r: %s", feed_url, exc)
             return None
 

--- a/core/podcast_ingest_guard.py
+++ b/core/podcast_ingest_guard.py
@@ -1,0 +1,267 @@
+"""Guards for everything the podcast side takes in from outside: urls and xml.
+
+podcasts are the one side of the app where a url comes from outside: an rss feed
+somebody pastes, an opml file exported by another app, an enclosure url chosen by
+whoever runs that feed. every one of those ends up in a server-side fetch.
+
+audiobooks solved the same problem with an allowlist (api/audiobooks.py,
+is_allowed_sample_url) because a sample only ever comes from audible or apple.
+podcast audio comes from thousands of cdns, so there is no list to check against
+and the test has to run the other way round: everything is allowed except the
+addresses that are not on the internet.
+
+what this blocks: loopback, private ranges, link-local (which covers the cloud
+metadata endpoint at 169.254.169.254), and the reserved blocks. plus anything
+that is not http or https, so file:// cannot be used to read a local file.
+
+self-hosting is a real podcast use case, so a lan address is allowed when
+podcasts.allow_private_feed_hosts is turned on. it is off by default: the person
+who needs it knows they need it, and everybody else should not be running an
+open relay to find out.
+
+residual risk worth naming: a host is resolved here and then resolved again by
+the http stack when it connects, so a dns entry that changes between the two can
+still slip past. pinning the address we checked would mean owning the socket, and
+that is a bigger change than this hole warrants. every practical version of this
+attack needs a name the user pasted in the first place.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import socket
+import xml.etree.ElementTree as ET
+from typing import Optional, Tuple
+from urllib.parse import urlparse
+
+from utils.logging_config import get_logger
+
+logger = get_logger("podcast_ingest_guard")
+
+# a feed is text. ten megabytes is far past the biggest real one and still small
+# enough that a hostile server cannot use it to exhaust memory.
+MAX_FEED_BYTES = 10 * 1024 * 1024
+
+# an opml file is a list of urls, so it is smaller again.
+MAX_OPML_BYTES = 5 * 1024 * 1024
+
+# how many hops a redirect chain may take before we stop following it. each hop
+# is re-checked, so this only bounds the work, not the safety.
+MAX_REDIRECTS = 5
+
+_ALLOWED_SCHEMES = ("http", "https")
+
+
+def _allow_private_hosts() -> bool:
+    """Whether the user has opted in to feeds on their own network."""
+    try:
+        from core.settings import config_manager
+        if config_manager is None:
+            return False
+        return bool(config_manager.get("podcasts.allow_private_feed_hosts", False))
+    except Exception:                                        # noqa: BLE001
+        # a config read that fails must not open the gate
+        return False
+
+
+def _address_is_public(addr: str) -> bool:
+    """False for anything that is not a routable internet address."""
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        # ::ffff:127.0.0.1 is loopback wearing a v6 hat
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve(host: str) -> list:
+    """Every address this host answers with, or [] when it does not resolve."""
+    try:
+        infos = socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, ValueError):
+        return []
+    return [i[4][0] for i in infos]
+
+
+def check_url(url: str) -> Tuple[bool, str]:
+    """(ok, reason). reason is empty when ok is True and safe to show a user.
+
+    Checked in the order a person would: is it a url at all, is it a scheme we
+    fetch, does the name resolve, and is every address it resolves to on the
+    internet. ALL addresses have to pass - a name that answers with both a public
+    and a private address is a rebinding trick, not a misconfiguration.
+    """
+    raw = (url or "").strip()
+    if not raw:
+        return False, "No URL was given"
+    try:
+        parsed = urlparse(raw)
+    except ValueError:
+        return False, "That does not parse as a URL"
+
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        return False, f"Only http and https URLs can be fetched, not {scheme or 'a relative path'}"
+
+    host = (parsed.hostname or "").strip().rstrip(".")
+    if not host:
+        return False, "That URL has no host"
+
+    if _allow_private_hosts():
+        return True, ""
+
+    # a bare ip needs no dns
+    try:
+        ipaddress.ip_address(host)
+        return (True, "") if _address_is_public(host) else (
+            False, "That address is on a private or local network")
+    except ValueError:
+        pass
+
+    addresses = _resolve(host)
+    if not addresses:
+        return False, f"Could not resolve {host}"
+    for addr in addresses:
+        if not _address_is_public(addr):
+            return False, "That host resolves to a private or local network address"
+    return True, ""
+
+
+def has_fetchable_scheme(url: str) -> bool:
+    """http or https, and nothing else. Pure - never touches dns.
+
+    This is the check for a parser. Working out whether a NAME points somewhere
+    private means resolving it, and a parser that resolves is a parser that does
+    network i/o: an opml file with 200 feeds would make 200 lookups before it
+    could show a preview. The address check runs at fetch time instead, in
+    check_url, which is the only place it can be trusted anyway - the answer can
+    change between parsing a file and fetching from it.
+
+    What this DOES settle cheaply is scheme, so file:// and friends never reach
+    the watchlist at all.
+    """
+    try:
+        parsed = urlparse((url or "").strip())
+    except ValueError:
+        return False
+    return (parsed.scheme or "").lower() in _ALLOWED_SCHEMES and bool(parsed.hostname)
+
+
+def is_public_url(url: str) -> bool:
+    """check_url without the reason, for call sites that only branch on it."""
+    ok, _ = check_url(url)
+    return ok
+
+
+def read_capped(response, limit: int) -> Optional[bytes]:
+    """Read at most limit bytes from a streaming response, or None if it exceeds.
+
+    requests' .content reads whatever the server sends, so a feed url pointed at
+    something enormous is a memory problem before it is ever a parse problem.
+    None rather than a truncated body on purpose: half an xml document is not a
+    feed, and treating it as one would report a parse error for a size problem.
+    """
+    chunks = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=64 * 1024):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > limit:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def fetch_guarded(session, url: str, *, timeout: int, limit: int,
+                  headers: Optional[dict] = None):
+    """GET a checked url, following redirects by hand so each hop is checked too.
+
+    requests follows redirects itself, which would let a url that passes the
+    check 302 straight to 127.0.0.1. Every hop goes back through check_url.
+
+    Returns (body_bytes, error). Exactly one of them is None.
+    """
+    current = url
+    for _ in range(MAX_REDIRECTS + 1):
+        ok, reason = check_url(current)
+        if not ok:
+            return None, reason
+        try:
+            resp = session.get(current, timeout=timeout, stream=True,
+                               allow_redirects=False, headers=headers or None)
+        except Exception as exc:                             # noqa: BLE001
+            return None, f"Could not fetch that URL: {exc}"
+
+        if resp.status_code in (301, 302, 303, 307, 308):
+            nxt = resp.headers.get("Location") or ""
+            resp.close()
+            if not nxt:
+                return None, "That host redirected without saying where"
+            # a relative Location is resolved against the hop we just made
+            from urllib.parse import urljoin
+            current = urljoin(current, nxt)
+            continue
+
+        try:
+            if resp.status_code >= 400:
+                return None, f"That host returned {resp.status_code}"
+            body = read_capped(resp, limit)
+        finally:
+            resp.close()
+
+        if body is None:
+            return None, "That response was too large to read"
+        return body, None
+
+    return None, "That URL redirected too many times"
+
+
+# ---------------------------------------------------------------------------
+# xml
+# ---------------------------------------------------------------------------
+
+# a DOCTYPE is the only way an xml document can define entities, and entity
+# expansion is the whole billion-laughs family. stdlib ElementTree already
+# refuses to fetch an EXTERNAL entity, so a feed cannot read a local file, but
+# it happily expands INTERNAL ones: measured on this interpreter, four levels
+# turned a 224 byte document into 10,000 characters, and each further level
+# multiplies by ten again.
+#
+# no real feed or opml export has a DOCTYPE. refusing the declaration outright
+# is both the whole fix and less code than counting expansions.
+_DOCTYPE_RE = re.compile(rb"<!DOCTYPE", re.IGNORECASE)
+
+
+class UnsafeXmlError(ValueError):
+    """Raised for xml we will not parse. The message is safe to show a user."""
+
+
+def parse_xml_safely(content):
+    """ET.fromstring for untrusted xml. Raises UnsafeXmlError on a DOCTYPE.
+
+    Takes bytes or str and always parses BYTES, so ElementTree honours the
+    document's own encoding declaration rather than whatever we decoded with.
+    """
+    if isinstance(content, str):
+        raw = content.strip().encode("utf-8", "replace")
+    else:
+        raw = bytes(content or b"")
+    if not raw:
+        raise UnsafeXmlError("That document was empty")
+    # only the prolog can carry a DOCTYPE, so a bounded look is enough and a
+    # feed that merely mentions the word in an episode title stays readable
+    if _DOCTYPE_RE.search(raw[:4096]):
+        raise UnsafeXmlError(
+            "That document declares a DOCTYPE, which SoulSync will not parse")
+    return ET.fromstring(raw)

--- a/core/server_activity.py
+++ b/core/server_activity.py
@@ -62,6 +62,11 @@ def _plex_config(db=None) -> Dict[str, str]:
 _server_cache: Dict[str, Any] = {"srv": None, "at": 0.0, "key": ""}
 
 
+def invalidate_plex_server_cache() -> None:
+    """Force the next _plex_server call to reconnect."""
+    _server_cache.update(srv=None, at=0.0, key="")
+
+
 def _plex_server(db=None):
     """A connected PlexServer (cached ~60s so a 3s poll doesn't reconnect each
     time). Returns None when Plex isn't configured or is unreachable."""
@@ -70,7 +75,7 @@ def _plex_server(db=None):
         return None
     key = cfg["base_url"] + "|" + cfg["token"][:6]
     now = time.time()
-    if _server_cache["srv"] is not None and _server_cache["key"] == key and now - _server_cache["at"] < 60:
+    if _server_cache["key"] == key and now - _server_cache["at"] < 60:
         return _server_cache["srv"]
     try:
         from plexapi.server import PlexServer
@@ -419,6 +424,7 @@ def get_activity(db=None) -> Dict[str, Any]:
             platform = "plex"
         except Exception:   # noqa: BLE001 - configured but unreachable
             logger.debug("plex sessions() failed", exc_info=True)
+            _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
 
     jf_sessions, jf_name = _jellyfin_activity(db)
     if jf_name is not None:                       # Jellyfin is configured
@@ -523,6 +529,7 @@ def get_history(db=None, limit: int = 40) -> Dict[str, Any]:
         items = srv.history(maxresults=limit)
     except Exception:   # noqa: BLE001
         logger.debug("plex history() failed", exc_info=True)
+        _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
         return {"ok": False, "reason": "unreachable", "history": []}
     key = str(_g(srv, "machineIdentifier", "") or "plex")
     accounts, devices = _lookups(srv, key)
@@ -607,6 +614,7 @@ def get_stats(db=None, days: int = 30) -> Dict[str, Any]:
         items = srv.history(maxresults=1000, mindate=datetime.now() - timedelta(days=days))
     except Exception:   # noqa: BLE001
         logger.debug("plex history() for stats failed", exc_info=True)
+        _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
         return {"ok": False, "reason": "unreachable"}
     accounts, devices = _lookups(srv, str(_g(srv, "machineIdentifier", "") or "plex"))
     data = compute_stats(items or [], accounts, devices, days)

--- a/core/server_activity.py
+++ b/core/server_activity.py
@@ -13,6 +13,8 @@ shape differs and is added in :func:`_jellyfin_sessions`).
 from __future__ import annotations
 
 import time
+import threading
+import hashlib
 from typing import Any, Dict, List, Optional
 
 from utils.logging_config import get_logger
@@ -60,11 +62,13 @@ def _plex_config(db=None) -> Dict[str, str]:
 
 
 _server_cache: Dict[str, Any] = {"srv": None, "at": 0.0, "key": ""}
+_server_cache_lock = threading.RLock()
 
 
 def invalidate_plex_server_cache() -> None:
     """Force the next _plex_server call to reconnect."""
-    _server_cache.update(srv=None, at=0.0, key="")
+    with _server_cache_lock:
+        _server_cache.update(srv=None, at=0.0, key="")
 
 
 def _plex_server(db=None):
@@ -73,19 +77,27 @@ def _plex_server(db=None):
     cfg = _plex_config(db)
     if not cfg["base_url"] or not cfg["token"]:
         return None
-    key = cfg["base_url"] + "|" + cfg["token"][:6]
-    now = time.time()
-    if _server_cache["key"] == key and now - _server_cache["at"] < 60:
-        return _server_cache["srv"]
-    try:
-        from plexapi.server import PlexServer
-        srv = PlexServer(cfg["base_url"], cfg["token"], timeout=_PLEX_TIMEOUT)
-        _server_cache.update(srv=srv, at=now, key=key)
-        return srv
-    except Exception:   # noqa: BLE001 - unreachable server is an expected state
-        logger.debug("plex connect failed for activity", exc_info=True)
-        _server_cache.update(srv=None, at=now, key=key)
-        return None
+    key = hashlib.sha256(f"{cfg['base_url']}|{cfg['token']}".encode()).hexdigest()
+    with _server_cache_lock:
+        now = time.time()
+        if _server_cache["key"] == key and 0 <= now - _server_cache["at"] < 60:
+            return _server_cache["srv"]
+        try:
+            from plexapi.server import PlexServer
+            srv = PlexServer(cfg["base_url"], cfg["token"], timeout=_PLEX_TIMEOUT)
+            _server_cache.update(srv=srv, at=time.time(), key=key)
+            return srv
+        except Exception:   # noqa: BLE001 - unreachable server is an expected state
+            logger.debug("plex connect failed for activity", exc_info=True)
+            _server_cache.update(srv=None, at=time.time(), key=key)
+            return None
+
+
+def _mark_plex_unreachable(srv):
+    # A late failure from an old credential's client must not poison a newer one.
+    with _server_cache_lock:
+        if _server_cache['srv'] is srv:
+            _server_cache.update(srv=None, at=time.time())
 
 
 # ── normalization (pure — unit-tested with fakes) ────────────────────────────
@@ -424,7 +436,7 @@ def get_activity(db=None) -> Dict[str, Any]:
             platform = "plex"
         except Exception:   # noqa: BLE001 - configured but unreachable
             logger.debug("plex sessions() failed", exc_info=True)
-            _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
+            _mark_plex_unreachable(srv)
 
     jf_sessions, jf_name = _jellyfin_activity(db)
     if jf_name is not None:                       # Jellyfin is configured
@@ -529,7 +541,7 @@ def get_history(db=None, limit: int = 40) -> Dict[str, Any]:
         items = srv.history(maxresults=limit)
     except Exception:   # noqa: BLE001
         logger.debug("plex history() failed", exc_info=True)
-        _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
+        _mark_plex_unreachable(srv)
         return {"ok": False, "reason": "unreachable", "history": []}
     key = str(_g(srv, "machineIdentifier", "") or "plex")
     accounts, devices = _lookups(srv, key)
@@ -614,7 +626,7 @@ def get_stats(db=None, days: int = 30) -> Dict[str, Any]:
         items = srv.history(maxresults=1000, mindate=datetime.now() - timedelta(days=days))
     except Exception:   # noqa: BLE001
         logger.debug("plex history() for stats failed", exc_info=True)
-        _server_cache.update(srv=None, at=time.time(), key=_server_cache.get("key", ""))
+        _mark_plex_unreachable(srv)
         return {"ok": False, "reason": "unreachable"}
     accounts, devices = _lookups(srv, str(_g(srv, "machineIdentifier", "") or "plex"))
     data = compute_stats(items or [], accounts, devices, days)

--- a/core/soulseek_client.py
+++ b/core/soulseek_client.py
@@ -2256,6 +2256,19 @@ class SoulseekClient(DownloadSourcePlugin):
         from urllib.parse import quote
         return quote(str(part), safe="")
 
+    async def get_chat_connection_state(self) -> Dict[str, Any]:
+        """Chat requires a Soulseek login, not merely a reachable slskd API."""
+        state = await self._make_request('GET', 'server/state')
+        if not isinstance(state, dict) or not state:
+            return {"connected": False, "code": "slskd_unavailable",
+                    "error": "Cannot check slskd's Soulseek connection. Check that slskd is running and its API key is valid."}
+        connected = state.get('isConnected', state.get('IsConnected', False))
+        logged_in = state.get('isLoggedIn', state.get('IsLoggedIn', False))
+        if connected is True and logged_in is True:
+            return {"connected": True}
+        return {"connected": False, "code": "slskd_disconnected",
+                "error": "slskd is not connected and logged in to Soulseek. Reconnect in slskd, then try again. Your message has not been sent."}
+
     async def get_joined_rooms(self) -> List[str]:
         """Names of the rooms slskd is currently in ([] when none/unreachable)."""
         res = await self._make_request('GET', 'rooms/joined')

--- a/core/soulseek_client.py
+++ b/core/soulseek_client.py
@@ -2035,17 +2035,18 @@ class SoulseekClient(DownloadSourcePlugin):
             return False
 
         try:
-            # Primary check: server/state tells us if slskd is connected to the Soulseek network
-            state = await self._make_request('GET', 'server/state')
-            if state is not None:
-                is_connected = state.get('isConnected') or state.get('IsConnected', False)
-                is_logged_in = state.get('isLoggedIn') or state.get('IsLoggedIn', False)
-                if not (is_connected and is_logged_in):
-                    logger.debug(f"Soulseek not fully connected: isConnected={is_connected}, isLoggedIn={is_logged_in}")
-                return is_connected and is_logged_in
+            # Primary check: server or server/state tells us if slskd is connected to the Soulseek network
+            for endpoint in ('server', 'server/state'):
+                state = await self._make_request('GET', endpoint)
+                if isinstance(state, dict) and any(k in state for k in ('isConnected', 'IsConnected', 'isLoggedIn', 'IsLoggedIn')):
+                    is_connected = state.get('isConnected') or state.get('IsConnected', False)
+                    is_logged_in = state.get('isLoggedIn') or state.get('IsLoggedIn', False)
+                    if not (is_connected and is_logged_in):
+                        logger.debug(f"Soulseek not fully connected: isConnected={is_connected}, isLoggedIn={is_logged_in}")
+                    return is_connected and is_logged_in
 
-            # Fallback: if server/state endpoint unavailable (older slskd), check API reachability
-            logger.debug("server/state endpoint unavailable, falling back to session check")
+            # Fallback: if server endpoints unavailable (older slskd), check API reachability
+            logger.debug("server endpoints unavailable, falling back to session check")
             response = await self._make_request('GET', 'session')
             return response is not None
         except Exception as e:
@@ -2257,17 +2258,24 @@ class SoulseekClient(DownloadSourcePlugin):
         return quote(str(part), safe="")
 
     async def get_chat_connection_state(self) -> Dict[str, Any]:
-        """Chat requires a Soulseek login, not merely a reachable slskd API."""
-        state = await self._make_request('GET', 'server/state')
-        if not isinstance(state, dict) or not state:
-            return {"connected": False, "code": "slskd_unavailable",
-                    "error": "Cannot check slskd's Soulseek connection. Check that slskd is running and its API key is valid."}
-        connected = state.get('isConnected', state.get('IsConnected', False))
-        logged_in = state.get('isLoggedIn', state.get('IsLoggedIn', False))
-        if connected is True and logged_in is True:
-            return {"connected": True}
-        return {"connected": False, "code": "slskd_disconnected",
-                "error": "slskd is not connected and logged in to Soulseek. Reconnect in slskd, then try again. Your message has not been sent."}
+        """Chat requires a Soulseek login, not merely a reachable slskd API.
+
+        slskd exposes server state at /api/v0/server in standard releases,
+        and /api/v0/server/state in some builds. Probe both so endpoint differences
+        do not falsely lock users out of chat.
+        """
+        for endpoint in ('server', 'server/state'):
+            state = await self._make_request('GET', endpoint)
+            if isinstance(state, dict) and any(k in state for k in ('isConnected', 'IsConnected', 'isLoggedIn', 'IsLoggedIn')):
+                connected = state.get('isConnected', state.get('IsConnected', False))
+                logged_in = state.get('isLoggedIn', state.get('IsLoggedIn', False))
+                if connected is True and logged_in is True:
+                    return {"connected": True}
+                return {"connected": False, "code": "slskd_disconnected",
+                        "error": "slskd is not connected and logged in to Soulseek. Reconnect in slskd, then try again. Your message has not been sent."}
+
+        return {"connected": False, "code": "slskd_unavailable",
+                "error": "Cannot check slskd's Soulseek connection. Check that slskd is running and its API key is valid."}
 
     async def get_joined_rooms(self) -> List[str]:
         """Names of the rooms slskd is currently in ([] when none/unreachable)."""

--- a/core/soulseek_client.py
+++ b/core/soulseek_client.py
@@ -1,5 +1,6 @@
 import requests
 import asyncio
+import threading
 import aiohttp
 import os
 from typing import List, Optional, Dict, Any
@@ -2447,3 +2448,36 @@ class SoulseekClient(DownloadSourcePlugin):
     def __del__(self):
         # No persistent session to clean up
         pass
+_SHARED_LOCK = threading.Lock()
+_SHARED_CACHE: Dict[str, Any] = {"key": None, "client": None}
+
+
+def get_shared_soulseek_client():
+    """One client per slskd configuration, shared by every caller.
+
+    Constructing one is not free: it logs at INFO and mkdirs the download path.
+    Callers on a timer - the audiobook download monitor ticks every few seconds
+    and touches several helpers per pass - turned that into a wall of identical
+    "configured with slskd at ..." lines in app.log and a filesystem hit for
+    each one.
+
+    Keyed on the url and api key rather than cached outright, so saving new
+    slskd settings takes effect without a restart. The cache lives here rather
+    than in a caller because the cost it avoids is this module's.
+    """
+    try:
+        cfg = config_manager.get("soulseek", {}) or {}
+        key = f"{cfg.get('slskd_url', '')}::{cfg.get('api_key', '')}"
+    except Exception:                                       # noqa: BLE001
+        key = "::"
+
+    with _SHARED_LOCK:
+        cached = _SHARED_CACHE["client"]
+        if cached is not None and _SHARED_CACHE["key"] == key:
+            return cached
+        client = SoulseekClient()
+        _SHARED_CACHE["key"] = key
+        _SHARED_CACHE["client"] = client
+        return client
+
+

--- a/core/video/health.py
+++ b/core/video/health.py
@@ -312,6 +312,14 @@ def collect(db) -> dict:
                 checks.append(_check(key + "_space", label, "warning",
                                      "%.1f GB free — the drive is nearly full" % free))
 
+    from core.video.library_roots import ADDITIONAL_KEYS, additional_paths
+    for key in ADDITIONAL_KEYS:
+        for index, path in enumerate(additional_paths(db, key)):
+            if not os.path.isdir(path):
+                label = "Additional movie library" if key.startswith("movies") else "Additional TV library"
+                checks.append(_check(f"{key}_{index}", label, "error",
+                                     f"{path} is unreachable — a drive or mount may be down"))
+
     # 2) recycle override folder (auto per-library folders create themselves)
     override = str(settings.get("recycle_path") or "").strip()
     if settings.get("recycle_deletes", True) and override and not os.path.isdir(override):

--- a/core/video/library_roots.py
+++ b/core/video/library_roots.py
@@ -1,0 +1,58 @@
+"""Configured video libraries; additional roots never change import destinations."""
+import json
+import os
+
+ADDITIONAL_KEYS = ("movies_additional_paths", "tv_additional_paths")
+
+
+def normalize_paths(value):
+    if not isinstance(value, list) or any(not isinstance(p, str) for p in value):
+        raise ValueError("Additional library paths must be a list of folder paths")
+    result = []
+    seen = set()
+    for path in value:
+        path = path.strip()
+        if not path:
+            continue
+        if "\x00" in path:
+            raise ValueError("Library paths cannot contain null characters")
+        key = os.path.normcase(os.path.normpath(path))
+        if key not in seen:
+            seen.add(key)
+            result.append(path)
+    return result
+
+
+def additional_paths(db, key):
+    try:
+        value = db.get_setting(key) or "[]"
+        return normalize_paths(json.loads(value) if isinstance(value, str) else value)
+    except (ValueError, TypeError):
+        return []
+
+
+def library_roots(db, kind=None):
+    roots = []
+    kinds = (kind,) if kind else ("movie", "episode", "youtube")
+    for item in kinds:
+        key = {"movie": "movies_path", "episode": "tv_path", "youtube": "youtube_path"}[item]
+        primary = db.get_setting(key)
+        if primary:
+            roots.append(str(primary))
+        if item != "youtube":
+            roots.extend(additional_paths(db, key.replace("_path", "_additional_paths")))
+    return normalize_paths(roots)
+
+
+def containing_root(path, roots):
+    """Use the deepest configured parent, keeping renames on their current drive."""
+    matches = []
+    absolute = os.path.abspath(path)
+    for root in roots:
+        candidate = os.path.abspath(root)
+        try:
+            if os.path.commonpath([absolute, candidate]) == candidate:
+                matches.append(candidate)
+        except ValueError:
+            continue
+    return max(matches, key=len) if matches else None

--- a/core/video/path_resolver.py
+++ b/core/video/path_resolver.py
@@ -23,15 +23,12 @@ _PROBE_DEPTH = 4
 
 def video_base_dirs(db) -> list:
     """The local folders video files can live under, per the user's settings:
-    the movie/TV library roots + the transfer folder. Missing/blank skipped."""
-    dirs = []
-    for key in ("movies_path", "tv_path", "transfer_path"):
-        try:
-            v = db.get_setting(key)
-        except Exception:   # noqa: BLE001 - a settings hiccup just narrows the search
-            v = None
-        if v:
-            dirs.append(str(v))
+    primary and additional library roots + the transfer folder. Blanks skipped."""
+    from core.video.library_roots import library_roots
+    dirs = library_roots(db)
+    transfer = db.get_setting("transfer_path")
+    if transfer and transfer not in dirs:
+        dirs.append(str(transfer))
     return dirs
 
 
@@ -66,11 +63,12 @@ def resolve_video_file_path(stored_path, base_dirs, *, size_bytes=None,
         except Exception:   # noqa: BLE001 - unreadable size → can't prove identity
             return False
 
-    for base in (base_dirs or []):
-        base = str(base or "").rstrip("/\\")
-        if not base:
-            continue
-        for k in range(min(_PROBE_DEPTH, len(parts)), 0, -1):
+    # Prefer specific folder matches across ALL drives before a bare filename.
+    for k in range(min(_PROBE_DEPTH, len(parts)), 0, -1):
+        for base in (base_dirs or []):
+            base = str(base or "").rstrip("/\\")
+            if not base:
+                continue
             cand = os.path.join(base, *parts[-k:])
             if exists(cand) and _same_file(cand):
                 return cand

--- a/core/video/recycle.py
+++ b/core/video/recycle.py
@@ -38,19 +38,9 @@ logger = get_logger("video.recycle")
 
 TRASH_DIRNAME = "ss_recycle"
 
-_ROOT_SETTINGS = ("movies_path", "tv_path", "youtube_path")
-
-
 def _library_roots(db) -> list:
-    roots = []
-    for key in _ROOT_SETTINGS:
-        try:
-            v = str(db.get_setting(key) or "").strip()
-        except Exception:   # noqa: BLE001
-            v = ""
-        if v:
-            roots.append(v)
-    return roots
+    from core.video.library_roots import library_roots
+    return library_roots(db)
 
 
 def _root_for(path: str, roots) -> Optional[str]:

--- a/core/video/repair/naming_conformance.py
+++ b/core/video/repair/naming_conformance.py
@@ -99,8 +99,8 @@ class NamingConformanceJob(VideoRepairJob):
         result = JobResult()
         settings = organization.load(context.db)
         base_dirs = video_base_dirs(context.db)
-        roots = {"movie": str(context.db.get_setting("movies_path") or "").strip(),
-                 "episode": str(context.db.get_setting("tv_path") or "").strip()}
+        from core.video.library_roots import library_roots, containing_root
+        roots = {kind: library_roots(context.db, kind) for kind in ("movie", "episode")}
         rows = context.db.repair_library_files() or []
         context.report(total=len(rows), phase="checking names")
         valid = []
@@ -108,14 +108,18 @@ class NamingConformanceJob(VideoRepairJob):
             context.check_stop()
             result.scanned += 1
             context.report(processed=i, current_item=r.get("title"))
-            root = roots.get(r["scope"])
-            if not root:
+            configured_roots = roots.get(r["scope"])
+            if not configured_roots:
                 result.skipped += 1          # that library has no configured folder
                 continue
             real = resolve_video_file_path(r.get("relative_path"), base_dirs,
                                            size_bytes=r.get("size_bytes"))
             if not real:
                 result.skipped += 1          # can't locate locally — never guess
+                continue
+            root = containing_root(real, configured_roots)
+            if not root:
+                result.skipped += 1
                 continue
             ext = os.path.splitext(real)[1]
             expected = organization.render_path(r["scope"], root, _fields_of(r),

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 import re
 import time
+import threading
+import hashlib
 from typing import Any, Dict
 
 from utils.logging_config import get_logger
@@ -29,11 +31,15 @@ PLEX_CONNECT_TIMEOUT = 8
 PLEX_SCAN_TIMEOUT = 120
 
 _plex_srv_cache: Dict[str, Any] = {"srv": None, "at": 0.0, "key": ""}
+_plex_status_cache: Dict[str, Any] = {"srv": None, "at": 0.0, "key": ""}
+_plex_cache_lock = threading.RLock()
 
 
 def invalidate_video_source_cache() -> None:
     """Force the next _build_source call to re-establish connections."""
-    _plex_srv_cache.update(srv=None, at=0.0, key="")
+    with _plex_cache_lock:
+        _plex_srv_cache.update(srv=None, at=0.0, key="")
+        _plex_status_cache.update(srv=None, at=0.0, key="")
 
 
 def _to_int(val):
@@ -244,7 +250,7 @@ def video_jellyfin_test(cfg):
     return True, "Connected to %s" % name
 
 
-def _build_source(movies_lib=None, tv_lib=None):
+def _build_source(movies_lib=None, tv_lib=None, *, interactive=False):
     """Build a media source for the VIDEO server (see resolve_video_server),
     restricted to the named Movies/TV libraries when given. Uses VIDEO's OWN
     effective connection config (its creds, or inherited from music) — never the
@@ -257,21 +263,26 @@ def _build_source(movies_lib=None, tv_lib=None):
         base_url, token = cfg.get("base_url"), cfg.get("token")
         if not base_url or not token:
             return None
-        key = f"{base_url}|{token[:6]}"
-        now = time.time()
-        if _plex_srv_cache["key"] == key and now - _plex_srv_cache["at"] < 60:
-            srv = _plex_srv_cache["srv"]
-            return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib) if srv is not None else None
-
-        try:
-            from plexapi.server import PlexServer
-            srv = PlexServer(base_url, token, timeout=(PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT))
-            _plex_srv_cache.update(srv=srv, at=now, key=key)
-            return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib)
-        except Exception as e:
-            logger.warning("video sources: Plex connect failed: %s", e)
-            _plex_srv_cache.update(srv=None, at=now, key=key)
-            return None
+        key = hashlib.sha256(f"{base_url}|{token}".encode()).hexdigest()
+        cache = _plex_status_cache if interactive else _plex_srv_cache
+        with _plex_cache_lock:
+            now = time.time()
+            if cache["key"] == key and 0 <= now - cache["at"] < 60:
+                srv = cache["srv"]
+                return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib) if srv is not None else None
+            try:
+                from plexapi.server import PlexServer
+                # The constructor itself makes an HTTP request. A short connect
+                # timeout alone cannot bound a server that accepts TCP then stalls.
+                srv = PlexServer(base_url, token, timeout=(PLEX_CONNECT_TIMEOUT, PLEX_CONNECT_TIMEOUT))
+                if not interactive:
+                    srv._timeout = (PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT)
+                cache.update(srv=srv, at=time.time(), key=key)
+                return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib)
+            except Exception as e:
+                logger.warning("video sources: Plex connect failed: %s", e)
+                cache.update(srv=None, at=time.time(), key=key)
+                return None
 
     if server == "jellyfin":
         return _video_jellyfin_source(video_jellyfin_config(db), movies_lib, tv_lib)
@@ -292,11 +303,11 @@ def _load_selection():
         return {}
 
 
-def get_active_video_source():
+def get_active_video_source(*, interactive=False):
     """Source for SCANNING — restricted to the user-mapped Movies/TV libraries.
     Falls back to all libraries when nothing is mapped yet."""
     sel = _load_selection() or {}
-    return _build_source(sel.get("movies") or None, sel.get("tv") or None)
+    return _build_source(sel.get("movies") or None, sel.get("tv") or None, interactive=interactive)
 
 
 def normalize_media_type(media_type) -> str:
@@ -354,14 +365,16 @@ def video_server_scan_in_progress(media_type="all"):
     for 'all'); False if idle; None if it can't be determined — no server, or an
     adapter that can't report scan state. Callers fall back to a fixed wait on None."""
     media_type = normalize_media_type(media_type)
-    src = get_active_video_source()
+    src = get_active_video_source(interactive=True)
     if src is None or not hasattr(src, "is_scanning"):
         return None
     try:
         return bool(src.is_scanning(media_type))
     except Exception:
         logger.debug("video sources: scan-status check failed", exc_info=True)
-        invalidate_video_source_cache()
+        with _plex_cache_lock:
+            if _plex_status_cache['srv'] is getattr(src, '_server', None):
+                _plex_status_cache.update(srv=None, at=time.time())
         return None
 
 
@@ -938,6 +951,11 @@ class PlexVideoSource:
         """True if any SELECTED video section (scoped by media_type) is currently
         being scanned by Plex. Checks the per-section refreshing flag, then the
         server activity feed (real-time) — mirrors the music PlexClient check."""
+        # PlexAPI caches library sections on the connected server object.
+        # Reusing the connection must not reuse yesterday's refreshing flag.
+        reload_library = getattr(self._server.library, 'reload', None)
+        if callable(reload_library):
+            reload_library()
         sections = []
         for kind, name in (("movie", self._movies_lib), ("show", self._tv_lib)):
             if media_type != "all" and media_type != kind:

--- a/core/video/sources.py
+++ b/core/video/sources.py
@@ -14,6 +14,8 @@ these adapters.
 from __future__ import annotations
 
 import re
+import time
+from typing import Any, Dict
 
 from utils.logging_config import get_logger
 
@@ -21,7 +23,17 @@ logger = get_logger("video_sources")
 
 # Library scans are bulk operations — a far longer per-request timeout than the
 # shared client's interactive one, so big libraries don't read-timeout mid-scan.
+# However, connection attempts (TCP SYN) must fail quickly (8s) to avoid stalling
+# Gunicorn workers on unreachable or offline servers.
+PLEX_CONNECT_TIMEOUT = 8
 PLEX_SCAN_TIMEOUT = 120
+
+_plex_srv_cache: Dict[str, Any] = {"srv": None, "at": 0.0, "key": ""}
+
+
+def invalidate_video_source_cache() -> None:
+    """Force the next _build_source call to re-establish connections."""
+    _plex_srv_cache.update(srv=None, at=0.0, key="")
 
 
 def _to_int(val):
@@ -245,12 +257,20 @@ def _build_source(movies_lib=None, tv_lib=None):
         base_url, token = cfg.get("base_url"), cfg.get("token")
         if not base_url or not token:
             return None
+        key = f"{base_url}|{token[:6]}"
+        now = time.time()
+        if _plex_srv_cache["key"] == key and now - _plex_srv_cache["at"] < 60:
+            srv = _plex_srv_cache["srv"]
+            return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib) if srv is not None else None
+
         try:
             from plexapi.server import PlexServer
-            srv = PlexServer(base_url, token, timeout=PLEX_SCAN_TIMEOUT)
+            srv = PlexServer(base_url, token, timeout=(PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT))
+            _plex_srv_cache.update(srv=srv, at=now, key=key)
             return PlexVideoSource(srv, movies_lib=movies_lib, tv_lib=tv_lib)
-        except Exception:
-            logger.exception("video sources: Plex connect failed")
+        except Exception as e:
+            logger.warning("video sources: Plex connect failed: %s", e)
+            _plex_srv_cache.update(srv=None, at=now, key=key)
             return None
 
     if server == "jellyfin":
@@ -306,6 +326,7 @@ def refresh_video_server_sections(media_type="all"):
         return src.refresh_sections(media_type)
     except Exception as e:   # noqa: BLE001 - surface any server error to the automation
         logger.exception("video sources: refresh failed")
+        invalidate_video_source_cache()
         return {"ok": False, "error": str(e)}
 
 
@@ -324,6 +345,7 @@ def set_video_poster(server_id, *, image_url=None, image_bytes=None, kind="movie
                               delete_key=delete_key)
     except Exception as e:   # noqa: BLE001 - surface any server error to the caller
         logger.exception("video sources: set_poster failed")
+        invalidate_video_source_cache()
         return {"ok": False, "error": str(e)}
 
 
@@ -339,6 +361,7 @@ def video_server_scan_in_progress(media_type="all"):
         return bool(src.is_scanning(media_type))
     except Exception:
         logger.debug("video sources: scan-status check failed", exc_info=True)
+        invalidate_video_source_cache()
         return None
 
 
@@ -356,6 +379,7 @@ def video_server_has_item(media_type, item) -> bool:
         return bool(src.has_item(media_type, item))
     except Exception:
         logger.debug("video sources: has_item probe failed", exc_info=True)
+        invalidate_video_source_cache()
         return False
 
 

--- a/core/watchlist/auto_scan.py
+++ b/core/watchlist/auto_scan.py
@@ -207,11 +207,37 @@ def process_watchlist_scan_automatically(automation_id=None, profile_id=None, de
                         log_line=f"{len(watchlist_artists)} artists ({profile_label})",
                         log_type='info',
                     )
+                elif event_type == 'matching_sources':
+                    # The phase BEFORE any artist is scanned: every artist is
+                    # matched against every other metadata provider, one lookup
+                    # each. For a few hundred artists that is the longest part of
+                    # the run, and the card used to sit on 'Loading watchlist' at
+                    # 5% for all of it, which reads as a hang (#1240).
+                    done = payload.get('artists_done', 0)
+                    artists_total = max(1, payload.get('artists_total', 1))
+                    src_no = payload.get('source_number', 1)
+                    src_total = max(1, payload.get('source_total', 1))
+                    # the whole matching phase occupies the 5-10% band, so the
+                    # artist loop still owns 10-95 and nothing goes backwards
+                    within = (done / artists_total) / src_total
+                    pct = 5 + (((src_no - 1) / src_total) + within) * 5
+                    deps.update_automation_progress(
+                        automation_id,
+                        progress=pct,
+                        phase=(f"Matching to {payload.get('source', '')} "
+                               f"({done}/{artists_total} artists)"),
+                        processed=done,
+                        total=artists_total,
+                    )
                 elif event_type == 'artist_started':
                     total = max(1, payload.get('total_artists', len(watchlist_artists)))
                     idx = payload.get('artist_index', 1)
                     artist_name = payload.get('artist_name', '')
-                    pct = 5 + ((idx - 1) / total) * 90
+                    # 10-95, because 5-10 now belongs to the source-matching
+                    # phase that runs before this loop. Leaving this at 5 would
+                    # send the bar BACKWARDS from 10% to 5% the moment the first
+                    # artist started.
+                    pct = 10 + ((idx - 1) / total) * 85
                     deps.update_automation_progress(
                         automation_id,
                         progress=pct,

--- a/core/watchlist_scanner.py
+++ b/core/watchlist_scanner.py
@@ -1284,12 +1284,72 @@ class WatchlistScanner:
             if source in {'spotify', 'itunes', 'deezer', 'discogs', 'musicbrainz'}
         ]
 
-        for provider in providers_to_backfill:
+        # The backfill is the longest phase of a scan for anyone who has just
+        # added artists, and it used to run silently with no way out: the page
+        # showed 0 of N for tens of minutes and Cancel did nothing, because the
+        # only cancel check was in the artist loop this runs before (#1240).
+        # It reports its own phase now, and it stops when asked.
+        backfill_cancelled = False
+        for provider_number, provider in enumerate(providers_to_backfill, 1):
+            # No cancel check out here on purpose. _backfill_missing_ids returns
+            # early without asking when a provider has nothing to match, and a
+            # pre-check here would consult the caller once per provider even
+            # then - work that does not exist cannot be worth cancelling, and
+            # asking anyway changes how often the check is called.
             try:
                 logger.info("Checking for missing %s IDs in watchlist...", provider)
-                self._backfill_missing_ids(watchlist_artists, provider)
+
+                def _backfill_progress(done, total, _p=provider, _n=provider_number):
+                    if scan_state is not None:
+                        scan_state.update({
+                            'current_phase': 'matching_sources',
+                            'matching_source': _p,
+                            'matching_source_number': _n,
+                            'matching_source_total': len(providers_to_backfill),
+                            'matching_artists_done': done,
+                            'matching_artists_total': total,
+                        })
+                    _emit(
+                        'matching_sources',
+                        profile_id=profile_id,
+                        source=_p,
+                        source_number=_n,
+                        source_total=len(providers_to_backfill),
+                        artists_done=done,
+                        artists_total=total,
+                    )
+
+                completed = self._backfill_missing_ids(
+                    watchlist_artists, provider,
+                    cancel_check=cancel_check,
+                    on_progress=_backfill_progress,
+                )
+                # ONLY an explicit False means "a cancel was honoured". A
+                # stub, a subclass or an older override that returns None is
+                # saying nothing, and reading that as a cancel would abort every
+                # scan before it started.
+                if completed is False:
+                    backfill_cancelled = True
+                    break
             except Exception as backfill_error:
                 logger.warning("Error during %s ID backfilling: %s", provider, backfill_error)
+
+        if backfill_cancelled:
+            logger.info("Watchlist scan cancelled during source matching")
+            if scan_state is not None:
+                scan_state.update({
+                    'status': 'cancelled',
+                    'current_phase': 'cancelled',
+                    'summary': {
+                        'total_artists': 0,
+                        'successful_scans': 0,
+                        'new_tracks_found': 0,
+                        'tracks_added_to_wishlist': 0,
+                        'cancelled': True,
+                    },
+                })
+            _emit('cancelled', processed=0, total=len(watchlist_artists))
+            return scan_results
 
         lookback_period = self._get_lookback_period_setting()
         is_full_discography = (lookback_period == 'all')
@@ -1753,9 +1813,31 @@ class WatchlistScanner:
             logger.error(f"Error getting discography for artist {artist_id}: {e}")
             return None
 
-    def _backfill_missing_ids(self, artists: List[WatchlistArtist], provider: str):
+    def _backfill_missing_ids(
+        self,
+        artists: List[WatchlistArtist],
+        provider: str,
+        *,
+        cancel_check: Optional[Callable[[], bool]] = None,
+        on_progress: Optional[Callable[[int, int], None]] = None,
+    ) -> bool:
         """
         Proactively match ALL artists missing IDs for the current provider.
+
+        Returns False when a cancel was honoured part way through, else True.
+
+        This runs BEFORE the artist loop and is usually the longest part of a
+        scan: one network lookup per artist per provider, with a sleep between
+        each. Somebody who has just added a few hundred artists has almost no
+        provider ids yet, so nearly every artist needs looking up against every
+        other provider - 379 artists over five providers is 1,895 lookups,
+        which is tens of minutes.
+
+        It used to run silently and ignore cancellation, so for all that time
+        the watchlist page sat on "0 / 379 artists" and the cancel button did
+        nothing - the only cancel check lived in the artist loop that had not
+        started yet. That is #1240: shows as scanning but never starts, and
+        cannot be cancelled.
         
         Example: User has 50 artists with only Spotify IDs.
         When iTunes becomes active, this matches ALL 50 to iTunes in one batch.
@@ -1771,13 +1853,13 @@ class WatchlistScanner:
 
         if not id_attr:
             logger.debug(f"Backfill not supported for provider: {provider}")
-            return
+            return True
 
         artists_to_match = [a for a in artists if not getattr(a, id_attr, None)]
 
         if not artists_to_match:
             logger.info(f"All artists already have {provider} IDs")
-            return
+            return True
 
         logger.info(f"Backfilling {len(artists_to_match)} artists with {provider} IDs...")
 
@@ -1799,11 +1881,25 @@ class WatchlistScanner:
 
         if not match_fn or not update_fn:
             logger.debug(f"No match/update function available for provider: {provider}")
-            return
+            return True
 
         matched_count = 0
         unmatched_names = []
-        for artist in artists_to_match:
+        total_to_match = len(artists_to_match)
+        for done, artist in enumerate(artists_to_match):
+            # checked BEFORE the lookup, so a cancel lands within one artist
+            # rather than after a whole provider pass
+            if cancel_check and cancel_check():
+                logger.info(
+                    "%s ID backfill cancelled after %s/%s artists",
+                    provider, done, total_to_match,
+                )
+                return False
+            if on_progress:
+                try:
+                    on_progress(done, total_to_match)
+                except Exception:                        # noqa: BLE001
+                    logger.debug("backfill progress callback failed", exc_info=True)
             try:
                 new_id = match_fn(artist.artist_name)
                 if new_id:
@@ -1821,10 +1917,16 @@ class WatchlistScanner:
                 unmatched_names.append(artist.artist_name)
                 continue
 
+        if on_progress:
+            try:
+                on_progress(total_to_match, total_to_match)
+            except Exception:                            # noqa: BLE001
+                logger.debug("backfill progress callback failed", exc_info=True)
         logger.info(f"Backfilled {matched_count}/{len(artists_to_match)} artists with {provider} IDs")
         if unmatched_names:
             logger.warning(f"Could not confidently match {len(unmatched_names)} artists: {', '.join(unmatched_names[:10])}"
                           f"{'...' if len(unmatched_names) > 10 else ''} — use Watchlist Settings to link manually")
+        return True
 
     @staticmethod
     def _normalize_artist_name(name: str) -> str:

--- a/core/watchlist_scanner.py
+++ b/core/watchlist_scanner.py
@@ -1461,7 +1461,19 @@ class WatchlistScanner:
                 artist_new_tracks = 0
                 artist_added_tracks = 0
 
+                artist_was_cancelled = False
                 for album_index, album in enumerate(albums):
+                    # The album loop had no cancel point at all, so a cancel
+                    # could only land between ARTISTS. An artist with thirty
+                    # albums is thirty fetches and thirty sleeps first, and a
+                    # slow provider makes that minutes of an unstoppable scan.
+                    if cancel_check and cancel_check():
+                        artist_was_cancelled = True
+                        logger.info(
+                            "Cancel received while checking albums for %s (%s of %s)",
+                            artist.artist_name, album_index, len(albums),
+                        )
+                        break
                     try:
                         album_data = album_fetcher(album.id, getattr(album, 'name', ''))
                         tracks = self._extract_track_items(album_data)
@@ -1606,6 +1618,12 @@ class WatchlistScanner:
                     new_tracks_found=artist_new_tracks,
                     tracks_added_to_wishlist=artist_added_tracks,
                 )
+
+                # a cancelled artist gets no discovery work and no pacing
+                # delay; the loop head handles the cancelled state properly
+                # on the next pass.
+                if artist_was_cancelled:
+                    continue
 
                 try:
                     if scan_state is not None:

--- a/database/music_database.py
+++ b/database/music_database.py
@@ -767,7 +767,7 @@ class MusicDatabase:
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS watchlist_podcasts (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    feed_url TEXT UNIQUE NOT NULL,
+                    feed_url TEXT NOT NULL,
                     itunes_id INTEGER,
                     title TEXT NOT NULL,
                     author TEXT,
@@ -781,13 +781,88 @@ class MusicDatabase:
                     last_scan_timestamp TIMESTAMP,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    profile_id INTEGER DEFAULT 1
+                    profile_id INTEGER DEFAULT 1,
+                    UNIQUE(feed_url, profile_id)
                 )
             """)
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_watchlist_podcasts_feed "
                            "ON watchlist_podcasts (feed_url)")
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_watchlist_podcasts_itunes "
                            "ON watchlist_podcasts (itunes_id)")
+
+            # feed_url used to be unique on its own, which reads fine until a
+            # second profile follows a show the first one already follows: the
+            # insert hit ON CONFLICT(feed_url) and UPDATED the first profile's
+            # row instead of making a new one, so the second person got a
+            # success and an empty watchlist. the rows are per profile, so the
+            # constraint has to be per profile too.
+            #
+            # sqlite cannot alter a constraint, so the table is rebuilt. it only
+            # holds subscriptions, so it is small, and the whole thing runs in
+            # one transaction - either the new table is in place with every row
+            # copied or nothing changed at all.
+            try:
+                _wp_sql = cursor.execute(
+                    "SELECT sql FROM sqlite_master WHERE type='table' AND name='watchlist_podcasts'"
+                ).fetchone()
+                _wp_sql = (_wp_sql[0] if _wp_sql else "") or ""
+                _wp_norm = " ".join(_wp_sql.split())
+                # two ways to be wrong: no pair constraint at all, or a pair
+                # constraint sitting next to the old column-level UNIQUE, which
+                # still refuses the second profile. either shape gets rebuilt.
+                _wp_needs_rebuild = (
+                    "UNIQUE(feed_url, profile_id)" not in _wp_norm
+                    or "feed_url TEXT UNIQUE" in _wp_norm
+                )
+                if _wp_sql and _wp_needs_rebuild:
+                    logger.info("Migrating watchlist_podcasts to a per-profile unique key")
+                    cursor.execute("""
+                        CREATE TABLE watchlist_podcasts_migrating (
+                            id INTEGER PRIMARY KEY AUTOINCREMENT,
+                            feed_url TEXT NOT NULL,
+                            itunes_id INTEGER,
+                            title TEXT NOT NULL,
+                            author TEXT,
+                            description TEXT,
+                            artwork_url TEXT,
+                            website TEXT,
+                            auto_download INTEGER NOT NULL DEFAULT 1,
+                            retention_days INTEGER NOT NULL DEFAULT 14,
+                            episode_count INTEGER,
+                            date_added TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                            last_scan_timestamp TIMESTAMP,
+                            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                            profile_id INTEGER DEFAULT 1,
+                            UNIQUE(feed_url, profile_id)
+                        )
+                    """)
+                    cursor.execute("""
+                        INSERT INTO watchlist_podcasts_migrating (
+                            id, feed_url, itunes_id, title, author, description,
+                            artwork_url, website, auto_download, retention_days,
+                            episode_count, date_added, last_scan_timestamp,
+                            created_at, updated_at, profile_id
+                        )
+                        SELECT id, feed_url, itunes_id, title, author, description,
+                               artwork_url, website, auto_download, retention_days,
+                               episode_count, date_added, last_scan_timestamp,
+                               created_at, updated_at, COALESCE(profile_id, 1)
+                        FROM watchlist_podcasts
+                    """)
+                    cursor.execute("DROP TABLE watchlist_podcasts")
+                    cursor.execute("ALTER TABLE watchlist_podcasts_migrating "
+                                   "RENAME TO watchlist_podcasts")
+                    cursor.execute("CREATE INDEX IF NOT EXISTS idx_watchlist_podcasts_feed "
+                                   "ON watchlist_podcasts (feed_url)")
+                    cursor.execute("CREATE INDEX IF NOT EXISTS idx_watchlist_podcasts_itunes "
+                                   "ON watchlist_podcasts (itunes_id)")
+                    cursor.execute("CREATE INDEX IF NOT EXISTS idx_watchlist_podcasts_profile "
+                                   "ON watchlist_podcasts (profile_id)")
+            except Exception as _wp_err:
+                # a failed migration must not stop the database opening. the old
+                # shape still works for one profile, which is what it did before.
+                logger.error("watchlist_podcasts migration skipped: %s", _wp_err)
 
             # Downloaded podcast episodes tracker (for auto-download deduplication and retention pruning)
             cursor.execute("""
@@ -13503,7 +13578,7 @@ class MusicDatabase:
                     "feed_url, itunes_id, title, author, description, artwork_url, website, "
                     "auto_download, retention_days, episode_count, profile_id"
                     ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                    "ON CONFLICT(feed_url) DO UPDATE SET "
+                    "ON CONFLICT(feed_url, profile_id) DO UPDATE SET "
                     "itunes_id=COALESCE(excluded.itunes_id, watchlist_podcasts.itunes_id), "
                     "title=excluded.title, "
                     "author=COALESCE(excluded.author, watchlist_podcasts.author), "
@@ -13537,24 +13612,34 @@ class MusicDatabase:
         feed_url: Optional[str] = None,
         itunes_id: Optional[int] = None,
         podcast_id: Optional[int] = None,
+        profile_id: Optional[int] = None,
     ) -> bool:
-        """Unfollow a podcast by feed_url, itunes_id, or database id."""
+        """Unfollow a podcast by feed_url, itunes_id, or database id.
+
+        Scoped to one profile when profile_id is given. Without it this deleted
+        by feed_url alone, so one profile could unfollow another profile's show.
+        """
         try:
             with self._get_connection() as conn:
+                # profile_id None means "any profile", which is what this did
+                # before it took the argument at all. Every caller in the app
+                # passes one; leaving None working keeps older callers honest.
+                scope = "" if profile_id is None else " AND COALESCE(profile_id, 1) = ?"
+                extra = () if profile_id is None else (int(profile_id),)
                 if feed_url:
                     cur = conn.execute(
-                        "DELETE FROM watchlist_podcasts WHERE feed_url = ?",
-                        (str(feed_url).strip(),),
+                        "DELETE FROM watchlist_podcasts WHERE feed_url = ?" + scope,
+                        (str(feed_url).strip(),) + extra,
                     )
                 elif itunes_id:
                     cur = conn.execute(
-                        "DELETE FROM watchlist_podcasts WHERE itunes_id = ?",
-                        (int(itunes_id),),
+                        "DELETE FROM watchlist_podcasts WHERE itunes_id = ?" + scope,
+                        (int(itunes_id),) + extra,
                     )
                 elif podcast_id:
                     cur = conn.execute(
-                        "DELETE FROM watchlist_podcasts WHERE id = ?",
-                        (int(podcast_id),),
+                        "DELETE FROM watchlist_podcasts WHERE id = ?" + scope,
+                        (int(podcast_id),) + extra,
                     )
                 else:
                     return False
@@ -13568,27 +13653,55 @@ class MusicDatabase:
         self,
         feed_url: Optional[str] = None,
         itunes_id: Optional[int] = None,
+        profile_id: Optional[int] = None,
     ) -> bool:
-        """Check if a podcast is followed by feed_url or itunes_id."""
+        """Check if a podcast is followed by feed_url or itunes_id.
+
+        Scoped to one profile when profile_id is given. Unscoped this answered
+        True for a show somebody ELSE follows, so the button read "following"
+        on a page whose watchlist did not contain it.
+        """
         try:
             with self._get_connection() as conn:
+                scope = "" if profile_id is None else " AND COALESCE(profile_id, 1) = ?"
+                extra = () if profile_id is None else (int(profile_id),)
                 if feed_url:
                     row = conn.execute(
-                        "SELECT 1 FROM watchlist_podcasts WHERE feed_url = ?",
-                        (str(feed_url).strip(),),
+                        "SELECT 1 FROM watchlist_podcasts WHERE feed_url = ?" + scope,
+                        (str(feed_url).strip(),) + extra,
                     ).fetchone()
                     if row:
                         return True
                 if itunes_id:
                     row = conn.execute(
-                        "SELECT 1 FROM watchlist_podcasts WHERE itunes_id = ?",
-                        (int(itunes_id),),
+                        "SELECT 1 FROM watchlist_podcasts WHERE itunes_id = ?" + scope,
+                        (int(itunes_id),) + extra,
                     ).fetchone()
                     if row:
                         return True
                 return False
         except Exception:
             return False
+
+    def profiles_with_podcast_rows(self) -> List[int]:
+        """Every profile that actually follows a podcast.
+
+        A timed scan has no request behind it, so there is no caller whose
+        profile it could act as - system automations all run as profile 1. That
+        meant a second person's shows were never scanned at all. The profile has
+        to come from the rows instead, which is how the audiobook wishlist
+        worker solves the same problem.
+        """
+        try:
+            with self._get_connection() as conn:
+                rows = conn.execute(
+                    "SELECT DISTINCT COALESCE(profile_id, 1) AS pid "
+                    "FROM watchlist_podcasts ORDER BY pid"
+                ).fetchall()
+                return [int(r["pid"]) for r in rows] or [1]
+        except Exception as e:
+            logger.error("profiles_with_podcast_rows failed: %s", e)
+            return [1]
 
     def get_watchlist_podcasts(self, profile_id: int = 1) -> List[Dict[str, Any]]:
         """List all watchlisted podcasts."""
@@ -13616,24 +13729,31 @@ class MusicDatabase:
         self,
         feed_url: Optional[str] = None,
         itunes_id: Optional[int] = None,
+        profile_id: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Get a single watchlisted podcast record by feed_url or itunes_id."""
+        """Get a single watchlisted podcast record by feed_url or itunes_id.
+
+        Scoped to one profile when profile_id is given, so the row handed back
+        is the caller's own settings rather than whoever followed the show first.
+        """
         try:
             with self._get_connection() as conn:
+                scope = "" if profile_id is None else " AND COALESCE(profile_id, 1) = ?"
+                extra = () if profile_id is None else (int(profile_id),)
                 row = None
                 if feed_url:
                     row = conn.execute(
                         "SELECT id, feed_url, itunes_id, title, author, description, artwork_url, website, "
                         "auto_download, retention_days, episode_count, date_added, last_scan_timestamp "
-                        "FROM watchlist_podcasts WHERE feed_url = ?",
-                        (str(feed_url).strip(),),
+                        "FROM watchlist_podcasts WHERE feed_url = ?" + scope,
+                        (str(feed_url).strip(),) + extra,
                     ).fetchone()
                 if not row and itunes_id:
                     row = conn.execute(
                         "SELECT id, feed_url, itunes_id, title, author, description, artwork_url, website, "
                         "auto_download, retention_days, episode_count, date_added, last_scan_timestamp "
-                        "FROM watchlist_podcasts WHERE itunes_id = ?",
-                        (int(itunes_id),),
+                        "FROM watchlist_podcasts WHERE itunes_id = ?" + scope,
+                        (int(itunes_id),) + extra,
                     ).fetchone()
                 if row:
                     d = dict(row)
@@ -13651,8 +13771,14 @@ class MusicDatabase:
         *,
         auto_download: Optional[bool] = None,
         retention_days: Optional[int] = None,
+        profile_id: Optional[int] = None,
     ) -> bool:
-        """Update auto_download or retention_days settings for a followed podcast."""
+        """Update auto_download or retention_days settings for a followed podcast.
+
+        Scoped to one profile when profile_id is given. Unscoped this matched on
+        feed_url alone, so changing your own retention rewrote the row of
+        whoever followed the show first.
+        """
         feed_url = str(feed_url or '').strip()
         if not feed_url:
             return False
@@ -13668,10 +13794,15 @@ class MusicDatabase:
             return True
         clauses.append("updated_at = CURRENT_TIMESTAMP")
         params.append(feed_url)
+        scope = ""
+        if profile_id is not None:
+            scope = " AND COALESCE(profile_id, 1) = ?"
+            params.append(int(profile_id))
         try:
             with self._get_connection() as conn:
                 cur = conn.execute(
-                    f"UPDATE watchlist_podcasts SET {', '.join(clauses)} WHERE feed_url = ?",
+                    f"UPDATE watchlist_podcasts SET {', '.join(clauses)} "
+                    f"WHERE feed_url = ?{scope}",
                     params,
                 )
                 conn.commit()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,11 +70,30 @@ services:
       # ─── Video libraries (OUTPUT) — one per content type ─────────────────
       # The video Downloads tab sorts finished files into these by type. Point each
       # at where Plex/Jellyfin reads from, then set the matching path on
-      # Settings → Downloads (the in-app placeholders match the in-container paths):
+      # Settings → Library → Folders → Videos (container paths):
       #   Movies → /media/movies   ·   TV → /media/tv   ·   YouTube → /media/youtube
       - ./Movies:/media/movies
       - ./TV:/media/tv
       - ./YouTube:/media/youtube
+      # Multiple movie / TV drives: give EVERY mount a UNIQUE container path.
+      # Mounts do not merge: do NOT bind several drives to /media/movies or /media/tv.
+      # Replace the host paths below with your real folders, then uncomment:
+      # - /mnt/drive2/Movies:/media/movies2:rw
+      # - /mnt/drive3/Movies:/media/movies3:rw
+      # - /mnt/drive4/Movies:/media/movies4:rw
+      # - /mnt/drive2/TV:/media/tv2:rw
+      # - /mnt/drive3/TV:/media/tv3:rw
+      # - /mnt/drive4/TV:/media/tv4:rw
+      # Recreate the container after adding mounts. In Settings → Library →
+      # Folders → Videos, add /media/movies2, /media/movies3, /media/movies4 under
+      # Additional Movie Libraries, and the /media/tv2 etc. paths under Additional
+      # TV Libraries. Enter CONTAINER paths (right side), not /mnt/drive2 paths.
+      # Keep /media/movies and /media/tv as primary destinations for new downloads.
+      # Extra paths let SoulSync locate existing files for playback, upgrades,
+      # renaming and recycling; :rw permits those file operations.
+      # Plex/Jellyfin must also have these folders mounted and included in the
+      # libraries selected for SoulSync's video scan. Adding paths here does not
+      # create media-server libraries or directly crawl unindexed video folders.
       # Use named volume for database persistence (separate from host database)
       # NOTE: Changed from /app/database to /app/data to avoid overwriting Python package
       # Holds BOTH databases (music_library.db + video_library.db) plus the video

--- a/docs/performance-1245.md
+++ b/docs/performance-1245.md
@@ -1,0 +1,71 @@
+# Performance investigation: issue 1245
+
+Reviewed baseline: `73e1f9abc`. No live media services, production database,
+reporter machine, or actual music files were used by these reproductions.
+
+## Reproduced before fixing
+
+| Path | Before | After |
+| --- | --- | --- |
+| Re-register 75 known artwork URLs | SQLite trace recorded 75 INSERT/upsert transactions | Zero repeated registrations within a 60-second coalescing window |
+| Stuck-download status recovery with a blocked filesystem finder | Another thread could not acquire the global task lock within 200 ms | Lock remains available and the status response returns while the finder is still blocked |
+| Manual import with a blocked processor | HTTP response could not complete while processing was blocked | Opt-in asynchronous POST returns 202 and a job ID while processing continues |
+
+The regression tests were run against the original behavior and failed on those
+specific assertions before their corresponding production fixes were applied.
+They use event-controlled I/O, rather than assuming a particular disk speed.
+These are proofs of blocking/extra work, not benchmarks of the reporter's system.
+
+## Changes and safeguards
+
+- File recovery has two background workers and at most two outstanding scans.
+  Repeated polls cannot duplicate a probe. Results are applied only if the same
+  task/attempt is still current; cancellation, retries, removal, and completion
+  supersede the scan. Failed post-processing submission restores a retryable
+  state instead of leaving a task stuck in Processing with no worker.
+- Artwork registration uses a bounded 4096-entry memo with a 60-second refresh.
+  Eviction and clear invalidate the memo; image serving still updates access
+  timestamps. First-time URL registration and actual image fetching retain
+  their existing behavior.
+- The browser opts into manual import jobs with `Prefer: respond-async` and an
+  idempotency key. Jobs are profile-owned, have two workers and a 16-job active
+  capacity, and retain results for one hour (maximum 1024 retained jobs).
+  Duplicate keys return the existing job; conflicting payloads are rejected.
+  Polling preserves existing HTTP errors, including the disconnected-server
+  signal that stops a batch. Synchronous API clients remain supported.
+- The frontend preserves the old long timeout for compatibility with old
+  servers. It does not automatically resubmit an uncertain POST to an old
+  server that may ignore idempotency keys. Its key generation works on HTTP LAN
+  origins, and polling retries transient network failures without resubmitting.
+
+## Scope and limitations
+
+These changes remove avoidable blocking and repeated writes. They do not make
+metadata providers, audio verification, or network storage intrinsically faster,
+and do not prove the exact cause of the reporter's twenty-minute processing wait.
+
+The separate hypothesis that cold artwork requests exhaust Gunicorn's request
+threads has not been reproduced with the real browser/server workload. No
+artwork-fetch admission, placeholder, or retry behavior was changed speculatively.
+
+Import jobs are in-process, matching the current single-worker deployment.
+A server restart loses job records; an unknown job returns an explicit error
+asking the caller to check imported files before resubmitting. This is not a
+persistent or restart-resumable job system. A stopped browser does not cancel an
+already accepted import.
+
+## Verification
+
+Deterministic reproductions and race/lifecycle coverage are in
+`tests/test_performance_1245.py`. Existing status tests now account for background
+recovery. The frontend import API tests cover job polling and failure delivery.
+
+A pre-existing failure was observed before any production edits:
+`tests/downloads/test_downloads_status.py::test_external_audiobook_progress_survives_music_timeout_and_serializes`
+expects `downloading` but receives `queued`. It remains outside this change.
+
+Final validation: the main affected backend run had 125 passes and the known
+baseline failure above; an adjacent status/post-processing/image-normalization
+run had 65 passes. These runs overlap in regression coverage and should not be
+added as a unique test count. All 18 frontend import tests passed. Ruff, targeted
+TypeScript lint/type checking, and git whitespace validation passed.

--- a/docs/performance-review-1245.md
+++ b/docs/performance-review-1245.md
@@ -1,0 +1,83 @@
+# Review of the five unpushed performance commits
+
+Reviewed range: `origin/dev..b4c0f1a51`, oldest first:
+
+- `a15e8fd51`: download recovery, image registration, asynchronous manual imports.
+- `808c09f14`: LRClib transport timeouts.
+- `734a07887`: Plex/video timeouts and offline caches.
+- `d684a3178`: watchdog heartbeat and metadata search deadline.
+- `b4c0f1a51`: slskd server endpoint compatibility.
+
+## Validated findings and corrections
+
+1. **P1: expired searches left unbounded provider workers behind.** Each request
+   created its own pool and returned without waiting for active work. Twelve
+   event-blocked requests left twelve workers running in the reproduction.
+   Searches now share eight workers, permit at most 24 running/queued provider
+   tasks, cancel queued work at expiry, and do not start fallback searches after
+   their deadline. Providers already inside blocking I/O cannot be forcibly
+   stopped; they retain their capacity slot until they finish.
+
+2. **P1: video status still had a 120-second read timeout.** `(8, 120)` limited
+   TCP connection time, not a server accepting TCP then failing to respond.
+   Constructor requests now have short connect AND read timeouts. Status uses
+   a separately cached short-timeout client; bulk scans retain the 120-second
+   read allowance after the initial handshake. This bounds individual network
+   operations, not the entire multi-request status handler.
+
+3. **P2: credential changes could reuse an old Plex connection or cached
+   failure.** Both keys used only six token characters. The regression changes
+   the token suffix while keeping the prefix and URL unchanged. Cache identity
+   now hashes the complete credentials. Cache timestamps start after connection
+   attempts finish, reconnects are serialized, and old-client failures cannot
+   invalidate a newer activity client.
+
+4. **P2: recovery could start after cancellation was already requested.** My
+   original identity check handled cancellation during I/O but not cancellation
+   present before scheduling. Such requests are now skipped.
+
+5. **P2: recovery rollback could overwrite a newer attempt.** If submission
+   raised after another attempt moved into Processing, the old rollback checked
+   only status and object identity. It now compares the exact processing attempt
+   before restoring state. The test reproduces a new attempt starting inside a
+   failed submission and verifies its state survives.
+
+6. **P2: cached Plex section state could report an already-finished scan as
+   active.** PlexAPI caches library sections on the server's Library object.
+   The reproduction changes a remote refreshing flag from true to false while
+   reusing the client; previously the result stayed true. The status path now
+   reloads library data before examining section flags.
+
+The first five regression cases (worker growth, status timeout, two credential
+cache cases, and already-requested cancellation) all failed before corrections.
+The retry rollback and stale-section reproductions were also run and failed
+before their respective fixes. Tests are in `tests/test_performance_review.py`.
+
+## Other commits
+
+The LRClib session injection addresses the missing transport timeout in both
+import processing and direct player lookups. The watchdog heartbeat reset
+prevents a prior run's timestamp being reused at launch. The slskd endpoint
+probe retains the requirement for network login before chat. No additional
+production changes were needed in those paths during this review.
+
+## Limits
+
+These changes do not demonstrate that every symptom in the supplied logs is
+resolved. Transport read timeouts are inactivity limits, not total deadlines;
+providers can still be slow. Import job state remains in-process and is lost on
+server restart, as documented in `docs/performance-1245.md`. The review does not
+claim a zero-regression guarantee or a live-production performance measurement.
+
+## Validation results
+
+- Broader backend review suite: **284 passed** (lyrics, watchdog/automation,
+  chat, import/recovery regressions, video APIs, source caches, activity, search).
+- Final focused rerun after the last correction: **74 passed**. This overlaps
+  the broader run; the numbers are not a unique combined test count.
+- Frontend import feature: **18 passed**.
+- Ruff and `git diff --check`: passed.
+
+Corrections are left uncommitted in the working tree; the five existing commits
+were not rewritten or pushed. Supplied logs and the unrelated release
+announcement were not modified.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,47 +1,79 @@
-# soulsync 3.3.3: `dev` → `main`
+# soulsync 3.4.0: `dev` → `main`
 
-chat that reaches people outside your install, smarter release parsing, self-hosted musicbrainz, and a discover pass.
+two new sides to the app, podcasts and audiobooks, and a settings page rebuilt from the ground up. plus ten reported fixes.
 
-## chat, beyond soulsync
+## podcasts
 
-messages go both ways with people who aren't running soulsync, and the history sticks around. overlay templates can be shared straight into a room, picked from a modal.
+a whole new section. search itunes, or paste an rss url straight into the search bar and it works out that's what you did. custom, patreon and private feeds are supported, and there's a proper OPML 2.0 import and export so you can bring your subscriptions over from whatever you were using, with a live checklist preview before anything subscribes.
 
-## release parsing
+browse, show detail with the full episode tracklist, and a player. episodes download through the existing downloads page with the existing cards, and show up in download history.
 
-reads the actual bitrate, sample rate and codec first and only falls back to the uploader's title, the way lidarr does. a repack wins the tie as the corrected copy. quality now survives the whole source pipeline, so a complete album can't fall back to a worse copy than one already found. lossless preview clips get caught on import. you can say which indexer you trust, and usenet results show the post age. built on #1224 from nick2000713.
+the watchlist auto-downloads new episodes, with retention settings so a daily show doesn't eat your disk. library path and organization templates are yours to set. downloaded episodes get rich metadata embedded plus sidecars for your media server, and there's a static mp4 conversion option so podcasts show up properly on media servers that only really do video.
 
-## self-hosted musicbrainz
+podcast downloads are isolated from the music worker pool and the music wishlist, so a feed with 400 episodes can't starve your album downloads.
 
-point soulsync at your own server, in settings under Connections.
+## audiobooks
 
-## concerts on the artist page
+audible's public catalog api is the metadata spine. search by keyword, title, author or narrator, and narrator search is the one nothing else can answer. series in reading order, per-genre charts, ratings distributions, sample audio. browse, detail, author and narrator pages on top of it.
 
-upcoming dates and real setlists, via ticketmaster.
+acquisition runs through prowlarr category 3030 and the shared torrent and usenet clients, plus soulseek. releases are explained and filtered before a download is spent, and results stream in as they arrive rather than making you wait for the slowest source.
 
-## video
+isolated from music by construction rather than by convention: its own sqlite file, its own download source chain (five of music's sources are streaming services with no audiobooks in them, so a book on the music chain would burn an attempt on each before it could succeed), and a test that parses the real imports, calls and routes of every audiobook module and fails if one reaches music state.
 
-detail page polish and movie sync fixes. the dashboard shows what's downloading right now with posters. continue watching reads your real resume position. torrent grabs track properly, a refused grab says why, seed removal is honoured in client mode, and EXT.to magnets resolve after selection.
+then the parts that make it a real side rather than a demo: quality profile for the whole side, blocklist where a failed download blocks the release it came from (without that the wishlist finds the same broken posting next pass, grabs it, fails, and loops forever), library scan, recycle bin, author watchlist and post-processing.
+
+the wishlist drains through the shared automation engine, so it can be paused, rescheduled or run by hand like everything else. it's a tab on the existing wishlist page rather than a second page.
+
+## settings, rebuilt
+
+22 services lived in two "API Configuration" groups as nested accordions. finding out whether last.fm was even configured meant scrolling a wall of chevrons and opening them one at a time. they're tiles now, with media tabs, and each one says whether it's configured without being opened.
+
+the forms are not rebuilt. a tile opens the real panel by moving the node into a modal and puts it back in the exact slot it came from. cloning would duplicate about 200 field ids, and on this page a duplicated id is how a save reads one element and writes another, which is how live prowlarr, torrent and usenet urls got blanked.
+
+every download source is on one Sources tab now, behind the tile it belongs to. the torrent client, the usenet client and prowlarr came over from the Downloads tab, and yt-dlp came over from Advanced, three tabs away from the youtube source it exists to serve. the download chain replaced the source dropdown and is one editor shared by music, video and audiobooks.
+
+the Library and Quality tabs were merged the same way. the Quality tab had two cards both called "Quality", the music profile and the video ladder, and nobody had noticed because the tab hid the music half on the video side, so the pair could never appear on screen together. hiding a collision doesn't remove it, it removes the evidence.
+
+underneath: one type scale for every text rule, one grammar for every row, and all 31 section toggles reachable by keyboard instead of mouse only.
+
+## youtube cookies
+
+"YouTube download source not available" with no reason to go on. the probe behind the Test button was hardcoded to return true, so the dot was green no matter what and every part of the cookie diagnosis work was unreachable from the button people actually press.
+
+with a real probe wired up, the actual error was one line: soulsync runs under wsl and looks for a linux chrome profile, but chrome is a windows install. browser cookie mode cannot work in that arrangement at all, same as docker, same as any headless box. it now says so, names app-bound encryption where that's the cause, marks the browsers that cannot work without breaking their config, and points at paste cookies.txt, which is the mode that works everywhere.
+
+## reverse proxy
+
+url base paths are supported, so soulsync can live at `/soulsync` behind a proxy instead of needing its own hostname.
+
+## profiles
+
+podcasts and audiobooks are under the profile system now. neither had been wired in, so both pages can be granted or denied per profile, audiobook wishlists and followed authors belong to the person who made them instead of everyone sharing profile 1's, and timed passes sweep every profile with rows rather than just the first.
+
+one real hole closed while doing it: the download permission check read the caller's own `X-Profile-Id` header, which let the caller vote on its own permissions. a restricted profile just omitted the header and the download went through. it reads from the session now.
+
+## reported fixes
+
+- **#1226** manual streaming redownload batches weren't monitored
+- **#1227** the download modal was unusable on narrow phones
+- **#1228** qbittorrent 5.0 renamed `pausedDL`/`pausedUP` to `stoppedDL`/`stoppedUP`, so paused torrents read as unknown, and the configured category was being overwritten by the default
+- **#1229** soulseek download status was looked up by filename as if it were a transfer id, so it always came back empty
+- **#1230** `escapeHtml` didn't escape a double quote, so a title containing one broke out of the attribute it was written into
+- **#1231** the library re-tag repair job reported no progress: the worker counted internally and never handed the count to the reporter
+- **#1232** jellyfin rejected the api key. it only ever got the legacy `X-Emby-Token` header and newer servers want the `Authorization: MediaBrowser` form. both are sent now, and a failed test says what the server actually answered instead of "connection failed"
+- **#1233** youtube cookies, above
+- **#1234** discovery crashed on open with "e.artists is not iterable". the enrich endpoint answers with a map keyed by artist id and the react port iterated it as a list. the loop ran inside a state updater, so react invoked it during render, past the try/catch meant to catch exactly this. the unit test mocked a list, a contract the server has never had, so it was green the whole time
+- **#1235** the bulk reorganize queue lived only in process memory. a gunicorn worker recycle took every queued album with it, silently: about 1,815 albums lost on one run while the job still logged "complete" and the status endpoint returned all zeros, leaving a library half in the old folder format and half in the new one. outstanding items are mirrored to a table now and the queue reloads whatever the previous process died holding
 
 ## discover
 
-play buttons on mix cards and track rows now play. playback is confirmed by the player before it's reported, so you know when audio actually started. a mix resolves against your library in one query instead of one per track, so it starts in about a second.
+stations and Because You Listen To were rebuilt. shelves repeated the same album under near-identical headings, and a station offered one click that started endless radio with nothing to inspect, download or sync. seed identity is a (provider, id) pair now, and the raw per-seed edges are read directly, because the grouped query was taking `MAX(source_artist_id)` and destroying every edge but one.
 
-hero controls sit in their own row on both pages, cards and dialogs work by keyboard and touch, and the taste dial is a real slider.
-
-on video: browsing keeps the newest search's results, a failed request says so instead of showing an empty shelf, and Not Interested removes every copy of a title with an Undo.
-
-## tools
-
-split into Tools and Operations. artist views are named Discography and Your library. "cleanup recommended" says what it means.
-
-## notifications
-
-ntfy and gotify are real actions now.
+mix durations and download metadata are preserved, shelves are compacter, and a station that fails says so.
 
 ## also
 
-- an error page shows the actual error with a copy button, so a report has something in it
-- play the album you own instead of downloading it
-- the upgrade backlog is sorted worst-first and folded to albums
-- self-service profile credentials, and switching login profiles asks for the password
-- less idle polling and fewer broad soulseek searches
+- the sidebar toggle says Audio instead of Music, with a headphones icon, because it covers three kinds of audio now
+- music videos and basic-search downloads appear on the Downloads page
+- video: client grabs stay out of soulseek retry searches, and stall timestamps are written in UTC
+- an updated media player queue design

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,79 +1,46 @@
-# soulsync 3.4.0: `dev` → `main`
+# SoulSync 3.4.1: `dev` → `main`
 
-two new sides to the app, podcasts and audiobooks, and a settings page rebuilt from the ground up. plus ten reported fixes.
+This release addresses long waits during download processing, manual imports and navigation, refreshes Discover, Watchlist and Settings, and improves audiobook library scanning and download tracking. Scope: commits since the `3.4.0` tag.
 
-## podcasts
+## Performance and reliability — #1245
 
-a whole new section. search itunes, or paste an rss url straight into the search bar and it works out that's what you did. custom, patreon and private feeds are supported, and there's a proper OPML 2.0 import and export so you can bring your subscriptions over from whatever you were using, with a live checklist preview before anything subscribes.
+- LRClib requests now have transport timeouts, so a stalled lyrics service cannot leave a request waiting indefinitely.
+- Manual imports use background jobs with progress polling and retry-safe submission. Existing synchronous callers remain supported.
+- Download file recovery runs outside the shared status lock with bounded work. Cancellation and newer download attempts are preserved during recovery and failed submission.
+- Repeated image URL registration is cached; dashboard rails use cached thumbnails and invalidate stale full-size responses.
+- Multi-source metadata searches return completed results within a deadline and use bounded shared worker capacity. Already-running provider calls can finish in the background without creating a new pool for every request.
+- Offline Plex connections are cached. Interactive video checks use short network timeouts while bulk operations retain longer reads. Credential changes invalidate cached connections, and scan checks refresh library state.
+- Database-update watchdogs receive an initial progress timestamp.
 
-browse, show detail with the full episode tracklist, and a player. episodes download through the existing downloads page with the existing cards, and show up in download history.
+These changes address specific blocking paths; they do not promise a fixed end-to-end processing time for every external service or installation.
 
-the watchlist auto-downloads new episodes, with retention settings so a daily show doesn't eat your disk. library path and organization templates are yours to set. downloaded episodes get rich metadata embedded plus sidecars for your media server, and there's a static mp4 conversion option so podcasts show up properly on media servers that only really do video.
+## Discover, Watchlist and Settings
 
-podcast downloads are isolated from the music worker pool and the music wishlist, so a feed with 400 episodes can't starve your album downloads.
+- Refreshed layouts, artwork, responsive spacing and controls across all three pages.
+- Deezer editorial playlists, all 28 genres, playlist search and visible sync handoff progress. Public browse requests no longer send an unnecessary access token.
+- Watchlist source matching reports progress on the page and automation card, and cancellation works during a long artist match (#1240).
+- Shared Folders and Organization cards retain music and video controls. Video Library settings load from either media side, with refined navigation, responsive forms and safe search.
+- Cross-page navigation keeps the sidebar selection in sync.
 
-## audiobooks
+## Audiobooks
 
-audible's public catalog api is the metadata spine. search by keyword, title, author or narrator, and narrator search is the one nothing else can answer. series in reading order, per-genre charts, ratings distributions, sample audio. browse, detail, author and narrator pages on top of it.
+- Index existing libraries and browse them in the rebuilt library view; the wishlist uses cover cards.
+- Match catalogue editions using file metadata and download provenance, with review controls for uncertain matches.
+- Report live client progress and status while keeping audiobook jobs outside music timeout handling.
+- Persist cancellation, match Soulseek filename references to peer transfers, reuse the Soulseek client, and move wishlist rows beyond “sent to downloads” as jobs finish.
 
-acquisition runs through prowlarr category 3030 and the shared torrent and usenet clients, plus soulseek. releases are explained and filtered before a download is spent, and results stream in as they arrive rather than making you wait for the slowest source.
+## Other fixes
 
-isolated from music by construction rather than by convention: its own sqlite file, its own download source chain (five of music's sources are streaming services with no audiobooks in them, so a book on the music chain would burn an attempt on each before it could succeed), and a test that parses the real imports, calls and routes of every audiobook module and fails if one reaches music state.
+- SoundCloud downloads are found and passed on for import and tagging (#1239).
+- Last.fm usernames can be corrected without stale import state (#1241).
+- Deezer import keeps the track ID used for the download instead of searching for a replacement.
+- Chat requires an active Soulseek login, guards send actions and preserves unsent drafts. Connection detection probes both slskd server endpoints.
+- Podcast fetches are guarded against unsafe destinations, and watchlist automation respects profile ownership.
+- Additional video library paths support libraries spread across drives.
 
-then the parts that make it a real side rather than a demo: quality profile for the whole side, blocklist where a failed download blocks the release it came from (without that the wishlist finds the same broken posting next pass, grabs it, fails, and loops forever), library scan, recycle bin, author watchlist and post-processing.
+## Validation
 
-the wishlist drains through the shared automation engine, so it can be paused, rescheduled or run by hand like everything else. it's a tab on the existing wishlist page rather than a second page.
-
-## settings, rebuilt
-
-22 services lived in two "API Configuration" groups as nested accordions. finding out whether last.fm was even configured meant scrolling a wall of chevrons and opening them one at a time. they're tiles now, with media tabs, and each one says whether it's configured without being opened.
-
-the forms are not rebuilt. a tile opens the real panel by moving the node into a modal and puts it back in the exact slot it came from. cloning would duplicate about 200 field ids, and on this page a duplicated id is how a save reads one element and writes another, which is how live prowlarr, torrent and usenet urls got blanked.
-
-every download source is on one Sources tab now, behind the tile it belongs to. the torrent client, the usenet client and prowlarr came over from the Downloads tab, and yt-dlp came over from Advanced, three tabs away from the youtube source it exists to serve. the download chain replaced the source dropdown and is one editor shared by music, video and audiobooks.
-
-the Library and Quality tabs were merged the same way. the Quality tab had two cards both called "Quality", the music profile and the video ladder, and nobody had noticed because the tab hid the music half on the video side, so the pair could never appear on screen together. hiding a collision doesn't remove it, it removes the evidence.
-
-underneath: one type scale for every text rule, one grammar for every row, and all 31 section toggles reachable by keyboard instead of mouse only.
-
-## youtube cookies
-
-"YouTube download source not available" with no reason to go on. the probe behind the Test button was hardcoded to return true, so the dot was green no matter what and every part of the cookie diagnosis work was unreachable from the button people actually press.
-
-with a real probe wired up, the actual error was one line: soulsync runs under wsl and looks for a linux chrome profile, but chrome is a windows install. browser cookie mode cannot work in that arrangement at all, same as docker, same as any headless box. it now says so, names app-bound encryption where that's the cause, marks the browsers that cannot work without breaking their config, and points at paste cookies.txt, which is the mode that works everywhere.
-
-## reverse proxy
-
-url base paths are supported, so soulsync can live at `/soulsync` behind a proxy instead of needing its own hostname.
-
-## profiles
-
-podcasts and audiobooks are under the profile system now. neither had been wired in, so both pages can be granted or denied per profile, audiobook wishlists and followed authors belong to the person who made them instead of everyone sharing profile 1's, and timed passes sweep every profile with rows rather than just the first.
-
-one real hole closed while doing it: the download permission check read the caller's own `X-Profile-Id` header, which let the caller vote on its own permissions. a restricted profile just omitted the header and the download went through. it reads from the session now.
-
-## reported fixes
-
-- **#1226** manual streaming redownload batches weren't monitored
-- **#1227** the download modal was unusable on narrow phones
-- **#1228** qbittorrent 5.0 renamed `pausedDL`/`pausedUP` to `stoppedDL`/`stoppedUP`, so paused torrents read as unknown, and the configured category was being overwritten by the default
-- **#1229** soulseek download status was looked up by filename as if it were a transfer id, so it always came back empty
-- **#1230** `escapeHtml` didn't escape a double quote, so a title containing one broke out of the attribute it was written into
-- **#1231** the library re-tag repair job reported no progress: the worker counted internally and never handed the count to the reporter
-- **#1232** jellyfin rejected the api key. it only ever got the legacy `X-Emby-Token` header and newer servers want the `Authorization: MediaBrowser` form. both are sent now, and a failed test says what the server actually answered instead of "connection failed"
-- **#1233** youtube cookies, above
-- **#1234** discovery crashed on open with "e.artists is not iterable". the enrich endpoint answers with a map keyed by artist id and the react port iterated it as a list. the loop ran inside a state updater, so react invoked it during render, past the try/catch meant to catch exactly this. the unit test mocked a list, a contract the server has never had, so it was green the whole time
-- **#1235** the bulk reorganize queue lived only in process memory. a gunicorn worker recycle took every queued album with it, silently: about 1,815 albums lost on one run while the job still logged "complete" and the status endpoint returned all zeros, leaving a library half in the old folder format and half in the new one. outstanding items are mirrored to a table now and the queue reloads whatever the previous process died holding
-
-## discover
-
-stations and Because You Listen To were rebuilt. shelves repeated the same album under near-identical headings, and a station offered one click that started endless radio with nothing to inspect, download or sync. seed identity is a (provider, id) pair now, and the raw per-seed edges are read directly, because the grouped query was taking `MAX(source_artist_id)` and destroying every edge but one.
-
-mix durations and download metadata are preserved, shelves are compacter, and a station that fails says so.
-
-## also
-
-- the sidebar toggle says Audio instead of Music, with a headphones icon, because it covers three kinds of audio now
-- music videos and basic-search downloads appear on the Downloads page
-- video: client grabs stay out of soulseek retry searches, and stall timestamps are written in UTC
-- an updated media player queue design
+- Performance review: 284 backend tests passed, followed by 74 focused tests after the final correction; 18 frontend import tests passed.
+- Audiobook inventory lint correction: 69 library tests passed.
+- Updated regression contracts: 205 affected tests and 109 audiobook state/monitor tests passed. Repository-wide lint and diff checks passed.
+- The supplied full CI run had six failures and 18,487 passes. All six failing cases are covered by the corrected targeted runs; the full suite has not been rerun locally.

--- a/tests/automation/test_handlers_maintenance.py
+++ b/tests/automation/test_handlers_maintenance.py
@@ -159,12 +159,78 @@ class TestDatabaseUpdate:
         assert result['status'] == 'completed'
 
 
+    def test_auto_start_database_update_resets_last_progress_at_heartbeat(self):
+        # A stale last_progress_at from the prior hour must be updated
+        # to now upon launch so the watchdog does not falsely declare
+        # a stall at second 0 (#859).
+        import time
+        from core.database_update_health import is_db_update_stalled
+
+        old_epoch = time.time() - 3600
+        state = {'status': 'idle', 'last_progress_at': old_epoch}
+        executor = _StubExecutor()
+
+        def fake_task(*_a, **_k):
+            # Check state while the task is supposedly running
+            assert state['status'] == 'running'
+            assert state['last_progress_at'] > old_epoch
+            assert abs(state['last_progress_at'] - time.time()) < 5.0
+            assert is_db_update_stalled(state, time.time()) is False
+            state['status'] = 'finished'
+
+        executor.submit = lambda fn, *a, **k: fake_task()
+        deps = _build_deps(
+            get_db_update_state=lambda: state,
+            db_update_executor=executor,
+            run_db_update_task=fake_task,
+        )
+        import core.automation.handlers.database_update as module
+        original = module.time.sleep
+        module.time.sleep = lambda _: None
+        try:
+            result = auto_start_database_update({'_automation_id': 'auto-hb'}, deps)
+        finally:
+            module.time.sleep = original
+        assert result['status'] == 'completed'
+        assert state['last_progress_at'] > old_epoch
+
+
 class TestDeepScan:
     def test_already_running_returns_skipped(self):
         state = {'status': 'running'}
         deps = _build_deps(get_db_update_state=lambda: state)
         result = auto_deep_scan_library({}, deps)
         assert result == {'status': 'skipped', 'reason': 'Database update already running'}
+
+    def test_auto_deep_scan_resets_last_progress_at_heartbeat(self):
+        import time
+        from core.database_update_health import is_db_update_stalled
+
+        old_epoch = time.time() - 3600
+        state = {'status': 'idle', 'last_progress_at': old_epoch}
+        executor = _StubExecutor()
+
+        def fake_task(*_a, **_k):
+            assert state['status'] == 'running'
+            assert state['last_progress_at'] > old_epoch
+            assert is_db_update_stalled(state, time.time()) is False
+            state['status'] = 'finished'
+
+        executor.submit = lambda fn, *a, **k: fake_task()
+        deps = _build_deps(
+            get_db_update_state=lambda: state,
+            db_update_executor=executor,
+            run_deep_scan_task=fake_task,
+        )
+        import core.automation.handlers.database_update as module
+        original = module.time.sleep
+        module.time.sleep = lambda _: None
+        try:
+            result = auto_deep_scan_library({'_automation_id': 'auto-deep-hb'}, deps)
+        finally:
+            module.time.sleep = original
+        assert result['status'] == 'completed'
+        assert state['last_progress_at'] > old_epoch
 
 
 # ─── duplicate_cleaner ────────────────────────────────────────────────

--- a/tests/downloads/test_downloads_status.py
+++ b/tests/downloads/test_downloads_status.py
@@ -971,3 +971,21 @@ def test_manual_pick_rejected_fails_immediately_without_grace():
     out = st.build_batch_status_data('b1', batch, live, deps)
     assert out['tasks'][0]['status'] == 'failed'  # immediate, no 60s wait
     assert download_tasks['t1']['status'] == 'failed'
+
+
+def test_external_audiobook_progress_survives_music_timeout_and_serializes():
+    import time
+    from core.audiobook_download_state import register_download, update_progress, BATCH_ID
+    register_download('book', 'Rhythm of War', protocol='soulseek')
+    download_tasks['book']['status_change_time'] = time.time() - 3600
+    update_progress('book', percent=37.5, bytes_done=375000, bytes_total=1000000, speed=25000)
+    deps, submitted = _build_deps()
+    result = st.build_batch_status_data(BATCH_ID, download_batches[BATCH_ID], {}, deps)
+    assert result['tasks'][0]['progress'] == 37.5
+    assert result['tasks'][0]['status'] == 'downloading'
+    assert download_tasks['book']['error_message'] is None
+    assert submitted == []
+    unified = st.build_unified_downloads_response(20, deps)
+    row = next(item for item in unified['downloads'] if item['task_id'] == 'book')
+    assert row['progress'] == 37.5
+    assert row['status'] == 'downloading'

--- a/tests/downloads/test_downloads_status.py
+++ b/tests/downloads/test_downloads_status.py
@@ -469,7 +469,11 @@ def test_safety_valve_stuck_searching_marks_not_found():
     assert 'Search stuck' in download_tasks['t1']['error_message']
 
 
-def test_safety_valve_stuck_downloading_with_recovered_file_routes_to_post_processing():
+def test_safety_valve_stuck_downloading_with_recovered_file_routes_to_post_processing(monkeypatch):
+    # This unit test calls the formatter without its HTTP lock. Execute the
+    # recovery inline; threaded HTTP/cancellation coverage lives in #1245 tests.
+    from types import SimpleNamespace
+    monkeypatch.setattr(st, '_recovery_pool', SimpleNamespace(submit=lambda fn: fn()))
     deps, submitted = _build_deps(
         config=_FakeConfig({'soulseek.download_timeout': 1, 'soulseek.download_path': '/d', 'soulseek.transfer_path': '/t'}),
         find_completed=lambda *a, **kw: ('/found.flac', 'transfer'),
@@ -485,7 +489,11 @@ def test_safety_valve_stuck_downloading_with_recovered_file_routes_to_post_proce
     assert submitted == [('t1', 'b1')]
 
 
-def test_safety_valve_stuck_downloading_no_file_marks_failed():
+def test_safety_valve_stuck_downloading_no_file_marks_failed(monkeypatch):
+    # This unit test calls the formatter without its HTTP lock. Execute the
+    # recovery inline; threaded HTTP/cancellation coverage lives in #1245 tests.
+    from types import SimpleNamespace
+    monkeypatch.setattr(st, '_recovery_pool', SimpleNamespace(submit=lambda fn: fn()))
     deps, _ = _build_deps(config=_FakeConfig({'soulseek.download_timeout': 1}))
     download_tasks['t1'] = {
         'track_index': 0, 'status': 'downloading', 'track_info': {},

--- a/tests/downloads/test_downloads_status.py
+++ b/tests/downloads/test_downloads_status.py
@@ -983,8 +983,10 @@ def test_manual_pick_rejected_fails_immediately_without_grace():
 
 def test_external_audiobook_progress_survives_music_timeout_and_serializes():
     import time
-    from core.audiobook_download_state import register_download, update_progress, BATCH_ID
+    from core.audiobook_download_state import register_download, update_progress, mark_status, BATCH_ID
     register_download('book', 'Rhythm of War', protocol='soulseek')
+    # The monitor sets status separately from transfer counters.
+    mark_status('book', 'downloading')
     download_tasks['book']['status_change_time'] = time.time() - 3600
     update_progress('book', percent=37.5, bytes_done=375000, bytes_total=1000000, speed=25000)
     deps, submitted = _build_deps()

--- a/tests/downloads/test_file_finder_encoded_names.py
+++ b/tests/downloads/test_file_finder_encoded_names.py
@@ -1,0 +1,85 @@
+"""The finder has to read a source's dispatch key, not guess at it.
+
+A streaming source does not hand over a path. It encodes what its worker needs
+to start the download, and the finder wants only the human-readable tail so it
+can match the file that actually landed on disk.
+
+Most sources encode two parts, ``id||name``. SoundCloud encodes three,
+``id||url||name``, because its worker needs the permalink. The finder read
+everything after the FIRST separator, so for a SoundCloud track it went looking
+for a file called ``https://soundcloud.com/...||SSIO - Alles oder Nix``.
+
+Nothing is called that. The file was never found, so post-processing never ran:
+no tags were written and the file stayed in the completed folder, while the
+download reported success (#1239).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.downloads.file_finder import _encoded_display_name, _extract_basename
+
+SOUNDCLOUD = ("2093480||https://soundcloud.com/probst-jakob/ssio-alles-oder-nix-x-acdc"
+              "||SSIO - Alles oder Nix x ACDC")
+
+
+def test_a_soundcloud_key_yields_the_name_that_is_on_disk():
+    assert _encoded_display_name(SOUNDCLOUD) == "SSIO - Alles oder Nix x ACDC"
+
+
+def test_the_url_never_reaches_the_search_target():
+    """The whole failure: a url in the middle became part of what we looked for."""
+    assert "soundcloud.com" not in (_encoded_display_name(SOUNDCLOUD) or "")
+    assert "||" not in (_encoded_display_name(SOUNDCLOUD) or "")
+
+
+@pytest.mark.parametrize("key,expected", [
+    ("dQw4w9WgXcQ||Rick Astley - Never Gonna Give You Up",
+     "Rick Astley - Never Gonna Give You Up"),          # youtube
+    ("434945950||Aphex Twin - Xtal", "Aphex Twin - Xtal"),   # tidal
+    ("12345||Artist - Title", "Artist - Title"),             # qobuz / hifi / deezer
+])
+def test_two_part_keys_read_exactly_as_before(key, expected):
+    assert _encoded_display_name(key) == expected
+
+
+def test_a_title_containing_a_slash_is_not_a_path(   ):
+    """#835. A '/' in a title is part of the title, not a directory.
+
+    Splitting on it truncated the target to 'T:T' and quarantined good files.
+    """
+    assert _encoded_display_name("abc||YouSeeBIGGIRL/T:T") == "YouSeeBIGGIRL/T:T"
+
+
+def test_a_title_containing_pipes_is_left_alone():
+    """The three-part shape is recognised by its url, not by counting parts.
+
+    Counting would make 'abc||A || B' look like a soundcloud key and truncate
+    the title to 'B'.
+    """
+    assert _encoded_display_name("abc||A || B") == "A || B"
+
+
+@pytest.mark.parametrize("not_encoded", [
+    "music/Artist/Album/01 - Song.flac",
+    "01 - Song.flac",
+    "",
+    None,
+])
+def test_a_real_remote_path_is_not_an_encoded_key(not_encoded):
+    """None sends the caller down the path-handling branch, as before."""
+    assert _encoded_display_name(not_encoded) is None
+
+
+def test_a_middle_part_that_is_not_a_url_is_not_treated_as_soundcloud():
+    assert _encoded_display_name("id||notaurl||name") == "notaurl||name"
+
+
+def test_the_helper_and_the_live_path_agree():
+    """_extract_basename used its own copy of this parse and disagreed.
+
+    Two readings of one format is how the finder ended up looking for a url.
+    """
+    assert _extract_basename(SOUNDCLOUD) == _encoded_display_name(SOUNDCLOUD)
+    assert _extract_basename("abc||Title") == _encoded_display_name("abc||Title")

--- a/tests/listening_import/test_lastfm_import.py
+++ b/tests/listening_import/test_lastfm_import.py
@@ -308,3 +308,47 @@ def test_lastfm_status_normalizes_false_complete_even_when_backfill_flag_was_set
     assert state["progress"] == 1
     assert state["last_success_at"] is None
 
+
+
+def test_corrected_username_does_not_reuse_old_accounts_cursor(tmp_path, monkeypatch):
+    import json
+    import core.listening_import.lastfm as module
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    db.set_metadata("lastfm_listening_import_state", json.dumps({
+        "username": "k", "status": "complete", "backfill_complete": True,
+        "last_imported_ts": 999999, "page": 3, "total_pages": 3,
+    }))
+    calls = []
+    class Client:
+        def __init__(self, **kwargs):
+            pass
+        def get_user_recent_tracks(self, username, **kwargs):
+            calls.append((username, kwargs["page"], kwargs["from_ts"]))
+            return _recent_tracks_payload(page=1, total_pages=1, uts_values=[100])
+    monkeypatch.setattr(module, "LastFMClient", Client)
+    state = LastFMListeningImportWorker(db, _Config()).run_once(username="corrected")
+    assert state["status"] == "complete"
+    assert calls == [("corrected", 1, None)]
+    assert state["last_imported_ts"] == 100
+
+
+def test_failed_corrected_account_does_not_keep_old_pending_cursor(tmp_path, monkeypatch):
+    import json
+    import core.listening_import.lastfm as module
+    db = MusicDatabase(str(tmp_path / "music.db"))
+    db.set_metadata("lastfm_listening_import_state", json.dumps({
+        "username": "k", "status": "error", "pending_last_imported_ts": 999999,
+        "last_imported_ts": 999999, "page": 2, "total_pages": 3,
+    }))
+    class Client:
+        def __init__(self, **kwargs):
+            pass
+        def get_user_recent_tracks(self, username, **kwargs):
+            raise RuntimeError("Account unavailable")
+    monkeypatch.setattr(module, "LastFMClient", Client)
+    monkeypatch.setattr(module, "TRANSIENT_PAGE_RETRIES", 1)
+    state = LastFMListeningImportWorker(db, _Config()).run_once(username="corrected")
+    assert state["status"] == "error"
+    assert state["username"] == "corrected"
+    assert not state.get("last_imported_ts")
+    assert not state.get("pending_last_imported_ts")

--- a/tests/metadata/test_deezer_provenance.py
+++ b/tests/metadata/test_deezer_provenance.py
@@ -1,0 +1,358 @@
+"""A deezer download already knows which deezer track it is.
+
+Enrichment used to work that out again by text search: search_track(artist,
+title) takes the FIRST hit of a query and both names then have to clear
+_names_match. For a remix, a mashup or a differently credited artist that misses,
+and the result was no DEEZER_TRACK_ID at all - on a track that had just been
+downloaded from deezer, by id.
+
+The id rides along on the search result as _source_metadata and reaches the
+import context through candidate.__dict__, which is the same path tidal and hifi
+already use for theirs.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from core.metadata import source as ms
+
+
+class _Config:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+class _DzClient:
+    """Records what it was asked, so a test can prove a call did NOT happen."""
+
+    def __init__(self, search_result=None, details=None):
+        self.search_result = search_result
+        self.details = details or {}
+        self.search_calls = []
+        self.detail_calls = []
+
+    def search_track(self, artist_name, track_title):
+        self.search_calls.append((artist_name, track_title))
+        return self.search_result
+
+    def get_track_details(self, track_id):
+        self.detail_calls.append(str(track_id))
+        return self.details
+
+
+def _runtime(client):
+    return types.SimpleNamespace(deezer_worker=types.SimpleNamespace(client=client))
+
+
+def _pp():
+    return {"id_tags": {}, "release_year": None, "deezer_bpm": None, "deezer_isrc": None}
+
+
+DEEZER_PROV = {"source": "deezer", "track_id": "498543342", "artist_id": "14069",
+               "album_id": "77", "": None}
+
+
+# ---------------------------------------------------------------------------
+# the fact beats the guess
+# ---------------------------------------------------------------------------
+
+def test_a_known_track_id_is_used_without_searching():
+    client = _DzClient(details={"bpm": 128, "isrc": "USX123456789"})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Revolution 09 (Final Cut Pro Mix)", "Gene Farris",
+                              provenance=DEEZER_PROV)
+
+    assert pp["id_tags"]["DEEZER_TRACK_ID"] == "498543342"
+    assert pp["id_tags"]["DEEZER_ARTIST_ID"] == "14069"
+    assert client.search_calls == [], "it already knew the id; it must not search"
+    assert client.detail_calls == ["498543342"]
+    assert pp["deezer_bpm"] == 128
+    assert pp["deezer_isrc"] == "USX123456789"
+
+
+def test_the_remix_that_used_to_lose_its_id():
+    """The whole point. A title the fuzzy gate rejects still gets its id.
+
+    Left to search_track, this returns some other track, _names_match refuses
+    it, and nothing at all is embedded.
+    """
+    wrong_hit = {"id": 99, "title": "Revolution", "artist": {"name": "Someone Else", "id": 1}}
+    client = _DzClient(search_result=wrong_hit, details={})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Revolution 09 (Final Cut Pro Mix)", "Gene Farris",
+                              provenance=DEEZER_PROV)
+
+    assert pp["id_tags"]["DEEZER_TRACK_ID"] == "498543342"
+    assert client.search_calls == []
+
+
+def test_without_provenance_it_searches_exactly_as_before():
+    hit = {"id": 555, "title": "Song One", "artist": {"name": "Artist One", "id": 7},
+           "album": {"release_date": "2001-05-04"}}
+    client = _DzClient(search_result=hit, details={"bpm": 100})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Song One", "Artist One")
+
+    assert client.search_calls == [("Artist One", "Song One")]
+    assert pp["id_tags"]["DEEZER_TRACK_ID"] == "555"
+    assert pp["id_tags"]["DEEZER_ARTIST_ID"] == "7"
+    assert pp["release_year"] == "2001"
+
+
+def test_a_search_the_fuzzy_gate_rejects_still_embeds_nothing():
+    """Unchanged behaviour on the no-provenance path: a bad hit is refused."""
+    wrong_hit = {"id": 99, "title": "Something Else", "artist": {"name": "Nobody", "id": 1}}
+    client = _DzClient(search_result=wrong_hit)
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Song One", "Artist One")
+
+    assert pp["id_tags"] == {}
+
+
+# ---------------------------------------------------------------------------
+# provenance from somewhere else is not deezer's
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("provenance", [
+    {"source": "tidal", "track_id": "434945950"},
+    {"source": "hifi", "track_id": "1"},
+    {"source": "soundcloud", "track_id": "2"},
+    {"source": "deezer"},                      # deezer, but no id
+    {"track_id": "3"},                         # id, but no source
+    {},
+    None,
+    "not-a-dict",
+])
+def test_only_a_deezer_id_is_trusted(provenance):
+    """A tidal id handed to deezer would be a wrong answer, not a shortcut."""
+    hit = {"id": 555, "title": "Song One", "artist": {"name": "Artist One", "id": 7}}
+    client = _DzClient(search_result=hit)
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Song One", "Artist One", provenance=provenance)
+
+    assert client.search_calls == [("Artist One", "Song One")], (
+        "anything that is not a deezer track id must fall back to searching"
+    )
+    assert pp["id_tags"]["DEEZER_TRACK_ID"] == "555"
+
+
+def test_the_helper_reads_only_deezer_ids():
+    assert ms._deezer_provenance_id({"source": "deezer", "track_id": "9"}) == "9"
+    assert ms._deezer_provenance_id({"source": "DEEZER", "track_id": "9"}) == "9"
+    assert ms._deezer_provenance_id({"source": "tidal", "track_id": "9"}) == ""
+    assert ms._deezer_provenance_id({"source": "deezer"}) == ""
+    assert ms._deezer_provenance_id(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# the rest of the handler still behaves
+# ---------------------------------------------------------------------------
+
+def test_release_year_comes_off_the_details_call_on_the_id_path():
+    client = _DzClient(details={"album": {"release_date": "2009-08-01"}})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "T", "A", provenance=DEEZER_PROV)
+
+    assert pp["release_year"] == "2009"
+
+
+def test_a_release_year_already_found_is_not_overwritten():
+    client = _DzClient(details={"album": {"release_date": "2009-08-01"}})
+    pp = _pp()
+    pp["release_year"] = "1999"
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "T", "A", provenance=DEEZER_PROV)
+
+    assert pp["release_year"] == "1999"
+
+
+def test_embed_tags_off_still_wins_over_provenance():
+    client = _DzClient()
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": False}), _runtime(client),
+                              "T", "A", provenance=DEEZER_PROV)
+
+    assert pp["id_tags"] == {}
+    assert client.detail_calls == []
+
+
+def test_no_client_is_a_quiet_no_op():
+    pp = _pp()
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}),
+                              types.SimpleNamespace(deezer_worker=None), "T", "A",
+                              provenance=DEEZER_PROV)
+    assert pp["id_tags"] == {}
+
+
+def test_a_missing_title_no_longer_blocks_a_known_id():
+    """The old guard returned early without a title. With an id in hand there is
+    nothing to search for, so a thin title must not throw the id away."""
+    client = _DzClient(details={})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "", "", provenance=DEEZER_PROV)
+
+    assert pp["id_tags"]["DEEZER_TRACK_ID"] == "498543342"
+
+
+def test_programmer_errors_still_surface():
+    class _Boom:
+        def search_track(self, *_a):
+            raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        ms._process_deezer_source(_pp(), {}, _Config({"deezer.embed_tags": True}),
+                                  _runtime(_Boom()), "Song One", "Artist One")
+
+
+# ---------------------------------------------------------------------------
+# the stamp itself, and the path it travels
+# ---------------------------------------------------------------------------
+
+def test_a_deezer_search_result_carries_the_ids(monkeypatch):
+    """Without this stamp there is nothing for enrichment to trust."""
+    import core.deezer_download_client as ddc
+
+    payload = {"data": [{
+        "id": 498543342,
+        "title": "Revolution 09 (Final Cut Pro Mix)",
+        "duration": 353,
+        "artist": {"id": 14069, "name": "Gene Farris"},
+        "album": {"id": 77, "title": "Revolution 09"},
+        "track_position": 4,
+    }]}
+
+    class _Resp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return payload
+
+    client = ddc.DeezerDownloadClient.__new__(ddc.DeezerDownloadClient)
+    client._authenticated = True
+    client._session = types.SimpleNamespace(get=lambda *a, **k: _Resp())
+    client._config = types.SimpleNamespace(get=lambda *a, **k: None)
+    client._quality = "flac"
+
+    results, _albums = client._search_sync("gene farris revolution")
+
+    assert len(results) == 1
+    meta = results[0]._source_metadata
+    assert meta["source"] == "deezer"
+    assert meta["track_id"] == "498543342"
+    assert meta["artist_id"] == "14069"
+    assert meta["album_id"] == "77"
+
+
+def test_the_stamp_survives_into_the_download_payload():
+    """candidate.__dict__ is how it reaches the import context.
+
+    core/downloads/candidates.py builds the payload as ``candidate.__dict__``
+    and copies it into ``original_search_result``, which is where enrichment
+    reads ``_source_metadata`` back out. If TrackResult ever stops carrying it
+    as a plain attribute, every source's provenance goes quiet at once.
+    """
+    from core.download_plugins.types import TrackResult
+
+    tr = TrackResult(
+        username="deezer_dl", filename="498543342||Gene Farris - Revolution 09",
+        size=1, bitrate=1411, duration=1000, quality="flac",
+        free_upload_slots=1, upload_speed=1, queue_length=0,
+        artist="Gene Farris", title="Revolution 09",
+        _source_metadata={"source": "deezer", "track_id": "498543342"},
+    )
+
+    payload = tr.__dict__
+    assert payload["_source_metadata"]["track_id"] == "498543342"
+
+    original_search_result = payload.copy()
+    from core.imports.context import get_import_original_search
+    context = {"original_search_result": original_search_result}
+    assert get_import_original_search(context).get("_source_metadata", {}).get("source") == "deezer"
+
+
+# ---------------------------------------------------------------------------
+# the old path must stay the old path
+# ---------------------------------------------------------------------------
+
+class _Recorder(_DzClient):
+    """Records the ORDER of api calls, not just that they happened."""
+
+    def __init__(self, search_result=None, details=None):
+        super().__init__(search_result, details)
+        self.calls = []
+
+    def search_track(self, artist_name, track_title):
+        self.calls.append(("search", artist_name, track_title))
+        return super().search_track(artist_name, track_title)
+
+    def get_track_details(self, track_id):
+        self.calls.append(("details", str(track_id)))
+        return super().get_track_details(track_id)
+
+
+_GOOD_HIT = {"id": 555, "title": "Song One", "artist": {"name": "Artist One", "id": 7},
+             "album": {"release_date": "2001-05-04"}}
+
+
+@pytest.mark.parametrize("hit,details,title,artist,enabled,expected_calls", [
+    (_GOOD_HIT, {"bpm": 100}, "Song One", "Artist One", True,
+     [("search", "Artist One", "Song One"), ("details", "555")]),
+    ({"id": 9, "title": "Nope", "artist": {"name": "Other", "id": 1}}, {},
+     "Song One", "Artist One", True, [("search", "Artist One", "Song One")]),
+    (None, {}, "Song One", "Artist One", True, [("search", "Artist One", "Song One")]),
+    (_GOOD_HIT, {}, "", "Artist One", True, []),
+    (_GOOD_HIT, {}, "Song One", "", True, []),
+    (_GOOD_HIT, {}, "Song One", "Artist One", False, []),
+])
+def test_the_no_provenance_path_makes_exactly_the_calls_it_always_made(
+        hit, details, title, artist, enabled, expected_calls):
+    """Provenance is additive: with none, this is the pre-existing function.
+
+    Pinned as a call SEQUENCE because that is what a refactor silently changes -
+    an extra lookup here is somebody else's rate limit. Verified against the
+    pre-change implementation, which produced these exact sequences.
+    """
+    client = _Recorder(hit, details)
+    ms._process_deezer_source(_pp(), {}, _Config({"deezer.embed_tags": enabled}),
+                              _runtime(client), title, artist)
+    assert client.calls == expected_calls
+
+
+def test_the_release_year_fallback_is_not_widened_for_the_search_path():
+    """The details call carries an album too, but the search path must not start
+    reading it - that would be a new behaviour on the path that runs for every
+    non-deezer download."""
+    hit_without_album = {"id": 5, "title": "Song One", "artist": {"name": "Artist One", "id": 7}}
+    client = _DzClient(search_result=hit_without_album,
+                       details={"album": {"release_date": "1999-01-01"}})
+    pp = _pp()
+
+    ms._process_deezer_source(pp, {}, _Config({"deezer.embed_tags": True}), _runtime(client),
+                              "Song One", "Artist One")
+
+    assert pp["release_year"] is None, "search path started using the details album"

--- a/tests/metadata/test_multi_source_search.py
+++ b/tests/metadata/test_multi_source_search.py
@@ -1,0 +1,114 @@
+"""Unit tests for multi-source parallel metadata search and timeout enforcement."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import List
+
+from core.metadata.multi_source_search import (
+    TrackQuery,
+    search_all_sources,
+)
+
+
+@dataclass
+class _DummyTrack:
+    id: str
+    name: str
+    artists: List[str]
+    album: str = "Test Album"
+    duration_ms: int = 180000
+    image_url: str = "http://example.com/art.jpg"
+
+
+class _FastClient:
+    def __init__(self, tracks: List[_DummyTrack]):
+        self.tracks = tracks
+
+    def search_tracks(self, query: str, limit: int = 10):
+        return self.tracks
+
+
+class _HangingClient:
+    def __init__(self, delay_seconds: float = 3.0):
+        self.delay_seconds = delay_seconds
+
+    def search_tracks(self, query: str, limit: int = 10):
+        time.sleep(self.delay_seconds)
+        return [_DummyTrack(id="slow-1", name="Slow Track", artists=["Slow Artist"])]
+
+
+def test_search_all_sources_fast_completion():
+    query = TrackQuery(title="Come Together", artist="The Beatles", duration_ms=259000)
+    spotify_track = _DummyTrack(id="sp-1", name="Come Together", artists=["The Beatles"], duration_ms=259000)
+    itunes_track = _DummyTrack(id="it-1", name="Come Together", artists=["The Beatles"], duration_ms=258000)
+
+    sources = [
+        ("spotify", _FastClient([spotify_track])),
+        ("itunes", _FastClient([itunes_track])),
+    ]
+
+    result = search_all_sources(query, sources, timeout_seconds=5.0)
+
+    assert "spotify" in result.metadata_results
+    assert "itunes" in result.metadata_results
+    assert len(result.metadata_results["spotify"]) == 1
+    assert len(result.metadata_results["itunes"]) == 1
+    assert result.best_match is not None
+    assert result.best_match["source"] in ("spotify", "itunes")
+
+
+def test_search_all_sources_timeout_omits_slow_source_gracefully():
+    query = TrackQuery(title="Come Together", artist="The Beatles", duration_ms=259000)
+    fast_track = _DummyTrack(id="sp-1", name="Come Together", artists=["The Beatles"], duration_ms=259000)
+
+    sources = [
+        ("spotify", _FastClient([fast_track])),
+        ("slow_provider", _HangingClient(delay_seconds=3.0)),
+    ]
+
+    t0 = time.time()
+    result = search_all_sources(query, sources, timeout_seconds=0.3)
+    elapsed = time.time() - t0
+
+    # Ensure function did not wait for the 3.0s hanging client
+    assert elapsed < 1.0, f"Search took {elapsed:.2f}s; expected < 1.0s"
+
+    # Fast source returned results
+    assert len(result.metadata_results["spotify"]) == 1
+    assert result.metadata_results["spotify"][0]["id"] == "sp-1"
+
+    # Slow source timed out and has empty results list, NOT missing key
+    assert "slow_provider" in result.metadata_results
+    assert result.metadata_results["slow_provider"] == []
+    assert result.raw_tracks["slow_provider"] == []
+
+    # Best match correctly chosen from completed provider
+    assert result.best_match is not None
+    assert result.best_match["source"] == "spotify"
+
+
+def test_search_all_sources_all_slow_returns_empty_results():
+    query = TrackQuery(title="Song", artist="Artist")
+    sources = [
+        ("slow_1", _HangingClient(delay_seconds=2.0)),
+        ("slow_2", _HangingClient(delay_seconds=2.0)),
+    ]
+
+    t0 = time.time()
+    result = search_all_sources(query, sources, timeout_seconds=0.2)
+    elapsed = time.time() - t0
+
+    assert elapsed < 0.8
+    assert result.metadata_results["slow_1"] == []
+    assert result.metadata_results["slow_2"] == []
+    assert result.best_match is None
+
+
+def test_search_all_sources_empty_sources():
+    query = TrackQuery(title="Song", artist="Artist")
+    result = search_all_sources(query, [])
+    assert result.metadata_results == {}
+    assert result.raw_tracks == {}
+    assert result.best_match is None

--- a/tests/test_audiobook_database.py
+++ b/tests/test_audiobook_database.py
@@ -68,7 +68,7 @@ def test_the_schema_holds_only_audiobook_tables(db):
     }
     assert tables == {
         "audiobook_wishlist", "audiobook_downloads",
-        "audiobook_library", "audiobook_watchlist", "audiobook_library_scan_state",
+        "audiobook_library", "audiobook_watchlist", "audiobook_library_scan_state", "audiobook_library_file_cache",
         "audiobook_blocklist",
     }
 

--- a/tests/test_audiobook_database.py
+++ b/tests/test_audiobook_database.py
@@ -68,7 +68,7 @@ def test_the_schema_holds_only_audiobook_tables(db):
     }
     assert tables == {
         "audiobook_wishlist", "audiobook_downloads",
-        "audiobook_library", "audiobook_watchlist",
+        "audiobook_library", "audiobook_watchlist", "audiobook_library_scan_state",
         "audiobook_blocklist",
     }
 
@@ -471,3 +471,25 @@ def test_a_failed_scan_records_why(db):
     db.follow_author("Brandon Sanderson")
     db.mark_author_scanned("Brandon Sanderson", error="catalogue unreachable")
     assert db.get_watchlist()[0]["last_error"] == "catalogue unreachable"
+
+
+def test_existing_library_migrates_without_losing_books(tmp_path):
+    import sqlite3
+    path = str(tmp_path / 'existing.db')
+    with sqlite3.connect(path) as conn:
+        conn.execute('''CREATE TABLE audiobook_library (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, asin TEXT NOT NULL UNIQUE,
+            title TEXT NOT NULL, author TEXT DEFAULT '', narrator TEXT DEFAULT '',
+            series_title TEXT DEFAULT '', series_sequence TEXT DEFAULT '',
+            path TEXT NOT NULL, file_count INTEGER DEFAULT 0, size_bytes INTEGER DEFAULT 0,
+            audio_format TEXT DEFAULT '', runtime_minutes INTEGER DEFAULT 0, imported_at REAL NOT NULL)''')
+        conn.execute("INSERT INTO audiobook_library (asin, title, path, imported_at) VALUES ('B000000001', 'Existing Book', '/books/Existing', 1)")
+    migrated = AudiobookDatabase(path)
+    try:
+        row = migrated.get_library()[0]
+        assert row['title'] == 'Existing Book' and row['source'] == 'download'
+        assert row['cover_url'] == '' and row['scan_signature'] == ''
+        migrated.set_library_scan_state({'status': 'completed', 'checked': 1})
+        assert migrated.get_library_scan_state()['checked'] == 1
+    finally:
+        migrated.close()

--- a/tests/test_audiobook_download_monitor.py
+++ b/tests/test_audiobook_download_monitor.py
@@ -323,7 +323,7 @@ def test_the_monitor_reuses_the_music_path_resolver():
 # is_music_batch() already honours. No music file changes for this to work.
 # ---------------------------------------------------------------------------
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def clean_runtime_state():
     from core.runtime_state import download_batches, download_tasks
 
@@ -763,7 +763,7 @@ def test_a_soulseek_row_is_polled_through_the_peer_client():
         status = _get_status("soulseek", "{}")
 
     assert status.state == "downloading"
-    assert status.progress == 42.0
+    assert status.progress == 0.42
     assert status.save_path == "/downloads/Book"
 
 
@@ -856,3 +856,46 @@ def test_a_single_file_torrent_points_at_the_file_not_the_root():
         check_complete=_capture_path(seen),
     )
     assert seen["path"] == "/downloads/Kings.m4b"
+
+@pytest.mark.parametrize('percent', [0.5, 1.0, 42.0, 100.0])
+def test_soulseek_progress_units_and_bytes_reach_monitor(percent):
+    from core.audiobook_download_monitor import _SoulseekStatus
+    status = _SoulseekStatus({'state':'downloading','progress':percent,'size':10000,
+        'transferred':int(percent*100),'speed':300,'total':20,'finished':3})
+    result = process_download(_row(source='soulseek'), get_status=lambda *_:status,
+        resolve_path=_identity_path, organize=_ok_organize())
+    assert result['progress'] == percent
+    assert result['bytes_done'] == int(percent*100)
+    assert result['speed'] == 300
+
+
+def test_soulseek_finished_files_enter_import_instead_of_downloading_forever():
+    from core.audiobook_download_monitor import _SoulseekStatus
+    status = _SoulseekStatus({'state':'done','progress':100,'size':1000,
+        'transferred':1000,'total':20,'finished':20,'save_path':'/downloads/Book'})
+    organize = MagicMock(return_value={'ok':True,'path':'/library/Book','files':[]})
+    result = process_download(_row(source='soulseek'), get_status=lambda *_:status,
+        resolve_path=_identity_path, organize=organize, check_complete=_whole_book)
+    assert result['status'] == 'completed'
+    organize.assert_called_once()
+
+
+def test_monitor_reattaches_after_restart_and_recovers_old_watchdog_failure(db, clean_runtime_state):
+    from core.audiobook_download_monitor import _SoulseekStatus
+    tasks, _ = clean_runtime_state
+    db.record_download('book-live', 'B1', 'Rhythm of War', 'soulseek', client_id='refs')
+    live = _SoulseekStatus({'state':'downloading','progress':25,'size':1000,
+        'transferred':250,'speed':75,'total':12,'finished':3})
+    with patch('core.audiobook_download_monitor._get_status', return_value=live):
+        tick(db=db)
+        assert tasks['book-live']['progress'] == 25
+        assert tasks['book-live']['bytes_transferred'] == 250
+        assert tasks['book-live']['speed'] == 75
+        tasks['book-live']['status'] = 'failed'
+        tasks['book-live']['error_message'] = 'Task stuck in downloading state for 10 minutes'
+        live.progress = .5
+        live.downloaded = 500
+        tick(db=db)
+    assert tasks['book-live']['status'] == 'downloading'
+    assert tasks['book-live']['progress'] == 50
+    assert tasks['book-live']['error_message'] is None

--- a/tests/test_audiobook_download_monitor.py
+++ b/tests/test_audiobook_download_monitor.py
@@ -140,13 +140,13 @@ def test_a_failed_organize_fails_the_download():
     assert "No audio files" in patch_out["error"]
 
 
-def test_a_poll_that_returns_nothing_changes_nothing():
+def test_a_missing_client_job_waits_without_claiming_to_download():
     # A client restarting or a momentary timeout must not mark a perfectly
     # healthy download as broken.
     assert process_download(
         _row(), get_status=lambda s, r: None,
         resolve_path=_identity_path, organize=_ok_organize(),
-    ) == {}
+    ) == {"status": "unavailable", "error": "Waiting for the download client to report this job"}
 
 
 def test_a_complete_download_with_no_visible_path_waits():
@@ -899,3 +899,71 @@ def test_monitor_reattaches_after_restart_and_recovers_old_watchdog_failure(db, 
     assert tasks['book-live']['status'] == 'downloading'
     assert tasks['book-live']['progress'] == 50
     assert tasks['book-live']['error_message'] is None
+
+
+@pytest.mark.parametrize("client_state", ["queued", "paused", "downloading", "unavailable"])
+def test_client_state_is_preserved(client_state):
+    result = process_download(_row(), get_status=lambda s, r: _status(client_state),
+                              resolve_path=_identity_path, organize=_ok_organize())
+    assert result["status"] == client_state
+
+
+def test_cancel_survives_cleanup_restart_and_late_poll(db, clean_runtime_state):
+    from core.audiobook_download_monitor import cancel_downloads
+    from core.audiobook_download_state import register_download
+    tasks, batches = clean_runtime_state
+    db.add_to_wishlist({"asin": "B1", "title": "Book"})
+    db.mark_wishlist_status("B1", "grabbed")
+    db.record_download("d1", "B1", "Book", "torrent", client_id="h1")
+    register_download("d1", "Book")
+    with patch("core.audiobook_download_monitor._cancel_at_client") as cancel:
+        assert cancel_downloads(db=db) == 1
+        cancel.assert_called_once()
+    tasks.clear()
+    batches.clear()
+    assert not db.update_download("d1", status="downloading", progress=50)
+    assert not db.update_download("d1", status="completed")
+    with patch("core.audiobook_download_monitor._get_status") as poll:
+        tick(db=db)
+        poll.assert_not_called()
+    assert not tasks and not batches
+    assert db.get_downloads(active_only=True) == []
+    assert db.get_wishlist()[0]["status"] == "cancelled"
+    assert db.get_wishlist()[0]["download_status"] == "cancelled"
+    assert db.get_wishlist_due() == []
+
+
+def test_cancel_one_book_preserves_other_jobs(db, clean_runtime_state):
+    from core.audiobook_download_monitor import cancel_downloads
+    for i in (1, 2):
+        db.record_download(f"d{i}", f"B{i}", f"Book {i}", "torrent", client_id=f"h{i}")
+    with patch("core.audiobook_download_monitor._cancel_at_client"):
+        assert cancel_downloads(["d1"], db=db) == 1
+    assert [r["download_id"] for r in db.get_downloads(active_only=True)] == ["d2"]
+
+
+@pytest.mark.parametrize("single", [False, True])
+def test_download_page_cancel_routes_persist_before_runtime_cleanup(db, clean_runtime_state, single):
+    # Execute the actual route body without starting web_server's background services.
+    import ast
+    import threading
+    from pathlib import Path
+    from flask import Flask, request, jsonify
+    from core.audiobook_download_state import register_download
+    tasks, _ = clean_runtime_state
+    db.record_download("d1", "B1", "Book", "torrent", client_id="h1")
+    register_download("d1", "Book")
+    name = "cancel_task_v2" if single else "cancel_batch"
+    tree = ast.parse((Path(__file__).parents[1] / "web_server.py").read_text(encoding="utf-8"))
+    node = next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == name)
+    node.decorator_list = []
+    scope = {"request": request, "jsonify": jsonify, "tasks_lock": threading.Lock(),
+             "_find_task_by_playlist_track": lambda *args: ("d1", tasks["d1"])}
+    exec(compile(ast.Module(body=[node], type_ignores=[]), "web_server.py", "exec"), scope)
+    with Flask(__name__).test_request_context(json={"playlist_id": "audiobooks", "track_index": 0}), \
+         patch("core.audiobook_database.get_audiobook_db", return_value=db), \
+         patch("core.audiobook_download_monitor._cancel_at_client"):
+        result = scope[name]() if single else scope[name]("audiobooks")
+    assert result.get_json()["success"] is True
+    assert db.get_downloads()[0]["status"] == "cancelled"
+    assert "d1" not in tasks

--- a/tests/test_audiobook_download_state.py
+++ b/tests/test_audiobook_download_state.py
@@ -98,7 +98,7 @@ def test_audiobooks_never_touch_the_music_batches():
 def test_a_grabbed_book_appears_as_a_card():
     assert _register() is True
     task = download_tasks["hash-1"]
-    assert task["status"] == "downloading"
+    assert task["status"] == "queued"
     assert task["batch_id"] == BATCH_ID
     assert task["track_info"]["title"] == "The Final Empire"
     # The cards read the music shape; author and series are the honest mapping.

--- a/tests/test_audiobook_library_matching.py
+++ b/tests/test_audiobook_library_matching.py
@@ -1,0 +1,155 @@
+from unittest.mock import MagicMock, patch
+import pytest
+from core.audiobook_database import AudiobookDatabase
+from core.audiobook_library_matching import score_candidate, match_one, match_library
+from core.audiobook_library_scan import scan, MIN_BOOK_BYTES
+
+BOOK = {'asin':'B000000001','title':'The Long Journey','author_names':['Alice Writer'],
+        'narrator_names':['Bob Reader'],'runtime_minutes':600,'language':'english',
+        'format_type':'unabridged','source':'audible'}
+LOCAL = {'title':'The Long Journey','title_source':'metadata','author':'Alice Writer',
+         'narrator':'Bob Reader','runtime_minutes':600,'language':'eng','format_type':'unabridged'}
+
+@pytest.fixture
+def db(tmp_path):
+    instance = AudiobookDatabase(str(tmp_path/'books.db'))
+    yield instance
+    instance.close()
+
+def local_row(db):
+    db.add_to_library({'asin':'local:one','title':LOCAL['title']}, '/library/book', source='scan', metadata_json=LOCAL, scan_signature='v1')
+    return db.get_library_entry('local:one')
+
+@pytest.mark.parametrize('change', [
+    {'narrator_names':['Someone Else']}, {'author_names':['Someone Else']},
+    {'runtime_minutes':300}, {'language':'german'}, {'format_type':'abridged'},
+    {'title':'The Long Journey 2'},
+])
+def test_conflicting_editions_cannot_auto_match(change):
+    result = score_candidate(LOCAL,{**BOOK,**change})
+    assert result['conflicts'] and not result['automatic_eligible']
+
+@pytest.mark.parametrize('field',['author','narrator','runtime_minutes'])
+def test_missing_evidence_requires_review(field):
+    result=score_candidate({**LOCAL,field:''},BOOK)
+    assert not result['automatic_eligible']
+
+def test_unique_strong_match_sets_ownership_without_changing_local_id(db):
+    row=local_row(db); client=MagicMock(); client.search.return_value=[BOOK]
+    assert match_one(db,row,client)=='automatic'
+    assert db.is_owned(BOOK['asin']) and db.get_library_entry('local:one')
+    assert db.get_library_entry('local:one')['origin']=='disk'
+
+def test_two_plausible_editions_require_review(db):
+    row=local_row(db); client=MagicMock(); client.search.return_value=[BOOK,{**BOOK,'asin':'B000000002'}]
+    assert match_one(db,row,client)=='suggested'
+    assert db.owned_asins()==set()
+
+def test_bad_title_does_not_get_high_confidence_from_other_fields(db):
+    assert not score_candidate({**LOCAL,'title':'Other Book'},BOOK)['automatic_eligible']
+
+def test_filename_only_title_cannot_auto_match():
+    assert not score_candidate({**LOCAL,'title_source':'filename'},BOOK)['automatic_eligible']
+
+def test_manual_choice_wins_over_inflight_automatic_result(db):
+    row=local_row(db)
+    assert db.apply_library_match(row['asin'],signature='v1',revision=0,status='confirmed',catalog_asin='B000000002',manual=True)
+    client=MagicMock();client.search.return_value=[BOOK]
+    assert match_one(db,row,client)=='unchanged'
+    assert db.is_owned('B000000002') and not db.is_owned(BOOK['asin'])
+
+def test_ignore_is_persistent_and_drops_ownership(db):
+    row=local_row(db)
+    assert db.apply_library_match(row['asin'],signature='v1',revision=0,status='ignored',manual=True)
+    client=MagicMock()
+    assert match_library(db,client)['match_checked']==0
+    client.search.assert_not_called()
+
+def test_catalogue_failure_preserves_inventory_and_uses_short_retry(db):
+    local_row(db); client=MagicMock();client.search.side_effect=RuntimeError('Catalogue offline')
+    result=match_library(db,client)
+    assert result['match_errors']==1 and len(db.get_library())==1
+    assert db.get_library()[0]['match_status']=='error'
+    assert match_library(db,client)['match_checked']==0
+
+def test_matching_batch_is_bounded(db):
+    for i in range(5):
+        db.add_to_library({'asin':f'local:{i}','title':'Book'},f'/books/{i}',source='scan',metadata_json=LOCAL)
+    client=MagicMock();client.search.return_value=[]
+    result=match_library(db,client,limit=2)
+    assert result['match_checked']==2 and result['match_pending']==3
+    assert client.search.call_count==2
+
+def test_scanned_duplicate_copies_share_catalogue_identity(db,tmp_path):
+    from core.audiobook_post_processor import build_opf
+    for name in ['one','two']:
+        folder=tmp_path/name;folder.mkdir()
+        (folder/'01.mp3').write_bytes(b'a'*(MIN_BOOK_BYTES+1))
+        (folder/'metadata.opf').write_text(build_opf(BOOK))
+    scan(str(tmp_path),db)
+    assert len(db.get_library())==2
+    assert {r['catalog_asin'] for r in db.get_library()}=={BOOK['asin']}
+    assert db.owned_asins()=={BOOK['asin']}
+
+def test_moving_unmatched_book_preserves_manual_choice_and_origin(db,tmp_path):
+    folder=tmp_path/'Old';folder.mkdir();(folder/'01.mp3').write_bytes(b'a'*(MIN_BOOK_BYTES+1))
+    scan(str(tmp_path),db);row=db.get_library()[0]
+    db.apply_library_match(row['asin'],signature=row['scan_signature'],revision=row['match_revision'],status='confirmed',catalog_asin=BOOK['asin'],manual=True)
+    folder.rename(tmp_path/'New')
+    result=scan(str(tmp_path),db)
+    updated=db.get_library()[0]
+    assert result['moved']==1 and updated['asin']==row['asin']
+    assert updated['match_status']=='confirmed' and updated['catalog_asin']==BOOK['asin']
+    assert updated['origin']=='disk'
+
+def test_flat_tagged_chapters_group_without_owning_root(db,tmp_path):
+    for i in range(2): (tmp_path/f'{i}.mp3').write_bytes(b'a'*(MIN_BOOK_BYTES+1))
+    audio=MagicMock();audio.info.length=1800;audio.tags={'album':['Book'],'artist':['Author']}
+    with patch('mutagen.File',return_value=audio): scan(str(tmp_path),db)
+    row=db.get_library()[0]
+    assert len(db.get_library())==1 and len(row['file_paths'])==2
+    assert row['file_scope']=='files' and row['path']!=str(tmp_path)
+
+def test_different_tagged_books_in_same_folder_stay_separate(db,tmp_path):
+    folder=tmp_path/'Mixed';folder.mkdir()
+    for name in ['one','two']: (folder/f'{name}.mp3').write_bytes(b'a'*(MIN_BOOK_BYTES+1))
+    def audio_for(file):
+        audio=MagicMock();audio.info.length=1800;audio.tags={'album':[file.stem],'artist':['Author']};return audio
+    with patch('mutagen.File',side_effect=audio_for): scan(str(tmp_path),db)
+    assert len(db.get_library())==2
+    assert all(r['file_scope']=='files' for r in db.get_library())
+
+def test_legacy_source_default_is_not_download_proof(db):
+    db.add_to_library(BOOK,'/books/old')
+    assert db.get_library()[0]['origin']=='unknown'
+
+def test_explicit_download_import_records_provenance(db):
+    db.add_to_library(BOOK,'/books/imported',download_id='torrent-id',origin='soulsync')
+    row=db.get_library()[0]
+    assert row['origin']=='soulsync' and row['download_id']=='torrent-id'
+
+def test_release_marker_links_completed_history(db,tmp_path):
+    from core.audiobook_post_processor import build_opf
+    folder=tmp_path/'Book';folder.mkdir();(folder/'01.mp3').write_bytes(b'a'*(MIN_BOOK_BYTES+1))
+    (folder/'metadata.opf').write_text(build_opf(BOOK));(folder/'.soulsync-release').write_text('Release.One')
+    db.record_download('dl1',BOOK['asin'],BOOK['title'],'torrent',release_title='Release.One')
+    db.update_download('dl1',status='completed')
+    scan(str(tmp_path),db)
+    row=db.get_library()[0]
+    assert row['origin']=='soulsync' and row['download_id']=='dl1'
+
+def test_replaced_recording_does_not_inherit_old_identifier(db, tmp_path):
+    from core.audiobook_post_processor import build_opf
+    folder = tmp_path / 'Book'
+    folder.mkdir()
+    audio = folder / '01.mp3'
+    audio.write_bytes(b'a' * (MIN_BOOK_BYTES + 1))
+    sidecar = folder / 'metadata.opf'
+    sidecar.write_text(build_opf(BOOK))
+    scan(str(tmp_path), db)
+    assert db.is_owned(BOOK['asin'])
+    audio.write_bytes(b'b' * (MIN_BOOK_BYTES + 2))
+    sidecar.unlink()
+    scan(str(tmp_path), db)
+    assert not db.is_owned(BOOK['asin'])
+    assert db.get_library()[0]['match_status'] == 'unmatched'

--- a/tests/test_audiobook_library_scan.py
+++ b/tests/test_audiobook_library_scan.py
@@ -192,15 +192,15 @@ def test_an_adopted_book_keeps_its_title_and_author(tmp_path, db):
     assert row["narrator"] == "Ray Porter"
 
 
-def test_a_book_with_no_sidecar_is_left_alone(tmp_path, db):
-    # Guessing an identity from a folder name would mark a book owned that the
-    # user does not have, and the wishlist would then refuse to fetch it.
+def test_a_book_with_no_sidecar_is_indexed_without_guessing_ownership(tmp_path, db):
     make_book_folder(tmp_path, "Andy Weir", "Project Hail Mary", sidecar=False)
-
     summary = scan(root=str(tmp_path), db=db)
-
-    assert summary["adopted"] == 0
-    assert db.get_library() == []
+    assert summary["adopted"] == 1
+    row = db.get_library()[0]
+    assert row["title"] == "Project Hail Mary"
+    assert row["asin"].startswith("local:")
+    assert db.owned_asins() == set()
+    assert not db.is_owned(BOOK["asin"])
 
 
 def test_adoption_never_duplicates_a_book_already_recorded(tmp_path, db):
@@ -219,7 +219,8 @@ def test_a_book_moved_on_disk_is_adopted_at_its_new_home(tmp_path, db):
 
     summary = scan(root=str(tmp_path), db=db)
 
-    assert summary["removed"] == 1 and summary["adopted"] == 1
+    assert summary["adopted"] == 1
+    assert len(db.get_library()) == 1
     assert db.get_library()[0]["path"].endswith("Project Hail Mary")
     assert db.is_owned("B08G9PRS1K") is True
 
@@ -256,7 +257,7 @@ def test_a_row_that_will_not_delete_does_not_stop_the_scan(tmp_path):
 
     summary = scan(root=str(tmp_path), db=stubborn)
 
-    assert summary["checked"] == 2 and summary["removed"] == 1
+    assert summary["removed"] == 1 and summary["errors"] == 1
 
 
 def test_the_root_falls_back_to_the_configured_library(tmp_path, db):
@@ -297,3 +298,145 @@ def test_a_real_book_beside_the_bin_is_still_found(tmp_path, db):
     scan(root=str(tmp_path), db=db)
 
     assert [r["asin"] for r in db.get_library()] == ["KEEP"]
+
+
+def test_flat_library_indexes_each_file_and_never_the_root(tmp_path, db):
+    for name in ('Book One.m4b', 'Book Two.mp3'):
+        (tmp_path / name).write_bytes(b'x' * (MIN_BOOK_BYTES + 1))
+    result = scan(root=str(tmp_path), db=db)
+    assert result['adopted'] == 2
+    assert {r['title'] for r in db.get_library()} == {'Book One', 'Book Two'}
+    assert all(Path(r['path']).is_file() for r in db.get_library())
+    assert scan(root=str(tmp_path), db=db)['adopted'] == 0
+    assert len(db.get_library()) == 2
+
+
+def test_separate_m4b_books_in_author_folder_are_not_merged(tmp_path, db):
+    author = tmp_path / 'Author'
+    author.mkdir()
+    for name in ('Book One.m4b', 'Book Two.m4b'):
+        (author / name).write_bytes(b'x' * (MIN_BOOK_BYTES + 1))
+    assert scan(root=str(tmp_path), db=db)['adopted'] == 2
+
+
+def test_cd_subfolders_form_one_book(tmp_path, db):
+    make_book_folder(tmp_path, 'Author', 'Book', 'CD1', sidecar=False)
+    make_book_folder(tmp_path, 'Author', 'Book', 'CD2', sidecar=False)
+    assert scan(root=str(tmp_path), db=db)['adopted'] == 1
+    row = db.get_library()[0]
+    assert row['title'] == 'Book' and row['file_count'] == 4
+
+
+def test_local_tags_supply_title_author_narrator_and_duration(tmp_path, db):
+    make_book_folder(tmp_path, 'Unknown folder', sidecar=False)
+    audio = MagicMock()
+    audio.info.length = 1800
+    audio.tags = {'album': ['Tagged Book'], 'artist': ['An Author'], 'composer': ['A Narrator']}
+    with patch('mutagen.File', return_value=audio):
+        scan(root=str(tmp_path), db=db)
+    row = db.get_library()[0]
+    assert row['title'] == 'Tagged Book'
+    assert row['author'] == 'An Author' and row['narrator'] == 'A Narrator'
+    assert row['runtime_minutes'] == 60
+
+
+def test_unchanged_audio_does_not_get_reprobed(tmp_path, db):
+    make_book_folder(tmp_path, 'Book', sidecar=False)
+    scan(root=str(tmp_path), db=db)
+    with patch('core.audiobook_library_metadata.read_metadata') as read:
+        result = scan(root=str(tmp_path), db=db)
+    read.assert_not_called()
+    assert result['adopted'] == 0 and result['updated'] == 0
+
+
+def test_local_book_promotes_only_when_explicit_asin_appears(tmp_path, db):
+    folder = make_book_folder(tmp_path, 'Book', sidecar=False)
+    scan(root=str(tmp_path), db=db)
+    assert db.owned_asins() == set()
+    (folder / OPF_NAME).write_text(build_opf(BOOK), encoding='utf-8')
+    scan(root=str(tmp_path), db=db)
+    assert len(db.get_library()) == 1
+    assert db.owned_asins() == {BOOK['asin']}
+
+
+def test_duplicate_asin_keeps_both_copies_without_overwriting(tmp_path, db):
+    make_book_folder(tmp_path, 'Copy One')
+    make_book_folder(tmp_path, 'Copy Two')
+    scan(root=str(tmp_path), db=db)
+    assert len(db.get_library()) == 2
+    assert db.owned_asins() == {BOOK['asin']}
+    assert len({r['path'] for r in db.get_library()}) == 2
+
+
+def test_unreadable_branch_preserves_missing_records(tmp_path, db):
+    blocked = tmp_path / 'Unavailable'
+    blocked.mkdir()
+    db.add_to_library(BOOK, str(blocked / 'Book'))
+    original = Path.iterdir
+    def listing(path):
+        if path == blocked:
+            raise PermissionError('unmounted')
+        return original(path)
+    with patch.object(Path, 'iterdir', listing):
+        result = scan(root=str(tmp_path), db=db)
+    assert result['errors'] == 1 and result['status'] == 'error'
+    assert db.is_owned(BOOK['asin'])
+
+
+def test_scan_does_not_follow_symlinks_outside_library(tmp_path, db):
+    root = tmp_path / 'library'
+    root.mkdir()
+    book = make_book_folder(tmp_path, 'outside')
+    (root / 'link').symlink_to(book, target_is_directory=True)
+    assert scan(root=str(root), db=db)['adopted'] == 0
+
+
+def test_completed_scan_state_survives_database_reopen(tmp_path, db):
+    make_book_folder(tmp_path, 'Book', sidecar=False)
+    result = scan(root=str(tmp_path), db=db)
+    saved = db.get_library_scan_state()
+    assert saved['status'] == 'completed'
+    assert saved['adopted'] == 1 and saved['finished_at'] == result['finished_at']
+
+
+def test_concurrent_scan_is_skipped(tmp_path, db):
+    from core.audiobook_library_scan import _SCAN_LOCK
+    with _SCAN_LOCK:
+        result = scan(root=str(tmp_path), db=db)
+    assert result['status'] == 'skipped'
+
+
+def test_first_use_automation_scans_existing_folder_without_database(tmp_path):
+    from core.automation.handlers.audiobook_scan_library import auto_scan_audiobook_library
+    with patch('core.audiobook_database.subsystem_in_use', return_value=False), \
+         patch('core.audiobook_library_scan.scan', return_value={'status': 'completed'}) as run:
+        result = auto_scan_audiobook_library({'root': str(tmp_path)}, MagicMock())
+    run.assert_called_once()
+    assert result['status'] == 'completed'
+
+
+def test_xml_metadata_decodes_escaped_titles(tmp_path, db):
+    folder = make_book_folder(tmp_path, 'Book', sidecar=False)
+    (folder / OPF_NAME).write_text(build_opf({**BOOK, 'title': 'War & Peace'}), encoding='utf-8')
+    scan(root=str(tmp_path), db=db)
+    assert db.get_library()[0]['title'] == 'War & Peace'
+
+
+def test_scan_refreshes_changed_tags(tmp_path, db):
+    folder = make_book_folder(tmp_path, 'Book', sidecar=False)
+    scan(root=str(tmp_path), db=db)
+    (folder / 'metadata.json').write_text('{"title":"Updated title","authors":["Writer"]}', encoding='utf-8')
+    result = scan(root=str(tmp_path), db=db)
+    assert result['updated'] == 1
+    assert db.get_library()[0]['title'] == 'Updated title'
+
+
+def test_automation_reports_running_and_finished_progress(tmp_path, db):
+    from core.automation.handlers.audiobook_scan_library import auto_scan_audiobook_library
+    make_book_folder(tmp_path, 'Book', sidecar=False)
+    deps = MagicMock()
+    with patch('core.audiobook_database.get_audiobook_db', return_value=db):
+        result = auto_scan_audiobook_library({'root': str(tmp_path), '_automation_id': 7}, deps)
+    assert result['adopted'] == 1 and result['_manages_own_progress']
+    states = [call.kwargs['status'] for call in deps.update_progress.call_args_list]
+    assert 'running' in states and states[-1] == 'finished'

--- a/tests/test_audiobook_library_scan.py
+++ b/tests/test_audiobook_library_scan.py
@@ -293,11 +293,11 @@ def test_hidden_folders_are_left_alone_generally(tmp_path, db):
 
 def test_a_real_book_beside_the_bin_is_still_found(tmp_path, db):
     make_book_folder(tmp_path, ".deleted", "20260909_120000_Deleted Book", asin="OLD")
-    make_book_folder(tmp_path, "Andy Weir", "Project Hail Mary", asin="KEEP")
+    make_book_folder(tmp_path, "Andy Weir", "Project Hail Mary", asin="B00000KEEP")
 
     scan(root=str(tmp_path), db=db)
 
-    assert [r["asin"] for r in db.get_library()] == ["KEEP"]
+    assert [r["asin"] for r in db.get_library()] == ["B00000KEEP"]
 
 
 def test_flat_library_indexes_each_file_and_never_the_root(tmp_path, db):
@@ -436,7 +436,7 @@ def test_automation_reports_running_and_finished_progress(tmp_path, db):
     make_book_folder(tmp_path, 'Book', sidecar=False)
     deps = MagicMock()
     with patch('core.audiobook_database.get_audiobook_db', return_value=db):
-        result = auto_scan_audiobook_library({'root': str(tmp_path), '_automation_id': 7}, deps)
+        result = auto_scan_audiobook_library({'root': str(tmp_path), '_automation_id': 7, 'match_catalog': False}, deps)
     assert result['adopted'] == 1 and result['_manages_own_progress']
     states = [call.kwargs['status'] for call in deps.update_progress.call_args_list]
     assert 'running' in states and states[-1] == 'finished'

--- a/tests/test_audiobook_recycle.py
+++ b/tests/test_audiobook_recycle.py
@@ -255,8 +255,9 @@ def test_the_library_is_reachable_from_the_audiobooks_page():
 def test_deleting_a_book_says_it_is_recoverable():
     # A destructive action that does not say it can be undone reads as final.
     modal = _read("webui/src/routes/audiobooks/-ui/audiobook-library-modal.tsx")
-    assert "recycle bin first" in modal
-    assert "window.showConfirmDialog" in modal
+    assert "recycle bin settings apply" in modal
+    assert "Confirm delete" in modal
+    assert "Keep book" in modal
     assert "window.confirm" not in modal
 
 
@@ -458,3 +459,20 @@ def test_erasing_for_good_asks_first():
     modal = _read("webui/src/routes/audiobooks/-ui/audiobook-review-modal.tsx")
     assert "cannot be undone" in modal
     assert "window.showConfirmDialog" in modal
+
+
+def test_a_loose_book_file_can_be_recycled_and_restored(library):
+    file = library / 'Book.m4b'
+    file.write_bytes(b'book audio')
+    result = discard(str(file))
+    assert result['ok'] and not file.exists()
+    restored = restore(Path(result['moved_to']).name)
+    assert restored['ok'] and file.read_bytes() == b'book audio'
+
+
+def test_a_loose_book_file_can_be_deleted_with_recycling_disabled(library):
+    file = library / 'Book.m4b'
+    file.write_bytes(b'book audio')
+    with patch('core.audiobook_recycle.recycling_enabled', return_value=False):
+        result = discard(str(file))
+    assert result['ok'] and result['permanent'] and not file.exists()

--- a/tests/test_audiobook_soulseek.py
+++ b/tests/test_audiobook_soulseek.py
@@ -336,7 +336,7 @@ def test_a_folder_nothing_is_known_about_yet_is_queued():
 def test_files_slskd_has_forgotten_still_count_against_the_total():
     # Otherwise two finished files out of thirty would report the book done.
     rolled = aggregate([_status("a", "Completed, Succeeded")], expected=30)
-    assert rolled["state"] == "downloading"
+    assert rolled["state"] == "queued"
 
 
 def test_a_status_poll_only_counts_this_books_transfers():
@@ -392,3 +392,8 @@ def test_a_cancel_that_stops_nothing_reports_false():
 
 def test_cancelling_a_row_with_no_refs_is_not_an_error():
     assert cancel("", client=MagicMock()) is False
+
+
+@pytest.mark.parametrize("state", ["Queued, Remotely", "Requested", "Initializing"])
+def test_non_transferring_files_do_not_claim_to_download(state):
+    assert aggregate([_status("a", state)])["state"] == "queued"

--- a/tests/test_audiobook_soulseek.py
+++ b/tests/test_audiobook_soulseek.py
@@ -397,3 +397,30 @@ def test_cancelling_a_row_with_no_refs_is_not_an_error():
 @pytest.mark.parametrize("state", ["Queued, Remotely", "Requested", "Initializing"])
 def test_non_transferring_files_do_not_claim_to_download(state):
     assert aggregate([_status("a", state)])["state"] == "queued"
+
+
+def test_filename_refs_track_live_chapters_only_from_the_selected_peer():
+    client = MagicMock()
+    client.download_path = "/downloads"
+    def transfer(ref, filename, peer, state, size, done):
+        item = _status(ref, state, size, done)
+        item.filename = filename
+        item.username = peer
+        return item
+    async def everything():
+        return [
+            transfer("uuid-1", "Books/Book/01.mp3", "peer", "Completed, Succeeded", 100, 100),
+            transfer("uuid-2", "Books/Book/02.mp3", "peer", "InProgress", 100, 50),
+            transfer("uuid-3", "Books/Book/03.mp3", "peer", "Queued, Remotely", 100, 0),
+            transfer("other-peer", "Books/Book/02.mp3", "other", "InProgress", 900, 900),
+            transfer("other-folder", "Other/02.mp3", "peer", "InProgress", 900, 900),
+        ]
+    client.get_all_downloads = everything
+    refs = [r"Books\Book\01.mp3", r"Books\Book\02.mp3", r"Books\Book\03.mp3"]
+    result = status_for(encode_refs(refs, "peer", "Book"), client=client)
+    assert result["state"] == "downloading"
+    assert result["size"] == 300
+    assert result["transferred"] == 150
+    assert result["progress"] == 50
+    assert result["finished"] == 1
+    assert result["total"] == 3

--- a/tests/test_audiobook_soulseek_client_cache.py
+++ b/tests/test_audiobook_soulseek_client_cache.py
@@ -1,0 +1,147 @@
+"""One Soulseek client, not one per call.
+
+Every helper in core/audiobook_soulseek.py built its own SoulseekClient when it
+was not handed one. That constructor logs at INFO and mkdirs the download path,
+and the audiobook download monitor ticks every few seconds touching several of
+these per pass — so app.log filled with repeated "Soulseek client configured
+with slskd at ..." lines and the filesystem was hit for each one. Reported as a
+"wtf is this?" while reading the log, which is the right reaction: nothing was
+broken, but nothing needed doing either.
+
+Both halves are here: the cache's behaviour, and the structural invariant that a
+helper never reaches for the constructor instead of the cache.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SOURCE = (_ROOT / 'core' / 'audiobook_soulseek.py').read_text(encoding='utf-8')
+_CLIENT_SOURCE = (_ROOT / 'core' / 'soulseek_client.py').read_text(encoding='utf-8')
+
+
+def _below_the_cache() -> str:
+    """Everything after _shared_client's own definition."""
+    assert 'def _shared_client' in _SOURCE, 'the shared client builder is gone'
+    after = _SOURCE.split('def _shared_client', 1)[1]
+    # its body ends at the next top-level def
+    return re.split(r'\ndef ', after, maxsplit=1)[1]
+
+
+def test_there_is_a_shared_client_builder():
+    assert 'def _shared_client' in _SOURCE
+
+
+def test_no_helper_constructs_its_own_client():
+    assert 'SoulseekClient()' not in _below_the_cache(), (
+        'a helper builds its own client again; call _shared_client() instead'
+    )
+
+
+def test_the_audiobook_helper_never_constructs_a_client():
+    """Six helpers used to build their own. None should now."""
+    assert 'SoulseekClient()' not in _SOURCE
+
+
+def _builder() -> str:
+    return _CLIENT_SOURCE.split('def get_shared_soulseek_client', 1)[1].split('\ndef ', 1)[0]
+
+
+def test_the_cache_is_keyed_rather_than_permanent():
+    """Cached outright, saving a new slskd url or key would need a restart."""
+    assert '_SHARED_CACHE["key"]' in _builder()
+    assert 'slskd_url' in _builder() and 'api_key' in _builder()
+
+
+def test_the_cache_is_locked():
+    """The monitor thread and a request thread can both ask at once."""
+    assert 'with _SHARED_LOCK' in _builder()
+
+
+def test_a_broken_config_read_still_yields_a_client():
+    """A config that cannot be read must not take Soulseek down with it."""
+    assert 'except Exception' in _builder()
+
+
+def test_the_audiobook_side_reads_no_soulseek_config():
+    """test_audiobooks_isolation holds this line: music's soulseek settings must
+    never decide anything on the audiobook side. The cache key is a config read,
+    so the cache belongs in the client module, not here."""
+    for line in _SOURCE.splitlines():
+        if 'config_manager.get(' in line:
+            assert 'audiobooks.' in line, line.strip()
+
+
+# ---------------------------------------------------------------------------
+# the cache itself
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def soulseek(monkeypatch):
+    built = []
+
+    class _FakeClient:
+        def __init__(self):
+            built.append(1)
+            self.base_url = 'http://slskd:5030'
+            self.download_path = '/downloads'
+
+    # patched on the REAL module rather than swapping sys.modules: installing a
+    # fake module leaks into every later test in the session, which is the
+    # pollution class that already breaks this suite elsewhere
+    import core.soulseek_client as sc
+    monkeypatch.setattr(sc, 'SoulseekClient', _FakeClient)
+    monkeypatch.setitem(sc._SHARED_CACHE, 'key', None)
+    monkeypatch.setitem(sc._SHARED_CACHE, 'client', None)
+
+    import core.audiobook_soulseek as ab
+
+    settings = {'slskd_url': 'http://slskd:5030', 'api_key': 'k'}
+
+    class _Cfg:
+        def get(self, key, default=None):
+            return settings if key == 'soulseek' else default
+
+    monkeypatch.setattr(sc, 'config_manager', _Cfg(), raising=False)
+    return ab, built, settings
+
+
+def test_repeated_calls_build_one_client(soulseek):
+    ab, built, _ = soulseek
+    for _ in range(50):
+        ab._shared_client()
+    assert len(built) == 1, f'built {len(built)} clients for 50 calls'
+
+
+def test_changed_slskd_settings_rebuild_it(soulseek):
+    ab, built, settings = soulseek
+    ab._shared_client()
+    settings['api_key'] = 'a-new-key'
+    ab._shared_client()
+    assert len(built) == 2, 'a saved slskd change would need a restart'
+
+
+def test_unchanged_settings_do_not_rebuild_it(soulseek):
+    ab, built, settings = soulseek
+    ab._shared_client()
+    settings['api_key'] = 'k'
+    ab._shared_client()
+    assert len(built) == 1
+
+
+def test_it_returns_the_same_instance(soulseek):
+    ab, _built, _ = soulseek
+    assert ab._shared_client() is ab._shared_client()
+
+
+def test_the_builder_does_not_call_itself(soulseek):
+    """It did. A regex meant for the six call sites rewrote the constructor
+    inside the builder too, so _shared_client recursed forever and every test
+    that touched it hung rather than failed."""
+    ab, built, _ = soulseek
+    assert ab._shared_client() is not None
+    assert len(built) == 1

--- a/tests/test_audiobook_stuck_grabbed.py
+++ b/tests/test_audiobook_stuck_grabbed.py
@@ -1,0 +1,153 @@
+"""A wishlist row must never be left saying "sent to downloads" forever.
+
+Reported: lots of audiobook wishlist rows showing "sent to downloads" with
+nothing actually downloading.
+
+"grabbed" is a handover, not an end state. The row goes there the moment a
+download client accepts the release, and it is the download MONITOR that moves
+it off — to done when the book imports, to failed when the client gives up. The
+monitor only looks at rows with a LIVE download, so if that download never
+registered, was cleared, or the monitor stopped running, the row sits on
+"grabbed" for good: the retry query takes only "wanted" and "failed", so nothing
+ever looks at it again and nothing says so.
+
+This is the same class reset_stale_searching already solved for the state before
+it, and it gets the same treatment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.audiobook_database import (
+    STATUS_FAILED,
+    STATUS_GRABBED,
+    STATUS_WANTED,
+    AudiobookDatabase,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    return AudiobookDatabase(str(tmp_path / 'audiobooks.db'))
+
+
+def _wanted(db, asin='B001', title='A Book'):
+    db.add_to_wishlist({'asin': asin, 'title': title, 'authors': ['An Author']})
+    return asin
+
+
+def _age(db, asin, seconds):
+    """Push when the row last changed state into the past.
+
+    status_changed_at, not last_attempt_at: the latter only moves when
+    count_attempt is passed, and a manual grab deliberately does not count as an
+    attempt — so gating on it freed a grab that had just happened.
+    """
+    conn = db._connect()
+    conn.execute(
+        "UPDATE audiobook_wishlist SET status_changed_at = ? WHERE asin = ?",
+        (__import__('time').time() - seconds, asin),
+    )
+    conn.commit()
+
+
+def _status(db, asin):
+    for row in db.get_wishlist():
+        if row['asin'] == asin:
+            return row['status']
+    return None
+
+
+def test_a_grabbed_row_with_no_download_is_freed(db):
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    _age(db, asin, 60 * 60 * 24)
+
+    assert db.reset_stale_grabbed() == 1
+    assert _status(db, asin) == STATUS_WANTED
+
+
+def test_the_freed_row_says_why(db):
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    _age(db, asin, 60 * 60 * 24)
+    db.reset_stale_grabbed()
+
+    row = next(r for r in db.get_wishlist() if r['asin'] == asin)
+    assert 'nothing was tracking it' in (row.get('last_error') or '')
+
+
+def test_a_book_still_downloading_is_left_alone(db):
+    """A large audiobook on a thin swarm is normal, not stuck."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    db.record_download(download_id='d1', asin=asin, title='A Book', source='torrent')
+    _age(db, asin, 60 * 60 * 24 * 7)
+
+    assert db.reset_stale_grabbed() == 0
+    assert _status(db, asin) == STATUS_GRABBED
+
+
+def test_a_finished_download_does_not_protect_the_row(db):
+    """A completed or failed download is not something still tracking it."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    db.record_download(download_id='d1', asin=asin, title='A Book', source='torrent')
+    db.update_download('d1', status='failed', error='client gave up')
+    _age(db, asin, 60 * 60 * 24)
+
+    assert db.reset_stale_grabbed() == 1
+    assert _status(db, asin) == STATUS_WANTED
+
+
+def test_a_recent_grab_is_not_touched(db):
+    """The age gate stops a pass freeing a grab that just happened."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+
+    assert db.reset_stale_grabbed() == 0
+    assert _status(db, asin) == STATUS_GRABBED
+
+
+def test_other_states_are_untouched(db):
+    for asin, status in (('B1', STATUS_WANTED), ('B2', STATUS_FAILED)):
+        _wanted(db, asin, asin)
+        db.mark_wishlist_status(asin, status)
+        _age(db, asin, 60 * 60 * 24)
+
+    assert db.reset_stale_grabbed() == 0
+
+
+def test_the_freed_row_is_picked_up_again(db):
+    """The point of freeing it: the retry query only takes wanted and failed."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    _age(db, asin, 60 * 60 * 24)
+    assert db.get_wishlist_due(retry_after_seconds=0) == []
+
+    db.reset_stale_grabbed()
+    due = [r['asin'] for r in db.get_wishlist_due(retry_after_seconds=0)]
+    assert asin in due
+
+
+def test_a_manual_grab_is_not_freed_immediately(db):
+    """A manual grab does not count as an attempt, so last_attempt_at stays
+    where it was — gating the sweep on it freed the row on the very next pass.
+    status_changed_at moves on every status change, including this one."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)     # no count_attempt
+    assert db.reset_stale_grabbed() == 0
+    assert _status(db, asin) == STATUS_GRABBED
+
+
+def test_a_row_that_never_recorded_a_change_is_left_alone(db):
+    """Rows written before the column existed default to 0. Freeing those on
+    sight would reset every grabbed row the first time this ran."""
+    asin = _wanted(db)
+    db.mark_wishlist_status(asin, STATUS_GRABBED)
+    conn = db._connect()
+    conn.execute("UPDATE audiobook_wishlist SET status_changed_at = 0 WHERE asin = ?", (asin,))
+    conn.commit()
+
+    assert db.reset_stale_grabbed() == 0

--- a/tests/test_audiobooks_api.py
+++ b/tests/test_audiobooks_api.py
@@ -1042,13 +1042,13 @@ def test_the_library_lists_what_is_on_disk(client, catalog, wishlist_db):
 def test_deleting_a_book_recycles_it_and_forgets_it(client, catalog, wishlist_db):
     wishlist_db.add_to_library({"asin": "B1", "title": "PHM"}, "/books/PHM")
     with patch("core.audiobook_recycle.discard",
-               return_value={"ok": True, "permanent": False, "error": ""}) as discard:
+               return_value={"ok": True, "permanent": False, "error": ""}) as discard, \
+         patch("core.audiobook_organizer.library_root", return_value="/books"):
         body = client.delete("/api/audiobooks/library/B1").get_json()
 
     assert body["success"] is True and body["recycled"] is True
     discard.assert_called_once()
-    # The row goes either way: leaving it would put an Owned badge on a book
-    # that is no longer there.
+    # Only successful removal drops ownership.
     assert wishlist_db.is_owned("B1") is False
 
 
@@ -1062,3 +1062,59 @@ def test_the_recycle_bin_reports_what_is_recoverable(client, catalog, wishlist_d
         body = client.get("/api/audiobooks/library/recycle").get_json()
     assert body["entries"][0]["name"] == "x"
     assert body["keep_days"] == 7
+
+
+def test_failed_library_delete_keeps_ownership(client, wishlist_db):
+    wishlist_db.add_to_library({'asin': 'B1', 'title': 'Book'}, '/books/Book')
+    with patch('core.audiobook_recycle.discard', return_value={'ok': False, 'error': 'Permission denied'}), \
+         patch('core.audiobook_organizer.library_root', return_value='/books'):
+        response = client.delete('/api/audiobooks/library/B1')
+    assert response.status_code == 400
+    assert response.get_json()['success'] is False
+    assert wishlist_db.is_owned('B1')
+
+
+def test_library_delete_never_deletes_the_root(client, wishlist_db):
+    wishlist_db.add_to_library({'asin': 'local:bad', 'title': 'Root'}, '/books')
+    with patch('core.audiobook_recycle.discard') as discard, \
+         patch('core.audiobook_organizer.library_root', return_value='/books'):
+        assert client.delete('/api/audiobooks/library/local:bad').status_code == 400
+    discard.assert_not_called()
+
+
+def test_local_cover_and_scan_state_are_in_library_response(client, wishlist_db, tmp_path):
+    book = tmp_path / 'Book'
+    book.mkdir()
+    (book / 'cover.jpg').write_bytes(b'cover data')
+    wishlist_db.add_to_library({'asin': 'local:book', 'title': 'Book'}, str(book))
+    wishlist_db.set_library_scan_state({'status': 'completed', 'adopted': 1})
+    with patch('core.audiobook_organizer.library_root', return_value=str(tmp_path)):
+        body = client.get('/api/audiobooks/library').get_json()
+        assert body['scan']['adopted'] == 1
+        cover = client.get(body['books'][0]['cover_url'])
+    assert cover.status_code == 200 and cover.data == b'cover data'
+
+
+def test_local_cover_cannot_escape_library(client, wishlist_db, tmp_path):
+    root = tmp_path / 'library'
+    book = root / 'Book'
+    book.mkdir(parents=True)
+    outside = tmp_path / 'private.jpg'
+    outside.write_bytes(b'private')
+    (book / 'cover.jpg').symlink_to(outside)
+    wishlist_db.add_to_library({'asin': 'local:book', 'title': 'Book'}, str(book))
+    with patch('core.audiobook_organizer.library_root', return_value=str(root)):
+        assert client.get('/api/audiobooks/library/local:book/cover').status_code == 404
+
+
+def test_embedded_cover_is_served_without_writing_files(client, wishlist_db, tmp_path):
+    file = tmp_path / 'Book.m4b'
+    file.write_bytes(b'unchanged audio')
+    wishlist_db.add_to_library({'asin': 'local:book', 'title': 'Book'}, str(file))
+    audio = MagicMock()
+    audio.tags = {'covr': [b'\x89PNG\r\n\x1a\nimage']}
+    with patch('core.audiobook_organizer.library_root', return_value=str(tmp_path)), \
+         patch('mutagen.File', return_value=audio):
+        response = client.get('/api/audiobooks/library/local:book/cover')
+    assert response.status_code == 200 and response.mimetype == 'image/png'
+    assert file.read_bytes() == b'unchanged audio'

--- a/tests/test_audiobooks_api.py
+++ b/tests/test_audiobooks_api.py
@@ -1118,3 +1118,72 @@ def test_embedded_cover_is_served_without_writing_files(client, wishlist_db, tmp
         response = client.get('/api/audiobooks/library/local:book/cover')
     assert response.status_code == 200 and response.mimetype == 'image/png'
     assert file.read_bytes() == b'unchanged audio'
+
+def test_library_match_confirmation_keeps_physical_identity_and_origin(client, catalog, wishlist_db):
+    wishlist_db.add_to_library({'asin': 'local:copy', 'title': 'Local'}, '/books/Local', origin='disk')
+    row = wishlist_db.get_library_entry('local:copy')
+    catalog.get_book.return_value = _item('B000000001')
+    result = client.patch('/api/audiobooks/library/local:copy/match', json={
+        'action': 'confirm', 'catalog_asin': 'B000000001',
+        'scan_signature': row['scan_signature'], 'match_revision': row['match_revision'],
+    })
+    assert result.status_code == 200
+    saved = result.get_json()['book']
+    assert saved['asin'] == 'local:copy'
+    assert saved['origin'] == 'disk'
+    assert saved['path'] == '/books/Local'
+    assert saved['match_status'] == 'confirmed'
+    assert wishlist_db.is_owned('B000000001')
+    stale = client.patch('/api/audiobooks/library/local:copy/match', json={
+        'action': 'ignore', 'scan_signature': row['scan_signature'], 'match_revision': row['match_revision'],
+    })
+    assert stale.status_code == 409
+    assert wishlist_db.is_owned('B000000001')
+    ignored = client.patch('/api/audiobooks/library/local:copy/match', json={
+        'action': 'ignore', 'scan_signature': saved['scan_signature'], 'match_revision': saved['match_revision'],
+    })
+    assert ignored.status_code == 200
+    assert not wishlist_db.is_owned('B000000001')
+
+
+def test_library_match_lookup_failure_does_not_change_ownership(client, catalog, wishlist_db):
+    wishlist_db.add_to_library({'asin': 'local:copy', 'title': 'Local'}, '/books/Local')
+    row = wishlist_db.get_library_entry('local:copy')
+    catalog.get_book.return_value = None
+    result = client.patch('/api/audiobooks/library/local:copy/match', json={
+        'action': 'confirm', 'catalog_asin': 'B000000001',
+        'scan_signature': row['scan_signature'], 'match_revision': row['match_revision'],
+    })
+    assert result.status_code == 503
+    assert not wishlist_db.is_owned('B000000001')
+    assert wishlist_db.get_library_entry('local:copy')['match_revision'] == row['match_revision']
+
+
+def test_delete_shared_folder_only_discards_selected_manifest(client, wishlist_db, tmp_path):
+    first, second, neighbour = [tmp_path / name for name in ('01.mp3', '02.mp3', 'other.m4b')]
+    for file in (first, second, neighbour):
+        file.write_bytes(b'audio')
+    wishlist_db.add_to_library({'asin': 'local:copy', 'title': 'Local'}, str(first),
+        file_scope='files', file_paths=[str(first), str(second)])
+    with patch('core.audiobook_organizer.library_root', return_value=str(tmp_path)), \
+         patch('core.audiobook_recycle.discard', return_value={'ok': True}) as discard:
+        result = client.delete('/api/audiobooks/library/local:copy')
+    assert result.status_code == 200
+    assert [call.args[0] for call in discard.call_args_list] == [str(first), str(second)]
+    assert neighbour.exists()
+    assert wishlist_db.get_library_entry('local:copy') is None
+
+
+def test_delete_rejects_manifest_escape_before_moving_any_file(client, wishlist_db, tmp_path):
+    root = tmp_path / 'library'
+    root.mkdir()
+    first = root / 'book.mp3'
+    first.write_bytes(b'audio')
+    wishlist_db.add_to_library({'asin': 'local:copy', 'title': 'Local'}, str(first),
+        file_scope='files', file_paths=[str(first), str(tmp_path / 'outside.mp3')])
+    with patch('core.audiobook_organizer.library_root', return_value=str(root)), \
+         patch('core.audiobook_recycle.discard') as discard:
+        result = client.delete('/api/audiobooks/library/local:copy')
+    assert result.status_code == 400
+    discard.assert_not_called()
+    assert wishlist_db.get_library_entry('local:copy') is not None

--- a/tests/test_audiobooks_isolation.py
+++ b/tests/test_audiobooks_isolation.py
@@ -223,7 +223,7 @@ def test_only_the_acquisition_routes_write_anything():
                        # Deleting a book and putting one back are the two
                        # library writes. Both move files, neither touches a
                        # music path.
-                       "/api/audiobooks/library/<asin>",
+                       "/api/audiobooks/library/<asin>", "/api/audiobooks/library/<asin>/match",
                        "/api/audiobooks/library/recycle/<path:name>",
                        "/api/audiobooks/library/recycle"}
     for rule in _blueprint_app().url_map.iter_rules():

--- a/tests/test_automation_result_keys.py
+++ b/tests/test_automation_result_keys.py
@@ -28,6 +28,7 @@ _HANDLERS = _ROOT / 'core/automation/handlers'
 # action_type → (handler module, the result keys the sentence reads).
 # Keep in step with ACTION_SENTENCES in -automations.format.ts.
 SENTENCE_SOURCES = {
+    'audiobook_scan_library': ('audiobook_scan_library.py', ('checked', 'adopted', 'updated', 'removed')),
     'scan_watchlist': ('scan_watchlist.py',
                        ('artists_scanned', 'new_tracks_found', 'tracks_added_to_wishlist')),
     'scan_watchlist_podcasts': ('scan_watchlist_podcasts.py',

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -671,9 +671,18 @@ def test_chat_connection_requires_network_login(connection):
     assert "slskd" in state["error"]
 
 
-def test_chat_connection_accepts_logged_in_server():
-    client = _RecordingClient({("GET", "server/state"): {"isConnected": True, "isLoggedIn": True}})
+@pytest.mark.parametrize("endpoint", ["server", "server/state"])
+def test_chat_connection_accepts_logged_in_server(endpoint):
+    client = _RecordingClient({("GET", endpoint): {"isConnected": True, "isLoggedIn": True}})
     assert _run(client.get_chat_connection_state()) == {"connected": True}
+
+
+@pytest.mark.parametrize("endpoint", ["server", "server/state"])
+def test_chat_connection_reports_disconnected_per_endpoint(endpoint):
+    client = _RecordingClient({("GET", endpoint): {"isConnected": False, "isLoggedIn": False}})
+    state = _run(client.get_chat_connection_state())
+    assert state["connected"] is False
+    assert state["code"] == "slskd_disconnected"
 
 
 @pytest.mark.parametrize("path,payload", [

--- a/tests/test_chat_api.py
+++ b/tests/test_chat_api.py
@@ -657,3 +657,50 @@ class TestBrowseAndGrab:
     def test_download_requires_files(self, browse_app):
         http, state = browse_app
         assert http.post("/api/chat/user/pal/download", json={}).status_code == 400
+
+
+@pytest.mark.parametrize("connection", [
+    {"isConnected": False, "isLoggedIn": False, "state": "Disconnecting"},
+    {"isConnected": True, "isLoggedIn": False},
+    None,
+])
+def test_chat_connection_requires_network_login(connection):
+    client = _RecordingClient({("GET", "server/state"): connection})
+    state = _run(client.get_chat_connection_state())
+    assert state["connected"] is False
+    assert "slskd" in state["error"]
+
+
+def test_chat_connection_accepts_logged_in_server():
+    client = _RecordingClient({("GET", "server/state"): {"isConnected": True, "isLoggedIn": True}})
+    assert _run(client.get_chat_connection_state()) == {"connected": True}
+
+
+@pytest.mark.parametrize("path,payload", [
+    ("/api/chat/room/message", {"message": "draft"}),
+    ("/api/chat/conversations/peer", {"message": "draft"}),
+    ("/api/chat/room/protocol", {"p": {"k": "hello"}}),
+    ("/api/chat/room/react", {"message": "draft"}),
+])
+def test_disconnected_chat_never_submits_messages_or_carriers(chat_app, path, payload):
+    http, state = chat_app
+    client = state["client"]
+    client.get_chat_connection_state = lambda: {"connected": False, "code": "slskd_disconnected", "error": "Reconnect in slskd"}
+    response = http.post(path, json=payload)
+    assert response.status_code == 503
+    assert response.get_json()["code"] == "slskd_disconnected"
+    assert not client.sent_room and not client.sent_pm and not client.joined
+    assert http.get("/api/chat/status").get_json()["can_send"] is False
+
+
+def test_chat_recovers_on_next_poll_after_slskd_reconnects(chat_app):
+    http, state = chat_app
+    client = state["client"]
+    client.get_chat_connection_state = lambda: {"connected": False, "error": "Reconnect in slskd"}
+    assert http.get("/api/chat/room").status_code == 503
+    assert not client.joined
+    client.get_chat_connection_state = lambda: {"connected": True}
+    response = http.get("/api/chat/room")
+    assert response.status_code == 200
+    assert response.get_json()["can_send"] is True
+    assert not client.sent_room and not client.sent_pm  # never auto-resend drafts

--- a/tests/test_deezer_editorial_playlists.py
+++ b/tests/test_deezer_editorial_playlists.py
@@ -124,13 +124,18 @@ def test_an_empty_search_asks_nothing():
     c._api_get.assert_not_called()
 
 
-def test_the_genre_list_is_offered_without_a_request():
-    """The chips must not cost an api call just to know what to ask for."""
+def test_the_genre_list_is_worth_its_one_request():
+    """This used to assert the opposite: that the chips cost no api call.
+
+    That saved one request and cost sixteen genres, because the hardcoded set
+    held twelve of Deezer's twenty-eight. The trade was wrong, so the assertion
+    changed with the decision rather than being deleted — the fallback below is
+    what still protects the offline case.
+    """
     c = DeezerClient.__new__(DeezerClient)
-    c._api_get = MagicMock(side_effect=AssertionError("asked the api for its own genre list"))
-    genres = c.get_editorial_genres()
-    assert {'id': 0, 'name': 'Top'} in genres
-    assert any(g['name'] == 'Rock' for g in genres)
+    c._api_get = MagicMock(return_value={"data": [{"id": 464, "name": "Metal"}]})
+    assert c.get_editorial_genres() == [{'id': 464, 'name': 'Metal'}]
+    c._api_get.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -260,3 +265,47 @@ def test_a_token_is_still_attached_when_asked_for():
     c._api_get('chart/0/playlists', use_token=False)
     assert 'access_token' not in sent
     assert requests is not None
+
+
+# ---------------------------------------------------------------------------
+# the genre list
+# ---------------------------------------------------------------------------
+
+def test_the_genres_come_from_deezer_not_a_constant():
+    """Twelve were hardcoded to save a request. Deezer publishes 28, so that
+    quietly hid Metal, Country, Blues, Folk, Soul & Funk and every regional
+    category from the shelf."""
+    c = _client({"data": [
+        {"id": 0, "name": "All"},
+        {"id": 464, "name": "Metal"},
+        {"id": 84, "name": "Country"},
+    ]})
+    genres = c.get_editorial_genres()
+    assert [g['name'] for g in genres] == ['All', 'Country', 'Metal']
+    c._api_get.assert_called_once_with('genre', use_token=False)
+
+
+def test_all_stays_at_the_front():
+    """It is the row the shelf opens on; alphabetical would bury it."""
+    c = _client({"data": [{"id": 464, "name": "Metal"}, {"id": 0, "name": "All"}]})
+    assert c.get_editorial_genres()[0]['name'] == 'All'
+
+
+def test_an_unreachable_genre_list_falls_back_to_the_builtin_set():
+    """The chips must still appear when Deezer is down."""
+    c = _client(None)
+    genres = c.get_editorial_genres()
+    assert len(genres) > 5
+    assert any(g['name'] == 'Top' for g in genres)
+
+
+def test_malformed_genre_rows_are_dropped():
+    c = _client({"data": [{"id": 1}, {"name": "No id"}, "junk", {"id": 2, "name": "Good"}]})
+    assert c.get_editorial_genres() == [{'id': 2, 'name': 'Good'}]
+
+
+def test_the_genre_list_does_not_send_a_token():
+    """Same public endpoint, same OAuthException trap as the charts."""
+    c = _client({"data": [{"id": 0, "name": "All"}]})
+    c.get_editorial_genres()
+    assert c._api_get.call_args.kwargs.get('use_token') is False

--- a/tests/test_deezer_editorial_playlists.py
+++ b/tests/test_deezer_editorial_playlists.py
@@ -69,7 +69,7 @@ def test_the_id_is_the_one_the_existing_loader_takes():
 def test_it_asks_the_genre_chart_it_was_given():
     c = _client({"data": []})
     c.get_editorial_playlists(116, limit=10)
-    c._api_get.assert_called_once_with('chart/116/playlists', {'limit': 10})
+    c._api_get.assert_called_once_with('chart/116/playlists', {'limit': 10}, use_token=False)
 
 
 def test_the_biggest_artwork_wins():
@@ -113,7 +113,8 @@ def test_the_limit_is_bounded():
 def test_search_uses_the_playlist_search_endpoint():
     c = _client({"data": [_ROW]})
     out = c.search_playlists('deep house', limit=5)
-    c._api_get.assert_called_once_with('search/playlist', {'q': 'deep house', 'limit': 5})
+    c._api_get.assert_called_once_with('search/playlist', {'q': 'deep house', 'limit': 5},
+                                       use_token=False)
     assert out[0]['title'] == 'Rock Essentials'
 
 
@@ -192,3 +193,70 @@ def test_no_deezer_client_is_an_empty_shelf(monkeypatch):
 def test_the_genres_endpoint_lists_the_chips(client):
     body = client.get('/api/discover/deezer/genres').get_json()
     assert body['genres'] == [{'id': 0, 'name': 'Top'}]
+
+
+# ---------------------------------------------------------------------------
+# the browse endpoints are public and must stay that way
+# ---------------------------------------------------------------------------
+
+def test_the_chart_call_sends_no_access_token():
+    """These endpoints need no auth, and a STALE token does not get ignored:
+
+        {"error": {"type": "OAuthException", "message": "Invalid OAuth access token."}}
+
+    so a user whose Deezer link had expired lost the browse rows entirely —
+    rows that never needed their account. Reported as the shelf going back to
+    "Could not reach Deezer just now" after having worked.
+    """
+    c = _client({"data": []})
+    c.get_editorial_playlists(152)
+    assert c._api_get.call_args.kwargs.get('use_token') is False
+
+
+def test_the_search_call_sends_no_access_token():
+    c = _client({"data": []})
+    c.search_playlists('deep house')
+    assert c._api_get.call_args.kwargs.get('use_token') is False
+
+
+def test_api_get_still_sends_the_token_by_default():
+    """Only the public browse calls opt out; the user-level endpoints must not."""
+    import inspect
+
+    from core.deezer_client import DeezerClient as _DC
+
+    signature = inspect.signature(_DC._api_get)
+    assert signature.parameters['use_token'].default is True
+
+
+def test_a_token_is_still_attached_when_asked_for():
+    """The opt-out must not have quietly disabled auth everywhere."""
+    import requests
+
+    from core.deezer_client import DeezerClient as _DC
+
+    sent = {}
+
+    class _Session:
+        def get(self, url, params=None, timeout=None):
+            sent.update(params or {})
+
+            class _R:
+                status_code = 200
+
+                @staticmethod
+                def json():
+                    return {"ok": True}
+
+            return _R()
+
+    c = _DC.__new__(_DC)
+    c.session = _Session()
+    c._access_token = 'live-token'
+    c._api_get('user/me/albums')
+    assert sent.get('access_token') == 'live-token'
+
+    sent.clear()
+    c._api_get('chart/0/playlists', use_token=False)
+    assert 'access_token' not in sent
+    assert requests is not None

--- a/tests/test_deezer_editorial_playlists.py
+++ b/tests/test_deezer_editorial_playlists.py
@@ -1,0 +1,194 @@
+"""Deezer's own editors publish playlists, and the public API serves them free.
+
+This is the BROWSE half of a pipeline that already existed. Loading a playlist,
+matching its tracks and syncing the result is /api/deezer/playlist/<id> plus the
+/api/deezer/discovery/* family, all of it already shipped. The only thing
+missing was a way to find a playlist without pasting a url — which is what the
+ListenBrainz created-for shelf does for its own source.
+
+No live network here. The api layer is stubbed; the shapes are real responses,
+trimmed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from core.deezer_client import DeezerClient
+
+
+# a real chart/152/playlists row, trimmed
+_ROW = {
+    "id": 1306931615,
+    "title": "Rock Essentials",
+    "nb_tracks": 100,
+    "link": "https://www.deezer.com/playlist/1306931615",
+    "picture": "https://api.deezer.com/playlist/1306931615/image",
+    "picture_medium": "https://cdn/250.jpg",
+    "picture_xl": "https://cdn/1000.jpg",
+    "user": {"id": 5080304882, "name": "Rod - Deezer Rock Editor"},
+    "type": "playlist",
+}
+
+
+def _client(payload):
+    c = DeezerClient.__new__(DeezerClient)
+    c._api_get = MagicMock(return_value=payload)
+    return c
+
+
+# ---------------------------------------------------------------------------
+# the client
+# ---------------------------------------------------------------------------
+
+def test_an_editorial_row_becomes_the_shape_the_shelf_reads():
+    c = _client({"data": [_ROW]})
+    got = c.get_editorial_playlists(152)[0]
+
+    assert got == {
+        'id': '1306931615',
+        'title': 'Rock Essentials',
+        'creator': 'Rod - Deezer Rock Editor',
+        'track_count': 100,
+        'image_url': 'https://cdn/1000.jpg',
+        'link': 'https://www.deezer.com/playlist/1306931615',
+        'source': 'deezer',
+    }
+
+
+def test_the_id_is_the_one_the_existing_loader_takes():
+    """The whole point: a card picked here goes through the pipeline that is
+    already there, not a second one written for browsing."""
+    c = _client({"data": [_ROW]})
+    assert c.get_editorial_playlists(152)[0]['id'] == str(_ROW['id'])
+
+
+def test_it_asks_the_genre_chart_it_was_given():
+    c = _client({"data": []})
+    c.get_editorial_playlists(116, limit=10)
+    c._api_get.assert_called_once_with('chart/116/playlists', {'limit': 10})
+
+
+def test_the_biggest_artwork_wins():
+    """Shelf tiles are retina; the smaller keys are the same image scaled."""
+    c = _client({"data": [dict(_ROW, picture_xl=None)]})
+    assert c.get_editorial_playlists(0)[0]['image_url'] == 'https://cdn/250.jpg'
+
+
+def test_an_unnamed_or_id_less_row_is_dropped_not_rendered_blank():
+    c = _client({"data": [dict(_ROW, title=''), dict(_ROW, id=None), _ROW]})
+    assert len(c.get_editorial_playlists(0)) == 1
+
+
+def test_a_row_without_a_user_is_credited_to_deezer():
+    c = _client({"data": [dict(_ROW, user=None)]})
+    assert c.get_editorial_playlists(0)[0]['creator'] == 'Deezer'
+
+
+@pytest.mark.parametrize("payload", [None, {}, {"data": None}, {"data": []}])
+def test_a_failed_browse_is_an_empty_row_not_an_error(payload):
+    assert _client(payload).get_editorial_playlists(0) == []
+
+
+@pytest.mark.parametrize("genre,expected", [
+    ("152", 'chart/152/playlists'),
+    (None, 'chart/0/playlists'),
+    ("not-a-number", 'chart/0/playlists'),
+])
+def test_a_junk_genre_falls_back_to_the_everything_chart(genre, expected):
+    c = _client({"data": []})
+    c.get_editorial_playlists(genre)
+    assert c._api_get.call_args.args[0] == expected
+
+
+def test_the_limit_is_bounded():
+    c = _client({"data": []})
+    c.get_editorial_playlists(0, limit=9999)
+    assert c._api_get.call_args.args[1]['limit'] == 100
+
+
+def test_search_uses_the_playlist_search_endpoint():
+    c = _client({"data": [_ROW]})
+    out = c.search_playlists('deep house', limit=5)
+    c._api_get.assert_called_once_with('search/playlist', {'q': 'deep house', 'limit': 5})
+    assert out[0]['title'] == 'Rock Essentials'
+
+
+def test_an_empty_search_asks_nothing():
+    c = _client({"data": []})
+    assert c.search_playlists('   ') == []
+    c._api_get.assert_not_called()
+
+
+def test_the_genre_list_is_offered_without_a_request():
+    """The chips must not cost an api call just to know what to ask for."""
+    c = DeezerClient.__new__(DeezerClient)
+    c._api_get = MagicMock(side_effect=AssertionError("asked the api for its own genre list"))
+    genres = c.get_editorial_genres()
+    assert {'id': 0, 'name': 'Top'} in genres
+    assert any(g['name'] == 'Rock' for g in genres)
+
+
+# ---------------------------------------------------------------------------
+# the routes
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def client(monkeypatch):
+    import api.source_playlists as sp
+
+    fake = MagicMock()
+    fake.get_editorial_playlists.return_value = [dict(
+        id='1', title='Rock Essentials', creator='Rod', track_count=100,
+        image_url='https://cdn/1000.jpg', link='', source='deezer')]
+    fake.search_playlists.return_value = []
+    fake.get_editorial_genres.return_value = [{'id': 0, 'name': 'Top'}]
+    monkeypatch.setattr(sp, "_get_deezer_client", lambda: fake)
+
+    app = Flask(__name__)
+    app.register_blueprint(sp.bp)
+    app.config["TESTING"] = True
+    c = app.test_client()
+    c._fake = fake
+    return c
+
+
+def test_the_shelf_endpoint_returns_playlists(client):
+    body = client.get('/api/discover/deezer/editorial?genre=152').get_json()
+    assert body['success'] is True
+    assert body['count'] == 1
+    assert body['playlists'][0]['id'] == '1'
+    assert body['scope'] == {'kind': 'genre', 'genre': '152'}
+    client._fake.get_editorial_playlists.assert_called_once_with('152', limit=25)
+
+
+def test_a_query_searches_instead_of_browsing(client):
+    body = client.get('/api/discover/deezer/editorial?q=deep+house').get_json()
+    assert body['scope'] == {'kind': 'search', 'query': 'deep house'}
+    client._fake.search_playlists.assert_called_once_with('deep house', limit=25)
+    client._fake.get_editorial_playlists.assert_not_called()
+
+
+def test_a_client_that_blows_up_gives_an_empty_shelf_not_a_500(client):
+    client._fake.get_editorial_playlists.side_effect = RuntimeError("deezer is down")
+    resp = client.get('/api/discover/deezer/editorial')
+    assert resp.status_code == 200
+    assert resp.get_json()['playlists'] == []
+
+
+def test_no_deezer_client_is_an_empty_shelf(monkeypatch):
+    import api.source_playlists as sp
+    monkeypatch.setattr(sp, "_get_deezer_client", lambda: None)
+    app = Flask(__name__)
+    app.register_blueprint(sp.bp)
+    resp = app.test_client().get('/api/discover/deezer/editorial')
+    assert resp.status_code == 200
+    assert resp.get_json()['playlists'] == []
+
+
+def test_the_genres_endpoint_lists_the_chips(client):
+    body = client.get('/api/discover/deezer/genres').get_json()
+    assert body['genres'] == [{'id': 0, 'name': 'Top'}]

--- a/tests/test_image_cache_endpoints.py
+++ b/tests/test_image_cache_endpoints.py
@@ -1,9 +1,10 @@
 """The artwork-cache HTTP surface: status, clear, prune, and ?v= thumbnails.
 
-Thumbnails are OPT-IN and off by default, so `?v=grid` must be inert until
+General-purpose thumbnails are OPT-IN and off by default, so `?v=grid` must be inert until
 someone turns them on in Settings -> Advanced. The cache itself keeps its
 existing default (on) — it has been on for every install since it shipped, and
 turning it off would silently slow down everyone already benefiting.
+Compact dashboard rail images are always resized independently of that toggle.
 """
 
 from __future__ import annotations
@@ -208,3 +209,18 @@ def test_image_cache_settings_actually_persist():
 
     config_manager.set('image_cache.thumbnails', False)   # leave it off again
 
+
+@pytest.mark.parametrize('proxy', [False, True])
+def test_dashboard_rail_is_resized_even_when_optional_thumbnails_are_off(client, cache, monkeypatch, proxy):
+    from urllib.parse import quote
+    from PIL import Image
+    _thumbnails(monkeypatch, False)
+    url = f'/api/image-proxy?url={quote(URL, safe="")}&v=rail' if proxy else f'/api/image-cache/{_key(cache)}?v=rail'
+    response = client.get(url)
+    assert response.status_code == 200
+    with Image.open(io.BytesIO(response.data)) as image:
+        assert image.width == VARIANT_MAX_WIDTH['rail']
+    assert len(response.data) < len(BIG)
+    again = client.get(url)
+    assert again.headers['X-SoulSync-Image-Cache'] == 'hit'
+    assert again.data == response.data

--- a/tests/test_lastfm_username_setting.py
+++ b/tests/test_lastfm_username_setting.py
@@ -1,0 +1,78 @@
+"""The Last.fm username has to be editable somewhere.
+
+Reported as #1241: a user typed their username wrong on the Stats page and had
+no way to correct it. The Stats page asks for it once — `needsUsername` is false
+as soon as a username is stored, WRONG or not, so the input disappears
+permanently — and it lived nowhere else in the app.
+
+The fix is where the reporter suggested: beside the API key and secret, which is
+where every other Last.fm credential already lives.
+
+These read the real files rather than a running app, because the failure was
+never in behaviour: the field simply did not exist.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_INDEX = (_ROOT / "webui" / "index.html").read_text(encoding="utf-8", errors="ignore")
+_SETTINGS_JS = (_ROOT / "webui" / "static" / "settings.js").read_text(encoding="utf-8", errors="ignore")
+
+
+def _strip_comments(text: str) -> str:
+    """A guard must never pass on the text of a comment explaining it."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", text, flags=re.M)
+
+
+def test_the_field_exists_on_the_settings_page():
+    assert 'id="lastfm-username"' in _INDEX
+
+
+def test_it_sits_in_the_lastfm_service_card():
+    """Next to the key and secret — anywhere else and it is lost again."""
+    card = _INDEX.split('data-service="lastfm"', 1)[1].split("</div>\n                                </div>", 1)[0]
+    assert 'id="lastfm-username"' in card
+    assert 'id="lastfm-api-key"' in card
+
+
+def test_the_saved_value_is_read_back_into_the_field():
+    """Without the load half the field is blank every time settings open, and
+    saving then wipes the stored username."""
+    js = _strip_comments(_SETTINGS_JS)
+    assert "settings.lastfm?.username" in js
+
+
+def test_the_save_uses_cfgstr_not_a_raw_value_read():
+    """_cfgStr returns undefined for a missing element, and JSON.stringify drops
+    an undefined key. A raw .value read on a field that is not on the page is
+    how a save writes '' over a stored setting — the settings-wipe class."""
+    js = _strip_comments(_SETTINGS_JS)
+    assert re.search(r"username:\s*_cfgStr\('lastfm-username'", js), (
+        "the username must be collected with _cfgStr"
+    )
+    assert not re.search(r"username:\s*document\.getElementById\('lastfm-username'\)\.value", js)
+
+
+def test_the_key_path_is_the_one_the_importer_reads():
+    """The field is useless if it writes a key nothing consumes.
+
+    The settings POST writes `<section>.<key>`, so a `username` key inside the
+    `lastfm` section becomes `lastfm.username` — which is exactly what the
+    importer and the automation handler ask for.
+    """
+    importer = (_ROOT / "core" / "listening_import" / "lastfm.py").read_text(encoding="utf-8")
+    handler = (_ROOT / "core" / "automation" / "handlers" / "lastfm_import.py").read_text(encoding="utf-8")
+    assert 'get("lastfm.username"' in importer
+    assert 'get("lastfm.username"' in handler
+
+
+def test_lastfm_is_a_section_the_server_persists():
+    """A section missing from the server's list is accepted and silently
+    dropped — the class test_settings_persist_whitelist.py exists for."""
+    server = (_ROOT / "web_server.py").read_text(encoding="utf-8", errors="ignore")
+    line = next(ln for ln in server.splitlines() if "for service in [" in ln)
+    assert "'lastfm'" in line

--- a/tests/test_lastfm_username_setting.py
+++ b/tests/test_lastfm_username_setting.py
@@ -76,3 +76,17 @@ def test_lastfm_is_a_section_the_server_persists():
     server = (_ROOT / "web_server.py").read_text(encoding="utf-8", errors="ignore")
     line = next(ln for ln in server.splitlines() if "for service in [" in ln)
     assert "'lastfm'" in line
+
+
+def test_status_returns_corrected_configuration_instead_of_failed_username(monkeypatch):
+    from flask import Flask
+    from types import SimpleNamespace
+    import api.stats as stats
+    monkeypatch.setattr(stats, "config_manager", SimpleNamespace(get=lambda key, default=None: {"lastfm.username": "corrected", "lastfm.api_key": "key"}.get(key, default)))
+    monkeypatch.setattr(stats, "_lastfm_import_worker", lambda: SimpleNamespace(status=lambda: {"username": "k", "status": "error"}))
+    monkeypatch.setattr(stats, "_automation_engine", lambda: None)
+    app = Flask(__name__)
+    app.register_blueprint(stats.bp)
+    response = app.test_client().get("/api/lastfm/listening-import/status")
+    assert response.status_code == 200
+    assert response.get_json()["username"] == "corrected"

--- a/tests/test_lyrics_timeouts.py
+++ b/tests/test_lyrics_timeouts.py
@@ -1,0 +1,30 @@
+"""Issue 1245: lyrics must not hold imports or player requests indefinitely."""
+import pytest
+import requests
+
+from core.lyrics_client import LyricsClient
+
+
+def test_both_lrclib_lookups_have_transport_timeouts(monkeypatch):
+    timeouts = []
+    def stalled(self, method, url, **kwargs):
+        timeouts.append(kwargs.get('timeout'))
+        raise requests.exceptions.ReadTimeout('simulated unresponsive lyrics service')
+    monkeypatch.setattr(requests.Session, 'request', stalled)
+    client = LyricsClient()
+    assert client.api is not None
+    assert client._fetch_remote_lyrics('Song', 'Artist', 'Album', 180) is None
+    assert len(timeouts) == 2  # exact lookup and search fallback
+    assert all(isinstance(t, tuple) and 0 < t[0] <= 5 and 0 < t[1] <= 10 for t in timeouts), timeouts
+
+
+def test_player_direct_api_also_uses_timeout(monkeypatch):
+    timeouts = []
+    def stalled(self, method, url, **kwargs):
+        timeouts.append(kwargs.get('timeout'))
+        raise requests.exceptions.ReadTimeout('simulated lyrics timeout')
+    monkeypatch.setattr(requests.Session, 'request', stalled)
+    client = LyricsClient()
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        client.api.search_lyrics(track_name='Song', artist_name='Artist')
+    assert timeouts == [(3.05, 10)]

--- a/tests/test_performance_1245.py
+++ b/tests/test_performance_1245.py
@@ -1,0 +1,233 @@
+"""Deterministic slow-I/O regressions: no live services or real library files."""
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+from core.image_cache import ImageCache
+from core.downloads import status as st
+
+
+def test_repeated_library_images_do_not_repeat_transactions(tmp_path, monkeypatch):
+    cache = ImageCache(tmp_path)
+    urls = [f'https://example.test/{i}.jpg' for i in range(75)]
+    for url in urls:
+        cache.cache_url_for(url)
+    statements = []
+    connect = cache._connect
+    def traced():
+        conn = connect()
+        conn.set_trace_callback(statements.append)
+        return conn
+    monkeypatch.setattr(cache, '_connect', traced)
+    for url in urls:
+        cache.cache_url_for(url)
+    writes = [sql for sql in statements if sql.lstrip().upper().startswith('INSERT')]
+    assert not writes, f'Repeated library page performed {len(writes)} write transactions'
+
+
+def test_slow_recovery_does_not_hold_status_request_or_task_lock():
+    entered, release = threading.Event(), threading.Event()
+    def finder(*args):
+        entered.set()
+        assert release.wait(5)
+        return '/found.flac', 'downloads'
+    deps = st.StatusDeps(
+        config_manager=SimpleNamespace(get=lambda key, default=None: default),
+        docker_resolve_path=lambda p: p, find_completed_file=finder,
+        make_context_key=lambda u, f: f'{u}::{f}',
+        submit_post_processing=lambda *a: None, get_cached_transfer_data=lambda: {},
+    )
+    task = dict(track_index=0, status='downloading', track_info={},
+                filename='song.flac', status_change_time=0)
+    with st.tasks_lock:
+        st.download_tasks['perf-task'] = task
+        st.download_batches['perf-batch'] = dict(phase='downloading', queue=['perf-task'])
+    with ThreadPoolExecutor(1) as pool:
+        future = pool.submit(st.build_single_batch_status, 'perf-batch', deps)
+        try:
+            assert entered.wait(2)
+            acquired = st.tasks_lock.acquire(timeout=0.2)
+            if acquired:
+                st.tasks_lock.release()
+            assert acquired, 'Filesystem scan held the global download lock'
+            assert future.result(timeout=0.5)[1] == 200
+        finally:
+            release.set()
+            future.result(timeout=3)
+            with st.tasks_lock:
+                st.download_tasks.pop('perf-task', None)
+                st.download_batches.pop('perf-batch', None)
+
+
+def test_import_http_response_does_not_wait_for_processing(monkeypatch):
+    from flask import Flask
+    from api import import_routes as routes
+    entered, release = threading.Event(), threading.Event()
+    def process(runtime, data):
+        entered.set()
+        assert release.wait(5)
+        return {'success': True, 'processed': 1, 'total': 1, 'errors': []}, 200
+    monkeypatch.setattr(routes, '_build_import_route_runtime', lambda: None)
+    monkeypatch.setattr(routes, '_import_album_process', process)
+    app = Flask(__name__)
+    def request():
+        with app.test_request_context('/api/import/album/process', method='POST',
+                                     json={'album': {}, 'matches': []},
+                                     headers={'Prefer': 'respond-async', 'Idempotency-Key': 'proof-1245'}):
+            response, status = routes.import_album_process()
+            return response.get_json(), status
+    with ThreadPoolExecutor(1) as pool:
+        future = pool.submit(request)
+        try:
+            assert entered.wait(2)
+            payload, status = future.result(timeout=0.3)
+            assert status == 202
+            assert payload['job_id']
+        finally:
+            release.set()
+            future.result(timeout=3)
+
+
+def test_cache_registration_survives_clear_and_refreshes_timestamp(tmp_path, monkeypatch):
+    import core.image_cache as module
+    cache = ImageCache(tmp_path)
+    now = [1000.0]
+    monkeypatch.setattr(module.time, 'time', lambda: now[0])
+    url = 'https://example.test/cover.jpg'
+    key = cache.key_for_url(url)
+    cache.cache_url_for(url)
+    cache.clear()
+    cache.cache_url_for(url)
+    assert cache._get_row(key) is not None
+    now[0] += 61
+    cache.cache_url_for(url)
+    assert cache._get_row(key)['last_accessed'] == now[0]
+
+
+def test_recovery_never_overwrites_cancellation_or_retries(monkeypatch):
+    for mutation in ({'status': 'cancelled'}, {'download_id': 'new-attempt'}, {'status': 'completed'}, {'cancel_requested': True}):
+        entered, release, done = threading.Event(), threading.Event(), threading.Event()
+        submitted = []
+        def finder(*args):
+            entered.set()
+            assert release.wait(3)
+            return '/found.flac', 'downloads'
+        class Pool:
+            def submit(self, fn):
+                def run():
+                    try:
+                        fn()
+                    finally:
+                        done.set()
+                threading.Thread(target=run).start()
+        monkeypatch.setattr(st, '_recovery_pool', Pool())
+        deps = st.StatusDeps(SimpleNamespace(get=lambda k, d=None: d), lambda p: p,
+                             finder, lambda u, f: f, lambda *a: submitted.append(a), lambda: {})
+        task = dict(status='downloading', filename='song.flac', status_change_time=0)
+        with st.tasks_lock:
+            st.download_tasks['race-1245'] = task
+            st._schedule_file_recovery('race-1245', 'batch', task, deps)
+        try:
+            assert entered.wait(2)
+            with st.tasks_lock:
+                task.update(mutation)
+                st._schedule_file_recovery('race-1245', 'batch', task, deps)
+            release.set()
+            assert done.wait(2)
+            assert not submitted
+            for key, value in mutation.items():
+                assert task[key] == value
+        finally:
+            release.set()
+            done.wait(3)
+            with st.tasks_lock:
+                st.download_tasks.pop('race-1245', None)
+
+
+def test_import_jobs_deduplicate_and_isolate_profiles():
+    from core.imports.jobs import ImportJobs
+    from core.profile_context import get_current_profile_id
+    jobs = ImportJobs(workers=1, capacity=1)
+    entered, release = threading.Event(), threading.Event()
+    calls = []
+    def operation():
+        calls.append(get_current_profile_id())
+        entered.set()
+        assert release.wait(3)
+        return {'success': True, 'processed': 1}, 200
+    try:
+        accepted, status = jobs.submit(7, 'key', 'album', {'a': 1}, operation)
+        assert status == 202 and entered.wait(2)
+        duplicate, _ = jobs.submit(7, 'key', 'album', {'a': 1}, operation)
+        assert duplicate == accepted
+        assert jobs.submit(7, 'key', 'album', {'a': 2}, operation)[1] == 409
+        assert jobs.submit(7, 'other', 'album', {}, operation)[1] == 429
+        assert jobs.get(8, accepted['job_id'])[1] == 404
+        release.set()
+        jobs.pool.shutdown(wait=True)
+        result, status = jobs.get(7, accepted['job_id'])
+        assert status == 200 and result['state'] == 'complete'
+        assert result['result']['processed'] == 1
+        assert calls == [7]
+    finally:
+        release.set()
+        jobs.pool.shutdown(wait=True)
+
+
+def test_recovery_submission_failure_does_not_strand_processing(monkeypatch):
+    monkeypatch.setattr(st, '_recovery_pool', SimpleNamespace(submit=lambda fn: fn()))
+    def rejected(*args):
+        raise RuntimeError('executor unavailable')
+    deps = st.StatusDeps(SimpleNamespace(get=lambda k, d=None: d), lambda p: p,
+                         lambda *a: ('/found.flac', 'downloads'), lambda u, f: f,
+                         rejected, lambda: {})
+    task = dict(status='downloading', filename='song.flac', status_change_time=0)
+    st.download_tasks['submit-1245'] = task
+    try:
+        st._schedule_file_recovery('submit-1245', 'batch', task, deps)
+        assert task['status'] == 'downloading'
+        assert 'submit-1245' not in st._recovery_pending
+    finally:
+        st.download_tasks.pop('submit-1245', None)
+
+
+def test_import_job_errors_are_reported_without_reexecuting():
+    from core.imports.jobs import ImportJobs
+    jobs = ImportJobs(workers=1)
+    def fail():
+        raise RuntimeError('provider failed')
+    accepted, _ = jobs.submit(1, 'fail', 'single', {}, fail)
+    jobs.pool.shutdown(wait=True)
+    payload, _ = jobs.get(1, accepted['job_id'])
+    assert payload['state'] == 'complete'
+    assert payload['result']['success'] is False
+    assert payload['status'] == 500
+    assert jobs.submit(1, 'fail', 'single', {}, fail)[0] == accepted
+
+
+def test_job_http_failure_preserves_disconnected_server_error(monkeypatch):
+    from flask import Flask
+    from api import import_routes as routes
+    from core.imports import jobs as module
+    jobs = module.ImportJobs(workers=1)
+    monkeypatch.setattr(module, 'import_jobs', jobs)
+    result = {'success': False, 'error': 'Server disconnected', 'error_code': 'media_server_not_connected'}
+    accepted, _ = jobs.submit(1, 'offline', 'album', {}, lambda: (result, 503))
+    jobs.pool.shutdown(wait=True)
+    app = Flask(__name__)
+    with app.test_request_context():
+        response, status = routes.import_job_status(accepted['job_id'])
+        assert status == 503
+        assert response.get_json() == result
+
+
+def test_synchronous_import_api_remains_compatible(monkeypatch):
+    from flask import Flask
+    from api import import_routes as routes
+    monkeypatch.setattr(routes, '_build_import_route_runtime', lambda: None)
+    result = {'success': True, 'processed': 1, 'total': 1, 'errors': []}
+    monkeypatch.setattr(routes, '_import_album_process', lambda runtime, data: (result, 200))
+    with Flask(__name__).test_request_context(method='POST', json={}):
+        response, status = routes.import_album_process()
+        assert status == 200
+        assert response.get_json() == result

--- a/tests/test_performance_review.py
+++ b/tests/test_performance_review.py
@@ -1,0 +1,181 @@
+"""Behavioral regressions found reviewing the five unpushed #1245 commits."""
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_repeated_search_timeouts_do_not_accumulate_unbounded_workers(monkeypatch):
+    from core.metadata import multi_source_search as m
+    release = threading.Event()
+    condition = threading.Condition()
+    active = 0
+    def blocked(name, *args, **kwargs):
+        nonlocal active
+        with condition:
+            active += 1
+            condition.notify_all()
+        try:
+            assert release.wait(5)
+            return name, [], []
+        finally:
+            with condition:
+                active -= 1
+                condition.notify_all()
+    monkeypatch.setattr(m, '_search_one_source', blocked)
+    try:
+        for i in range(12):
+            m.search_all_sources(m.TrackQuery('song', 'artist'), [(str(i), None)], timeout_seconds=0.02)
+        with condition:
+            assert active <= 8, f'{active} provider workers still running after 12 expired requests'
+    finally:
+        release.set()
+        with condition:
+            assert condition.wait_for(lambda: active == 0, timeout=3)
+
+
+def test_video_status_has_short_read_timeout(monkeypatch):
+    from core.video import sources as m
+    import plexapi.server
+    m.invalidate_video_source_cache()
+    monkeypatch.setattr(m, '_vdb', lambda: None)
+    monkeypatch.setattr(m, 'resolve_video_server', lambda db=None: 'plex')
+    monkeypatch.setattr(m, '_load_selection', lambda: {})
+    monkeypatch.setattr(m, 'video_plex_config', lambda db=None: {'base_url': 'http://example.test', 'token': 'token'})
+    seen = []
+    def connect(*args, timeout=None):
+        seen.append(timeout)
+        read_timeout = timeout[1] if isinstance(timeout, tuple) else timeout
+        assert read_timeout <= 8, 'Status handshake can wait 120 seconds for HTTP headers'
+        return SimpleNamespace(library=SimpleNamespace(sections=lambda: []), activities=lambda: [])
+    monkeypatch.setattr(plexapi.server, 'PlexServer', connect)
+    try:
+        assert m.video_server_scan_in_progress() is False
+        assert seen
+    finally:
+        m.invalidate_video_source_cache()
+
+
+@pytest.mark.parametrize('video', [False, True])
+def test_plex_token_suffix_changes_reconnect(monkeypatch, video):
+    import plexapi.server
+    if video:
+        from core.video import sources as m
+        invalidate, connect = m.invalidate_video_source_cache, m._build_source
+        monkeypatch.setattr(m, '_vdb', lambda: None)
+        monkeypatch.setattr(m, 'resolve_video_server', lambda db=None: 'plex')
+        config_name = 'video_plex_config'
+    else:
+        import core.server_activity as m
+        invalidate, connect = m.invalidate_plex_server_cache, m._plex_server
+        config_name = '_plex_config'
+    cfg = {'base_url': 'http://example.test', 'token': 'abcdef-old'}
+    monkeypatch.setattr(m, config_name, lambda db=None: cfg)
+    seen = []
+    def build(url, token, **kwargs):
+        seen.append(token)
+        return SimpleNamespace()
+    monkeypatch.setattr(plexapi.server, 'PlexServer', build)
+    invalidate()
+    try:
+        connect()
+        cfg['token'] = 'abcdef-new'
+        connect()
+        assert seen == ['abcdef-old', 'abcdef-new']
+    finally:
+        invalidate()
+
+
+def test_recovery_does_not_start_for_already_requested_cancellation(monkeypatch):
+    from core.downloads import status as m
+    calls = []
+    monkeypatch.setattr(m, '_recovery_pool', SimpleNamespace(submit=lambda fn: calls.append(fn)))
+    task = {'status': 'downloading', 'filename': 'song.flac', 'cancel_requested': True}
+    try:
+        with m.tasks_lock:
+            m._schedule_file_recovery('review-cancel', 'batch', task, None)
+        assert not calls
+    finally:
+        if calls:
+            m._recovery_pending.pop('review-cancel', None)
+            m._recovery_slots.release()
+
+
+def test_recovery_submission_error_preserves_a_newer_attempt(monkeypatch):
+    from core.downloads import status as m
+    monkeypatch.setattr(m, '_recovery_pool', SimpleNamespace(submit=lambda fn: fn()))
+    task = dict(status='downloading', filename='old.flac', status_change_time=0)
+    def submit(*args):
+        task.update(filename='new.flac', status='post_processing', status_change_time=123)
+        raise RuntimeError('old submission failed after another attempt took over')
+    deps = m.StatusDeps(SimpleNamespace(get=lambda k, d=None: d), lambda p: p,
+                        lambda *args: ('/old.flac', 'downloads'), lambda u, f: f, submit, lambda: {})
+    m.download_tasks['review-retry'] = task
+    try:
+        m._schedule_file_recovery('review-retry', 'batch', task, deps)
+        assert task['status'] == 'post_processing'
+        assert task['status_change_time'] == 123
+    finally:
+        m.download_tasks.pop('review-retry', None)
+
+
+@pytest.mark.parametrize('video', [False, True])
+def test_offline_cache_ttl_starts_when_connection_finishes(monkeypatch, video):
+    import plexapi.server
+    if video:
+        from core.video import sources as m
+        invalidate, connect = m.invalidate_video_source_cache, m._build_source
+        monkeypatch.setattr(m, '_vdb', lambda: None)
+        monkeypatch.setattr(m, 'resolve_video_server', lambda db=None: 'plex')
+        config_name = 'video_plex_config'
+    else:
+        import core.server_activity as m
+        invalidate, connect = m.invalidate_plex_server_cache, m._plex_server
+        config_name = '_plex_config'
+    monkeypatch.setattr(m, config_name, lambda db=None: {'base_url': 'http://example.test', 'token': 'token'})
+    clock = [100.0]
+    monkeypatch.setattr(m.time, 'time', lambda: clock[0])
+    calls = []
+    def fail(*args, **kwargs):
+        calls.append(1)
+        clock[0] += 70
+        raise ConnectionError('slow failure')
+    monkeypatch.setattr(plexapi.server, 'PlexServer', fail)
+    invalidate()
+    try:
+        assert connect() is None
+        assert connect() is None
+        assert len(calls) == 1
+    finally:
+        invalidate()
+
+
+def test_expired_metadata_search_does_not_start_fallback_queries(monkeypatch):
+    from core.metadata import multi_source_search as m
+    clock = [10.0]
+    monkeypatch.setattr(m.time, 'monotonic', lambda: clock[0])
+    queries = []
+    def search(query, **kwargs):
+        queries.append(query)
+        clock[0] = 20.0
+        return []
+    m._search_one_source('deezer', SimpleNamespace(search_tracks=search), m.TrackQuery('Song', 'Artist'), 'Song', deadline=15.0)
+    assert len(queries) == 1
+
+
+def test_reused_plex_client_does_not_keep_old_refreshing_flag():
+    from core.video.sources import PlexVideoSource
+    state = {'refreshing': True}
+    class CachedLibrary:
+        def __init__(self):
+            self.cached = None
+        def reload(self):
+            self.cached = None
+        def sections(self):
+            if self.cached is None:
+                self.cached = [SimpleNamespace(type='movie', title='Movies', refreshing=state['refreshing'])]
+            return self.cached
+    src = PlexVideoSource(SimpleNamespace(library=CachedLibrary(), activities=lambda: []), movies_lib='Movies')
+    assert src.is_scanning('movie') is True
+    state['refreshing'] = False
+    assert src.is_scanning('movie') is False

--- a/tests/test_podcast_api_hardening.py
+++ b/tests/test_podcast_api_hardening.py
@@ -1,0 +1,140 @@
+"""The podcast endpoints that take a url or a file from the caller.
+
+audio-proxy is the one that matters most: it fetches whatever url it is handed,
+from the server, and streams the result back. SoulSync's login gate is off by
+default, so before it was checked anyone who could reach the web ui could read
+internal http services through it. The audiobook sample proxy says the same
+thing about itself in its docstring and solves it with an allowlist; podcast
+audio comes from thousands of cdns so the check is on the address instead.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+from api.podcasts import create_podcasts_blueprint
+from core.podcast_ingest_guard import MAX_OPML_BYTES
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(create_podcasts_blueprint())
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# audio-proxy
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1:8080/admin",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://192.168.1.1/",
+    "http://[::1]/",
+    "file:///etc/passwd",
+])
+def test_the_proxy_refuses_to_fetch_off_the_internet(client, url):
+    with patch("api.podcasts.requests.get",
+               side_effect=AssertionError("a refused url must never be fetched")):
+        resp = client.get("/api/podcasts/audio-proxy", query_string={"url": url})
+    assert resp.status_code == 400
+
+
+def test_the_proxy_still_streams_a_real_enclosure(client):
+    upstream = MagicMock()
+    upstream.status_code = 200
+    upstream.headers = {"Content-Type": "audio/mpeg", "Content-Length": "3"}
+    upstream.iter_content = lambda chunk_size=None: iter([b"abc"])
+
+    with patch("api.podcasts.check_url", return_value=(True, "")), \
+         patch("api.podcasts.requests.get", return_value=upstream):
+        resp = client.get("/api/podcasts/audio-proxy",
+                          query_string={"url": "https://cdn.example/ep1.mp3"})
+
+    assert resp.status_code == 200
+    assert resp.data == b"abc"
+
+
+def test_the_proxy_does_not_follow_a_redirect_blindly(client):
+    """A url that passes the check could still 302 straight to 127.0.0.1."""
+    redirect = MagicMock()
+    redirect.status_code = 302
+    redirect.headers = {"Location": "http://127.0.0.1:8080/admin"}
+
+    calls = []
+
+    def _get(url, **kw):
+        calls.append(url)
+        assert kw.get("allow_redirects") is False, "requests must not follow it for us"
+        return redirect
+
+    # the first hop passes the check; the loopback it redirects to must not
+    with patch("api.podcasts.check_url",
+               side_effect=lambda u: (not u.startswith("http://127."), "refused")), \
+         patch("api.podcasts.requests.get", side_effect=_get):
+        resp = client.get("/api/podcasts/audio-proxy",
+                          query_string={"url": "https://cdn.example/ep1.mp3"})
+
+    assert resp.status_code == 502
+    # the first hop was fetched, the loopback hop never was
+    assert calls == ["https://cdn.example/ep1.mp3"]
+
+
+def test_a_missing_url_is_still_a_400(client):
+    assert client.get("/api/podcasts/audio-proxy").status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# opml
+# ---------------------------------------------------------------------------
+
+def test_an_oversized_opml_upload_is_refused(client):
+    import io as _io
+    big = b"<opml>" + b"x" * (MAX_OPML_BYTES + 100) + b"</opml>"
+    resp = client.post(
+        "/api/podcasts/opml/import",
+        data={"file": (_io.BytesIO(big), "subs.opml")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 413
+
+
+def test_an_oversized_opml_body_is_refused(client):
+    resp = client.post("/api/podcasts/opml/import",
+                       json={"opml_text": "x" * (MAX_OPML_BYTES + 100)})
+    assert resp.status_code == 413
+
+
+def test_an_opml_declaring_entities_imports_nothing(client):
+    bomb = """<?xml version="1.0"?>
+<!DOCTYPE o [ <!ENTITY a "AAAAAAAAAA"> <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;"> ]>
+<opml version="2.0"><body><outline text="&b;" xmlUrl="https://feeds.example.com/x"/></body></opml>"""
+    resp = client.post("/api/podcasts/opml/import", json={"opml_text": bomb})
+    assert resp.status_code == 200
+    assert resp.get_json()["count"] == 0
+
+
+def test_a_normal_opml_still_previews(client):
+    opml = ('<opml version="2.0"><body>'
+            '<outline text="Show" xmlUrl="https://feeds.example.com/show.xml"/>'
+            '</body></opml>')
+    resp = client.post("/api/podcasts/opml/import", json={"opml_text": opml})
+    body = resp.get_json()
+    assert resp.status_code == 200
+    assert body["count"] == 1
+    assert body["feeds"][0]["feed_url"] == "https://feeds.example.com/show.xml"
+
+
+def test_opml_drops_a_scheme_we_would_never_fetch(client):
+    opml = ('<opml version="2.0"><body>'
+            '<outline text="Good" xmlUrl="https://feeds.example.com/a.xml"/>'
+            '<outline text="Bad" xmlUrl="file:///etc/passwd"/>'
+            '</body></opml>')
+    resp = client.post("/api/podcasts/opml/import", json={"opml_text": opml})
+    feeds = resp.get_json()["feeds"]
+    assert [f["feed_url"] for f in feeds] == ["https://feeds.example.com/a.xml"]

--- a/tests/test_podcast_automation.py
+++ b/tests/test_podcast_automation.py
@@ -15,8 +15,6 @@ from api.podcasts import create_podcasts_blueprint
 from core.podcast_automation import (
     get_scan_status,
     scan_and_auto_download_podcasts,
-    start_podcast_automation,
-    stop_podcast_automation,
 )
 from core.podcast_client import PodcastEpisode, PodcastShow
 
@@ -257,9 +255,14 @@ def test_api_watchlist_scan_endpoints(client):
     assert "status" in status_data
 
 
-def test_scan_only_downloads_most_recent_episode_even_with_many_unseen():
-    """Verify that when a feed has multiple (e.g. 5) un-downloaded episodes,
-    only the single newest episode is queued for download."""
+def test_a_row_with_no_follow_date_still_takes_only_the_newest():
+    """An older watchlist row has no date_added, so it keeps the old behaviour.
+
+    The scan takes what was published since you followed a show. A row written
+    before that had a follow date cannot answer "since when", and guessing would
+    mean claiming a back catalogue nobody asked for, so it falls back to the
+    single newest episode exactly as it did before.
+    """
     mock_db = MagicMock()
     mock_db.get_watchlist_podcasts.return_value = [
         {
@@ -331,3 +334,127 @@ def test_scan_only_downloads_most_recent_episode_even_with_many_unseen():
         assert args["title"] == "Episode 5"
         assert args["enclosure_url"] == "https://example.com/ep5.mp3"
 
+
+
+# ---------------------------------------------------------------------------
+# What counts as new: published since you followed the show
+# ---------------------------------------------------------------------------
+
+def _episode(n, published):
+    return PodcastEpisode(
+        guid=f"ep{n}", title=f"Episode {n}", enclosure_url=f"https://cdn.example/ep{n}.mp3",
+        enclosure_type="audio/mpeg", enclosure_length=1000, pub_date=published,
+        duration_seconds=300, description="", show_notes="", season=1,
+        episode_number=n, episode_type="full", artwork_url="", chapter_url=None,
+        transcript_url=None, show_title="Backlog Show", author="Host",
+    )
+
+
+def _show_with(episodes):
+    return PodcastShow(
+        feed_url="https://feeds.example.com/backlog.xml", title="Backlog Show",
+        author="Host", description="", artwork_url="", itunes_id=None, website="",
+        language="en", categories=[], explicit=False,
+        episode_count=len(episodes), episodes=episodes,
+    )
+
+
+def _scan_with(rows, episodes):
+    db = MagicMock()
+    db.get_watchlist_podcasts.return_value = rows
+    db.is_podcast_episode_downloaded.return_value = False
+    client = MagicMock()
+    client.fetch_feed.return_value = _show_with(episodes)
+    with patch("core.podcast_automation._get_db", return_value=db), \
+         patch("core.podcast_automation.get_podcast_client", return_value=client), \
+         patch("api.podcasts.queue_podcast_download",
+               return_value={"success": True, "task_id": "t"}) as queued:
+        result = scan_and_auto_download_podcasts(profile_id=1)
+    return result, queued
+
+
+def _row(followed_at):
+    return {
+        "id": 1, "feed_url": "https://feeds.example.com/backlog.xml",
+        "title": "Backlog Show", "author": "Host", "auto_download": 1,
+        "retention_days": 0, "date_added": followed_at,
+    }
+
+
+def test_every_episode_published_since_you_followed_is_taken():
+    """Three episodes between two passes used to lose two of them, silently.
+
+    The next pass looks at the newest again, finds it already downloaded, and
+    never looks further back - so the middle episodes never arrive and nothing
+    anywhere reports a problem.
+    """
+    followed = datetime.now(timezone.utc) - timedelta(days=10)
+    episodes = [_episode(n, followed + timedelta(days=n)) for n in (3, 2, 1)]
+    result, queued = _scan_with([_row(followed.isoformat())], episodes)
+
+    assert result["episodes_queued"] == 3
+    assert queued.call_count == 3
+
+
+def test_the_back_catalogue_from_before_you_followed_is_left_alone():
+    """Following a show with 800 old episodes must not queue 800 downloads."""
+    followed = datetime.now(timezone.utc)
+    old = [_episode(n, followed - timedelta(days=n)) for n in range(1, 20)]
+    result, queued = _scan_with([_row(followed.isoformat())], old)
+
+    assert result["episodes_queued"] == 0
+    assert queued.call_count == 0
+
+
+def test_one_show_cannot_claim_the_whole_pass():
+    from core.podcast_automation import MAX_BACKLOG_PER_SHOW_PER_PASS
+
+    followed = datetime.now(timezone.utc) - timedelta(days=100)
+    many = [_episode(n, followed + timedelta(days=n)) for n in range(40, 0, -1)]
+    result, _ = _scan_with([_row(followed.isoformat())], many)
+
+    assert result["episodes_queued"] == MAX_BACKLOG_PER_SHOW_PER_PASS
+
+
+def test_an_episode_with_no_date_is_treated_as_new():
+    """A feed that omits pub_date would otherwise never auto-download at all."""
+    followed = datetime.now(timezone.utc) - timedelta(days=5)
+    result, _ = _scan_with([_row(followed.isoformat())], [_episode(1, None)])
+
+    assert result["episodes_queued"] == 1
+
+
+def test_an_already_downloaded_episode_is_not_queued_again():
+    followed = datetime.now(timezone.utc) - timedelta(days=10)
+    episodes = [_episode(n, followed + timedelta(days=n)) for n in (2, 1)]
+
+    db = MagicMock()
+    db.get_watchlist_podcasts.return_value = [_row(followed.isoformat())]
+    # the newer one is already on disk, the older one is not
+    db.is_podcast_episode_downloaded.side_effect = lambda **kw: kw["guid"] == "ep2"
+    client = MagicMock()
+    client.fetch_feed.return_value = _show_with(episodes)
+    with patch("core.podcast_automation._get_db", return_value=db), \
+         patch("core.podcast_automation.get_podcast_client", return_value=client), \
+         patch("api.podcasts.queue_podcast_download",
+               return_value={"success": True, "task_id": "t"}) as queued:
+        result = scan_and_auto_download_podcasts(profile_id=1)
+
+    assert result["episodes_queued"] == 1
+    assert queued.call_args.args[0]["guid"] == "ep1"
+
+
+def test_a_naive_follow_date_from_sqlite_is_comparable():
+    """date_added comes back naive from sqlite while pub_date is aware.
+
+    Comparing those two directly raises TypeError, which the per-podcast except
+    would swallow into a scan error rather than a crash - so the episodes would
+    quietly stop arriving.
+    """
+    followed = datetime.now(timezone.utc) - timedelta(days=10)
+    sqlite_shape = followed.strftime("%Y-%m-%d %H:%M:%S")
+    episodes = [_episode(n, followed + timedelta(days=n)) for n in (2, 1)]
+    result, _ = _scan_with([_row(sqlite_shape)], episodes)
+
+    assert result["errors"] == []
+    assert result["episodes_queued"] == 2

--- a/tests/test_podcast_client.py
+++ b/tests/test_podcast_client.py
@@ -50,7 +50,23 @@ def _mock_response(json_data=None, content=b"", status_code=200, headers=None):
     if json_data is not None:
         resp.json = Mock(return_value=json_data)
     resp.content = content
+    # fetch_feed reads through the ingest guard now, which streams so it can stop
+    # at a size cap. one chunk is enough to stand in for that here.
+    resp.iter_content = lambda chunk_size=None: iter([content] if content else [])
     return resp
+
+
+@pytest.fixture(autouse=True)
+def _allow_test_feed_urls():
+    """These tests are about parsing, not about the url guard.
+
+    check_url does a real dns lookup, so leaving it live would make every feed
+    test depend on the network and on example.com resolving. The guard has its
+    own tests in test_podcast_ingest_guard.py, which is where its behaviour is
+    actually pinned.
+    """
+    with patch("core.podcast_ingest_guard.check_url", return_value=(True, "")):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_podcast_ingest_guard.py
+++ b/tests/test_podcast_ingest_guard.py
@@ -1,0 +1,203 @@
+"""Guards for what the podcast side accepts from outside: urls and xml.
+
+Podcasts are the one part of the app where a url comes from somewhere else - a
+feed somebody pastes, an opml file another app exported, an enclosure chosen by
+whoever runs the feed - and every one of those ends in a server-side fetch.
+
+No live dns here. getaddrinfo is patched, so a name resolves to whatever the
+test says it does and the suite does not depend on the network.
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from core.podcast_ingest_guard import (
+    MAX_FEED_BYTES,
+    MAX_OPML_BYTES,
+    UnsafeXmlError,
+    check_url,
+    has_fetchable_scheme,
+    is_public_url,
+    parse_xml_safely,
+    read_capped,
+)
+
+
+def _resolving_to(*addresses):
+    """Patch dns so any name answers with these addresses."""
+    infos = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (a, 0)) for a in addresses]
+    return patch("socket.getaddrinfo", return_value=infos)
+
+
+# ---------------------------------------------------------------------------
+# scheme
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "file:///etc/passwd",
+    "gopher://example.com/",
+    "data:text/html,<script>",
+    "ftp://example.com/f",
+    "",
+    "not-a-url",
+])
+def test_only_http_and_https_are_fetchable(url):
+    ok, reason = check_url(url)
+    assert ok is False
+    assert reason
+
+
+def test_a_scheme_check_needs_no_dns():
+    """has_fetchable_scheme is used by the opml parser, which must stay pure."""
+    with patch("socket.getaddrinfo", side_effect=AssertionError("dns was consulted")):
+        assert has_fetchable_scheme("https://feeds.example.com/rss") is True
+        assert has_fetchable_scheme("file:///etc/passwd") is False
+        assert has_fetchable_scheme("https://") is False
+
+
+# ---------------------------------------------------------------------------
+# address
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("literal", [
+    "http://127.0.0.1/x",           # loopback
+    "http://10.0.0.5/x",            # private
+    "http://192.168.1.1/x",         # private
+    "http://172.16.0.1/x",          # private
+    "http://169.254.169.254/x",     # link local: the cloud metadata endpoint
+    "http://0.0.0.0/x",             # unspecified
+    "http://[::1]/x",               # v6 loopback
+    "http://[::ffff:127.0.0.1]/x",  # v4 loopback wearing a v6 hat
+])
+def test_an_address_literal_off_the_internet_is_refused(literal):
+    with patch("socket.getaddrinfo", side_effect=AssertionError("a literal needs no dns")):
+        ok, reason = check_url(literal)
+    assert ok is False
+    assert reason
+
+
+def test_a_name_that_resolves_inward_is_refused():
+    with _resolving_to("127.0.0.1"):
+        ok, reason = check_url("http://podcast.internal/rss")
+    assert ok is False
+    assert "private or local" in reason
+
+
+def test_a_name_that_resolves_to_a_real_address_is_allowed():
+    with _resolving_to("93.184.216.34"):
+        assert is_public_url("https://feeds.example.com/rss") is True
+
+
+def test_one_private_answer_is_enough_to_refuse():
+    """A name answering with both a public and a private address is a trick."""
+    with _resolving_to("93.184.216.34", "127.0.0.1"):
+        ok, _ = check_url("https://split.example.com/rss")
+    assert ok is False
+
+
+def test_a_name_that_does_not_resolve_is_refused():
+    with patch("socket.getaddrinfo", side_effect=socket.gaierror("nope")):
+        ok, reason = check_url("https://nowhere.example/rss")
+    assert ok is False
+    assert "resolve" in reason
+
+
+def test_the_opt_in_lets_a_self_hoster_use_their_own_network():
+    class _Cfg:
+        def get(self, key, default=None):
+            return True if key == "podcasts.allow_private_feed_hosts" else default
+
+    with patch("core.settings.config_manager", _Cfg()):
+        assert is_public_url("http://192.168.1.50:8000/rss") is True
+
+
+def test_a_config_that_cannot_be_read_keeps_the_gate_shut():
+    class _Boom:
+        def get(self, key, default=None):
+            raise RuntimeError("database is down")
+
+    with patch("core.settings.config_manager", _Boom()):
+        assert is_public_url("http://192.168.1.50:8000/rss") is False
+
+
+# ---------------------------------------------------------------------------
+# xml
+# ---------------------------------------------------------------------------
+
+_BILLION_LAUGHS = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY a "AAAAAAAAAA">
+  <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+  <!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">
+]>
+<rss><channel><title>&c;</title></channel></rss>"""
+
+
+def test_entity_expansion_is_refused():
+    with pytest.raises(UnsafeXmlError):
+        parse_xml_safely(_BILLION_LAUGHS)
+
+
+def test_stdlib_would_have_expanded_it():
+    """The reason the guard exists, pinned so nobody 'simplifies' it away.
+
+    ElementTree refuses an EXTERNAL entity, so a feed cannot read a local file,
+    but it expands INTERNAL ones - which is the whole billion-laughs family.
+    """
+    import xml.etree.ElementTree as ET
+    root = ET.fromstring(_BILLION_LAUGHS)
+    grew = len(root.find("channel/title").text)
+    # three levels of ten, so the title is 10^3 characters. each further level
+    # multiplies by ten again, which is how a document this size reaches
+    # gigabytes - the fixture is deliberately kept small enough to be harmless.
+    assert grew == 1000
+    assert grew > 4 * len(_BILLION_LAUGHS)
+
+
+def test_a_real_feed_still_parses():
+    feed = b'<?xml version="1.0"?><rss><channel><title>Real</title></channel></rss>'
+    assert parse_xml_safely(feed).find("channel/title").text == "Real"
+
+
+def test_a_feed_that_merely_says_the_word_still_parses():
+    feed = b"<rss><channel><title>All About DOCTYPE Files</title></channel></rss>"
+    assert parse_xml_safely(feed).find("channel/title").text == "All About DOCTYPE Files"
+
+
+def test_str_input_is_parsed_as_bytes():
+    assert parse_xml_safely("<rss><channel><title>x</title></channel></rss>") is not None
+
+
+def test_empty_is_refused():
+    with pytest.raises(UnsafeXmlError):
+        parse_xml_safely(b"")
+
+
+# ---------------------------------------------------------------------------
+# size
+# ---------------------------------------------------------------------------
+
+class _Resp:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_content(self, chunk_size=None):
+        return iter(self._chunks)
+
+
+def test_a_body_within_the_cap_is_returned_whole():
+    assert read_capped(_Resp([b"abc", b"def"]), limit=100) == b"abcdef"
+
+
+def test_a_body_over_the_cap_is_refused_not_truncated():
+    """Half an xml document is not a feed, so this must not hand back a prefix."""
+    assert read_capped(_Resp([b"x" * 60, b"y" * 60]), limit=100) is None
+
+
+def test_the_caps_are_sane():
+    assert MAX_FEED_BYTES >= 1024 * 1024
+    assert MAX_OPML_BYTES >= 1024 * 1024

--- a/tests/test_podcast_module_isolation.py
+++ b/tests/test_podcast_module_isolation.py
@@ -1,0 +1,118 @@
+"""Podcasts may not reach into the music acquisition pipeline, or into video.
+
+There is already a behavioural isolation test (test_podcast_isolation.py) that
+checks is_music_batch keeps podcast batches out of the music worker pool. This
+one is the structural half: it reads the modules' real imports rather than
+trusting that nobody added one.
+
+The rules are NOT the audiobook rules, and the difference is the point.
+Audiobooks were built with their own database and may not import ``database``
+at all. Podcasts store the watchlist in music_library.db and write their
+progress into the shared runtime state so episodes appear on the existing
+Downloads page. Both of those are deliberate, and both are listed below as
+allowed with the reason, because an isolation test that forbids what the design
+actually does just gets edited until it passes.
+
+What podcasts must never touch is the music side's ACQUISITION: its download
+engine, its wishlist, its matching. That is what went wrong before podcasts were
+pulled back out of the music worker pool in cb6f1aeeb, and it is what this holds.
+
+The module list is derived from the filesystem on purpose. The audiobook guard
+hardcodes its list, and three modules added later were never covered by it.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _podcast_modules():
+    """Every podcast module there is, found rather than listed."""
+    found = sorted(_ROOT.glob("core/podcast*.py")) + sorted(_ROOT.glob("api/podcasts.py"))
+    assert found, "no podcast modules found - has the layout changed?"
+    return found
+
+
+# Reaching any of these is how an isolated feature stops being isolated.
+_FORBIDDEN = (
+    "core.downloads",            # the music download engine and its lifecycle
+    "core.download_engine",
+    "core.download_orchestrator",
+    "core.wishlist",             # the music wishlist
+    "core.matching_engine",
+    "core.spotify_client",
+    "core.plex_client",
+    "core.jellyfin_client",
+    "core.navidrome_client",
+    "core.video",                # the video side
+    "core.audiobook_",           # the audiobook side
+    "web_server",
+)
+
+# Deliberate, and each one earns its place:
+#   core.runtime_state   - podcast progress is written into the SHARED download
+#                          state under its own batch id, flagged is_music False,
+#                          which is how an episode shows on the Downloads page
+#                          without joining the music pipeline.
+#   database.music_...   - the podcast watchlist is a table in music_library.db.
+#                          audiobooks got their own file, podcasts did not, and
+#                          moving them now would be a migration for no gain.
+_ALLOWED_SHARED = ("core.runtime_state", "database.music_database")
+
+
+def _imported_names(path: Path):
+    """Every module name this file imports, including inside functions."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.append(node.module)
+    return names
+
+
+@pytest.mark.parametrize("path", _podcast_modules(), ids=lambda p: p.name)
+def test_a_podcast_module_never_imports_music_acquisition(path):
+    for name in _imported_names(path):
+        if name in _ALLOWED_SHARED:
+            continue
+        for banned in _FORBIDDEN:
+            assert not (name == banned.rstrip(".") or name.startswith(banned)), (
+                f"{path.relative_to(_ROOT)} imports {name}, which belongs to "
+                f"another side of the app"
+            )
+
+
+def test_the_shared_state_podcasts_do_use_is_the_state_music_skips():
+    """The allowance above is only safe because the music side honours the flag.
+
+    is_music_batch is what keeps the music worker pool, the batch healer and the
+    music wishlist failure processor away from a podcast batch. If that stops
+    being true, writing into the shared state stops being safe and this test is
+    the one that should say so.
+    """
+    from core.downloads.lifecycle import is_music_batch
+
+    assert is_music_batch("podcasts", {}) is False
+    assert is_music_batch("batch-x", {"is_music": False}) is False
+    assert is_music_batch("batch-x", {"managed_externally": True}) is False
+    # and a real music batch is still a music batch
+    assert is_music_batch("batch-x", {"playlist_id": "p1"}) is True
+
+
+def test_every_podcast_module_is_covered():
+    """The list is a glob, so this is really a check that the glob still finds
+    them - a module renamed out of the pattern would silently stop being held."""
+    covered = {p.name for p in _podcast_modules()}
+    assert "podcasts.py" in covered
+    assert "podcast_client.py" in covered
+    assert "podcast_automation.py" in covered
+    assert "podcast_download_client.py" in covered
+    assert "podcast_post_processor.py" in covered
+    assert "podcast_ingest_guard.py" in covered

--- a/tests/test_podcast_profiles.py
+++ b/tests/test_podcast_profiles.py
@@ -1,0 +1,220 @@
+"""The podcast watchlist belongs to a profile, and every query has to say so.
+
+Podcasts shipped before the profile lessons the audiobook side was built with.
+The rows always carried a profile_id and get_watchlist_podcasts always filtered
+on it, but every other query matched on feed_url alone, and the table's unique
+key was feed_url on its own - so a second person following a show they both
+like got a success, no row, and an empty watchlist.
+
+These pin the whole set: the schema, each scoped query, and the timed scan
+sweeping everybody rather than profile 1.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from database.music_database import MusicDatabase
+
+FEED = "https://feeds.example.com/shared-show"
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return MusicDatabase(str(tmp_path / "test_music.db"))
+
+
+def _follow(db, profile_id, feed=FEED, title="Shared Show", **kw):
+    return db.add_watchlist_podcast(feed_url=feed, title=title,
+                                    profile_id=profile_id, **kw)
+
+
+# ---------------------------------------------------------------------------
+# schema
+# ---------------------------------------------------------------------------
+
+def test_the_unique_key_is_the_pair_not_the_feed(tmp_db):
+    sql = sqlite3.connect(tmp_db.database_path).execute(
+        "SELECT sql FROM sqlite_master WHERE name='watchlist_podcasts'"
+    ).fetchone()[0]
+    assert "UNIQUE(feed_url, profile_id)" in sql
+
+
+def test_two_profiles_can_follow_the_same_show(tmp_db):
+    assert _follow(tmp_db, 1) is True
+    assert _follow(tmp_db, 2) is True
+    assert [p["feed_url"] for p in tmp_db.get_watchlist_podcasts(profile_id=1)] == [FEED]
+    assert [p["feed_url"] for p in tmp_db.get_watchlist_podcasts(profile_id=2)] == [FEED]
+
+
+def test_following_twice_on_one_profile_is_still_idempotent(tmp_db):
+    _follow(tmp_db, 1)
+    _follow(tmp_db, 1, title="Renamed")
+    rows = tmp_db.get_watchlist_podcasts(profile_id=1)
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Renamed"
+
+
+def test_a_database_with_the_old_shape_migrates_without_losing_rows(tmp_path):
+    """The rebuild has to be exact: this is somebody's live subscriptions."""
+    path = str(tmp_path / "old.db")
+    con = sqlite3.connect(path)
+    con.execute("""CREATE TABLE watchlist_podcasts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, feed_url TEXT UNIQUE NOT NULL,
+        itunes_id INTEGER, title TEXT NOT NULL, author TEXT, description TEXT,
+        artwork_url TEXT, website TEXT, auto_download INTEGER NOT NULL DEFAULT 1,
+        retention_days INTEGER NOT NULL DEFAULT 14, episode_count INTEGER,
+        date_added TIMESTAMP DEFAULT CURRENT_TIMESTAMP, last_scan_timestamp TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, profile_id INTEGER DEFAULT 1)""")
+    con.execute("INSERT INTO watchlist_podcasts (feed_url,title,profile_id,retention_days) "
+                "VALUES (?,?,?,?)", ("https://a.example/rss", "Show A", 1, 30))
+    con.execute("INSERT INTO watchlist_podcasts (feed_url,title,profile_id) "
+                "VALUES (?,?,?)", ("https://b.example/rss", "Show B", 2))
+    con.commit()
+    before = con.execute("SELECT id, feed_url, title, profile_id, retention_days "
+                         "FROM watchlist_podcasts ORDER BY id").fetchall()
+    con.close()
+
+    MusicDatabase(path)
+
+    con = sqlite3.connect(path)
+    after = con.execute("SELECT id, feed_url, title, profile_id, retention_days "
+                        "FROM watchlist_podcasts ORDER BY id").fetchall()
+    assert after == before
+    sql = con.execute("SELECT sql FROM sqlite_master WHERE name='watchlist_podcasts'").fetchone()[0]
+    assert "UNIQUE(feed_url, profile_id)" in sql
+
+    # and it does not run a second time
+    MusicDatabase(path)
+    assert con.execute("SELECT COUNT(*) FROM watchlist_podcasts").fetchone()[0] == 2
+
+
+def test_a_half_migrated_shape_is_also_rebuilt(tmp_path):
+    """A pair constraint next to the old column UNIQUE still refuses profile 2.
+
+    That shape is reachable by anyone who ran a build between the create being
+    fixed and the column UNIQUE being dropped, so detection has to catch it
+    rather than see the pair constraint and call the table done.
+    """
+    path = str(tmp_path / "half.db")
+    con = sqlite3.connect(path)
+    con.execute("""CREATE TABLE watchlist_podcasts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, feed_url TEXT UNIQUE NOT NULL,
+        itunes_id INTEGER, title TEXT NOT NULL, author TEXT, description TEXT,
+        artwork_url TEXT, website TEXT, auto_download INTEGER NOT NULL DEFAULT 1,
+        retention_days INTEGER NOT NULL DEFAULT 14, episode_count INTEGER,
+        date_added TIMESTAMP DEFAULT CURRENT_TIMESTAMP, last_scan_timestamp TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, profile_id INTEGER DEFAULT 1,
+        UNIQUE(feed_url, profile_id))""")
+    con.execute("INSERT INTO watchlist_podcasts (feed_url,title,profile_id) VALUES (?,?,?)",
+                (FEED, "Shared Show", 1))
+    con.commit()
+    con.close()
+
+    db = MusicDatabase(path)
+    assert _follow(db, 2) is True
+    assert len(db.get_watchlist_podcasts(profile_id=2)) == 1
+
+
+# ---------------------------------------------------------------------------
+# scoped queries
+# ---------------------------------------------------------------------------
+
+def test_one_profile_cannot_unfollow_anothers_show(tmp_db):
+    _follow(tmp_db, 1)
+    _follow(tmp_db, 2)
+    tmp_db.remove_watchlist_podcast(feed_url=FEED, profile_id=2)
+    assert len(tmp_db.get_watchlist_podcasts(profile_id=1)) == 1
+    assert tmp_db.get_watchlist_podcasts(profile_id=2) == []
+
+
+def test_following_is_answered_for_the_asking_profile(tmp_db):
+    _follow(tmp_db, 1)
+    assert tmp_db.is_podcast_in_watchlist(feed_url=FEED, profile_id=1) is True
+    assert tmp_db.is_podcast_in_watchlist(feed_url=FEED, profile_id=2) is False
+
+
+def test_the_row_handed_back_is_the_asking_profiles_own(tmp_db):
+    _follow(tmp_db, 1, retention_days=30)
+    _follow(tmp_db, 2, retention_days=7)
+    assert tmp_db.get_watchlist_podcast(feed_url=FEED, profile_id=1)["retention_days"] == 30
+    assert tmp_db.get_watchlist_podcast(feed_url=FEED, profile_id=2)["retention_days"] == 7
+
+
+def test_changing_your_settings_does_not_rewrite_someone_elses(tmp_db):
+    _follow(tmp_db, 1, retention_days=30)
+    _follow(tmp_db, 2, retention_days=30)
+    tmp_db.update_watchlist_podcast_settings(FEED, retention_days=1, profile_id=2)
+    assert tmp_db.get_watchlist_podcast(feed_url=FEED, profile_id=1)["retention_days"] == 30
+    assert tmp_db.get_watchlist_podcast(feed_url=FEED, profile_id=2)["retention_days"] == 1
+
+
+def test_leaving_the_profile_out_still_means_any_profile(tmp_db):
+    """Backwards compatible: this is what every one of these did before."""
+    _follow(tmp_db, 2)
+    assert tmp_db.is_podcast_in_watchlist(feed_url=FEED) is True
+    assert tmp_db.get_watchlist_podcast(feed_url=FEED) is not None
+
+
+# ---------------------------------------------------------------------------
+# the sweep
+# ---------------------------------------------------------------------------
+
+def test_profiles_with_rows_lists_everyone_who_follows_something(tmp_db):
+    _follow(tmp_db, 1, feed="https://a.example/rss", title="A")
+    _follow(tmp_db, 3, feed="https://b.example/rss", title="B")
+    _follow(tmp_db, 3, feed="https://c.example/rss", title="C")
+    assert tmp_db.profiles_with_podcast_rows() == [1, 3]
+
+
+def test_profiles_with_rows_never_returns_nothing(tmp_db):
+    """An empty table still has to give the scan something to iterate."""
+    assert tmp_db.profiles_with_podcast_rows() == [1]
+
+
+def test_a_timed_scan_sweeps_every_profile_not_just_the_first():
+    """A system automation runs as profile 1, so the profile has to come from
+    the rows. Without this a second person's shows were never scanned at all."""
+    from core.podcast_automation import scan_and_auto_download_podcasts
+
+    db = MagicMock()
+    db.profiles_with_podcast_rows.return_value = [1, 2, 7]
+    db.get_watchlist_podcasts.return_value = []
+
+    with patch("core.podcast_automation._get_db", return_value=db):
+        result = scan_and_auto_download_podcasts()
+
+    assert result["profiles_scanned"] == 3
+    assert [c.kwargs["profile_id"] for c in db.get_watchlist_podcasts.call_args_list] == [1, 2, 7]
+
+
+def test_an_explicit_profile_scans_only_that_one():
+    """Scan Now is a person asking about their own shows."""
+    from core.podcast_automation import scan_and_auto_download_podcasts
+
+    db = MagicMock()
+    db.get_watchlist_podcasts.return_value = []
+
+    with patch("core.podcast_automation._get_db", return_value=db):
+        scan_and_auto_download_podcasts(profile_id=4)
+
+    db.profiles_with_podcast_rows.assert_not_called()
+    assert db.get_watchlist_podcasts.call_args.kwargs["profile_id"] == 4
+
+
+def test_a_database_that_cannot_list_profiles_still_scans_the_first():
+    from core.podcast_automation import scan_and_auto_download_podcasts
+
+    db = MagicMock()
+    db.profiles_with_podcast_rows.side_effect = RuntimeError("db is down")
+    db.get_watchlist_podcasts.return_value = []
+
+    with patch("core.podcast_automation._get_db", return_value=db):
+        result = scan_and_auto_download_podcasts()
+
+    assert result["profiles_scanned"] == 1

--- a/tests/test_quality_panel_layout.py
+++ b/tests/test_quality_panel_layout.py
@@ -1,0 +1,113 @@
+"""The Quality tab's profile panel has to fit inside the settings column.
+
+It did not, for a while. The panel was written to hang OUTSIDE the column:
+``.qp-layout`` was one panel-width wider than its container, so the panel spilled
+into the empty margin to the right. That was a reasonable trade when the settings
+column was 920px, because giving 320px of it to a panel would have left the tiles
+too narrow.
+
+Then the settings overhaul widened the column to --settings-max-width. The panel
+rule still added its width on top of whatever the column was, so instead of
+landing in empty margin it landed past the settings card's border, floating
+outside the page with nothing behind it. A user reported it.
+
+The number that broke it lived in a comment ("the normal centered 920px settings
+column") rather than anywhere a change to the column width would have touched.
+That is what this test is really for: it ties the two together so widening the
+column again cannot silently push the panel back out.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_CSS = Path(__file__).resolve().parents[1] / "webui" / "static" / "style.css"
+
+
+def _css():
+    return _CSS.read_text(encoding="utf-8")
+
+
+def _rule_body(selector: str, source: str) -> str:
+    """The declarations of the first rule for this exact selector."""
+    marker = selector + " {"
+    assert marker in source, f"no rule for {selector}"
+    start = source.index(marker)
+    return source[start:source.index("}", start)]
+
+
+def _strip_comments(text: str) -> str:
+    """A guard must never pass on the text of a comment explaining it."""
+    return re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+
+
+def test_the_layout_is_not_wider_than_its_container():
+    body = _strip_comments(_rule_body(".qp-layout", _css()))
+    # anchored to line start: "\bwidth:" also matches --qp-side-width
+    width = re.search(r"^\s*width:\s*([^;]+);", body, re.M)
+    assert width, "no width declaration on .qp-layout"
+    value = width.group(1).strip()
+    assert value == "100%", (
+        f".qp-layout width is {value!r}. Anything that adds the panel width on "
+        f"top of 100% makes the panel hang outside the settings card again."
+    )
+
+
+def test_the_two_columns_add_up_to_the_whole_width():
+    css = _strip_comments(_css())
+    layout = _rule_body(".qp-layout", css)
+    main = _rule_body(".qp-main", css)
+
+    panel = int(re.search(r"--qp-side-width:\s*(\d+)px", layout).group(1))
+    gap = int(re.search(r"--qp-side-gap:\s*(\d+)px", layout).group(1))
+
+    # the tiles claim everything the panel and the gap do not
+    basis = re.search(r"^\s*flex:\s*([^;]+);", main, re.M).group(1)
+    assert "100%" in basis
+    assert "--qp-side-width" in basis and "--qp-side-gap" in basis, (
+        "the tile column must be derived from the panel width and gap, so the "
+        "two can never be set to values that overflow"
+    )
+
+    # and at the real column width the split leaves the tiles usable
+    column = int(re.search(r"--settings-max-width:\s*(\d+)px", css).group(1))
+    tiles = column - panel - gap
+    assert tiles + gap + panel == column
+    assert tiles >= 920, (
+        f"tiles get {tiles}px. The panel used to hang outside precisely so the "
+        f"tiles could keep the full 920px column, so dropping below that would "
+        f"be a regression on the reason it was built that way."
+    )
+
+
+def test_it_stacks_before_the_two_columns_get_tight():
+    """The stacking breakpoint has to be about the column, not the old margin.
+
+    It was 1800px, which was the width the viewport needed for a 920px column
+    PLUS a panel hanging off it. Nothing hangs off it now, so a 1440p screen
+    should get the two columns rather than stacking for a reason that is gone.
+    """
+    css = _css()
+    stacking = [int(m) for m in re.findall(r"@media \(max-width:\s*(\d+)px\)[^{]*\{\s*\.qp-layout", css)]
+    assert stacking, "no stacking breakpoint for .qp-layout"
+    assert max(stacking) <= 1200, (
+        f"stacks at {max(stacking)}px. That is wide enough to stack screens that "
+        f"have room for both columns."
+    )
+
+
+def test_the_stale_920_comment_is_gone():
+    """The comment asserting a 920px column outlived the column being 920px.
+
+    It is the thing that made the bug hard to see, so it should not come back
+    while the panel lives inside the column.
+    """
+    layout_area = _css()
+    idx = layout_area.index(".qp-layout {")
+    preamble = layout_area[max(0, idx - 1200):idx]
+    assert "centered 920px" not in preamble, (
+        "the comment above .qp-layout still claims the column is 920px"
+    )

--- a/tests/test_server_activity.py
+++ b/tests/test_server_activity.py
@@ -229,6 +229,77 @@ def test_get_history_no_server(monkeypatch):
     assert get_history()["ok"] is False
 
 
+def test_plex_server_negative_cache_prevents_repeated_connect_attempts(monkeypatch):
+    import core.server_activity as sa
+    sa.invalidate_plex_server_cache()
+
+    monkeypatch.setattr(sa, "_plex_config", lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "abcdef123456"})
+    connect_attempts = 0
+
+    def fake_plex_init(*args, **kwargs):
+        nonlocal connect_attempts
+        connect_attempts += 1
+        raise ConnectionError("Host unreachable")
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_plex_init)
+
+    # First attempt: connection fails, recorded in cache
+    res1 = sa._plex_server()
+    assert res1 is None
+    assert connect_attempts == 1
+
+    # Second attempt within 60s: hits negative cache immediately without calling PlexServer
+    res2 = sa._plex_server()
+    assert res2 is None
+    assert connect_attempts == 1
+
+    # Third attempt after 60s TTL expires: reconnects
+    original_at = sa._server_cache["at"]
+    sa._server_cache["at"] = original_at - 61.0
+    res3 = sa._plex_server()
+    assert res3 is None
+    assert connect_attempts == 2
+
+    # Credential change bypasses negative cache immediately
+    monkeypatch.setattr(sa, "_plex_config", lambda db=None: {"base_url": "http://192.0.2.2:32400", "token": "abcdef123456"})
+    res4 = sa._plex_server()
+    assert res4 is None
+    assert connect_attempts == 3
+
+    # Cleanup
+    sa.invalidate_plex_server_cache()
+
+
+def test_get_activity_sessions_failure_marks_server_unreachable(monkeypatch):
+    import core.server_activity as sa
+    sa.invalidate_plex_server_cache()
+
+    class _FailingPlex:
+        def sessions(self):
+            raise ConnectionError("Plex crashed")
+
+    monkeypatch.setattr(sa, "_plex_config", lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "abcdef123456"})
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", lambda *a, **kw: _FailingPlex())
+
+    # Initial connect succeeds
+    srv = sa._plex_server()
+    assert srv is not None
+
+    # Calling get_activity encounters sessions() failure
+    act = sa.get_activity()
+    assert act["ok"] is False
+    assert act["reason"] == "unreachable"
+
+    # Subsequent _plex_server call should now return None immediately from cache
+    assert sa._plex_server() is None
+
+    # Cleanup
+    sa.invalidate_plex_server_cache()
+
+
 # ── stream termination ───────────────────────────────────────────────────────
 def test_stop_session_calls_stop_with_message(monkeypatch):
     import core.server_activity as sa

--- a/tests/test_settings_sources_tab.py
+++ b/tests/test_settings_sources_tab.py
@@ -691,7 +691,7 @@ def test_the_library_tab_speaks_one_card_language():
 
     assert titles == [
         # files & folders
-        "Music Folders", "Music Organization", "Video Folders", "Video Organization",
+        "Folders", "Organization",
         # processing
         "Post-Processing", "Import", "Filtering",
         # your library
@@ -862,10 +862,10 @@ def test_library_headers_report_what_is_set_not_what_is_inside(index, js):
         bug generator, and this page has already been bitten by exactly that
         kind of drift twice (the download-mode select, the slskd form).
     """
-    slots = re.findall(r'<span class="settings-section-hint"[^>]*data-stg-summary="([^"]+)"[^>]*>', index)
+    slots = re.findall(r'<span[^>]*data-stg-summary="([^"]+)"[^>]*>', index)
     assert len(slots) >= 8, f"only {len(slots)} headers report live values"
 
-    for m in re.finditer(r'<span class="settings-section-hint"[^>]*data-stg-summary="[^"]+"[^>]*>', index):
+    for m in re.finditer(r'<span[^>]*data-stg-summary="[^"]+"[^>]*>', index):
         assert 'data-stg-fallback="' in m.group(0), (
             "no fallback - a header that cannot compute its summary would go blank"
         )
@@ -903,14 +903,8 @@ def test_a_failed_settings_load_does_not_summarise_an_empty_form(js):
 
 
 def test_the_two_sides_name_their_sections_the_same_way():
-    """Music used to have ONE card called "Paths & Organization" while video had
-    TWO, "Video Folders" and "Video Organization". That is not a naming quibble:
-    the combined name existed because the card was combined, so the same feature
-    looked like two different features depending on which half you were reading.
-
-    Folders is where things live. Organization is how they get named. Both sides
-    answer both questions under the same two words now, and this fails if one
-    side grows a section the other does not have.
+    """Folders and Organization are shared cards, each retaining both media
+    contexts so neither music nor video settings disappear in consolidation.
     """
     index = _read("webui/index.html")
     markup = re.sub(r"<!--.*?-->", "", index, flags=re.S)
@@ -922,12 +916,13 @@ def test_the_two_sides_name_their_sections_the_same_way():
             titles.append(re.sub(r"<[^>]+>", "", t.group(1)).strip())
 
     for noun in ("Folders", "Organization"):
-        music = f"Music {noun}"
-        video = f"Video {noun}"
-        assert music in titles, f"no {music} - the sides have drifted apart again"
-        assert video in titles, f"no {video} - the sides have drifted apart again"
+        assert titles.count(noun) == 1, f"expected one shared {noun} card"
+        card = re.split(r'<div class="settings-section-header[^"]*"[^>]*data-stg="library"',
+                        markup.split(f'<h3>{noun}</h3>', 1)[1], maxsplit=1)[0]
+        for media in ("Music", "Video"):
+            assert f'<strong>{media} {noun.lower()}</strong>' in card
 
-    # the combined name is what the split replaced; its return means the merge undid
+    # Folder locations and naming rules remain separate subjects.
     assert "Paths &amp; Organization" not in titles
 
 

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -663,7 +663,8 @@ def test_downloads_config_save_load(tmp_path, monkeypatch):
             "download_mode": "soulseek", "hybrid_order": ["soulseek"],
             # seeding lifecycle (arr-parity P5) rides the same config payload
             "seed_ratio_goal": 0.0, "seed_time_goal_hours": 0, "seed_remove_data": True,
-            "seed_mode": "soulsync", "seed_overrides": {}}
+            "seed_mode": "soulsync", "seed_overrides": {},
+            "movies_additional_paths": [], "tv_additional_paths": []}
         # Round-trips: libraries → video.db, the INPUT folder → the SHARED music key.
         client.post("/api/video/downloads/config",
                     json={"download_path": " /mnt/v/dl ", "movies_path": "/media/movies",
@@ -674,7 +675,8 @@ def test_downloads_config_save_load(tmp_path, monkeypatch):
             "tv_path": "/media/tv", "youtube_path": "/media/yt",
             "download_mode": "hybrid", "hybrid_order": ["torrent", "usenet"],
             "seed_ratio_goal": 0.0, "seed_time_goal_hours": 0, "seed_remove_data": True,
-            "seed_mode": "soulsync", "seed_overrides": {}}
+            "seed_mode": "soulsync", "seed_overrides": {},
+            "movies_additional_paths": [], "tv_additional_paths": []}
         # The input folder is the SHARED soulseek.download_path (so music sees it too);
         # it is NOT stored in video.db.
         assert fake.get("soulseek.download_path") == "/mnt/v/dl"
@@ -1924,3 +1926,16 @@ def test_a_broken_alias_lookup_never_blocks_a_grab(tmp_path, monkeypatch):
         assert _acceptable_titles("Password (2022)", "show", 203254) == ["Password (2022)"]
     finally:
         videoapi._video_db = None
+
+
+def test_additional_library_paths_roundtrip_validate_and_preserve(tmp_path):
+    client, api = _make_client(tmp_path)
+    url = "/api/video/downloads/config"
+    assert client.post(url, json={"movies_path": "/movies", "movies_additional_paths": [" /movies2 ", "/movies2", ""], "tv_additional_paths": ["/tv2"]}).status_code == 200
+    assert client.get(url).get_json()["movies_additional_paths"] == ["/movies2"]
+    client.post(url, json={"movies_path": "/new"})
+    assert client.get(url).get_json()["tv_additional_paths"] == ["/tv2"]
+    assert client.post(url, json={"movies_path": "/bad", "movies_additional_paths": "oops"}).status_code == 400
+    assert client.get(url).get_json()["movies_path"] == "/new"
+    client.post(url, json={"movies_additional_paths": []})
+    assert client.get(url).get_json()["movies_additional_paths"] == []

--- a/tests/test_video_api.py
+++ b/tests/test_video_api.py
@@ -179,7 +179,7 @@ def test_scan_request_threads_mode_and_media_type(tmp_path, monkeypatch):
     import core.video.scanner as scanner_mod
     import core.video.sources as sources_mod
     monkeypatch.setattr(scanner_mod, "get_video_scanner", lambda db: _FakeScanner())
-    monkeypatch.setattr(sources_mod, "get_active_video_source", lambda: None)
+    monkeypatch.setattr(sources_mod, "get_active_video_source", lambda **kwargs: None)
 
     # default body → both libraries, full
     assert client.post("/api/video/scan/request", json={}).get_json()["media_type"] == "all"

--- a/tests/test_video_download_config.py
+++ b/tests/test_video_download_config.py
@@ -271,7 +271,8 @@ def test_the_video_save_button_cannot_write_a_retired_form():
     """
     js = (_WEBUI / "static" / "video" / "video-settings.js").read_text(encoding="utf-8")
 
-    chain = js.split("Promise.all([", 1)[1].split("])", 1)[0]
+    save_handler = js.split("e.stopImmediatePropagation();", 1)[1]
+    chain = save_handler.split("Promise.all([", 1)[1].split("])", 1)[0]
     assert "saveSlskd" not in chain, (
         "the video save button posts the retired slskd form again"
     )

--- a/tests/test_video_path_resolver.py
+++ b/tests/test_video_path_resolver.py
@@ -144,3 +144,25 @@ def test_owned_library_dir_resolves_real_folder(db, tmp_path, monkeypatch):
     # Unowned target → None (template destination applies).
     dl2 = dict(dl, media_id="999")
     assert _owned_library_dir(db, dl2) is None
+
+
+def test_extra_drive_resolution_and_recycling_stay_on_that_drive(db, tmp_path):
+    from core.video.recycle import trash_dir_for
+    from core.video.library_roots import containing_root, library_roots
+    root = tmp_path / "movies2"
+    file = root / "Film" / "Film.mkv"
+    file.parent.mkdir(parents=True)
+    file.write_bytes(b"movie")
+    db.set_setting("movies_path", str(tmp_path / "primary"))
+    db.set_setting("movies_additional_paths", json.dumps([str(root)]))
+    resolved = resolve_video_file_path("/plex/movies/Film/Film.mkv", video_base_dirs(db), size_bytes=5)
+    assert resolved == str(file)
+    assert containing_root(resolved, library_roots(db, "movie")) == str(root)
+    assert trash_dir_for(resolved, {}, db) == str(root / "ss_recycle")
+    assert db.get_setting("movies_path") == str(tmp_path / "primary")
+
+
+def test_specific_folder_on_extra_drive_beats_primary_basename():
+    files = {"/primary/movie.mkv", "/extra/Film/movie.mkv"}
+    assert resolve_video_file_path("/server/Film/movie.mkv", ["/primary", "/extra"],
+                                   exists=lambda path: path in files) == "/extra/Film/movie.mkv"

--- a/tests/test_video_scan_scope.py
+++ b/tests/test_video_scan_scope.py
@@ -163,7 +163,7 @@ def test_plex_is_scanning_falls_back_to_activity_feed():
 
 def test_scan_status_helper_is_none_when_no_server(monkeypatch):
     import core.video.sources as srcmod
-    monkeypatch.setattr(srcmod, "get_active_video_source", lambda: None)
+    monkeypatch.setattr(srcmod, "get_active_video_source", lambda **kwargs: None)
     assert srcmod.video_server_scan_in_progress("all") is None   # caller falls back to fixed wait
 
 
@@ -207,5 +207,5 @@ def test_plex_has_item_checks_specific_episode():
 
 def test_has_item_helper_false_when_no_server(monkeypatch):
     import core.video.sources as srcmod
-    monkeypatch.setattr(srcmod, "get_active_video_source", lambda: None)
+    monkeypatch.setattr(srcmod, "get_active_video_source", lambda **kwargs: None)
     assert srcmod.video_server_has_item("movie", {"title": "X"}) is False

--- a/tests/test_video_side_shell.py
+++ b/tests/test_video_side_shell.py
@@ -363,7 +363,7 @@ def test_video_settings_module_referenced_and_isolated():
     stripped = _VSETTINGS_JS.strip()
     assert stripped.startswith("/*") or stripped.startswith("(function")
     assert "(function" in _VSETTINGS_JS and "})();" in _VSETTINGS_JS
-    assert "window." not in _VSETTINGS_JS
+    assert set(re.findall(r"window\.\w+", _VSETTINGS_JS)) <= {"window.refreshLibrarySummaries"}
     assert "addEventListener" in _VSETTINGS_JS
     assert "/api/video/libraries" in _VSETTINGS_JS
     assert "soulsync:video-page-shown" in _VSETTINGS_JS

--- a/tests/test_video_sources_caching.py
+++ b/tests/test_video_sources_caching.py
@@ -1,0 +1,210 @@
+"""Tests for video sources connection timeout and offline caching resilience."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+import core.video.sources as sources_mod
+from core.video.sources import (
+    PLEX_CONNECT_TIMEOUT,
+    PLEX_SCAN_TIMEOUT,
+    _build_source,
+    get_active_video_source,
+    invalidate_video_source_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    invalidate_video_source_cache()
+    yield
+    invalidate_video_source_cache()
+
+
+def test_plex_connect_timeout_configured_properly():
+    assert PLEX_CONNECT_TIMEOUT == 8
+    assert PLEX_SCAN_TIMEOUT == 120
+
+
+def test_build_source_passes_timeout_tuple(monkeypatch):
+    monkeypatch.setattr(sources_mod, "resolve_video_server", lambda db=None: "plex")
+    monkeypatch.setattr(
+        sources_mod,
+        "video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "tok12345"},
+    )
+
+    captured_kwargs = {}
+
+    def fake_plex_init(base_url, token, timeout=None):
+        captured_kwargs["base_url"] = base_url
+        captured_kwargs["token"] = token
+        captured_kwargs["timeout"] = timeout
+        return MagicMock()
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_plex_init)
+
+    src = _build_source()
+    assert src is not None
+    assert captured_kwargs["timeout"] == (PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT)
+
+
+def test_build_source_negative_cache_prevents_repeated_connect_attempts(monkeypatch):
+    monkeypatch.setattr(sources_mod, "resolve_video_server", lambda db=None: "plex")
+    monkeypatch.setattr(
+        sources_mod,
+        "video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "tok12345"},
+    )
+
+    attempts = 0
+
+    def fake_failing_init(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise ConnectionError("Server offline")
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_failing_init)
+
+    # First attempt: connection fails, recorded in cache
+    src1 = _build_source()
+    assert src1 is None
+    assert attempts == 1
+
+    # Second attempt within 60s: hits negative cache immediately without calling PlexServer
+    src2 = _build_source()
+    assert src2 is None
+    assert attempts == 1
+
+    # Call through get_active_video_source: also hits negative cache immediately
+    monkeypatch.setattr(sources_mod, "_load_selection", lambda: {})
+    src_active = get_active_video_source()
+    assert src_active is None
+    assert attempts == 1
+
+    # Fast forward time beyond 60s TTL: reconnects
+    original_at = sources_mod._plex_srv_cache["at"]
+    sources_mod._plex_srv_cache["at"] = original_at - 61.0
+
+    src3 = _build_source()
+    assert src3 is None
+    assert attempts == 2
+
+
+def test_build_source_credential_change_invalidates_cache(monkeypatch):
+    monkeypatch.setattr(sources_mod, "resolve_video_server", lambda db=None: "plex")
+    monkeypatch.setattr(
+        sources_mod,
+        "video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "tok12345"},
+    )
+
+    attempts = 0
+
+    def fake_failing_init(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise ConnectionError("Server offline")
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_failing_init)
+
+    # First call fails
+    assert _build_source() is None
+    assert attempts == 1
+
+    # Change credentials
+    monkeypatch.setattr(
+        sources_mod,
+        "video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.2:32400", "token": "tok99999"},
+    )
+
+    # Reconnects immediately
+    assert _build_source() is None
+    assert attempts == 2
+
+
+def test_build_source_positive_caching_reuses_instance(monkeypatch):
+    monkeypatch.setattr(sources_mod, "resolve_video_server", lambda db=None: "plex")
+    monkeypatch.setattr(
+        sources_mod,
+        "video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "tok12345"},
+    )
+
+    fake_server = MagicMock()
+    init_count = 0
+
+    def fake_plex_init(*args, **kwargs):
+        nonlocal init_count
+        init_count += 1
+        return fake_server
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_plex_init)
+
+    src1 = _build_source(movies_lib="Movies")
+    assert src1 is not None
+    assert src1._server is fake_server
+    assert src1._movies_lib == "Movies"
+    assert init_count == 1
+
+    # Second call with different library mapping reuses the underlying connection
+    src2 = _build_source(tv_lib="TV Shows")
+    assert src2 is not None
+    assert src2._server is fake_server
+    assert src2._tv_lib == "TV Shows"
+    assert init_count == 1
+
+    # Explicit invalidation forces reconnect
+    invalidate_video_source_cache()
+    src3 = _build_source()
+    assert src3 is not None
+    assert init_count == 2
+
+
+def test_video_server_config_test_uses_connect_timeout(tmp_path, monkeypatch):
+    from flask import Flask, g
+    import api.video as videoapi
+    from database.video_database import VideoDatabase
+
+    videoapi._video_db = VideoDatabase(database_path=str(tmp_path / "video_library.db"))
+    app = Flask(__name__)
+
+    @app.before_request
+    def _stamp_g():
+        g.is_admin = True
+        g.can_download = True
+
+    app.register_blueprint(videoapi.create_video_blueprint(), url_prefix="/api/video")
+    client = app.test_client()
+
+    monkeypatch.setattr(
+        "core.video.sources.video_plex_config",
+        lambda db=None: {"base_url": "http://192.0.2.1:32400", "token": "tok12345"},
+    )
+
+    captured_timeout = None
+
+    class _FakePlex:
+        friendlyName = "Test Plex"
+
+    def fake_plex_init(base_url, token, timeout=None):
+        nonlocal captured_timeout
+        captured_timeout = timeout
+        return _FakePlex()
+
+    import plexapi.server
+    monkeypatch.setattr(plexapi.server, "PlexServer", fake_plex_init)
+
+    res = client.post("/api/video/server-config/test", json={"server": "plex"})
+    assert res.status_code == 200
+    assert res.get_json()["success"] is True
+    assert captured_timeout == PLEX_CONNECT_TIMEOUT
+

--- a/tests/test_video_sources_caching.py
+++ b/tests/test_video_sources_caching.py
@@ -50,7 +50,8 @@ def test_build_source_passes_timeout_tuple(monkeypatch):
 
     src = _build_source()
     assert src is not None
-    assert captured_kwargs["timeout"] == (PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT)
+    assert captured_kwargs["timeout"] == (PLEX_CONNECT_TIMEOUT, PLEX_CONNECT_TIMEOUT)
+    assert src._server._timeout == (PLEX_CONNECT_TIMEOUT, PLEX_SCAN_TIMEOUT)
 
 
 def test_build_source_negative_cache_prevents_repeated_connect_attempts(monkeypatch):

--- a/tests/test_watchlist_backfill_progress.py
+++ b/tests/test_watchlist_backfill_progress.py
@@ -1,0 +1,162 @@
+"""The source-matching phase has to be visible and interruptible.
+
+A watchlist scan does not begin with the artist loop. It first matches every
+watchlisted artist against every other metadata provider, one network lookup per
+artist per provider with a sleep between each. For somebody who has just added a
+few hundred artists that is the longest part of the scan by far - 379 artists
+across five providers is 1,895 lookups.
+
+That phase used to report nothing and ignore cancellation. The page showed
+"0 / 379 artists" the whole time, because progress is only written by the artist
+loop, and Cancel did nothing, because the only cancel check lived in that same
+loop. From outside it looked like a scan that started and hung (#1240).
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.watchlist_scanner import WatchlistScanner
+
+
+def _artist(n):
+    return types.SimpleNamespace(
+        id=n, artist_name=f"Artist {n}",
+        spotify_artist_id=None, itunes_artist_id=None, deezer_artist_id=None,
+        discogs_artist_id=None, musicbrainz_artist_id=None,
+        # read as an argument when the artist loop is entered
+        last_scan_timestamp=None,
+    )
+
+
+@pytest.fixture
+def scanner(monkeypatch):
+    sc = WatchlistScanner.__new__(WatchlistScanner)
+    # `database` is a lazy property with no setter; fill its backing field so
+    # nothing here can reach a real database.
+    sc._database = MagicMock()
+    sc.database_path = ':memory:'
+    # no sleeping in tests - the pacing is not what is under test here
+    monkeypatch.setattr("core.watchlist_scanner.time.sleep", lambda *_a: None)
+    return sc
+
+
+def _match_always(name):
+    return f"id-for-{name}"
+
+
+def test_the_backfill_reports_progress_as_it_goes(scanner, monkeypatch):
+    monkeypatch.setattr(scanner, "_match_to_itunes", _match_always, raising=False)
+    seen = []
+
+    ok = scanner._backfill_missing_ids(
+        [_artist(i) for i in range(5)], "itunes",
+        on_progress=lambda done, total: seen.append((done, total)),
+    )
+
+    assert ok is True
+    # one before each artist, and a final one at completion
+    assert seen == [(0, 5), (1, 5), (2, 5), (3, 5), (4, 5), (5, 5)]
+
+
+def test_a_cancel_is_honoured_inside_the_backfill(scanner, monkeypatch):
+    """Before this, cancel was only read between ARTISTS in the scan loop -
+    a loop that had not started yet, so there was no way to stop at all."""
+    looked_up = []
+
+    def _match(name):
+        looked_up.append(name)
+        return "x"
+
+    monkeypatch.setattr(scanner, "_match_to_itunes", _match, raising=False)
+
+    ok = scanner._backfill_missing_ids(
+        [_artist(i) for i in range(20)], "itunes",
+        cancel_check=lambda: len(looked_up) >= 3,
+    )
+
+    assert ok is False
+    assert len(looked_up) == 3, "it kept going after the cancel"
+
+
+def test_cancel_is_checked_before_the_lookup_not_after(scanner, monkeypatch):
+    """A cancel must land within one artist, not one provider pass."""
+    monkeypatch.setattr(scanner, "_match_to_itunes", _match_always, raising=False)
+
+    ok = scanner._backfill_missing_ids(
+        [_artist(i) for i in range(50)], "itunes", cancel_check=lambda: True,
+    )
+
+    assert ok is False
+    scanner.database.update_watchlist_itunes_id.assert_not_called()
+
+
+def test_nothing_to_do_completes_rather_than_returning_none(scanner):
+    """The caller reads the return value to decide whether to stop."""
+    already = _artist(1)
+    already.itunes_artist_id = "have-it"
+    assert scanner._backfill_missing_ids([already], "itunes") is True
+
+
+def test_an_unknown_provider_completes(scanner):
+    assert scanner._backfill_missing_ids([_artist(1)], "not-a-provider") is True
+
+
+def test_a_failing_lookup_does_not_stop_the_pass(scanner, monkeypatch):
+    def _boom(name):
+        if name == "Artist 1":
+            raise RuntimeError("provider down")
+        return "ok"
+
+    monkeypatch.setattr(scanner, "_match_to_itunes", _boom, raising=False)
+    seen = []
+
+    ok = scanner._backfill_missing_ids(
+        [_artist(i) for i in range(4)], "itunes",
+        on_progress=lambda d, t: seen.append(d),
+    )
+
+    assert ok is True
+    assert seen[-1] == 4, "the pass did not run to the end"
+
+
+def test_a_broken_progress_callback_cannot_break_the_scan(scanner, monkeypatch):
+    monkeypatch.setattr(scanner, "_match_to_itunes", _match_always, raising=False)
+
+    def _bad(_done, _total):
+        raise RuntimeError("ui blew up")
+
+    assert scanner._backfill_missing_ids([_artist(1)], "itunes", on_progress=_bad) is True
+
+
+def test_a_backfill_that_answers_nothing_does_not_abort_the_scan(monkeypatch):
+    """None means "said nothing", not "cancelled".
+
+    The caller reads the return value to decide whether to stop the whole scan.
+    Reading a bare None as a cancel aborted every scan before the artist loop -
+    which is what a stub, a subclass, or any older override returns.
+    """
+    from core.watchlist_scanner import WatchlistScanner
+
+    sc = WatchlistScanner.__new__(WatchlistScanner)
+    sc._database = MagicMock()
+    sc.database_path = ':memory:'
+    monkeypatch.setattr("core.watchlist_scanner.time.sleep", lambda *_a: None)
+    monkeypatch.setattr(sc, "_apply_global_watchlist_overrides", lambda *_a, **_k: None)
+    monkeypatch.setattr(sc, "_backfill_missing_ids", lambda *_a, **_k: None)
+    monkeypatch.setattr(sc, "_watchlist_source_priority", lambda: ['itunes'])
+    monkeypatch.setattr(sc, "_get_lookback_period_setting", lambda: 'all')
+    # the artist loop stops at the first artist; all we need to know is that it
+    # was REACHED rather than skipped by a false cancel
+    reached = []
+    monkeypatch.setattr(sc, "get_artist_discography_for_watchlist",
+                        lambda *_a, **_k: reached.append(1) or None)
+
+    state = {}
+    sc.scan_watchlist_artists([_artist(1)], scan_state=state)
+
+    assert reached, "the scan aborted before the artist loop"
+    assert state.get('status') != 'cancelled'

--- a/tests/test_watchlist_backfill_progress.py
+++ b/tests/test_watchlist_backfill_progress.py
@@ -160,3 +160,79 @@ def test_a_backfill_that_answers_nothing_does_not_abort_the_scan(monkeypatch):
 
     assert reached, "the scan aborted before the artist loop"
     assert state.get('status') != 'cancelled'
+
+
+# ---------------------------------------------------------------------------
+# cancelling mid-artist
+# ---------------------------------------------------------------------------
+
+def test_cancel_lands_inside_the_album_loop_not_just_between_artists(monkeypatch):
+    """An artist with many albums used to be unstoppable.
+
+    cancel_check was read once per ARTIST. An artist with thirty albums meant
+    thirty fetches and thirty pacing sleeps before the scan would even look at
+    the request, and a slow provider turned that into minutes of a scan that
+    would not stop (#1240: "I can't cancelled this").
+    """
+    from core.watchlist_scanner import WatchlistScanner
+
+    sc = WatchlistScanner.__new__(WatchlistScanner)
+    sc._database = MagicMock()
+    sc.database_path = ':memory:'
+    sc._database.has_fresh_similar_artists.return_value = True
+    monkeypatch.setattr("core.watchlist_scanner.time.sleep", lambda *_a: None)
+    monkeypatch.setattr(sc, "_apply_global_watchlist_overrides", lambda *_a, **_k: None)
+    monkeypatch.setattr(sc, "_backfill_missing_ids", lambda *_a, **_k: True)
+    monkeypatch.setattr(sc, "_watchlist_source_priority", lambda: [])
+    monkeypatch.setattr(sc, "_get_lookback_period_setting", lambda: 'recent')
+    monkeypatch.setattr(sc, "get_artist_image_url", lambda *_a, **_k: '')
+
+    albums = [types.SimpleNamespace(id=f"al{i}", name=f"Album {i}") for i in range(30)]
+    monkeypatch.setattr(sc, "get_artist_discography_for_watchlist", lambda *_a, **_k: albums)
+
+    fetched = []
+
+    def _fetch(album_id, album_name=''):
+        fetched.append(album_id)
+        return None          # no track data; the loop just moves on
+
+    # lazy property, no setter - fill the backing field
+    sc._metadata_service = types.SimpleNamespace(get_album=_fetch)
+
+    # cancel once three albums have been looked at
+    sc.scan_watchlist_artists(
+        [_artist(1)],
+        scan_state={},
+        cancel_check=lambda: len(fetched) >= 3,
+    )
+
+    assert len(fetched) == 3, (
+        f"kept fetching albums after the cancel: {len(fetched)} of {len(albums)}"
+    )
+
+
+def test_a_cancelled_artist_skips_its_discovery_work(monkeypatch):
+    """No point spending a similar-artists lookup on an artist we abandoned."""
+    from core.watchlist_scanner import WatchlistScanner
+
+    sc = WatchlistScanner.__new__(WatchlistScanner)
+    sc._database = MagicMock()
+    sc.database_path = ':memory:'
+    monkeypatch.setattr("core.watchlist_scanner.time.sleep", lambda *_a: None)
+    monkeypatch.setattr(sc, "_apply_global_watchlist_overrides", lambda *_a, **_k: None)
+    monkeypatch.setattr(sc, "_backfill_missing_ids", lambda *_a, **_k: True)
+    monkeypatch.setattr(sc, "_watchlist_source_priority", lambda: [])
+    monkeypatch.setattr(sc, "_get_lookback_period_setting", lambda: 'recent')
+    monkeypatch.setattr(sc, "get_artist_image_url", lambda *_a, **_k: '')
+
+    albums = [types.SimpleNamespace(id="al0", name="Album 0")]
+    monkeypatch.setattr(sc, "get_artist_discography_for_watchlist", lambda *_a, **_k: albums)
+    sc._metadata_service = types.SimpleNamespace(get_album=lambda *_a, **_k: None)
+
+    similar_calls = []
+    monkeypatch.setattr(sc, "update_similar_artists",
+                        lambda *_a, **_k: similar_calls.append(1))
+
+    sc.scan_watchlist_artists([_artist(1)], scan_state={}, cancel_check=lambda: True)
+
+    assert similar_calls == []

--- a/tests/test_watchlist_scanner_scan.py
+++ b/tests/test_watchlist_scanner_scan.py
@@ -573,16 +573,29 @@ def test_scan_watchlist_artists_honors_cancel_check(monkeypatch):
     monkeypatch.setattr(scanner, "_should_include_track", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(scanner, "is_track_missing_from_library", lambda *_args, **_kwargs: False)
     monkeypatch.setattr(scanner, "add_track_to_wishlist", lambda *_args, **_kwargs: False)
-    monkeypatch.setattr(scanner, "update_artist_scan_timestamp", lambda *_args, **_kwargs: True)
+    # The user presses Cancel once Artist One has finished. Modelled as a FLAG
+    # rather than iter([False, True]): a real cancel_check reads
+    # watchlist_scan_state['cancel_requested'] and can be asked any number of
+    # times. A two-item iterator instead pins how OFTEN the scan is allowed to
+    # ask, which is not behaviour anyone relies on - and cancellation is now
+    # checked inside the album loop too, so that a long artist can be
+    # interrupted at all. What this test actually guards is unchanged: a cancel
+    # arriving after Artist One keeps Artist One's result.
+    cancel_requested = {'value': False}
+
+    def _finish_artist(*_args, **_kwargs):
+        cancel_requested['value'] = True
+        return True
+
+    monkeypatch.setattr(scanner, "update_artist_scan_timestamp", _finish_artist)
     monkeypatch.setattr(scanner, "update_similar_artists", lambda *_args, **_kwargs: True)
     monkeypatch.setattr(scanner, "_backfill_similar_artists_fallback_ids", lambda *_args, **_kwargs: 0)
 
-    cancels = iter([False, True])
     scan_state = {}
     results = scanner.scan_watchlist_artists(
         [artist_a, artist_b],
         scan_state=scan_state,
-        cancel_check=lambda: next(cancels),
+        cancel_check=lambda: cancel_requested['value'],
     )
 
     assert len(results) == 1

--- a/tests/video/test_naming_conformance.py
+++ b/tests/video/test_naming_conformance.py
@@ -142,3 +142,16 @@ def test_surfaces_are_wired():
     assert "naming_mismatch: 'Rename'" in _REPAIR_JS
     assert "renamed: 'Renamed'" in _REPAIR_JS
     assert "function namingDetailHTML" in _REPAIR_JS
+
+
+def test_renaming_an_extra_library_keeps_the_file_on_its_drive(db, worker, tmp_path):
+    import json
+    root = tmp_path / "Movies2"
+    db.set_setting("movies_additional_paths", json.dumps([str(root)]))
+    _, old = _seed_movie_file(db, tmp_path, title="Ronin", year=1998, rel="Movies2/old.mkv")
+    worker._run_job("naming_conformance", forced=True)
+    finding = _pending(db)[0]
+    destination = Path(finding["details"]["expected_path"])
+    assert destination.is_relative_to(root)
+    assert worker.fix_finding(finding["id"])["success"]
+    assert destination.exists() and not old.exists()

--- a/tests/video/test_video_health.py
+++ b/tests/video/test_video_health.py
@@ -498,3 +498,12 @@ def test_a_disabled_list_does_not_count(db, monkeypatch):
         [{"id": 1, "name": "Off", "source": "tmdb_list", "ref": "1", "enabled": False}]))
     _automation(monkeypatch, {"enabled": 0})
     assert _il(collect(db)) is None
+
+
+def test_missing_additional_mount_is_reported(db, tmp_path):
+    import json
+    missing = str(tmp_path / "missing-extra-drive")
+    db.set_setting("tv_additional_paths", json.dumps([missing]))
+    check = next(c for c in collect(db)["checks"] if c["id"] == "tv_additional_paths_0")
+    assert check["status"] == "error"
+    assert missing in check["detail"]

--- a/web_server.py
+++ b/web_server.py
@@ -15770,6 +15770,18 @@ def cancel_task_v2():
             "error": "Missing playlist_id or track_index"
         }), 400
 
+    if playlist_id == 'audiobooks':
+        from core.audiobook_download_monitor import cancel_downloads as cancel_audiobooks
+        with tasks_lock:
+            task_id, _ = _find_task_by_playlist_track(playlist_id, track_index)
+        if not task_id:
+            return jsonify({"success": False, "error": "Audiobook task not found"}), 404
+        try:
+            cancel_audiobooks([task_id])
+            return jsonify({"success": True, "message": "Audiobook cancelled"})
+        except Exception as exc:
+            return jsonify({"success": False, "error": str(exc)}), 500
+
     try:
         # Everything in one atomic operation within the lock
         with tasks_lock:
@@ -15916,6 +15928,14 @@ def cancel_batch(batch_id):
     Cancels an entire batch - useful for cancelling during analysis phase
     or cancelling all downloads at once.
     """
+    if batch_id == 'audiobooks':
+        from core.audiobook_download_monitor import cancel_downloads as cancel_audiobooks
+        try:
+            count = cancel_audiobooks()
+            return jsonify({"success": True, "cancelled_tasks": count})
+        except Exception as exc:
+            return jsonify({"success": False, "error": str(exc)}), 500
+
     try:
         with tasks_lock:
             if batch_id not in download_batches:

--- a/web_server.py
+++ b/web_server.py
@@ -45,7 +45,7 @@ logger = setup_logging(_log_level, _log_path)
 
 # App version — single source of truth for backup metadata, system-info, update check, etc.
 # Semver: MAJOR.MINOR.PATCH. Bump at each dev→main release.
-_SOULSYNC_BASE_VERSION = "3.4.0"
+_SOULSYNC_BASE_VERSION = "3.4.1"
 
 def _build_version_string():
     """Append short commit hash to version when available (e.g. 2.35+abc1234)."""

--- a/webui/index.html
+++ b/webui/index.html
@@ -5240,17 +5240,17 @@
                                 <span class="stg-cardgroup-label">Files &amp; folders</span>
                                 <span class="stg-cardgroup-sub">Where things live on disk, and how they get named</span>
                             </div>
-                            <!-- Split from one "Paths &amp; Organization" card so the music side names
-                                 its sections the same way the video side does: Folders for where things
-                                 live, Organization for how they get named. One combined card on one side
-                                 and two split cards on the other made the two halves look like different
-                                 features rather than the same feature twice. -->
+                            <!-- Shared media tabs keep each set of controls mounted while switching. -->
                             <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''" role="button" tabindex="0" aria-expanded="false">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Music Folders</h3>
-                                <span class="settings-section-hint" data-stg-summary="library-paths" data-stg-fallback="Downloads, library &amp; extra folders">Downloads, library &amp; extra folders</span>
+                                <h3>Folders</h3>
+                                <span class="settings-section-hint">Downloads and library locations</span>
                             </div>
-                            <div class="settings-section-body collapsed" data-stg="library">
+<div class="settings-section-body collapsed stg-media-card" data-stg="library">
+<div class="stg-media-switcher" role="tablist" aria-label="Folders media type"><button type="button" id="folders-music-tab" role="tab" aria-selected="true" aria-controls="folders-music-panel" tabindex="0" onclick="switchLibraryMediaTab(this)" onkeydown="handleLibraryMediaTabKey(event)">Music</button><button type="button" id="folders-video-tab" role="tab" aria-selected="false" aria-controls="folders-video-panel" tabindex="-1" onclick="switchLibraryMediaTab(this)" onkeydown="handleLibraryMediaTabKey(event)">Video</button></div>
+<div id="folders-music-panel" role="tabpanel" aria-labelledby="folders-music-tab" class="stg-media-panel" tabindex="0">
+<div class="stg-media-context"><strong>Music folders</strong><span class="stg-media-summary" data-stg-summary="library-paths" data-stg-fallback="Downloads, library &amp; extra folders">Downloads, library &amp; extra folders</span></div>
+
 <div class="settings-group" data-stg="library">
                                 <h3>Folder Paths</h3>
                                 <div class="setting-help-text" style="margin-bottom: 4px;">
@@ -5406,13 +5406,47 @@
                                     <button class="test-button" onclick="addMusicPathRow()">+ Add Path</button>
                                 </div>
                             </div>
+
+</div>
+<div id="folders-video-panel" role="tabpanel" aria-labelledby="folders-video-tab" class="stg-media-panel" hidden tabindex="0">
+<div class="stg-media-context"><strong>Video folders</strong><span class="stg-media-summary" data-stg-summary="library-video-folders" data-stg-fallback="Movies, TV &amp; YouTube libraries">Movies, TV &amp; YouTube libraries</span></div>
+
+<div class="settings-group" data-stg="library">
+
+                                <div class="setting-help-text">
+                                    One shared download folder (where slskd / torrent drop files), then a separate library folder per type — finished files are sorted to the right one automatically. SEPARATE from your Music paths.
+                                </div>
+                                <div class="form-group">
+                                    <label>Download Folder (Input — shared with Music):</label>
+                                    <input type="text" id="video-download-path" placeholder="./downloads">
+                                    <div class="setting-help-text">Where downloads land — point this at the same folder as your slskd / torrent client. This is the SAME folder as the Music side; changing it here changes it there too.</div>
+                                </div>
+                                <div class="form-group">
+                                    <label>🎬 Movies Library:</label>
+                                    <input type="text" id="video-movies-path" placeholder="/media/movies">
+                                </div>
+                                <div class="form-group">
+                                    <label>📺 TV Shows Library:</label>
+                                    <input type="text" id="video-tv-path" placeholder="/media/tv">
+                                </div>
+                                <div class="form-group">
+                                    <label>▶️ YouTube Library:</label>
+                                    <input type="text" id="video-youtube-path" placeholder="/media/youtube">
+                                </div>
                             </div>
+
+</div>
+</div>
                             <div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''" role="button" tabindex="0" aria-expanded="false">
                                 <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Music Organization</h3>
-                                <span class="settings-section-hint" data-stg-summary="library-music-org" data-stg-fallback="File naming templates &amp; reorganize">File naming templates &amp; reorganize</span>
+                                <h3>Organization</h3>
+                                <span class="settings-section-hint">Naming, layout and file handling</span>
                             </div>
-                            <div class="settings-section-body collapsed" data-stg="library">
+<div class="settings-section-body collapsed stg-media-card" data-stg="library">
+<div class="stg-media-switcher" role="tablist" aria-label="Organization media type"><button type="button" id="organization-music-tab" role="tab" aria-selected="true" aria-controls="organization-music-panel" tabindex="0" onclick="switchLibraryMediaTab(this)" onkeydown="handleLibraryMediaTabKey(event)">Music</button><button type="button" id="organization-video-tab" role="tab" aria-selected="false" aria-controls="organization-video-panel" tabindex="-1" onclick="switchLibraryMediaTab(this)" onkeydown="handleLibraryMediaTabKey(event)">Video</button></div>
+<div id="organization-music-panel" role="tabpanel" aria-labelledby="organization-music-tab" class="stg-media-panel" tabindex="0">
+<div class="stg-media-context"><strong>Music organization</strong><span class="stg-media-summary" data-stg-summary="library-music-org" data-stg-fallback="File naming templates &amp; reorganize">File naming templates &amp; reorganize</span></div>
+
 <div class="settings-group" data-stg="library">
                                 <h3>File Organization</h3>
 
@@ -5752,44 +5786,11 @@
                                     no needless renames. Turn off to match the metadata source exactly.
                                 </div>
                             </div>
-                            </div>
                             
-<div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''" role="button" tabindex="0" aria-expanded="false">
-                                <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Video Folders</h3>
-                                <span class="settings-section-hint" data-stg-summary="library-video-folders" data-stg-fallback="Movies, TV &amp; YouTube libraries">Movies, TV &amp; YouTube libraries</span>
-                            </div>
-                            <div class="settings-section-body collapsed" data-stg="library">
-<div class="settings-group" data-stg="library">
-                                
-                                <div class="setting-help-text">
-                                    One shared download folder (where slskd / torrent drop files), then a separate library folder per type — finished files are sorted to the right one automatically. SEPARATE from your Music paths.
-                                </div>
-                                <div class="form-group">
-                                    <label>Download Folder (Input — shared with Music):</label>
-                                    <input type="text" id="video-download-path" placeholder="./downloads">
-                                    <div class="setting-help-text">Where downloads land — point this at the same folder as your slskd / torrent client. This is the SAME folder as the Music side; changing it here changes it there too.</div>
-                                </div>
-                                <div class="form-group">
-                                    <label>🎬 Movies Library:</label>
-                                    <input type="text" id="video-movies-path" placeholder="/media/movies">
-                                </div>
-                                <div class="form-group">
-                                    <label>📺 TV Shows Library:</label>
-                                    <input type="text" id="video-tv-path" placeholder="/media/tv">
-                                </div>
-                                <div class="form-group">
-                                    <label>▶️ YouTube Library:</label>
-                                    <input type="text" id="video-youtube-path" placeholder="/media/youtube">
-                                </div>
-                            </div>
-                            </div>
-<div class="settings-section-header collapsed" data-stg="library" onclick="this.classList.toggle('collapsed'); const b=this.nextElementSibling; b.classList.toggle('collapsed'); b.style.display=b.classList.contains('collapsed')?'none':''" role="button" tabindex="0" aria-expanded="false">
-                                <span class="settings-section-arrow">&#9660;</span>
-                                <h3>Video Organization</h3>
-                                <span class="settings-section-hint">Path templates, post-processing &amp; recycle</span>
-                            </div>
-                            <div class="settings-section-body collapsed" data-stg="library">
+</div>
+<div id="organization-video-panel" role="tabpanel" aria-labelledby="organization-video-tab" class="stg-media-panel" hidden tabindex="0">
+<div class="stg-media-context"><strong>Video organization</strong><span class="stg-media-summary">Path templates, post-processing &amp; recycle</span></div>
+
 <div class="settings-group" data-stg="library">
                                 
 
@@ -5933,7 +5934,12 @@
                                     <small class="settings-hint">Restores the Radarr/Sonarr standard layout.</small>
                                 </div>
                             </div>
-                            </div>
+
+</div>
+</div>
+
+
+
                             <div class="stg-cardgroup" data-stg="library">
                                 <span class="stg-cardgroup-label">Processing</span>
                                 <span class="stg-cardgroup-sub">What happens to a file after it arrives</span>

--- a/webui/index.html
+++ b/webui/index.html
@@ -2957,10 +2957,10 @@
                                                 placeholder="Last.fm API Secret (required for scrobbling)">
                                         </div>
                                         <div class="form-group">
-                                            <label>Username:</label>
+                                            <label for="lastfm-username">Username:</label>
                                             <input type="text" id="lastfm-username"
                                                 placeholder="Your Last.fm username">
-                                            <small>Whose listening history to import on the Stats page. The Stats page only asks for this once, so a typo could not be corrected anywhere until now (#1241).</small>
+                                            <small>The Last.fm account whose listening history to import. You can correct this username here or on the Stats page.</small>
                                         </div>
                                         <div class="callback-info">
                                             <div class="callback-help">Get your API key and secret from <a

--- a/webui/index.html
+++ b/webui/index.html
@@ -2574,63 +2574,59 @@
                     </div>
                 </div>
                 <div class="settings-content">
-                    <!-- Master Navigation Sidebar (Apple / Meta Category Rail) -->
-                    <nav class="stg-nav-rail" aria-label="Settings Categories">
-                        <div class="stg-nav-search-wrap">
+                    <nav class="stg-category-nav" aria-label="Settings categories">
+                        <div class="stg-navigation-heading">
+                            <div><span class="stg-eyebrow">YOUR WORKSPACE</span><h2>Settings</h2></div>
+<div class="stg-nav-search-wrap">
                             <svg class="stg-search-icon" viewBox="0 0 24 24"><path d="M21.71 20.29l-5.4-5.4a8 8 0 1 0-1.42 1.42l5.4 5.4a1 1 0 0 0 1.42-1.42zM4 10a6 6 0 1 1 6 6 6 6 0 0 1-6-6z"/></svg>
-                            <input type="text" id="stg-search-input" placeholder="Search settings..." aria-label="Search settings" oninput="if(typeof filterSettings==='function')filterSettings(this.value)">
+                            <input type="text" id="stg-search-input" placeholder="Search settings..." aria-label="Search settings" autocomplete="off" aria-controls="stg-search-results" onkeydown="if(event.key==='Escape'){this.value='';filterSettings('')}" oninput="if(typeof filterSettings==='function')filterSettings(this.value)">
                         </div>
-                        <div class="stg-nav-section-title">Connectivity</div>
+                        </div>
+                        <div id="stg-search-results" class="stg-search-results" hidden></div>
                         <div class="stg-tabbar">
-                            <button type="button" class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">
+<button type="button" class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">
                                 <span class="stg-tab-badge badge-connections">
                                     <svg viewBox="0 0 24 24"><path d="M18 10h-2V7a4 4 0 0 0-8 0v3H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2zm-8-3a2 2 0 0 1 4 0v3h-4V7zm8 13H6v-8h12v8z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Connections</span>
                             </button>
-                            <button type="button" class="stg-tab" data-tab="sources" onclick="switchSettingsTab('sources')">
+<button type="button" class="stg-tab" data-tab="sources" onclick="switchSettingsTab('sources')">
                                 <span class="stg-tab-badge badge-sources">
                                     <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 14.93V18a1 1 0 0 1-2 0v-1.07A7 7 0 0 1 5.07 11H4a1 1 0 0 1 0-2h1.07A7 7 0 0 1 11 5.07V4a1 1 0 0 1 2 0v1.07A7 7 0 0 1 18.93 11H20a1 1 0 0 1 0 2h-1.07A7 7 0 0 1 13 16.93zM12 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Sources</span>
                             </button>
-                        </div>
-                        <div class="stg-nav-section-title">Media Engine</div>
-                        <div class="stg-tabbar">
-                            <button type="button" class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">
+<button type="button" class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">
                                 <span class="stg-tab-badge badge-downloads">
                                     <svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Downloads</span>
                             </button>
-                            <button type="button" class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">
+<button type="button" class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">
                                 <span class="stg-tab-badge badge-quality">
                                     <svg viewBox="0 0 24 24"><path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Quality</span>
                             </button>
-                            <button type="button" class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">
+<button type="button" class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">
                                 <span class="stg-tab-badge badge-library">
                                     <svg viewBox="0 0 24 24"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Library</span>
                             </button>
-                        </div>
-                        <div class="stg-nav-section-title">System &amp; Preferences</div>
-                        <div class="stg-tabbar">
-                            <button type="button" class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">
+<button type="button" class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">
                                 <span class="stg-tab-badge badge-appearance">
                                     <svg viewBox="0 0 24 24"><path d="M12 3c-4.97 0-9 4.03-9 9 0 2.12.74 4.07 1.97 5.61L4.35 19.4a1 1 0 0 0 .71 1.6h4.52A8.96 8.96 0 0 0 12 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-5 9c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm3-4c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm4 0c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm3 4c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Appearance</span>
                             </button>
-                            <button type="button" class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">
+<button type="button" class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">
                                 <span class="stg-tab-badge badge-advanced">
                                     <svg viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54A.48.48 0 0 0 13.9 2h-3.8a.49.49 0 0 0-.49.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.73 8.47c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.48.48 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.8c.24 0 .44-.17.49-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
                                 </span>
                                 <span class="stg-tab-label">Advanced</span>
                             </button>
-                            <button type="button" class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">
+<button type="button" class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">
                                 <span class="stg-tab-badge badge-logs">
                                     <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
                                 </span>
@@ -2639,7 +2635,7 @@
                         </div>
                     </nav>
 
-                    <!-- Detail Workspace Canvas -->
+                    <!-- Settings category content -->
                     <div class="stg-detail-pane">
                         <div class="settings-nav-row">
                             <div class="stg-active-section-title">

--- a/webui/index.html
+++ b/webui/index.html
@@ -5429,6 +5429,21 @@
                                     <label>📺 TV Shows Library:</label>
                                     <input type="text" id="video-tv-path" placeholder="/media/tv">
                                 </div>
+                                <div class="setting-help-text">
+                                    Movies and TV folders above are the destinations for new downloads. Add extra libraries below for existing collections on other drives. Include those libraries in your Plex/Jellyfin scan selection. In Docker, mount each folder at a different container path and enter that path here; use read-write access for renaming, upgrades, and recycling.
+                                </div>
+                                <div class="form-group">
+                                    <label>Additional Movie Libraries:</label>
+                                    <div id="video-movies-additional-paths" data-video-extra-kind="movies"></div>
+                                    <button type="button" class="test-button" data-video-add-path="movies">+ Add Path</button>
+                                    <div class="setting-help-text">Extra folders only — no need to repeat the primary folder. Example: /media/movies2</div>
+                                </div>
+                                <div class="form-group">
+                                    <label>Additional TV Libraries:</label>
+                                    <div id="video-tv-additional-paths" data-video-extra-kind="tv"></div>
+                                    <button type="button" class="test-button" data-video-add-path="tv">+ Add Path</button>
+                                    <div class="setting-help-text">Extra folders only — no need to repeat the primary folder. Example: /media/tv2</div>
+                                </div>
                                 <div class="form-group">
                                     <label>▶️ YouTube Library:</label>
                                     <input type="text" id="video-youtube-path" placeholder="/media/youtube">

--- a/webui/index.html
+++ b/webui/index.html
@@ -102,6 +102,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-overlay-editor.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-collection-editor.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='settings-premier.css', v=static_v) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='discover-premier.css', v=static_v) }}">
     <style id="soulsync-initial-appearance">
         :root {
             --accent-rgb: {{ initial_accent_rgb }};

--- a/webui/index.html
+++ b/webui/index.html
@@ -101,6 +101,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-side.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-overlay-editor.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-collection-editor.css', v=static_v) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='settings-premier.css', v=static_v) }}">
     <style id="soulsync-initial-appearance">
         :root {
             --accent-rgb: {{ initial_accent_rgb }};
@@ -2573,24 +2574,87 @@
                     </div>
                 </div>
                 <div class="settings-content">
-                    <!-- Category Tab Bar -->
-                    <div class="settings-nav-row">
+                    <!-- Master Navigation Sidebar (Apple / Meta Category Rail) -->
+                    <nav class="stg-nav-rail" aria-label="Settings Categories">
+                        <div class="stg-nav-search-wrap">
+                            <svg class="stg-search-icon" viewBox="0 0 24 24"><path d="M21.71 20.29l-5.4-5.4a8 8 0 1 0-1.42 1.42l5.4 5.4a1 1 0 0 0 1.42-1.42zM4 10a6 6 0 1 1 6 6 6 6 0 0 1-6-6z"/></svg>
+                            <input type="text" id="stg-search-input" placeholder="Search settings..." aria-label="Search settings" oninput="if(typeof filterSettings==='function')filterSettings(this.value)">
+                        </div>
+                        <div class="stg-nav-section-title">Connectivity</div>
                         <div class="stg-tabbar">
-                            <button class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">Connections</button>
-                            <button class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">Downloads</button>
-                            <button class="stg-tab" data-tab="sources" onclick="switchSettingsTab('sources')">Sources</button>
-                            <button class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">Quality</button>
-                            <button class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">Library</button>
-                            <button class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">Appearance</button>
-                            <button class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">Advanced</button>
-                            <button class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">Logs</button>
+                            <button type="button" class="stg-tab active" data-tab="connections" onclick="switchSettingsTab('connections')">
+                                <span class="stg-tab-badge badge-connections">
+                                    <svg viewBox="0 0 24 24"><path d="M18 10h-2V7a4 4 0 0 0-8 0v3H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2zm-8-3a2 2 0 0 1 4 0v3h-4V7zm8 13H6v-8h12v8z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Connections</span>
+                            </button>
+                            <button type="button" class="stg-tab" data-tab="sources" onclick="switchSettingsTab('sources')">
+                                <span class="stg-tab-badge badge-sources">
+                                    <svg viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm1 14.93V18a1 1 0 0 1-2 0v-1.07A7 7 0 0 1 5.07 11H4a1 1 0 0 1 0-2h1.07A7 7 0 0 1 11 5.07V4a1 1 0 0 1 2 0v1.07A7 7 0 0 1 18.93 11H20a1 1 0 0 1 0 2h-1.07A7 7 0 0 1 13 16.93zM12 7a5 5 0 1 0 5 5 5 5 0 0 0-5-5z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Sources</span>
+                            </button>
                         </div>
-                        <div class="header-actions">
-                            <button class="save-button" id="save-settings">Save Settings</button>
+                        <div class="stg-nav-section-title">Media Engine</div>
+                        <div class="stg-tabbar">
+                            <button type="button" class="stg-tab" data-tab="downloads" onclick="switchSettingsTab('downloads')">
+                                <span class="stg-tab-badge badge-downloads">
+                                    <svg viewBox="0 0 24 24"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Downloads</span>
+                            </button>
+                            <button type="button" class="stg-tab" data-tab="quality" onclick="switchSettingsTab('quality')">
+                                <span class="stg-tab-badge badge-quality">
+                                    <svg viewBox="0 0 24 24"><path d="M3 17v2h6v-2H3zM3 5v2h10V5H3zm10 16v-2h8v-2h-8v-2h-2v6h2zM7 9v2H3v2h4v2h2V9H7zm14 4v-2H11v2h10zm-6-4h2V7h4V5h-4V3h-2v6z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Quality</span>
+                            </button>
+                            <button type="button" class="stg-tab" data-tab="library" onclick="switchSettingsTab('library')">
+                                <span class="stg-tab-badge badge-library">
+                                    <svg viewBox="0 0 24 24"><path d="M4 6H2v14c0 1.1.9 2 2 2h14v-2H4V6zm16-4H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H8V4h12v12z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Library</span>
+                            </button>
                         </div>
-                    </div>
-                    <!-- Settings Panels -->
-                    <div class="settings-columns">
+                        <div class="stg-nav-section-title">System &amp; Preferences</div>
+                        <div class="stg-tabbar">
+                            <button type="button" class="stg-tab" data-tab="appearance" onclick="switchSettingsTab('appearance')">
+                                <span class="stg-tab-badge badge-appearance">
+                                    <svg viewBox="0 0 24 24"><path d="M12 3c-4.97 0-9 4.03-9 9 0 2.12.74 4.07 1.97 5.61L4.35 19.4a1 1 0 0 0 .71 1.6h4.52A8.96 8.96 0 0 0 12 21c4.97 0 9-4.03 9-9s-4.03-9-9-9zm-5 9c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm3-4c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm4 0c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm3 4c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Appearance</span>
+                            </button>
+                            <button type="button" class="stg-tab" data-tab="advanced" onclick="switchSettingsTab('advanced')">
+                                <span class="stg-tab-badge badge-advanced">
+                                    <svg viewBox="0 0 24 24"><path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54A.48.48 0 0 0 13.9 2h-3.8a.49.49 0 0 0-.49.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.73 8.47c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.48.48 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.8c.24 0 .44-.17.49-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Advanced</span>
+                            </button>
+                            <button type="button" class="stg-tab" data-tab="logs" onclick="switchSettingsTab('logs')">
+                                <span class="stg-tab-badge badge-logs">
+                                    <svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z"/></svg>
+                                </span>
+                                <span class="stg-tab-label">Logs</span>
+                            </button>
+                        </div>
+                    </nav>
+
+                    <!-- Detail Workspace Canvas -->
+                    <div class="stg-detail-pane">
+                        <div class="settings-nav-row">
+                            <div class="stg-active-section-title">
+                                <span class="stg-active-title-text" id="stg-active-title">Connections</span>
+                                <span class="stg-active-sub-text" id="stg-active-sub">Accounts, media servers, and API keys SoulSync connects to</span>
+                            </div>
+                            <div class="header-actions">
+                                <button class="save-button" id="save-settings">
+                                    <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M17 3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V7l-4-4zm2 16H5V5h11.17L19 7.83V19zm-7-7c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3zM6 6h9v4H6z"/></svg>
+                                    <span>Save Settings</span>
+                                </button>
+                            </div>
+                        </div>
+                        <!-- Settings Panels -->
+                        <div class="settings-columns">
                         <!-- Left Column - API Configuration -->
                         <div class="settings-left-column">
                             <!-- API Configuration -->
@@ -7198,6 +7262,7 @@
                     </div>
 
                 </div>
+                </div><!-- /.stg-detail-pane -->
                 </div>
             </div>
 

--- a/webui/index.html
+++ b/webui/index.html
@@ -2956,6 +2956,12 @@
                                             <input type="password" id="lastfm-api-secret"
                                                 placeholder="Last.fm API Secret (required for scrobbling)">
                                         </div>
+                                        <div class="form-group">
+                                            <label>Username:</label>
+                                            <input type="text" id="lastfm-username"
+                                                placeholder="Your Last.fm username">
+                                            <small>Whose listening history to import on the Stats page. The Stats page only asks for this once, so a typo could not be corrected anywhere until now (#1241).</small>
+                                        </div>
                                         <div class="callback-info">
                                             <div class="callback-help">Get your API key and secret from <a
                                                     href="https://www.last.fm/api/account/create" target="_blank"

--- a/webui/index.html
+++ b/webui/index.html
@@ -103,6 +103,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='video/video-collection-editor.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='settings-premier.css', v=static_v) }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='discover-premier.css', v=static_v) }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='watchlist-premier.css', v=static_v) }}">
     <style id="soulsync-initial-appearance">
         :root {
             --accent-rgb: {{ initial_accent_rgb }};

--- a/webui/src/platform/artwork-thumb.test.ts
+++ b/webui/src/platform/artwork-thumb.test.ts
@@ -59,9 +59,11 @@ describe('thumb', () => {
 });
 
 it('bounds dashboard artwork from cache, proxy, and remote sources', () => {
-  expect(thumb('/api/image-cache/abc?v=hero', 'rail')).toBe('/api/image-cache/abc?v=rail');
+  expect(thumb('/api/image-cache/abc?v=hero', 'rail')).toBe(
+    '/api/image-cache/abc?v=rail&thumb_rev=2',
+  );
   const remote = 'https://cdn.example.test/large.jpg';
-  expect(thumb(remote, 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail`);
-  expect(thumb(imageProxyUrl(remote), 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail`);
+  expect(thumb(remote, 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail&thumb_rev=2`);
+  expect(thumb(imageProxyUrl(remote), 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail&thumb_rev=2`);
   expect(thumb('/static/placeholder.png', 'rail')).toBe('/static/placeholder.png');
 });

--- a/webui/src/platform/artwork-thumb.test.ts
+++ b/webui/src/platform/artwork-thumb.test.ts
@@ -57,3 +57,11 @@ describe('thumb', () => {
     expect(thumb('', 'grid')).toBe('');
   });
 });
+
+it('bounds dashboard artwork from cache, proxy, and remote sources', () => {
+  expect(thumb('/api/image-cache/abc?v=hero', 'rail')).toBe('/api/image-cache/abc?v=rail');
+  const remote = 'https://cdn.example.test/large.jpg';
+  expect(thumb(remote, 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail`);
+  expect(thumb(imageProxyUrl(remote), 'rail')).toBe(`${imageProxyUrl(remote)}&v=rail`);
+  expect(thumb('/static/placeholder.png', 'rail')).toBe('/static/placeholder.png');
+});

--- a/webui/src/platform/artwork-thumb.ts
+++ b/webui/src/platform/artwork-thumb.ts
@@ -60,6 +60,9 @@ export function thumb<T extends string | null | undefined>(
     if (path.startsWith(CACHE_PREFIX) || path === IMAGE_PROXY_PREFIX) {
       const parsed = new URL(target, 'http://localhost');
       parsed.searchParams.set('v', 'rail');
+      // Older servers cached originals under ?v=rail for 30 days. A new URL
+      // prevents those browser responses from surviving the resize rollout.
+      parsed.searchParams.set('thumb_rev', '2');
       return `${parsed.pathname}${parsed.search}${parsed.hash}`;
     }
     return target;

--- a/webui/src/platform/artwork-thumb.ts
+++ b/webui/src/platform/artwork-thumb.ts
@@ -8,11 +8,12 @@
  *
  * Callers do NOT need to know whether thumbnails are switched on. The server
  * ignores the parameter when the setting is off and serves the original, so a
- * call site can always ask and the single Settings toggle stays authoritative.
+ * call site can always ask. The compact dashboard rail is an exception: its
+ * artwork is always bounded to avoid decoding full-size masters in tiny cards.
  * That also means no config has to be plumbed into the browser.
  */
 
-export type ThumbVariant = 'grid' | 'card' | 'hero';
+export type ThumbVariant = 'grid' | 'card' | 'hero' | 'rail';
 
 /** Only our own cache endpoint understands `?v=`. */
 const CACHE_PREFIX = '/api/image-cache/';
@@ -48,6 +49,21 @@ export function thumb<T extends string | null | undefined>(
   variant: ThumbVariant,
   serviceWorkerControlled = serviceWorkerControlsPage(),
 ): T | string {
+  // Dashboard rails need bounded images even when originals are preferred
+  // elsewhere. Route remote artwork through the same cached resize path.
+  if (url && variant === 'rail') {
+    let target = url as string;
+    if (/^https?:\/\//i.test(target) || target.startsWith('//')) {
+      target = imageProxyUrl(target.startsWith('//') ? `https:${target}` : target);
+    }
+    const path = target.split('?')[0];
+    if (path.startsWith(CACHE_PREFIX) || path === IMAGE_PROXY_PREFIX) {
+      const parsed = new URL(target, 'http://localhost');
+      parsed.searchParams.set('v', 'rail');
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    }
+    return target;
+  }
   const safeUrl = browserSafeImageUrl(url, serviceWorkerControlled);
   if (!safeUrl) return safeUrl;
   if (!safeUrl.startsWith(CACHE_PREFIX)) return safeUrl;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -672,6 +672,11 @@ declare global {
       pageId: string,
       options?: Record<string, unknown>,
     ) => boolean | Promise<boolean> | void;
+    /** sync-services.js:2719 — reads #deezer-url-input and runs the whole
+     *  Deezer playlist flow: fetch, mirror, render, state. The Discover
+     *  editorial shelf drives this rather than fetching the playlist itself,
+     *  so browsing and pasting a link stay one pipeline. */
+    loadDeezerPlaylist?: () => Promise<void> | void;
     SoulSyncWebRouter?: {
       routeManifest: ShellRouteDefinition[];
       getCurrentPath: () => string;

--- a/webui/src/platform/shell/globals.d.ts
+++ b/webui/src/platform/shell/globals.d.ts
@@ -672,11 +672,6 @@ declare global {
       pageId: string,
       options?: Record<string, unknown>,
     ) => boolean | Promise<boolean> | void;
-    /** sync-services.js:2719 — reads #deezer-url-input and runs the whole
-     *  Deezer playlist flow: fetch, mirror, render, state. The Discover
-     *  editorial shelf drives this rather than fetching the playlist itself,
-     *  so browsing and pasting a link stay one pipeline. */
-    loadDeezerPlaylist?: () => Promise<void> | void;
     SoulSyncWebRouter?: {
       routeManifest: ShellRouteDefinition[];
       getCurrentPath: () => string;

--- a/webui/src/platform/shell/navigate-entry.test.ts
+++ b/webui/src/platform/shell/navigate-entry.test.ts
@@ -1,0 +1,64 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Cross-page navigation goes through window.navigateToPage, never the raw
+ * SoulSyncWebRouter bridge.
+ *
+ * globals.d.ts says it above the declaration: navigateToPage is the entry that
+ * does the permission guard, the sidebar chrome (setActivePageChrome) and the
+ * currentPage bookkeeping before handing off to the router. The bridge does
+ * only the last part — so the URL changes, the page changes, and the sidebar
+ * carries on highlighting wherever you came from.
+ *
+ * Reported on the Deezer editorial shelf: clicking a playlist landed the user
+ * on Sync with Discover still selected. Three call sites had it, and one of
+ * them was the precedent the other two were copied from, which is why this is a
+ * test rather than three fixes.
+ */
+
+const SRC = join(__dirname, '..', '..');
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      sourceFiles(path, found);
+    } else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) && !entry.endsWith('.d.ts')) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+/** Call sites that navigate to another PAGE through the raw bridge. */
+function bridgeNavigations(): string[] {
+  const offenders: string[] = [];
+  for (const file of sourceFiles(SRC)) {
+    const source = readFileSync(file, 'utf8');
+    // the shell's own router plumbing legitimately talks to the bridge
+    if (file.includes(join('platform', 'shell')) || file.includes(join('shell', ''))) continue;
+    for (const line of source.split('\n')) {
+      if (/SoulSyncWebRouter\??\.?\s*\.?navigateToPage/.test(line)) {
+        offenders.push(`${file.slice(SRC.length + 1)}: ${line.trim()}`);
+      }
+    }
+  }
+  return offenders;
+}
+
+describe('cross-page navigation uses the sidebar-aware entry', () => {
+  it('scans a real tree', () => {
+    // a walk that found nothing would make the check below vacuous
+    expect(sourceFiles(SRC).length).toBeGreaterThan(100);
+  });
+
+  it('no route navigates through the raw router bridge', () => {
+    expect(
+      bridgeNavigations(),
+      'these move the URL but leave the sidebar on the previous page; call window.navigateToPage',
+    ).toEqual([]);
+  });
+});

--- a/webui/src/routes/audiobooks/-audiobooks.api.ts
+++ b/webui/src/routes/audiobooks/-audiobooks.api.ts
@@ -1,5 +1,8 @@
+import type { Automation } from '@/routes/automations/-automations.types';
+
 import { apiClient, readJson } from '@/app/api-client';
 import { getShellProfileContext } from '@/platform/shell/bridge';
+import { runAutomation } from '@/routes/automations/-automations.api';
 
 /**
  * Every audiobook request, tagged with whose it is.
@@ -33,6 +36,8 @@ import type {
   AudiobookHome,
   AudiobookItem,
   AudiobookLibraryEntry,
+  AudiobookLibrary,
+  AudiobookLibraryScan,
   AudiobookSearchResult,
   AudiobookPersonProfile,
   AudiobookRole,
@@ -522,24 +527,38 @@ export async function fetchReleaseContents(
 // Library — what is actually on disk
 // ---------------------------------------------------------------------------
 
-export async function fetchLibrary(): Promise<{
-  books: AudiobookLibraryEntry[];
-  totalBytes: number;
-}> {
-  try {
-    const data = await readJson<{
-      success?: boolean;
-      books?: AudiobookLibraryEntry[];
-      total_bytes?: number;
-    }>(audiobookClient.get('audiobooks/library'));
-    return {
-      books: data?.success && Array.isArray(data.books) ? data.books : [],
-      totalBytes: data?.total_bytes || 0,
-    };
-  } catch (err) {
-    console.error('Failed to load the audiobook library:', err);
-    return { books: [], totalBytes: 0 };
+export async function fetchLibrary(): Promise<AudiobookLibrary> {
+  const data = await readJson<{
+    success?: boolean;
+    books?: AudiobookLibraryEntry[];
+    total_bytes?: number;
+    root?: string;
+    scan?: AudiobookLibraryScan;
+    error?: string;
+  }>(audiobookClient.get('audiobooks/library'));
+  if (!data.success || !Array.isArray(data.books)) {
+    throw new Error(data.error || 'Could not read your audiobook library.');
   }
+  return {
+    books: data.books,
+    totalBytes: data.total_bytes || 0,
+    root: data.root || '',
+    scan: data.scan || { status: 'never' },
+  };
+}
+
+/** Use the engine's Run Now so the scan has normal progress and run history. */
+export async function scanLibrary(): Promise<void> {
+  const automations = await readJson<Automation[] | { error?: string }>(
+    apiClient.get('automations'),
+  );
+  if (!Array.isArray(automations))
+    throw new Error(automations.error || 'Could not load automations.');
+  const candidates = automations.filter((a) => a.action_type === 'audiobook_scan_library');
+  const automation = candidates.find((a) => a.is_system) || candidates[0];
+  if (!automation)
+    throw new Error('Add Scan Audiobook Library on the Automations page, then try again.');
+  await runAutomation(automation.id);
 }
 
 /**
@@ -562,7 +581,11 @@ export async function deleteLibraryBook(
     };
   } catch (err) {
     console.error('Failed to delete the book:', err);
-    return { ok: false, recycled: false, error: 'Request failed' };
+    return {
+      ok: false,
+      recycled: false,
+      error: err instanceof Error ? err.message : 'Request failed',
+    };
   }
 }
 

--- a/webui/src/routes/audiobooks/-audiobooks.api.ts
+++ b/webui/src/routes/audiobooks/-audiobooks.api.ts
@@ -38,6 +38,7 @@ import type {
   AudiobookLibraryEntry,
   AudiobookLibrary,
   AudiobookLibraryScan,
+  AudiobookMatchResults,
   AudiobookSearchResult,
   AudiobookPersonProfile,
   AudiobookRole,
@@ -823,4 +824,28 @@ export async function runAuthorScan(): Promise<Record<string, number> | null> {
     console.error('Failed to check followed authors:', err);
     return null;
   }
+}
+
+export async function fetchLibraryMatches(id: string, query = ''): Promise<AudiobookMatchResults> {
+  const data = await readJson<AudiobookMatchResults & { success?: boolean; error?: string }>(
+    audiobookClient.get(`audiobooks/library/${encodeURIComponent(id)}/matches`, {
+      searchParams: { q: query },
+    }),
+  );
+  if (!data.success) throw new Error(data.error || 'Could not search for matches.');
+  return data;
+}
+
+export async function saveLibraryMatch(
+  id: string,
+  snapshot: Pick<AudiobookMatchResults, 'scan_signature' | 'match_revision'>,
+  action: 'confirm' | 'ignore' | 'retry',
+  catalogAsin = '',
+): Promise<void> {
+  const data = await readJson<{ success?: boolean; error?: string }>(
+    audiobookClient.patch(`audiobooks/library/${encodeURIComponent(id)}/match`, {
+      json: { ...snapshot, action, catalog_asin: catalogAsin },
+    }),
+  );
+  if (!data.success) throw new Error(data.error || 'Could not save the match.');
 }

--- a/webui/src/routes/audiobooks/-audiobooks.types.ts
+++ b/webui/src/routes/audiobooks/-audiobooks.types.ts
@@ -151,7 +151,13 @@ export interface AudiobookPersonProfile {
 export type AudiobookNarratorMode = 'exact' | 'any';
 
 /** Where a wishlisted book has got to. */
-export type AudiobookWishlistStatus = 'wanted' | 'searching' | 'grabbed' | 'done' | 'failed';
+export type AudiobookWishlistStatus =
+  | 'wanted'
+  | 'searching'
+  | 'grabbed'
+  | 'done'
+  | 'failed'
+  | 'cancelled';
 
 export interface AudiobookWishlistEntry {
   id: number;
@@ -167,6 +173,7 @@ export interface AudiobookWishlistEntry {
   release_date: string;
   language: string;
   status: AudiobookWishlistStatus;
+  download_status?: string;
   narrator_mode: AudiobookNarratorMode;
   /** Drives the retry backoff, so it doubles as "how hard have we looked". */
   attempt_count: number;
@@ -176,6 +183,7 @@ export interface AudiobookWishlistEntry {
 }
 
 export interface AudiobookWishlistCounts {
+  cancelled?: number;
   wanted: number;
   searching: number;
   grabbed: number;

--- a/webui/src/routes/audiobooks/-audiobooks.types.ts
+++ b/webui/src/routes/audiobooks/-audiobooks.types.ts
@@ -267,6 +267,8 @@ export interface AudiobookDownload {
 
 /** One book on disk. */
 export interface AudiobookLibraryEntry {
+  cover_url?: string;
+  source?: string;
   asin: string;
   title: string;
   author: string;
@@ -322,4 +324,24 @@ export interface AudiobookFollowedAuthor {
    *  once when the author is followed, because nobody sees the book before it
    *  is queued — there is no modal to ask. */
   narrator_mode?: string;
+}
+
+export interface AudiobookLibraryScan {
+  status: 'never' | 'running' | 'completed' | 'error' | 'interrupted';
+  started_at?: number;
+  finished_at?: number;
+  checked?: number;
+  adopted?: number;
+  updated?: number;
+  removed?: number;
+  local?: number;
+  error?: string;
+  current?: string;
+}
+
+export interface AudiobookLibrary {
+  books: AudiobookLibraryEntry[];
+  totalBytes: number;
+  root: string;
+  scan: AudiobookLibraryScan;
 }

--- a/webui/src/routes/audiobooks/-audiobooks.types.ts
+++ b/webui/src/routes/audiobooks/-audiobooks.types.ts
@@ -267,6 +267,32 @@ export interface AudiobookDownload {
 
 /** One book on disk. */
 export interface AudiobookLibraryEntry {
+  catalog_asin?: string;
+  match_status?:
+    | 'unmatched'
+    | 'identifier'
+    | 'automatic'
+    | 'confirmed'
+    | 'suggested'
+    | 'ignored'
+    | 'changed'
+    | 'error';
+  match_score?: number;
+  match_revision?: number;
+  scan_signature?: string;
+  match_candidates?: AudiobookMatchCandidate[];
+  match_evidence?: string[];
+  origin?: 'soulsync' | 'disk' | 'unknown';
+  grouping?: string;
+  file_paths?: string[];
+  file_scope?: 'folder' | 'files';
+  download?: {
+    download_id: string;
+    source: string;
+    indexer: string;
+    release_title: string;
+    completed_at: number;
+  } | null;
   cover_url?: string;
   source?: string;
   asin: string;
@@ -337,6 +363,12 @@ export interface AudiobookLibraryScan {
   local?: number;
   error?: string;
   current?: string;
+  phase?: string;
+  matched?: number;
+  review?: number;
+  match_checked?: number;
+  match_pending?: number;
+  match_errors?: number;
 }
 
 export interface AudiobookLibrary {
@@ -344,4 +376,26 @@ export interface AudiobookLibrary {
   totalBytes: number;
   root: string;
   scan: AudiobookLibraryScan;
+}
+
+export interface AudiobookMatchCandidate {
+  book: {
+    asin: string;
+    title: string;
+    author_names?: string[];
+    narrator_names?: string[];
+    runtime_minutes?: number;
+    cover_url?: string;
+    language?: string;
+    format_type?: string;
+  };
+  score: number;
+  evidence: string[];
+  conflicts: string[];
+  automatic_eligible: boolean;
+}
+export interface AudiobookMatchResults {
+  candidates: AudiobookMatchCandidate[];
+  scan_signature: string;
+  match_revision: number;
 }

--- a/webui/src/routes/audiobooks/-ui/audiobook-library-match.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library-match.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useState } from 'react';
+
+import type { AudiobookLibraryEntry, AudiobookMatchResults } from '../-audiobooks.types';
+
+import { fetchLibraryMatches, saveLibraryMatch } from '../-audiobooks.api';
+import styles from './audiobook-library.module.css';
+
+export function AudiobookLibraryMatch({
+  book,
+  onBack,
+  onSaved,
+}: {
+  book: AudiobookLibraryEntry;
+  onBack: () => void;
+  onSaved: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<AudiobookMatchResults>({
+    candidates: book.match_candidates || [],
+    scan_signature: book.scan_signature || '',
+    match_revision: book.match_revision || 0,
+  });
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [searched, setSearched] = useState(Boolean(book.match_candidates?.length));
+
+  useEffect(() => {
+    setResults({
+      candidates: book.match_candidates || [],
+      scan_signature: book.scan_signature || '',
+      match_revision: book.match_revision || 0,
+    });
+  }, [book]);
+
+  const search = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setResults(await fetchLibraryMatches(book.asin, query));
+      setSearched(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not search the catalogue.');
+    } finally {
+      setLoading(false);
+    }
+  };
+  const save = async (action: 'confirm' | 'ignore' | 'retry', asin = '') => {
+    setSaving(true);
+    setError('');
+    try {
+      await saveLibraryMatch(book.asin, results, action, asin);
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not save the match.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.matchPane}>
+      <button type="button" className={styles.back} onClick={onBack}>
+        ← Back to library
+      </button>
+      <h3>Match this recording</h3>
+      <div className={styles.localEvidence}>
+        <strong>{book.title}</strong>
+        <p>
+          {book.author || 'Author unknown'} ·{' '}
+          {book.narrator ? `Narrated by ${book.narrator}` : 'Narrator unknown'} ·{' '}
+          {book.runtime_minutes ? `${book.runtime_minutes} minutes` : 'Runtime unknown'}
+        </p>
+        <p>
+          {book.file_count} files · {book.grouping || book.path}
+        </p>
+        {book.catalog_asin && <p>Saved catalogue edition: {book.catalog_asin}</p>}
+        {book.match_evidence?.map((line) => (
+          <p key={line}>{line}</p>
+        ))}
+      </div>
+      <p>
+        Compare the narrator, runtime and edition before confirming. Your choice changes the
+        catalogue link and ownership badges; it leaves your files and download origin intact.
+      </p>
+      <form
+        className={styles.matchSearch}
+        onSubmit={(e) => {
+          e.preventDefault();
+          void search();
+        }}
+      >
+        <input
+          aria-label="Search catalogue or enter ASIN"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={`${book.title} — or paste an Audible ASIN`}
+        />
+        <button type="submit" className={styles.primary} disabled={loading || saving}>
+          {loading ? 'Searching…' : 'Find editions'}
+        </button>
+      </form>
+      {error && (
+        <p role="alert" className={styles.notice}>
+          {error}
+        </p>
+      )}
+      {!searched && <p>Use Find editions to search, or keep this book unmatched.</p>}
+      {searched && !loading && results.candidates.length === 0 && (
+        <p>No candidates found. Try a shorter title, the author’s name, or an ASIN.</p>
+      )}
+      <ul className={styles.candidates}>
+        {results.candidates.map((candidate) => (
+          <li key={candidate.book.asin}>
+            {candidate.book.cover_url && (
+              <img src={candidate.book.cover_url} alt="" loading="lazy" />
+            )}
+            <div>
+              <h4>{candidate.book.title}</h4>
+              <p>{candidate.book.author_names?.join(', ') || 'Author unavailable'}</p>
+              <p>
+                {candidate.book.narrator_names?.join(', ') || 'Narrator unavailable'} ·{' '}
+                {candidate.book.runtime_minutes || '?'} min ·{' '}
+                {candidate.book.language || 'Language unknown'} ·{' '}
+                {candidate.book.format_type || 'Edition unknown'}
+              </p>
+              <p className={styles.matchScore}>
+                Match score {candidate.score}/100 · {candidate.book.asin}
+              </p>
+              <ul>
+                {candidate.evidence.map((line) => (
+                  <li key={line}>{line}</li>
+                ))}
+              </ul>
+              {candidate.conflicts.length > 0 && (
+                <p className={styles.conflict}>{candidate.conflicts.join(' · ')}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              className={styles.primary}
+              disabled={saving || loading}
+              onClick={() => void save('confirm', candidate.book.asin)}
+            >
+              Use this edition
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.matchActions}>
+        <button type="button" disabled={saving || loading} onClick={() => void save('ignore')}>
+          Keep unmatched
+        </button>
+        <button type="button" disabled={saving || loading} onClick={() => void save('retry')}>
+          Queue automatic matching
+        </button>
+        <small>
+          Queued books are checked on the next scan. Keeping a book unmatched prevents automatic
+          matching until you change it.
+        </small>
+      </div>
+    </div>
+  );
+}

--- a/webui/src/routes/audiobooks/-ui/audiobook-library-modal.test.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library-modal.test.tsx
@@ -1,13 +1,21 @@
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { deleteLibraryBook, fetchLibrary, scanLibrary } from '../-audiobooks.api';
+import {
+  deleteLibraryBook,
+  fetchLibrary,
+  scanLibrary,
+  fetchLibraryMatches,
+  saveLibraryMatch,
+} from '../-audiobooks.api';
 import { AudiobookLibraryModal } from './audiobook-library-modal';
 
 vi.mock('../-audiobooks.api', () => ({
   fetchLibrary: vi.fn(),
   scanLibrary: vi.fn(),
   deleteLibraryBook: vi.fn(),
+  fetchLibraryMatches: vi.fn(),
+  saveLibraryMatch: vi.fn(),
 }));
 vi.mock('./audiobook-overlay', () => ({
   AudiobookOverlay: ({ children }: { children: React.ReactNode }) => (
@@ -78,7 +86,7 @@ describe('audiobook library', () => {
     vi.mocked(deleteLibraryBook).mockResolvedValue({ ok: true, recycled: true, error: '' });
     render(<AudiobookLibraryModal onClose={() => {}} />);
     await screen.findByRole('heading', { name: 'A Local Book' });
-    fireEvent.click(screen.getByText('File details · Local'));
+    fireEvent.click(screen.getByText('File details'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete from disk' }));
     expect(deleteLibraryBook).not.toHaveBeenCalled();
     vi.mocked(fetchLibrary).mockResolvedValue({ ...response, books: [], totalBytes: 0 });
@@ -95,12 +103,62 @@ describe('audiobook library', () => {
     });
     render(<AudiobookLibraryModal onClose={() => {}} />);
     await screen.findByRole('heading', { name: 'A Local Book' });
-    fireEvent.click(screen.getByText('File details · Local'));
+    fireEvent.click(screen.getByText('File details'));
     fireEvent.click(screen.getByRole('button', { name: 'Delete from disk' }));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
     expect(await screen.findByRole('status')).toHaveTextContent('Permission denied');
     expect(
       within(screen.getByRole('list')).getByRole('heading', { name: 'A Local Book' }),
     ).toBeInTheDocument();
+  });
+  it('distinguishes proven downloads from disk discoveries and unknown history', async () => {
+    vi.mocked(fetchLibrary).mockResolvedValue({
+      ...response,
+      books: [
+        { ...book, origin: 'soulsync' },
+        { ...book, asin: 'local:two', title: 'Disk Book', origin: 'disk' },
+        { ...book, asin: 'local:three', title: 'Old Book', origin: 'unknown' },
+      ],
+    });
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'Disk Book' });
+    fireEvent.change(screen.getByLabelText('Filter by download origin'), {
+      target: { value: 'soulsync' },
+    });
+    expect(screen.getByRole('heading', { name: 'A Local Book' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Disk Book' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Old Book' })).not.toBeInTheDocument();
+  });
+
+  it('searches editions and saves a confirmation with the reviewed snapshot', async () => {
+    const snapshot = {
+      scan_signature: 'files-v2',
+      match_revision: 3,
+      candidates: [
+        {
+          book: { asin: 'B000000001', title: 'Catalogue Book', author_names: ['An Author'] },
+          score: 98,
+          evidence: ['Narrator agrees'],
+          conflicts: [],
+          automatic_eligible: true,
+        },
+      ],
+    };
+    vi.mocked(fetchLibraryMatches).mockResolvedValue(snapshot);
+    vi.mocked(saveLibraryMatch).mockResolvedValue();
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'A Local Book' });
+    fireEvent.click(screen.getByRole('button', { name: 'Unmatched' }));
+    fireEvent.change(screen.getByLabelText('Search catalogue or enter ASIN'), {
+      target: { value: 'B000000001' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Find editions' }));
+    await screen.findByRole('heading', { name: 'Catalogue Book' });
+    expect(fetchLibraryMatches).toHaveBeenCalledWith('local:one', 'B000000001');
+    fireEvent.click(screen.getByRole('button', { name: 'Use this edition' }));
+    await waitFor(() =>
+      expect(saveLibraryMatch).toHaveBeenCalledWith('local:one', snapshot, 'confirm', 'B000000001'),
+    );
+    await screen.findByRole('heading', { name: 'A Local Book' });
   });
 });

--- a/webui/src/routes/audiobooks/-ui/audiobook-library-modal.test.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library-modal.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { deleteLibraryBook, fetchLibrary, scanLibrary } from '../-audiobooks.api';
+import { AudiobookLibraryModal } from './audiobook-library-modal';
+
+vi.mock('../-audiobooks.api', () => ({
+  fetchLibrary: vi.fn(),
+  scanLibrary: vi.fn(),
+  deleteLibraryBook: vi.fn(),
+}));
+vi.mock('./audiobook-overlay', () => ({
+  AudiobookOverlay: ({ children }: { children: React.ReactNode }) => (
+    <div role="dialog">{children}</div>
+  ),
+}));
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <a href="#" onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const book = {
+  asin: 'local:one',
+  title: 'A Local Book',
+  author: 'An Author',
+  narrator: 'A Narrator',
+  series_title: '',
+  series_sequence: '',
+  path: '/books/Local Book',
+  file_count: 2,
+  size_bytes: 104857600,
+  audio_format: 'mp3',
+  runtime_minutes: 90,
+  imported_at: 1,
+};
+const response = {
+  books: [book],
+  totalBytes: book.size_bytes,
+  root: '/books',
+  scan: { status: 'never' as const },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(fetchLibrary).mockResolvedValue(response);
+});
+
+describe('audiobook library', () => {
+  it('shows local books and filters by narrator', async () => {
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'A Local Book' });
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'A Narrator' } });
+    expect(screen.getByRole('heading', { name: 'A Local Book' })).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'Missing' } });
+    expect(screen.getByText('No books match these filters.')).toBeInTheDocument();
+  });
+
+  it('starts the standard automation and prevents a second queued scan', async () => {
+    vi.mocked(scanLibrary).mockResolvedValue();
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'A Local Book' });
+    fireEvent.click(screen.getByRole('button', { name: 'Scan folder' }));
+    await waitFor(() => expect(scanLibrary).toHaveBeenCalledOnce());
+    expect(screen.getByRole('button', { name: 'Scanning…' })).toBeDisabled();
+  });
+
+  it('shows a load failure instead of pretending the library is empty', async () => {
+    vi.mocked(fetchLibrary).mockRejectedValue(new Error('Folder service unavailable'));
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    expect(await screen.findByRole('alert')).toHaveTextContent('Folder service unavailable');
+    expect(screen.queryByText('Your books belong here')).not.toBeInTheDocument();
+  });
+
+  it('requires confirmation and updates the size after a successful deletion', async () => {
+    vi.mocked(deleteLibraryBook).mockResolvedValue({ ok: true, recycled: true, error: '' });
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'A Local Book' });
+    fireEvent.click(screen.getByText('File details · Local'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete from disk' }));
+    expect(deleteLibraryBook).not.toHaveBeenCalled();
+    vi.mocked(fetchLibrary).mockResolvedValue({ ...response, books: [], totalBytes: 0 });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+    await screen.findByText('0 books · 0 MB on disk');
+    expect(deleteLibraryBook).toHaveBeenCalledWith('local:one');
+  });
+
+  it('keeps a book visible when deletion fails', async () => {
+    vi.mocked(deleteLibraryBook).mockResolvedValue({
+      ok: false,
+      recycled: false,
+      error: 'Permission denied',
+    });
+    render(<AudiobookLibraryModal onClose={() => {}} />);
+    await screen.findByRole('heading', { name: 'A Local Book' });
+    fireEvent.click(screen.getByText('File details · Local'));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete from disk' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+    expect(await screen.findByRole('status')).toHaveTextContent('Permission denied');
+    expect(
+      within(screen.getByRole('list')).getByRole('heading', { name: 'A Local Book' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/webui/src/routes/audiobooks/-ui/audiobook-library-modal.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library-modal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { AudiobookLibraryEntry, AudiobookLibraryScan } from '../-audiobooks.types';
 
 import { deleteLibraryBook, fetchLibrary, scanLibrary } from '../-audiobooks.api';
+import { AudiobookLibraryMatch } from './audiobook-library-match';
 import styles from './audiobook-library.module.css';
 import { AudiobookOverlay } from './audiobook-overlay';
 
@@ -15,6 +16,30 @@ function size(bytes: number): string {
 
 function duration(minutes: number): string {
   return minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`;
+}
+
+const ORIGINS: Record<string, string> = {
+  soulsync: 'SoulSync download',
+  disk: 'Found on disk',
+  unknown: 'Origin unknown',
+};
+const MATCHES: Record<string, string> = {
+  identifier: 'Identified by ASIN',
+  automatic: 'Auto-matched',
+  confirmed: 'Confirmed by you',
+  unmatched: 'Unmatched',
+  suggested: 'Review matches',
+  ignored: 'Kept unmatched',
+  changed: 'Files changed · review',
+  error: 'Match lookup failed',
+};
+function matchedAsin(book: AudiobookLibraryEntry): string {
+  return ['identifier', 'automatic', 'confirmed'].includes(book.match_status || '')
+    ? book.catalog_asin || ''
+    : '';
+}
+function needsReview(book: AudiobookLibraryEntry): boolean {
+  return !matchedAsin(book) && book.match_status !== 'ignored';
 }
 
 function Cover({ book }: { book: AudiobookLibraryEntry }) {
@@ -47,7 +72,9 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
   const [message, setMessage] = useState('');
   const [filter, setFilter] = useState('');
   const [sort, setSort] = useState('title');
-  const [localOnly, setLocalOnly] = useState(false);
+  const [matchFilter, setMatchFilter] = useState('all');
+  const [originFilter, setOriginFilter] = useState('all');
+  const [reviewBook, setReviewBook] = useState<AudiobookLibraryEntry | null>(null);
   const [confirm, setConfirm] = useState('');
   const [revision, setRevision] = useState(0);
   const [queuedAt, setQueuedAt] = useState(0);
@@ -92,14 +119,16 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
     };
   }, [revision, queuedAt, scan.status]);
 
-  const localCount = books.filter((book) => book.asin.startsWith('local:')).length;
+  const reviewCount = books.filter(needsReview).length;
   const totalBytes = books.reduce((sum, book) => sum + book.size_bytes, 0);
   const shown = useMemo(() => {
     const needle = filter.trim().toLowerCase();
     return books
       .filter(
         (book) =>
-          (!localOnly || book.asin.startsWith('local:')) &&
+          (matchFilter === 'all' ||
+            (matchFilter === 'review' ? needsReview(book) : Boolean(matchedAsin(book)))) &&
+          (originFilter === 'all' || (book.origin || 'unknown') === originFilter) &&
           (!needle ||
             [book.title, book.author, book.narrator, book.series_title].some((s) =>
               s.toLowerCase().includes(needle),
@@ -113,7 +142,7 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
             : (sort === 'author' ? a.author.localeCompare(b.author) : 0) ||
               a.title.localeCompare(b.title),
       );
-  }, [books, filter, sort, localOnly]);
+  }, [books, filter, sort, matchFilter, originFilter]);
 
   const startScan = async () => {
     scanBaseline.current = scan.started_at || 0;
@@ -152,7 +181,9 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
   const scanText = queuedAt
     ? 'Starting scan…'
     : scan.status === 'running'
-      ? `Scanning folder · ${scan.checked || 0} books checked`
+      ? scan.phase === 'matching'
+        ? `Matching catalogue · ${scan.match_checked || 0} checked`
+        : `Scanning folder · ${scan.checked || 0} books checked`
       : scan.status === 'completed' && scan.finished_at
         ? `Last scanned ${new Date(scan.finished_at * 1000).toLocaleString()}`
         : scan.status === 'never'
@@ -182,84 +213,139 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
           </button>
         </header>
 
-        <div className={styles.scanPanel}>
-          <div className={styles.scanInfo}>
-            <strong>
-              <span className={scanning ? styles.activeDot : styles.dot} />
-              {scanText}
-            </strong>
-            <span className={styles.root} title={root}>
-              {root || 'Set your audiobook folder in Settings → Library'}
-            </span>
-            {scan.status === 'completed' && (
-              <small>
-                {scan.adopted || 0} added · {scan.updated || 0} refreshed · {scan.removed || 0}{' '}
-                missing
-              </small>
+        {!reviewBook && (
+          <>
+            <div className={styles.scanPanel}>
+              <div className={styles.scanInfo}>
+                <strong>
+                  <span className={scanning ? styles.activeDot : styles.dot} />
+                  {scanText}
+                </strong>
+                <span className={styles.root} title={root}>
+                  {root || 'Set your audiobook folder in Settings → Library'}
+                </span>
+                {scan.status === 'completed' && (
+                  <small>
+                    {scan.adopted || 0} added · {scan.updated || 0} refreshed · {scan.removed || 0}{' '}
+                    missing
+                  </small>
+                )}
+              </div>
+              <div className={styles.scanActions}>
+                <button
+                  type="button"
+                  className={styles.primary}
+                  onClick={() => void startScan()}
+                  disabled={scanning || loading}
+                >
+                  {scanning ? 'Scanning…' : 'Scan folder'}
+                </button>
+                <Link
+                  to="/automations"
+                  search={{ action: 'audiobook_scan_library' }}
+                  onClick={onClose}
+                >
+                  Schedule & history ↗
+                </Link>
+              </div>
+            </div>
+            {scan.error && (
+              <p className={styles.notice} role="status">
+                {scan.error}
+              </p>
             )}
-          </div>
-          <div className={styles.scanActions}>
-            <button
-              type="button"
-              className={styles.primary}
-              onClick={() => void startScan()}
-              disabled={scanning || loading}
-            >
-              {scanning ? 'Scanning…' : 'Scan folder'}
-            </button>
-            <Link to="/automations" search={{ action: 'audiobook_scan_library' }} onClick={onClose}>
-              Schedule & history ↗
-            </Link>
-          </div>
-        </div>
-        {scan.error && (
-          <p className={styles.notice} role="status">
-            {scan.error}
-          </p>
-        )}
-        {message && (
-          <p className={styles.notice} role="status">
-            {message}
-          </p>
-        )}
-        {loadError && (
-          <p className={styles.notice} role="alert">
-            {loadError}{' '}
-            <button type="button" onClick={() => setRevision((v) => v + 1)}>
-              Retry
-            </button>
-          </p>
-        )}
+            {message && (
+              <p className={styles.notice} role="status">
+                {message}
+              </p>
+            )}
+            {loadError && (
+              <p className={styles.notice} role="alert">
+                {loadError}{' '}
+                <button type="button" onClick={() => setRevision((v) => v + 1)}>
+                  Retry
+                </button>
+              </p>
+            )}
 
-        <div className={styles.toolbar}>
-          <input
-            type="search"
-            aria-label="Search library"
-            placeholder="Search title, author, narrator or series…"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-          />
-          <select aria-label="Sort library" value={sort} onChange={(e) => setSort(e.target.value)}>
-            <option value="title">Title A–Z</option>
-            <option value="author">Author A–Z</option>
-            <option value="recent">Recently added</option>
-            <option value="size">Largest first</option>
-          </select>
-        </div>
-        <div className={styles.filters}>
-          <button type="button" aria-pressed={!localOnly} onClick={() => setLocalOnly(false)}>
-            All books <span>{books.length}</span>
-          </button>
-          <button type="button" aria-pressed={localOnly} onClick={() => setLocalOnly(true)}>
-            Local only <span>{localCount}</span>
-          </button>
-          <span className={styles.filterHint}>
-            Local books are indexed without guessing an Audible edition.
-          </span>
-        </div>
-
+            <div className={styles.toolbar}>
+              <input
+                type="search"
+                aria-label="Search library"
+                placeholder="Search title, author, narrator or series…"
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+              />
+              <select
+                aria-label="Sort library"
+                value={sort}
+                onChange={(e) => setSort(e.target.value)}
+              >
+                <option value="title">Title A–Z</option>
+                <option value="author">Author A–Z</option>
+                <option value="recent">Recently added</option>
+                <option value="size">Largest first</option>
+              </select>
+            </div>
+            <div className={styles.filters}>
+              <button
+                type="button"
+                aria-pressed={matchFilter === 'all'}
+                onClick={() => setMatchFilter('all')}
+              >
+                All books <span>{books.length}</span>
+              </button>
+              <button
+                type="button"
+                aria-pressed={matchFilter === 'review'}
+                onClick={() => setMatchFilter('review')}
+              >
+                Needs review <span>{reviewCount}</span>
+              </button>
+              <button
+                type="button"
+                aria-pressed={matchFilter === 'matched'}
+                onClick={() => setMatchFilter('matched')}
+              >
+                Matched
+              </button>
+              <select
+                aria-label="Filter by download origin"
+                value={originFilter}
+                onChange={(e) => setOriginFilter(e.target.value)}
+              >
+                <option value="all">All origins</option>
+                <option value="soulsync">SoulSync downloads</option>
+                <option value="disk">Found on disk</option>
+                <option value="unknown">Origin unknown</option>
+              </select>
+            </div>
+            {Boolean(scan.match_pending) && (
+              <p className={styles.notice}>
+                {scan.match_pending} books waiting for catalogue lookup. The automation processes a
+                limited batch each run.
+              </p>
+            )}
+            {Boolean(scan.match_errors) && (
+              <p className={styles.notice}>
+                {scan.match_errors} catalogue lookups failed. Your files are indexed; matching will
+                retry later.
+              </p>
+            )}
+          </>
+        )}
         <div className={styles.body} aria-busy={loading}>
-          {loading ? (
+          {reviewBook ? (
+            <AudiobookLibraryMatch
+              book={reviewBook}
+              onBack={() => setReviewBook(null)}
+              onSaved={() => {
+                setReviewBook(null);
+                setRevision((v) => v + 1);
+                setMessage('Catalogue match updated.');
+              }}
+            />
+          ) : loading ? (
             <p className={styles.empty}>Loading your shelves…</p>
           ) : books.length === 0 && !loadError ? (
             <div className={styles.empty}>
@@ -283,12 +369,12 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
             <ul className={styles.grid}>
               {shown.map((book) => (
                 <li className={styles.card} key={book.asin}>
-                  {book.asin.startsWith('local:') ? (
+                  {!matchedAsin(book) ? (
                     <Cover book={book} />
                   ) : (
                     <Link
                       to="/audiobooks/$asin"
-                      params={{ asin: book.asin }}
+                      params={{ asin: matchedAsin(book) }}
                       onClick={onClose}
                       aria-label={`View ${book.title}`}
                     >
@@ -309,15 +395,47 @@ export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
                     {book.runtime_minutes > 0 ? `${duration(book.runtime_minutes)} · ` : ''}
                     {size(book.size_bytes)}
                   </p>
+                  <div className={styles.badges}>
+                    <span data-origin={book.origin || 'unknown'}>
+                      {ORIGINS[book.origin || 'unknown']}
+                    </span>
+                    <button type="button" onClick={() => setReviewBook(book)}>
+                      {MATCHES[book.match_status || 'unmatched']}
+                    </button>
+                  </div>
                   <details className={styles.details}>
-                    <summary>
-                      File details{book.asin.startsWith('local:') ? ' · Local' : ''}
-                    </summary>
+                    <summary>File details</summary>
                     <p>
                       {book.file_count} {book.file_count === 1 ? 'audio file' : 'audio files'}
                     </p>
                     {book.narrator && <p>Narrated by {book.narrator}</p>}
                     <p className={styles.path}>{book.path}</p>
+                    {book.grouping && <p>{book.grouping}</p>}
+                    {book.file_paths && book.file_paths.length > 1 && (
+                      <details>
+                        <summary>Show {book.file_paths.length} audio files</summary>
+                        <ul className={styles.fileList}>
+                          {book.file_paths.map((path) => (
+                            <li key={path}>{path}</li>
+                          ))}
+                        </ul>
+                      </details>
+                    )}
+                    {book.download && (
+                      <div className={styles.downloadInfo}>
+                        <strong>Downloaded by SoulSync</strong>
+                        <p>{book.download.release_title}</p>
+                        <p>
+                          {book.download.indexer || book.download.source}
+                          {book.download.completed_at
+                            ? ` · ${new Date(book.download.completed_at * 1000).toLocaleDateString()}`
+                            : ''}
+                        </p>
+                      </div>
+                    )}
+                    <button type="button" onClick={() => setReviewBook(book)}>
+                      Change catalogue match
+                    </button>
                     {confirm === book.asin ? (
                       <div className={styles.confirm}>
                         <p>Delete this book from disk? Your recycle bin settings apply.</p>

--- a/webui/src/routes/audiobooks/-ui/audiobook-library-modal.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library-modal.tsx
@@ -1,196 +1,359 @@
-import { useEffect, useMemo, useState } from 'react';
+import { Link } from '@tanstack/react-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
-import type { AudiobookLibraryEntry } from '../-audiobooks.types';
+import type { AudiobookLibraryEntry, AudiobookLibraryScan } from '../-audiobooks.types';
 
-import { deleteLibraryBook, fetchLibrary } from '../-audiobooks.api';
+import { deleteLibraryBook, fetchLibrary, scanLibrary } from '../-audiobooks.api';
+import styles from './audiobook-library.module.css';
 import { AudiobookOverlay } from './audiobook-overlay';
-import styles from './audiobooks-page.module.css';
 
-function gb(bytes: number): string {
-  if (!bytes) return '';
-  const value = bytes / 1024 ** 3;
-  return value >= 1 ? `${value.toFixed(1)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`;
+function size(bytes: number): string {
+  return bytes >= 1024 ** 3
+    ? `${(bytes / 1024 ** 3).toFixed(1)} GB`
+    : `${Math.round(bytes / 1024 ** 2)} MB`;
 }
 
-function hours(minutes: number): string {
-  if (!minutes) return '';
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+function duration(minutes: number): string {
+  return minutes >= 60 ? `${Math.floor(minutes / 60)}h ${minutes % 60}m` : `${minutes}m`;
 }
 
-/**
- * What is actually on disk.
- *
- * Reads the library table the daily scan keeps honest, so this is what SoulSync
- * believes it has rather than a fresh walk of the folder — the same record that
- * decides the Owned badges, which means anything wrong here is visible and
- * fixable rather than hidden.
- *
- * Deleting sends the folder to the recycle bin, so a mis-click is recoverable
- * for as long as the keep window allows.
- */
+function Cover({ book }: { book: AudiobookLibraryEntry }) {
+  const [failed, setFailed] = useState(false);
+  return (
+    <div className={styles.art}>
+      {book.cover_url && !failed ? (
+        <img src={book.cover_url} alt="" loading="lazy" onError={() => setFailed(true)} />
+      ) : (
+        <div className={styles.coverFallback} aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.4">
+            <path d="M4 14v-3a8 8 0 0 1 16 0v3M4 13H2v7h5v-7H4Zm16 0h2v7h-5v-7h3Z" />
+          </svg>
+          <span>{book.title}</span>
+          <small>{book.author || 'AUDIOBOOK'}</small>
+        </div>
+      )}
+      <span className={styles.format}>{book.audio_format.toUpperCase() || 'AUDIO'}</span>
+    </div>
+  );
+}
+
 export function AudiobookLibraryModal({ onClose }: { onClose: () => void }) {
   const [books, setBooks] = useState<AudiobookLibraryEntry[]>([]);
-  const [totalBytes, setTotalBytes] = useState(0);
+  const [root, setRoot] = useState('');
+  const [scan, setScan] = useState<AudiobookLibraryScan>({ status: 'never' });
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [busy, setBusy] = useState('');
   const [message, setMessage] = useState('');
   const [filter, setFilter] = useState('');
+  const [sort, setSort] = useState('title');
+  const [localOnly, setLocalOnly] = useState(false);
+  const [confirm, setConfirm] = useState('');
+  const [revision, setRevision] = useState(0);
+  const [queuedAt, setQueuedAt] = useState(0);
+  const scanBaseline = useRef(0);
 
   useEffect(() => {
-    void (async () => {
-      const { books: rows, totalBytes: total } = await fetchLibrary();
-      setBooks(rows);
-      setTotalBytes(total);
-      setLoading(false);
-    })();
-  }, []);
+    let active = true;
+    let pending = false;
+    const refresh = async () => {
+      if (pending) return;
+      pending = true;
+      try {
+        const data = await fetchLibrary();
+        if (!active) return;
+        setBooks(data.books);
+        setRoot(data.root);
+        setScan(data.scan);
+        setLoadError('');
+        if (queuedAt && (data.scan.started_at || 0) > scanBaseline.current) {
+          setQueuedAt(0);
+          setMessage('');
+        } else if (queuedAt && Date.now() - queuedAt > 45_000) {
+          setQueuedAt(0);
+          setMessage('The scan has not started. Check its run history on the Automations page.');
+        }
+      } catch (error) {
+        if (active)
+          setLoadError(error instanceof Error ? error.message : 'Could not read your library.');
+      } finally {
+        pending = false;
+        if (active) setLoading(false);
+      }
+    };
+    void refresh();
+    const timer = window.setInterval(
+      () => void refresh(),
+      scan.status === 'running' || queuedAt ? 3000 : 30000,
+    );
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, [revision, queuedAt, scan.status]);
 
+  const localCount = books.filter((book) => book.asin.startsWith('local:')).length;
+  const totalBytes = books.reduce((sum, book) => sum + book.size_bytes, 0);
   const shown = useMemo(() => {
     const needle = filter.trim().toLowerCase();
-    if (!needle) return books;
-    return books.filter(
-      (b) =>
-        b.title.toLowerCase().includes(needle) ||
-        b.author.toLowerCase().includes(needle) ||
-        b.series_title.toLowerCase().includes(needle),
-    );
-  }, [books, filter]);
-
-  const remove = async (book: AudiobookLibraryEntry) => {
-    const ok = await window.showConfirmDialog?.({
-      title: 'Delete this book',
-      message: `Delete "${book.title}" from disk? It goes to the recycle bin first, so you can put it back.`,
-      confirmText: 'Delete',
-      destructive: true,
-    });
-    if (ok === false) return;
-
-    setBusy(book.asin);
-    const result = await deleteLibraryBook(book.asin);
-    setBusy('');
-    if (result.ok) {
-      setBooks((prev) => prev.filter((b) => b.asin !== book.asin));
-      setMessage(
-        result.recycled
-          ? `"${book.title}" moved to the recycle bin.`
-          : `"${book.title}" was deleted.`,
+    return books
+      .filter(
+        (book) =>
+          (!localOnly || book.asin.startsWith('local:')) &&
+          (!needle ||
+            [book.title, book.author, book.narrator, book.series_title].some((s) =>
+              s.toLowerCase().includes(needle),
+            )),
+      )
+      .sort((a, b) =>
+        sort === 'recent'
+          ? b.imported_at - a.imported_at
+          : sort === 'size'
+            ? b.size_bytes - a.size_bytes
+            : (sort === 'author' ? a.author.localeCompare(b.author) : 0) ||
+              a.title.localeCompare(b.title),
       );
-    } else {
-      setMessage(result.error || 'Could not delete that book.');
+  }, [books, filter, sort, localOnly]);
+
+  const startScan = async () => {
+    scanBaseline.current = scan.started_at || 0;
+    setQueuedAt(Date.now());
+    setMessage('');
+    try {
+      await scanLibrary();
+    } catch (error) {
+      setQueuedAt(0);
+      setMessage(error instanceof Error ? error.message : 'Could not start the scan.');
     }
   };
 
+  const remove = async (book: AudiobookLibraryEntry) => {
+    setBusy(book.asin);
+    try {
+      const result = await deleteLibraryBook(book.asin);
+      if (result.ok) {
+        setBooks((prev) => prev.filter((b) => b.asin !== book.asin));
+        setConfirm('');
+        setRevision((value) => value + 1);
+        setMessage(
+          result.recycled
+            ? `“${book.title}” moved to the recycle bin.`
+            : `“${book.title}” was deleted.`,
+        );
+      } else setMessage(result.error || 'Could not delete that book.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not delete that book.');
+    } finally {
+      setBusy('');
+    }
+  };
+
+  const scanning = scan.status === 'running' || queuedAt > 0;
+  const scanText = queuedAt
+    ? 'Starting scan…'
+    : scan.status === 'running'
+      ? `Scanning folder · ${scan.checked || 0} books checked`
+      : scan.status === 'completed' && scan.finished_at
+        ? `Last scanned ${new Date(scan.finished_at * 1000).toLocaleString()}`
+        : scan.status === 'never'
+          ? 'This folder has not been scanned yet'
+          : 'Scan needs attention';
+
   return (
     <AudiobookOverlay onClose={onClose} label="Your audiobook library">
-      <div className={styles.modal}>
-        <header className={styles.modalHeader}>
+      <section className={styles.modal}>
+        <header className={styles.header}>
           <div>
-            <span className={styles.modalEyebrow}>Library</span>
-            <h2 className={styles.modalTitle}>
-              {books.length} {books.length === 1 ? 'book' : 'books'}
-              {totalBytes > 0 && <span className={styles.librarySize}> · {gb(totalBytes)}</span>}
-            </h2>
+            <span className={styles.eyebrow}>Audiobooks / On your shelves</span>
+            <h2>Your library</h2>
+            <p>
+              {loading
+                ? 'Reading your library…'
+                : `${books.length} ${books.length === 1 ? 'book' : 'books'} · ${size(totalBytes)} on disk`}
+            </p>
           </div>
-          <button type="button" className={styles.modalClose} onClick={onClose} aria-label="Close">
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path
-                d="M6 6l12 12M18 6L6 18"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
-            </svg>
+          <button
+            type="button"
+            className={styles.close}
+            onClick={onClose}
+            aria-label="Close library"
+          >
+            ×
           </button>
         </header>
 
-        {message && <p className={styles.modalMessage}>{message}</p>}
+        <div className={styles.scanPanel}>
+          <div className={styles.scanInfo}>
+            <strong>
+              <span className={scanning ? styles.activeDot : styles.dot} />
+              {scanText}
+            </strong>
+            <span className={styles.root} title={root}>
+              {root || 'Set your audiobook folder in Settings → Library'}
+            </span>
+            {scan.status === 'completed' && (
+              <small>
+                {scan.adopted || 0} added · {scan.updated || 0} refreshed · {scan.removed || 0}{' '}
+                missing
+              </small>
+            )}
+          </div>
+          <div className={styles.scanActions}>
+            <button
+              type="button"
+              className={styles.primary}
+              onClick={() => void startScan()}
+              disabled={scanning || loading}
+            >
+              {scanning ? 'Scanning…' : 'Scan folder'}
+            </button>
+            <Link to="/automations" search={{ action: 'audiobook_scan_library' }} onClick={onClose}>
+              Schedule & history ↗
+            </Link>
+          </div>
+        </div>
+        {scan.error && (
+          <p className={styles.notice} role="status">
+            {scan.error}
+          </p>
+        )}
+        {message && (
+          <p className={styles.notice} role="status">
+            {message}
+          </p>
+        )}
+        {loadError && (
+          <p className={styles.notice} role="alert">
+            {loadError}{' '}
+            <button type="button" onClick={() => setRevision((v) => v + 1)}>
+              Retry
+            </button>
+          </p>
+        )}
 
-        <div className={styles.modalBody}>
+        <div className={styles.toolbar}>
+          <input
+            type="search"
+            aria-label="Search library"
+            placeholder="Search title, author, narrator or series…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+          <select aria-label="Sort library" value={sort} onChange={(e) => setSort(e.target.value)}>
+            <option value="title">Title A–Z</option>
+            <option value="author">Author A–Z</option>
+            <option value="recent">Recently added</option>
+            <option value="size">Largest first</option>
+          </select>
+        </div>
+        <div className={styles.filters}>
+          <button type="button" aria-pressed={!localOnly} onClick={() => setLocalOnly(false)}>
+            All books <span>{books.length}</span>
+          </button>
+          <button type="button" aria-pressed={localOnly} onClick={() => setLocalOnly(true)}>
+            Local only <span>{localCount}</span>
+          </button>
+          <span className={styles.filterHint}>
+            Local books are indexed without guessing an Audible edition.
+          </span>
+        </div>
+
+        <div className={styles.body} aria-busy={loading}>
           {loading ? (
-            <div className={styles.modalLoading}>
-              <span className={styles.spinner} aria-hidden="true" />
-              Reading your library…
-            </div>
-          ) : books.length === 0 ? (
-            <div className={styles.emptyState}>
-              <h3>Nothing here yet</h3>
+            <p className={styles.empty}>Loading your shelves…</p>
+          ) : books.length === 0 && !loadError ? (
+            <div className={styles.empty}>
+              <h3>Your books belong here</h3>
               <p>
-                Books appear once they have downloaded and been filed. The daily library scan also
-                picks up anything already on disk that SoulSync imported before.
+                Scan your audiobook folder to find the books you already own, including those added
+                outside SoulSync. Your files stay where they are.
               </p>
+              <button
+                type="button"
+                className={styles.primary}
+                disabled={scanning}
+                onClick={() => void startScan()}
+              >
+                {scanning ? 'Scanning…' : 'Scan my folder'}
+              </button>
             </div>
+          ) : shown.length === 0 && !loadError ? (
+            <p className={styles.empty}>No books match these filters.</p>
           ) : (
-            <>
-              {books.length > 6 && (
-                <input
-                  type="search"
-                  className={styles.libraryFilter}
-                  placeholder="Filter by title, author or series…"
-                  value={filter}
-                  onChange={(e) => setFilter(e.target.value)}
-                />
-              )}
-
-              <ul className={styles.releaseList}>
-                {shown.map((book) => (
-                  <li className={styles.releaseRow} key={book.asin}>
-                    <div className={styles.releaseMain}>
-                      <span className={styles.releaseTitle}>{book.title}</span>
-                      <div className={styles.releaseTags}>
-                        {book.author && <span className={styles.releaseTag}>{book.author}</span>}
-                        {book.series_title && (
-                          <span className={styles.releaseTag}>
-                            {book.series_title}
-                            {book.series_sequence ? ` #${book.series_sequence}` : ''}
-                          </span>
-                        )}
-                        {book.narrator && (
-                          <span className={styles.releaseTag}>🎙️ {book.narrator}</span>
-                        )}
-                        {book.audio_format && (
-                          <span className={styles.releaseTag}>
-                            {book.audio_format.toUpperCase()}
-                          </span>
-                        )}
-                        {book.file_count > 0 && (
-                          <span className={styles.releaseTag}>
-                            {book.file_count} {book.file_count === 1 ? 'file' : 'files'}
-                          </span>
-                        )}
-                        {book.size_bytes > 0 && (
-                          <span className={styles.releaseTag}>{gb(book.size_bytes)}</span>
-                        )}
-                        {book.runtime_minutes > 0 && (
-                          <span className={styles.releaseTag}>{hours(book.runtime_minutes)}</span>
-                        )}
-                      </div>
-                      <span className={styles.releaseReasons} title={book.path}>
-                        {book.path}
-                      </span>
-                    </div>
-
-                    <button
-                      type="button"
-                      className={styles.libraryDelete}
-                      onClick={() => void remove(book)}
-                      disabled={busy === book.asin}
-                      title="Delete from disk. Goes to the recycle bin first."
+            <ul className={styles.grid}>
+              {shown.map((book) => (
+                <li className={styles.card} key={book.asin}>
+                  {book.asin.startsWith('local:') ? (
+                    <Cover book={book} />
+                  ) : (
+                    <Link
+                      to="/audiobooks/$asin"
+                      params={{ asin: book.asin }}
+                      onClick={onClose}
+                      aria-label={`View ${book.title}`}
                     >
-                      {busy === book.asin ? 'Deleting…' : 'Delete'}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-
-              {shown.length === 0 && (
-                <p className={styles.blocklistNote}>Nothing matches &quot;{filter}&quot;.</p>
-              )}
-            </>
+                      <Cover book={book} />
+                    </Link>
+                  )}
+                  <h3 title={book.title}>{book.title}</h3>
+                  <p className={styles.author} title={book.author}>
+                    {book.author || 'Unknown author'}
+                  </p>
+                  {book.series_title && (
+                    <p className={styles.series} title={book.series_title}>
+                      {book.series_title}
+                      {book.series_sequence ? ` · ${book.series_sequence}` : ''}
+                    </p>
+                  )}
+                  <p className={styles.facts}>
+                    {book.runtime_minutes > 0 ? `${duration(book.runtime_minutes)} · ` : ''}
+                    {size(book.size_bytes)}
+                  </p>
+                  <details className={styles.details}>
+                    <summary>
+                      File details{book.asin.startsWith('local:') ? ' · Local' : ''}
+                    </summary>
+                    <p>
+                      {book.file_count} {book.file_count === 1 ? 'audio file' : 'audio files'}
+                    </p>
+                    {book.narrator && <p>Narrated by {book.narrator}</p>}
+                    <p className={styles.path}>{book.path}</p>
+                    {confirm === book.asin ? (
+                      <div className={styles.confirm}>
+                        <p>Delete this book from disk? Your recycle bin settings apply.</p>
+                        <button
+                          type="button"
+                          disabled={scanning || !!busy}
+                          className={styles.danger}
+                          onClick={() => void remove(book)}
+                        >
+                          {busy === book.asin ? 'Deleting…' : 'Confirm delete'}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={scanning || !!busy}
+                          onClick={() => setConfirm('')}
+                        >
+                          Keep book
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        className={styles.danger}
+                        disabled={scanning || !!busy}
+                        onClick={() => setConfirm(book.asin)}
+                      >
+                        Delete from disk
+                      </button>
+                    )}
+                  </details>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
-      </div>
+      </section>
     </AudiobookOverlay>
   );
 }

--- a/webui/src/routes/audiobooks/-ui/audiobook-library.module.css
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library.module.css
@@ -409,3 +409,179 @@
     padding: 10px 18px;
   }
 }
+
+.filters {
+  flex-wrap: wrap;
+}
+.filters select {
+  margin-left: auto;
+  padding: 7px 10px;
+  background: #1b1b22;
+  border: 1px solid #ffffff18;
+  border-radius: 8px;
+  color: #d8d3df;
+  font-size: 11px;
+  max-width: 100%;
+}
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin: 8px 0;
+}
+.badges span,
+.badges button {
+  border: 1px solid #ffffff18;
+  border-radius: 5px;
+  padding: 3px 6px;
+  background: #ffffff04;
+  font-size: 9px;
+  color: #bcb5c8;
+}
+.badges span[data-origin='soulsync'] {
+  color: #bce4c9;
+  border-color: #82b38d44;
+}
+.badges button {
+  cursor: pointer;
+  color: #ddc797;
+}
+.fileList {
+  padding-left: 14px;
+  font-size: 10px;
+  overflow-wrap: anywhere;
+}
+.downloadInfo {
+  border-left: 2px solid #82b38d66;
+  padding-left: 8px;
+  margin: 12px 0;
+}
+.matchPane {
+  font-size: 13px;
+  color: #c1bacb;
+}
+.matchPane > h3 {
+  color: #f2edf5;
+  font-size: 24px;
+  margin: 20px 0;
+}
+.matchPane > p {
+  line-height: 1.7;
+}
+.back,
+.matchActions button {
+  border: 1px solid #ffffff20;
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: #ffffff06;
+  color: #ddd5e6;
+  cursor: pointer;
+  font-size: 12px;
+}
+.localEvidence {
+  padding: 16px;
+  border: 1px solid #ffffff15;
+  border-radius: 12px;
+  background: #ffffff04;
+}
+.localEvidence strong {
+  color: #f2edf5;
+  font-size: 16px;
+}
+.localEvidence p {
+  margin: 7px 0 0;
+}
+.matchSearch {
+  display: flex;
+  gap: 10px;
+  margin: 20px 0;
+}
+.matchSearch input {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid #ffffff20;
+  background: #1b1b22;
+  border-radius: 8px;
+  padding: 10px;
+  color: #eee7f5;
+}
+.candidates {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.candidates > li {
+  padding: 16px;
+  display: flex;
+  gap: 16px;
+  align-items: start;
+  border: 1px solid #ffffff18;
+  border-radius: 12px;
+}
+.candidates > li > img {
+  width: 76px;
+  height: 76px;
+  object-fit: cover;
+  border-radius: 7px;
+}
+.candidates > li > div {
+  flex: 1;
+  min-width: 0;
+}
+.candidates h4 {
+  color: #f2edf5;
+  font-size: 15px;
+  margin: 0 0 7px;
+}
+.candidates p {
+  line-height: 1.5;
+  margin: 5px 0;
+}
+.candidates ul {
+  padding-left: 16px;
+  font-size: 11px;
+  line-height: 1.7;
+}
+.matchScore {
+  font-size: 11px;
+  color: #a9a1b3;
+}
+.conflict {
+  color: #f1b69f;
+}
+.matchActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+  align-items: center;
+}
+.matchActions small {
+  flex-basis: 100%;
+  color: #a69cae;
+  line-height: 1.7;
+}
+@media (max-width: 700px) {
+  .filters select {
+    margin-left: 0;
+    width: 100%;
+  }
+  .candidates > li {
+    flex-wrap: wrap;
+    padding: 12px;
+    gap: 10px;
+  }
+  .candidates > li > img {
+    width: 52px;
+    height: 52px;
+  }
+  .candidates > li > button {
+    width: 100%;
+  }
+  .matchSearch {
+    flex-direction: column;
+  }
+}

--- a/webui/src/routes/audiobooks/-ui/audiobook-library.module.css
+++ b/webui/src/routes/audiobooks/-ui/audiobook-library.module.css
@@ -1,0 +1,411 @@
+.modal {
+  width: min(1120px, calc(100vw - 48px));
+  height: min(880px, calc(100dvh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  background: #141419;
+  color: #f3f1ee;
+  box-shadow: 0 32px 100px #0009;
+  font-family: inherit;
+}
+.modal button,
+.modal input,
+.modal select {
+  font: inherit;
+}
+.modal button,
+.modal a,
+.modal summary,
+.modal select {
+  -webkit-tap-highlight-color: transparent;
+}
+.modal button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+.modal :is(button, a, input, select, summary):focus-visible {
+  outline: 2px solid var(--accent, #d2ba8c);
+  outline-offset: 3px;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px 32px 22px;
+}
+.eyebrow {
+  color: rgba(var(--accent-rgb), 0.9);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+.header h2 {
+  font-size: 32px;
+  letter-spacing: -0.04em;
+  margin: 7px 0 6px;
+  font-weight: 650;
+}
+.header p {
+  font-size: 13px;
+  color: #a7a5af;
+  margin: 0;
+}
+.close {
+  border: 1px solid #ffffff16;
+  border-radius: 50%;
+  color: #c7c5ce;
+  width: 36px;
+  height: 36px;
+  background: #ffffff06;
+  font-size: 25px !important;
+  cursor: pointer;
+}
+.scanPanel {
+  margin: 0 32px 22px;
+  padding: 16px 18px;
+  background: linear-gradient(110deg, rgba(var(--accent-rgb), 0.08), #ffffff02);
+  border: 1px solid rgba(var(--accent-rgb), 0.15);
+  border-radius: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+.scanInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.scanInfo strong {
+  font-size: 12px;
+  font-weight: 550;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.scanInfo small {
+  font-size: 11px;
+  color: #96939f;
+}
+.dot,
+.activeDot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #a5af95;
+}
+.activeDot {
+  background: var(--accent, #d2ba8c);
+  box-shadow: 0 0 0 4px rgba(var(--accent-rgb), 0.1);
+}
+.root {
+  font-size: 11px;
+  color: #a7a4ae;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.scanActions {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  flex-shrink: 0;
+}
+.scanActions a {
+  font-size: 11px;
+  color: #c5c2cd;
+  text-decoration: none;
+}
+.primary {
+  padding: 10px 17px;
+  border-radius: 9px;
+  border: 1px solid rgba(var(--accent-rgb), 0.35);
+  background: rgba(var(--accent-rgb), 0.17);
+  color: #fff;
+  font-size: 12px !important;
+  cursor: pointer;
+}
+.primary:hover:not(:disabled) {
+  background: rgba(var(--accent-rgb), 0.28);
+}
+.toolbar {
+  display: flex;
+  gap: 12px;
+  padding: 0 32px;
+}
+.toolbar input {
+  flex: 1;
+  min-width: 0;
+}
+.toolbar input,
+.toolbar select {
+  padding: 11px 14px;
+  border: 1px solid #ffffff18;
+  border-radius: 9px;
+  color: #e4e1e9;
+  background: #1b1b22;
+  font-size: 12px;
+}
+.toolbar input::placeholder {
+  color: #92909c;
+}
+.filters {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 16px 32px;
+  border-bottom: 1px solid #ffffff0d;
+}
+.filters button {
+  color: #a6a3af;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  padding: 6px 11px;
+  font-size: 11px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.filters button[aria-pressed='true'] {
+  border-color: #ffffff1f;
+  background: #ffffff0a;
+  color: #f1edf5;
+}
+.filters button span {
+  margin-left: 5px;
+  opacity: 0.65;
+}
+.filterHint {
+  margin-left: auto;
+  font-size: 10px;
+  color: #96929f;
+}
+.body {
+  padding: 24px 32px 32px;
+  overflow-y: auto;
+  min-height: 0;
+  flex: 1;
+}
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(156px, 1fr));
+  gap: 26px 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  align-items: start;
+}
+.card {
+  min-width: 0;
+}
+.card > a {
+  display: block;
+  text-decoration: none;
+  border-radius: 10px;
+}
+.art {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #24242c;
+  box-shadow: 0 8px 20px #0003;
+}
+.art img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+.coverFallback {
+  height: 100%;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  color: #e7dece;
+  background:
+    radial-gradient(ellipse at top left, rgba(var(--accent-rgb), 0.22), transparent 80%), #28282f;
+  box-sizing: border-box;
+}
+.coverFallback svg {
+  width: 25px;
+  height: 25px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.coverFallback span {
+  font:
+    500 17px/1.25 Georgia,
+    serif;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.coverFallback small {
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  max-width: 100%;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.format {
+  position: absolute;
+  bottom: 7px;
+  left: 7px;
+  padding: 3px 6px;
+  border: 1px solid #ffffff16;
+  border-radius: 4px;
+  background: #09090dc9;
+  color: #e5e2eb;
+  font-size: 8px;
+  letter-spacing: 0.06em;
+}
+.card h3 {
+  margin: 12px 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.author,
+.series {
+  font-size: 11px;
+  color: #b4afbc;
+  margin: 3px 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.series {
+  color: #a09aa9;
+}
+.facts {
+  font-size: 10px;
+  color: #9993a2;
+  margin: 8px 0;
+}
+.details {
+  font-size: 11px;
+  color: #b5afbf;
+}
+.details summary {
+  cursor: pointer;
+  padding: 3px 0;
+  font-size: 10px;
+  color: #b0aab8;
+}
+.details p {
+  line-height: 1.5;
+  margin: 8px 0;
+}
+.path {
+  word-break: break-word;
+  font-size: 10px;
+}
+.details button,
+.notice button {
+  font-size: 10px;
+  color: #d9d2df;
+  border: 1px solid #ffffff20;
+  border-radius: 6px;
+  background: #ffffff06;
+  padding: 7px 9px;
+  cursor: pointer;
+}
+.details .danger {
+  color: #f4a6a6;
+  border-color: #ef77772e;
+}
+.confirm {
+  border-top: 1px solid #ffffff14;
+  margin-top: 10px;
+  padding-top: 3px;
+}
+.confirm button {
+  margin: 0 4px 4px 0;
+}
+.notice {
+  margin: 0;
+  padding: 10px 32px;
+  background: rgba(var(--accent-rgb), 0.1);
+  color: #e0d9e5;
+  font-size: 12px;
+}
+.empty {
+  text-align: center;
+  padding: 50px 15px;
+  color: #aaa4b5;
+  font-size: 13px;
+}
+.empty h3 {
+  font-size: 22px;
+  font-weight: 500;
+  color: #e7e1ec;
+}
+.empty p {
+  max-width: 450px;
+  margin: 0 auto 24px;
+  line-height: 1.8;
+}
+@media (max-width: 700px) {
+  .modal {
+    width: calc(100vw - 48px);
+    height: calc(100dvh - 48px);
+    border-radius: 18px;
+  }
+  .header {
+    padding: 22px 18px 18px;
+  }
+  .header h2 {
+    font-size: 27px;
+  }
+  .scanPanel {
+    margin: 0 18px 16px;
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .scanActions {
+    justify-content: space-between;
+  }
+  .toolbar {
+    padding: 0 18px;
+    gap: 8px;
+  }
+  .toolbar select {
+    max-width: 120px;
+    padding: 10px 6px;
+  }
+  .filters {
+    padding: 12px 18px;
+  }
+  .filterHint {
+    display: none;
+  }
+  .body {
+    padding: 18px;
+  }
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px 14px;
+  }
+  .notice {
+    padding: 10px 18px;
+  }
+}

--- a/webui/src/routes/audiobooks/-ui/audiobooks-page.tsx
+++ b/webui/src/routes/audiobooks/-ui/audiobooks-page.tsx
@@ -204,7 +204,7 @@ export function AudiobooksBrowsePage() {
           type="button"
           className={styles.wishlistLink}
           onClick={() => setShowLibrary(true)}
-          title="Everything downloaded and filed"
+          title="Audiobooks in your library folder"
         >
           <svg viewBox="0 0 24 24" aria-hidden="true">
             <path

--- a/webui/src/routes/automations/-automations.format.ts
+++ b/webui/src/routes/automations/-automations.format.ts
@@ -114,6 +114,10 @@ const plural = (n: number, one: string, many = `${one}s`) =>
 type Sentence = (r: Record<string, unknown>) => string | null;
 
 const ACTION_SENTENCES: Record<string, Sentence> = {
+  audiobook_scan_library: (r) => {
+    if (typeof r.skipped === 'string') return r.skipped;
+    return `Scanned ${plural(num(r.checked), 'book')}, added ${num(r.adopted)}, refreshed ${num(r.updated)}, removed ${num(r.removed)} missing`;
+  },
   // artists_scanned / new_tracks_found / tracks_added_to_wishlist
   scan_watchlist: (r) => {
     const artists = num(r.artists_scanned);
@@ -278,6 +282,7 @@ const ACTION_LABELS: Record<string, string> = {
   process_wishlist: 'Process Wishlist',
   scan_watchlist: 'Scan Watchlist',
   scan_watchlist_podcasts: 'Scan Watchlist Podcasts',
+  audiobook_scan_library: 'Scan Audiobook Library',
   scan_library: 'Scan Library',
   refresh_mirrored: 'Refresh Mirrored',
   sync_playlist: 'Sync Playlist',

--- a/webui/src/routes/automations/-automations.icons.ts
+++ b/webui/src/routes/automations/-automations.icons.ts
@@ -6,6 +6,10 @@
  * variation selectors (the U+FE0F suffixes below).
  */
 export const AUTOMATION_ICONS: Record<string, string> = {
+  audiobook_process_wishlist: '\uD83D\uDCDA',
+  audiobook_scan_watchlist: '\u270D\uFE0F',
+  audiobook_scan_library: '\uD83C\uDFA7',
+  audiobook_purge_recycle: '\uD83D\uDDD1\uFE0F',
   schedule: '⏱️',
   daily_time: '🕰️',
   weekly_time: '📅',

--- a/webui/src/routes/dashboard/-ui/content-rails.tsx
+++ b/webui/src/routes/dashboard/-ui/content-rails.tsx
@@ -81,9 +81,10 @@ function RailCard({
         {src && (
           <img
             key={src}
-            src={thumb(src, 'grid')}
+            src={thumb(src, 'rail')}
             alt=""
             loading="lazy"
+            decoding="async"
             onError={() => setRung(rung + 1)}
           />
         )}

--- a/webui/src/routes/discover/-discover.deezer-editorial.test.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.test.ts
@@ -64,51 +64,84 @@ describe('fetchDeezerEditorialGenres', () => {
 });
 
 describe('openDeezerPlaylistInSync', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    document.body.innerHTML = '<input id="deezer-url-input" />';
-  });
   afterEach(() => {
-    vi.useRealTimers();
     document.body.innerHTML = '';
-    delete (window as { navigateToPage?: unknown }).navigateToPage;
-    delete (window as { loadDeezerPlaylist?: unknown }).loadDeezerPlaylist;
+    delete (window as { SoulSyncWebRouter?: unknown }).SoulSyncWebRouter;
   });
 
-  it('hands the playlist to the existing Sync flow rather than loading it itself', () => {
+  const TRACKS = [{ id: 't1', name: 'A Song', artists: ['An Artist'], duration_ms: 1000 }];
+
+  function stubLoad(
+    playlist: Record<string, unknown>,
+    mirror: Record<string, unknown> = { success: true },
+  ) {
+    const posted: unknown[] = [];
+    server.use(
+      http.get('/api/deezer/playlist/:id', () => HttpResponse.json(playlist)),
+      http.post('/api/mirror-playlist', async ({ request }) => {
+        posted.push(await request.json());
+        return HttpResponse.json(mirror);
+      }),
+    );
+    return posted;
+  }
+
+  it('mirrors the playlist and lands the user on the mirrored tab', async () => {
+    // this is the whole fix: the first version drove the RETIRED vanilla
+    // sync page and did nothing at all
+    document.body.innerHTML =
+      '<button class="sync-tab-button" data-tab="mirrored"></button>';
+    const clicked = vi.fn();
+    document.querySelector('.sync-tab-button')!.addEventListener('click', clicked);
     const navigate = vi.fn();
-    const load = vi.fn();
-    window.navigateToPage = navigate;
-    window.loadDeezerPlaylist = load;
+    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
 
-    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(true);
+    const posted = stubLoad({
+      id: '123', name: 'Rock Essentials', owner: 'Rod', image_url: 'https://cdn/x.jpg',
+      tracks: TRACKS,
+    });
+
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBeNull();
+
+    expect(posted).toHaveLength(1);
+    expect((posted[0] as { name: string }).name).toBe('Rock Essentials');
     expect(navigate).toHaveBeenCalledWith('sync');
-
-    // the input only exists after the page mounts, hence the deferral
-    vi.runAllTimers();
-    const input = document.getElementById('deezer-url-input') as HTMLInputElement;
-    expect(input.value).toBe(PLAYLIST.link);
-    expect(load).toHaveBeenCalled();
+    await vi.waitFor(() => expect(clicked).toHaveBeenCalled());
   });
 
-  it('builds a link when the api did not send one', () => {
-    window.navigateToPage = vi.fn();
-    window.loadDeezerPlaylist = vi.fn();
-    openDeezerPlaylistInSync({ ...PLAYLIST, link: '' });
-    vi.runAllTimers();
-    const input = document.getElementById('deezer-url-input') as HTMLInputElement;
-    expect(input.value).toBe('https://www.deezer.com/playlist/1306931615');
+  it('does not navigate when the playlist could not be loaded', async () => {
+    const navigate = vi.fn();
+    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    server.use(
+      http.get('/api/deezer/playlist/:id', () =>
+        HttpResponse.json({ error: 'Invalid Deezer playlist ID' }, { status: 400 }),
+      ),
+    );
+
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('Invalid Deezer playlist ID');
+    expect(navigate).not.toHaveBeenCalled();
   });
 
-  it('reports failure when the shell cannot navigate', () => {
-    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(false);
+  it('refuses an empty playlist rather than mirroring nothing', async () => {
+    const navigate = vi.fn();
+    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    stubLoad({ id: '123', name: 'Empty', tracks: [] });
+
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('That playlist came back empty');
+    expect(navigate).not.toHaveBeenCalled();
   });
 
-  it('does not throw when the Sync page has no url input', () => {
-    document.body.innerHTML = '';
-    window.navigateToPage = vi.fn();
-    window.loadDeezerPlaylist = vi.fn();
-    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(true);
-    expect(() => vi.runAllTimers()).not.toThrow();
+  it('reports a refused mirror instead of pretending it worked', async () => {
+    const navigate = vi.fn();
+    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    stubLoad({ id: '1', name: 'X', tracks: TRACKS }, { success: false, error: 'nope' });
+
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('nope');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('survives a transport failure', async () => {
+    server.use(http.get('/api/deezer/playlist/:id', () => HttpResponse.error()));
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBeTruthy();
   });
 });

--- a/webui/src/routes/discover/-discover.deezer-editorial.test.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.test.ts
@@ -7,6 +7,7 @@ import {
   fetchDeezerEditorial,
   fetchDeezerEditorialGenres,
   openDeezerPlaylistInSync,
+  searchDeezerPlaylists,
 } from './-discover.deezer-editorial';
 
 const PLAYLIST = {
@@ -208,5 +209,37 @@ describe('progress while a playlist loads', () => {
       ),
     );
     await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('Deezer refused the request');
+  });
+});
+
+describe('searchDeezerPlaylists', () => {
+  it('asks the server with q, not a genre', async () => {
+    // the route has supported ?q= since the shelf shipped and nothing called
+    // it — the capability existed and no user could reach it
+    let asked: URLSearchParams | null = null;
+    server.use(
+      http.get('/api/discover/deezer/editorial', ({ request }) => {
+        asked = new URL(request.url).searchParams;
+        return HttpResponse.json({ success: true, playlists: [PLAYLIST] });
+      }),
+    );
+    const rows = await searchDeezerPlaylists('deep house');
+    expect(asked!.get('q')).toBe('deep house');
+    expect(asked!.get('genre')).toBeNull();
+    expect(rows).toHaveLength(1);
+  });
+
+  it('asks nothing for a blank query', async () => {
+    server.use(
+      http.get('/api/discover/deezer/editorial', () => {
+        throw new Error('searched for nothing');
+      }),
+    );
+    await expect(searchDeezerPlaylists('   ')).resolves.toEqual([]);
+  });
+
+  it('a failed search is an empty result, not a thrown page', async () => {
+    server.use(http.get('/api/discover/deezer/editorial', () => HttpResponse.error()));
+    await expect(searchDeezerPlaylists('x')).resolves.toEqual([]);
   });
 });

--- a/webui/src/routes/discover/-discover.deezer-editorial.test.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.test.ts
@@ -67,7 +67,7 @@ describe('fetchDeezerEditorialGenres', () => {
 describe('openDeezerPlaylistInSync', () => {
   afterEach(() => {
     document.body.innerHTML = '';
-    delete (window as { SoulSyncWebRouter?: unknown }).SoulSyncWebRouter;
+    delete (window as { navigateToPage?: unknown }).navigateToPage;
   });
 
   const TRACKS = [{ id: 't1', name: 'A Song', artists: ['An Artist'], duration_ms: 1000 }];
@@ -95,7 +95,7 @@ describe('openDeezerPlaylistInSync', () => {
     const clicked = vi.fn();
     document.querySelector('.sync-tab-button')!.addEventListener('click', clicked);
     const navigate = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    window.navigateToPage = navigate;
 
     const posted = stubLoad({
       id: '123', name: 'Rock Essentials', owner: 'Rod', image_url: 'https://cdn/x.jpg',
@@ -112,7 +112,7 @@ describe('openDeezerPlaylistInSync', () => {
 
   it('does not navigate when the playlist could not be loaded', async () => {
     const navigate = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    window.navigateToPage = navigate;
     server.use(
       http.get('/api/deezer/playlist/:id', () =>
         HttpResponse.json({ error: 'Invalid Deezer playlist ID' }, { status: 400 }),
@@ -125,7 +125,7 @@ describe('openDeezerPlaylistInSync', () => {
 
   it('refuses an empty playlist rather than mirroring nothing', async () => {
     const navigate = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    window.navigateToPage = navigate;
     stubLoad({ id: '123', name: 'Empty', tracks: [] });
 
     await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('That playlist came back empty');
@@ -134,7 +134,7 @@ describe('openDeezerPlaylistInSync', () => {
 
   it('reports a refused mirror instead of pretending it worked', async () => {
     const navigate = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage: navigate } as never;
+    window.navigateToPage = navigate;
     stubLoad({ id: '1', name: 'X', tracks: TRACKS }, { success: false, error: 'nope' });
 
     await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('nope');
@@ -149,13 +149,13 @@ describe('openDeezerPlaylistInSync', () => {
 
 describe('progress while a playlist loads', () => {
   afterEach(() => {
-    delete (window as { SoulSyncWebRouter?: unknown }).SoulSyncWebRouter;
+    delete (window as { navigateToPage?: unknown }).navigateToPage;
   });
 
   it('reports the track count as the job reports it', async () => {
     // the whole complaint: the card said "Adding to Sync" for ~2 minutes with
     // no idea what was happening or how long was left
-    window.SoulSyncWebRouter = { navigateToPage: vi.fn() } as never;
+    window.navigateToPage = vi.fn();
     let polls = 0;
     server.use(
       http.get('/api/deezer/playlist/:id', () =>
@@ -188,7 +188,7 @@ describe('progress while a playlist loads', () => {
   });
 
   it('opens with the count it already knows, before the first poll', async () => {
-    window.SoulSyncWebRouter = { navigateToPage: vi.fn() } as never;
+    window.navigateToPage = vi.fn();
     server.use(
       http.get('/api/deezer/playlist/:id', () => HttpResponse.error()),
     );

--- a/webui/src/routes/discover/-discover.deezer-editorial.test.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.test.ts
@@ -1,0 +1,114 @@
+import { HttpResponse, http } from 'msw';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '@/test/msw';
+
+import {
+  fetchDeezerEditorial,
+  fetchDeezerEditorialGenres,
+  openDeezerPlaylistInSync,
+} from './-discover.deezer-editorial';
+
+const PLAYLIST = {
+  id: '1306931615',
+  title: 'Rock Essentials',
+  creator: 'Rod - Deezer Rock Editor',
+  track_count: 100,
+  image_url: 'https://cdn/1000.jpg',
+  link: 'https://www.deezer.com/playlist/1306931615',
+  source: 'deezer',
+};
+
+describe('fetchDeezerEditorial', () => {
+  it('returns the playlists for a genre', async () => {
+    let asked = '';
+    server.use(
+      http.get('/api/discover/deezer/editorial', ({ request }) => {
+        asked = new URL(request.url).searchParams.get('genre') ?? '';
+        return HttpResponse.json({ success: true, playlists: [PLAYLIST], count: 1 });
+      }),
+    );
+    const rows = await fetchDeezerEditorial(152);
+    expect(asked).toBe('152');
+    expect(rows[0].title).toBe('Rock Essentials');
+  });
+
+  it('a dead shelf is an empty shelf, never a thrown page', async () => {
+    // the row must not be able to take Discover down with it
+    server.use(http.get('/api/discover/deezer/editorial', () => HttpResponse.error()));
+    await expect(fetchDeezerEditorial(0)).resolves.toEqual([]);
+  });
+
+  it('survives a response with no playlists key', async () => {
+    server.use(
+      http.get('/api/discover/deezer/editorial', () => HttpResponse.json({ success: true })),
+    );
+    await expect(fetchDeezerEditorial(0)).resolves.toEqual([]);
+  });
+});
+
+describe('fetchDeezerEditorialGenres', () => {
+  it('returns the chips', async () => {
+    server.use(
+      http.get('/api/discover/deezer/genres', () =>
+        HttpResponse.json({ success: true, genres: [{ id: 0, name: 'Top' }] }),
+      ),
+    );
+    await expect(fetchDeezerEditorialGenres()).resolves.toEqual([{ id: 0, name: 'Top' }]);
+  });
+
+  it('an unreachable genre list hides the chips, not the shelf', async () => {
+    server.use(http.get('/api/discover/deezer/genres', () => HttpResponse.error()));
+    await expect(fetchDeezerEditorialGenres()).resolves.toEqual([]);
+  });
+});
+
+describe('openDeezerPlaylistInSync', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '<input id="deezer-url-input" />';
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+    delete (window as { navigateToPage?: unknown }).navigateToPage;
+    delete (window as { loadDeezerPlaylist?: unknown }).loadDeezerPlaylist;
+  });
+
+  it('hands the playlist to the existing Sync flow rather than loading it itself', () => {
+    const navigate = vi.fn();
+    const load = vi.fn();
+    window.navigateToPage = navigate;
+    window.loadDeezerPlaylist = load;
+
+    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(true);
+    expect(navigate).toHaveBeenCalledWith('sync');
+
+    // the input only exists after the page mounts, hence the deferral
+    vi.runAllTimers();
+    const input = document.getElementById('deezer-url-input') as HTMLInputElement;
+    expect(input.value).toBe(PLAYLIST.link);
+    expect(load).toHaveBeenCalled();
+  });
+
+  it('builds a link when the api did not send one', () => {
+    window.navigateToPage = vi.fn();
+    window.loadDeezerPlaylist = vi.fn();
+    openDeezerPlaylistInSync({ ...PLAYLIST, link: '' });
+    vi.runAllTimers();
+    const input = document.getElementById('deezer-url-input') as HTMLInputElement;
+    expect(input.value).toBe('https://www.deezer.com/playlist/1306931615');
+  });
+
+  it('reports failure when the shell cannot navigate', () => {
+    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(false);
+  });
+
+  it('does not throw when the Sync page has no url input', () => {
+    document.body.innerHTML = '';
+    window.navigateToPage = vi.fn();
+    window.loadDeezerPlaylist = vi.fn();
+    expect(openDeezerPlaylistInSync(PLAYLIST)).toBe(true);
+    expect(() => vi.runAllTimers()).not.toThrow();
+  });
+});

--- a/webui/src/routes/discover/-discover.deezer-editorial.test.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.test.ts
@@ -145,3 +145,68 @@ describe('openDeezerPlaylistInSync', () => {
     await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBeTruthy();
   });
 });
+
+describe('progress while a playlist loads', () => {
+  afterEach(() => {
+    delete (window as { SoulSyncWebRouter?: unknown }).SoulSyncWebRouter;
+  });
+
+  it('reports the track count as the job reports it', async () => {
+    // the whole complaint: the card said "Adding to Sync" for ~2 minutes with
+    // no idea what was happening or how long was left
+    window.SoulSyncWebRouter = { navigateToPage: vi.fn() } as never;
+    let polls = 0;
+    server.use(
+      http.get('/api/deezer/playlist/:id', () =>
+        HttpResponse.json({ pending: true, job_id: 'job-1' }),
+      ),
+      http.get('/api/deezer/playlist-load/job-1', () => {
+        polls += 1;
+        if (polls < 3) {
+          return HttpResponse.json({
+            status: 'running',
+            progress: { done: polls * 80, total: 200, phase: 'tracks' },
+          });
+        }
+        return HttpResponse.json({
+          status: 'complete',
+          playlist: { id: '1', name: 'Calm Piano', tracks: [{ id: 't', name: 'A' }] },
+        });
+      }),
+      http.post('/api/mirror-playlist', () => HttpResponse.json({ success: true })),
+    );
+
+    const stages: { phase: string; done?: number; total?: number }[] = [];
+    const error = await openDeezerPlaylistInSync(PLAYLIST, (s) => stages.push({ ...s }));
+
+    expect(error).toBeNull();
+    expect(stages.some((s) => s.phase === 'loading' && s.done === 80 && s.total === 200)).toBe(true);
+    expect(stages.some((s) => s.phase === 'loading' && s.done === 160)).toBe(true);
+    // and the final stage is the quick one, so the bar can finish
+    expect(stages.at(-1)?.phase).toBe('mirroring');
+  });
+
+  it('opens with the count it already knows, before the first poll', async () => {
+    window.SoulSyncWebRouter = { navigateToPage: vi.fn() } as never;
+    server.use(
+      http.get('/api/deezer/playlist/:id', () => HttpResponse.error()),
+    );
+    const stages: { phase: string; total?: number }[] = [];
+    await openDeezerPlaylistInSync({ ...PLAYLIST, track_count: 200 }, (s) => stages.push({ ...s }));
+    // the shelf already knows the playlist has 200 tracks; showing that at once
+    // beats an empty bar until the job's first frame lands
+    expect(stages[0]).toEqual({ phase: 'loading', total: 200 });
+  });
+
+  it('surfaces the loader error rather than a generic one', async () => {
+    server.use(
+      http.get('/api/deezer/playlist/:id', () =>
+        HttpResponse.json({ pending: true, job_id: 'job-2' }),
+      ),
+      http.get('/api/deezer/playlist-load/job-2', () =>
+        HttpResponse.json({ status: 'error', error: 'Deezer refused the request' }),
+      ),
+    );
+    await expect(openDeezerPlaylistInSync(PLAYLIST)).resolves.toBe('Deezer refused the request');
+  });
+});

--- a/webui/src/routes/discover/-discover.deezer-editorial.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.ts
@@ -169,7 +169,12 @@ export async function openDeezerPlaylistInSync(
 
   // only navigate once it is actually there, so the tab is never opened onto a
   // playlist that failed to arrive
-  window.SoulSyncWebRouter?.navigateToPage('sync');
+  // navigateToPage, NOT the SoulSyncWebRouter bridge: the bridge moves the
+  // url and leaves the sidebar marking the page you came from, so the user
+  // lands on Sync with Discover still highlighted. globals.d.ts says so above
+  // the declaration; I used the bridge anyway by copying a call site that has
+  // the same bug.
+  void window.navigateToPage?.('sync');
   window.setTimeout(() => {
     document.querySelector<HTMLElement>('.sync-tab-button[data-tab="mirrored"]')?.click();
   }, 200);

--- a/webui/src/routes/discover/-discover.deezer-editorial.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.ts
@@ -10,6 +10,8 @@
  */
 
 import { apiClient, readJson } from '@/app/api-client';
+import { postMirrorPlaylist } from '@/routes/sync/-sync.api';
+import { buildMirrorPayload } from '@/routes/sync/-sync.import';
 
 export interface DeezerEditorialPlaylist {
   id: string;
@@ -31,6 +33,15 @@ interface EditorialResponse {
   playlists?: DeezerEditorialPlaylist[];
   count?: number;
   error?: string;
+}
+
+/** What /api/deezer/playlist/<id> answers with. */
+interface DeezerPlaylistResponse {
+  id?: string | number;
+  name?: string;
+  owner?: string;
+  image_url?: string;
+  tracks?: unknown[];
 }
 
 interface GenresResponse {
@@ -68,30 +79,64 @@ export async function fetchDeezerEditorialGenres(): Promise<DeezerEditorialGenre
 }
 
 /**
- * Hand a playlist to the Sync page, the way a user would by pasting its link.
+ * Load a Deezer playlist and put it on the Sync page's mirrored tab.
  *
- * Deliberately NOT a second loader. `loadDeezerPlaylist` reads the url input and
- * runs the whole existing flow — fetch, mirror, render, state — so driving that
- * input is what keeps this one pipeline instead of two. The same handoff idiom
- * the global search widget uses for Soulseek (downloads.js, _gsNavigateToSearchPage).
+ * The first version of this drove `#deezer-url-input` and called the global
+ * `loadDeezerPlaylist`. Both are the RETIRED vanilla sync page: that input does
+ * not exist in index.html any more, and the React sheet's field is a controlled
+ * input, so assigning .value from outside would not update its state even if it
+ * were the right element. The click navigated and did nothing.
  *
- * Returns false when the Sync page is not reachable, so the caller can say so
- * rather than looking like the click did nothing.
+ * What actually makes a playlist appear is POST /api/mirror-playlist, which is
+ * the same call the Sync page makes after parsing a pasted link. So: fetch the
+ * playlist through the loader that already exists, mirror it with the payload
+ * builder that already exists, then show the user where it landed.
+ *
+ * Returns an error string on failure, or null when it worked.
  */
-export function openDeezerPlaylistInSync(playlist: DeezerEditorialPlaylist): boolean {
-  const link = playlist.link || `https://www.deezer.com/playlist/${playlist.id}`;
-  const navigate = window.navigateToPage;
-  if (typeof navigate !== 'function') return false;
-
-  navigate('sync');
-  // the input only exists once the page has mounted
-  window.setTimeout(() => {
-    const input = document.getElementById('deezer-url-input') as HTMLInputElement | null;
-    if (input) {
-      input.value = link;
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+export async function openDeezerPlaylistInSync(
+  playlist: DeezerEditorialPlaylist,
+): Promise<string | null> {
+  let loaded: DeezerPlaylistResponse;
+  try {
+    const response = await fetch(`/api/deezer/playlist/${encodeURIComponent(playlist.id)}`);
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as { error?: string };
+      return body.error || `Could not load that playlist (${response.status})`;
     }
-    void window.loadDeezerPlaylist?.();
-  }, 300);
-  return true;
+    loaded = (await response.json()) as DeezerPlaylistResponse;
+  } catch {
+    return 'Could not reach the server to load that playlist';
+  }
+
+  const tracks = loaded.tracks ?? [];
+  if (tracks.length === 0) return 'That playlist came back empty';
+
+  try {
+    const payload = buildMirrorPayload(
+      'deezer',
+      loaded.id ?? playlist.id,
+      loaded.name ?? playlist.title,
+      tracks as never,
+      {
+        owner: loaded.owner ?? playlist.creator,
+        image_url: loaded.image_url ?? playlist.image_url,
+        description: playlist.link,
+      },
+    );
+    const result = await postMirrorPlaylist(payload);
+    if (result.success === false) return result.error || 'Could not mirror that playlist';
+  } catch {
+    return 'Could not mirror that playlist';
+  }
+
+  // only navigate once it is actually there, so the tab is never opened onto
+  // a playlist that failed to arrive
+  window.SoulSyncWebRouter?.navigateToPage('sync');
+  window.setTimeout(() => {
+    document
+      .querySelector<HTMLElement>('.sync-tab-button[data-tab="mirrored"]')
+      ?.click();
+  }, 200);
+  return null;
 }

--- a/webui/src/routes/discover/-discover.deezer-editorial.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.ts
@@ -1,0 +1,97 @@
+/**
+ * Deezer's own editors publish playlists, and the public API serves them with
+ * no key and no linked account. This is the browse half of a pipeline that
+ * already exists: picking a card hands the playlist to the Sync page's Deezer
+ * flow, which is the same path a pasted deezer.com/playlist/... link takes —
+ * load, match, sync. Nothing new downstream.
+ *
+ * The genre chips are served rather than hardcoded here so the two ends cannot
+ * drift: core/deezer_client.py owns the list.
+ */
+
+import { apiClient, readJson } from '@/app/api-client';
+
+export interface DeezerEditorialPlaylist {
+  id: string;
+  title: string;
+  creator: string;
+  track_count: number;
+  image_url: string;
+  link: string;
+  source: string;
+}
+
+export interface DeezerEditorialGenre {
+  id: number;
+  name: string;
+}
+
+interface EditorialResponse {
+  success?: boolean;
+  playlists?: DeezerEditorialPlaylist[];
+  count?: number;
+  error?: string;
+}
+
+interface GenresResponse {
+  success?: boolean;
+  genres?: DeezerEditorialGenre[];
+}
+
+/**
+ * One genre's curated playlists.
+ *
+ * Never throws. A browse row that cannot load is an empty row — the server
+ * already answers 200 with an empty list rather than an error status, and a
+ * transport failure is treated the same way, because a dead shelf must not take
+ * the page with it.
+ */
+export async function fetchDeezerEditorial(genreId: number): Promise<DeezerEditorialPlaylist[]> {
+  try {
+    const data = await readJson<EditorialResponse>(
+      apiClient.get('discover/deezer/editorial', { searchParams: { genre: String(genreId) } }),
+    );
+    return data.playlists ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/** The chips. Empty on failure, which hides the chip row rather than the shelf. */
+export async function fetchDeezerEditorialGenres(): Promise<DeezerEditorialGenre[]> {
+  try {
+    const data = await readJson<GenresResponse>(apiClient.get('discover/deezer/genres'));
+    return data.genres ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Hand a playlist to the Sync page, the way a user would by pasting its link.
+ *
+ * Deliberately NOT a second loader. `loadDeezerPlaylist` reads the url input and
+ * runs the whole existing flow — fetch, mirror, render, state — so driving that
+ * input is what keeps this one pipeline instead of two. The same handoff idiom
+ * the global search widget uses for Soulseek (downloads.js, _gsNavigateToSearchPage).
+ *
+ * Returns false when the Sync page is not reachable, so the caller can say so
+ * rather than looking like the click did nothing.
+ */
+export function openDeezerPlaylistInSync(playlist: DeezerEditorialPlaylist): boolean {
+  const link = playlist.link || `https://www.deezer.com/playlist/${playlist.id}`;
+  const navigate = window.navigateToPage;
+  if (typeof navigate !== 'function') return false;
+
+  navigate('sync');
+  // the input only exists once the page has mounted
+  window.setTimeout(() => {
+    const input = document.getElementById('deezer-url-input') as HTMLInputElement | null;
+    if (input) {
+      input.value = link;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    void window.loadDeezerPlaylist?.();
+  }, 300);
+  return true;
+}

--- a/webui/src/routes/discover/-discover.deezer-editorial.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.ts
@@ -72,6 +72,28 @@ export async function fetchDeezerEditorial(genreId: number): Promise<DeezerEdito
   }
 }
 
+/**
+ * Search Deezer's playlists by name. Editorial and user playlists come back
+ * mixed, which is what Deezer's own search does.
+ *
+ * The server has supported ?q= since the shelf shipped; nothing called it, so
+ * the capability existed and no user could reach it.
+ */
+export async function searchDeezerPlaylists(
+  query: string,
+): Promise<DeezerEditorialPlaylist[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+  try {
+    const data = await readJson<EditorialResponse>(
+      apiClient.get('discover/deezer/editorial', { searchParams: { q: trimmed } }),
+    );
+    return data.playlists ?? [];
+  } catch {
+    return [];
+  }
+}
+
 /** The chips. Empty on failure, which hides the chip row rather than the shelf. */
 export async function fetchDeezerEditorialGenres(): Promise<DeezerEditorialGenre[]> {
   try {

--- a/webui/src/routes/discover/-discover.deezer-editorial.ts
+++ b/webui/src/routes/discover/-discover.deezer-editorial.ts
@@ -10,7 +10,11 @@
  */
 
 import { apiClient, readJson } from '@/app/api-client';
-import { postMirrorPlaylist } from '@/routes/sync/-sync.api';
+import {
+  type DeezerLoadProgress,
+  fetchDeezerLinkPlaylist,
+  postMirrorPlaylist,
+} from '@/routes/sync/-sync.api';
 import { buildMirrorPayload } from '@/routes/sync/-sync.import';
 
 export interface DeezerEditorialPlaylist {
@@ -94,25 +98,36 @@ export async function fetchDeezerEditorialGenres(): Promise<DeezerEditorialGenre
  *
  * Returns an error string on failure, or null when it worked.
  */
+export interface DeezerHandoffStage {
+  /** 'loading' while tracks come in, 'mirroring' once they are all here. */
+  phase: 'loading' | 'mirroring';
+  done?: number;
+  total?: number;
+}
+
 export async function openDeezerPlaylistInSync(
   playlist: DeezerEditorialPlaylist,
+  onStage?: (stage: DeezerHandoffStage) => void,
 ): Promise<string | null> {
   let loaded: DeezerPlaylistResponse;
   try {
-    const response = await fetch(`/api/deezer/playlist/${encodeURIComponent(playlist.id)}`);
-    if (!response.ok) {
-      const body = (await response.json().catch(() => ({}))) as { error?: string };
-      return body.error || `Could not load that playlist (${response.status})`;
-    }
-    loaded = (await response.json()) as DeezerPlaylistResponse;
-  } catch {
-    return 'Could not reach the server to load that playlist';
+    // the ASYNC loader, not the blocking one. a 200 track editorial playlist
+    // took 51 seconds on the reporter's machine and the card could say nothing
+    // but "adding to sync" for all of it. the job has always reported
+    // done/total; this is the first caller to read it.
+    onStage?.({ phase: 'loading', total: playlist.track_count || undefined });
+    loaded = (await fetchDeezerLinkPlaylist(playlist.id, (p: DeezerLoadProgress) =>
+      onStage?.({ phase: 'loading', done: p.done, total: p.total || playlist.track_count }),
+    )) as DeezerPlaylistResponse;
+  } catch (error) {
+    return (error as Error)?.message || 'Could not load that playlist';
   }
 
   const tracks = loaded.tracks ?? [];
   if (tracks.length === 0) return 'That playlist came back empty';
 
   try {
+    onStage?.({ phase: 'mirroring', done: tracks.length, total: tracks.length });
     const payload = buildMirrorPayload(
       'deezer',
       loaded.id ?? playlist.id,
@@ -130,13 +145,11 @@ export async function openDeezerPlaylistInSync(
     return 'Could not mirror that playlist';
   }
 
-  // only navigate once it is actually there, so the tab is never opened onto
-  // a playlist that failed to arrive
+  // only navigate once it is actually there, so the tab is never opened onto a
+  // playlist that failed to arrive
   window.SoulSyncWebRouter?.navigateToPage('sync');
   window.setTimeout(() => {
-    document
-      .querySelector<HTMLElement>('.sync-tab-button[data-tab="mirrored"]')
-      ?.click();
+    document.querySelector<HTMLElement>('.sync-tab-button[data-tab="mirrored"]')?.click();
   }, 200);
   return null;
 }

--- a/webui/src/routes/discover/-discover.layout.test.ts
+++ b/webui/src/routes/discover/-discover.layout.test.ts
@@ -153,10 +153,6 @@ describe('the empty policy is NOT uniform', () => {
       'cache-genre-releases',
       'cache-label-explorer',
       'cache-undiscovered',
-      // NEW since the port. Deezer's charts are always populated, so an empty
-      // row means the api was unreachable - and an explanation the user cannot
-      // act on is worse than no row at all.
-      'deezer-editorial',
       'listening-recs-section',
       'recommended-artists-section',
       'your-albums-section',
@@ -209,5 +205,22 @@ describe('isSectionVisible', () => {
     for (const id of ['lastfm-radio', 'listenbrainz', 'build-a-playlist'] as const) {
       expect(isSectionVisible(id, false, true)).toBe(false);
     }
+  });
+});
+
+describe('the Deezer editorial shelf stays in the layout', () => {
+  // It renders its own loading and empty states. A HIDE policy made the whole
+  // section null until rows arrived, so the loading row was unreachable and a
+  // slow or unreachable Deezer left no trace of the shelf at all.
+  it('is visible before its fetch has returned anything', () => {
+    expect(isSectionVisible('deezer-editorial', false, false)).toBe(true);
+  });
+
+  it('is still visible when the fetch came back empty', () => {
+    expect(isSectionVisible('deezer-editorial', false, true)).toBe(true);
+  });
+
+  it('is not governed by an empty policy', () => {
+    expect(SECTION_EMPTY_POLICY['deezer-editorial']).toBeUndefined();
   });
 });

--- a/webui/src/routes/discover/-discover.layout.test.ts
+++ b/webui/src/routes/discover/-discover.layout.test.ts
@@ -43,6 +43,10 @@ describe('the section order', () => {
       'cache-genre-explorer',
       'lastfm-radio',
       'listenbrainz',
+      // NEW since the port, not drift: Deezer's editors publish curated
+      // playlists and the public api serves them free. It sits with the other
+      // source-backed playlist rows because that is what it is.
+      'deezer-editorial',
       'build-a-playlist',
     ]);
   });
@@ -149,6 +153,10 @@ describe('the empty policy is NOT uniform', () => {
       'cache-genre-releases',
       'cache-label-explorer',
       'cache-undiscovered',
+      // NEW since the port. Deezer's charts are always populated, so an empty
+      // row means the api was unreachable - and an explanation the user cannot
+      // act on is worse than no row at all.
+      'deezer-editorial',
       'listening-recs-section',
       'recommended-artists-section',
       'your-albums-section',

--- a/webui/src/routes/discover/-discover.layout.ts
+++ b/webui/src/routes/discover/-discover.layout.ts
@@ -111,9 +111,6 @@ export const SECTION_EMPTY_POLICY: Partial<Record<DiscoverSectionId, EmptyPolicy
   'listening-recs-section': HIDE,
   'your-albums-section': HIDE,
   'your-artists-section': HIDE,
-  // Deezer's charts are always populated; an empty row means the api was
-  // unreachable, and an explanation nobody can act on is worse than no row.
-  'deezer-editorial': HIDE,
 
   // hideWhenEmpty absent → the controller default (false): stay and explain.
   'recent-releases': emptyState('No recent releases found'),
@@ -131,7 +128,14 @@ export const SECTION_EMPTY_POLICY: Partial<Record<DiscoverSectionId, EmptyPolicy
 };
 
 /** Sections that render regardless of data — controls, not shelves. */
-export const ALWAYS_VISIBLE: DiscoverSectionId[] = ['adv-wave'];
+export const ALWAYS_VISIBLE: DiscoverSectionId[] = [
+  'adv-wave',
+  // Renders its own loading and empty states. Without this the section is
+  // null for as long as the fetch takes - so the loading row could never
+  // appear, and a slow or unreachable Deezer left no trace of the shelf at
+  // all rather than a row that says what happened.
+  'deezer-editorial',
+];
 
 /**
  * Should this section be in the layout at all?

--- a/webui/src/routes/discover/-discover.layout.ts
+++ b/webui/src/routes/discover/-discover.layout.ts
@@ -36,6 +36,7 @@ export type DiscoverSectionId =
   | 'cache-deep-cuts'
   | 'lastfm-radio'
   | 'listenbrainz'
+  | 'deezer-editorial'
   | 'build-a-playlist';
 
 /** One entry: a full-width section, or a pair that renders two-up when both have content. */
@@ -77,6 +78,7 @@ export const DISCOVER_LAYOUT: DiscoverLayoutEntry[] = [
   single('cache-genre-explorer'), //                                  browse
   single('lastfm-radio'), //                                          stations & tools
   single('listenbrainz'),
+  single('deezer-editorial'), //                          deezer's own editors
   single('build-a-playlist'),
 ];
 
@@ -109,6 +111,9 @@ export const SECTION_EMPTY_POLICY: Partial<Record<DiscoverSectionId, EmptyPolicy
   'listening-recs-section': HIDE,
   'your-albums-section': HIDE,
   'your-artists-section': HIDE,
+  // Deezer's charts are always populated; an empty row means the api was
+  // unreachable, and an explanation nobody can act on is worse than no row.
+  'deezer-editorial': HIDE,
 
   // hideWhenEmpty absent → the controller default (false): stay and explain.
   'recent-releases': emptyState('No recent releases found'),

--- a/webui/src/routes/discover/-discover.zone-coverage.test.ts
+++ b/webui/src/routes/discover/-discover.zone-coverage.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { DISCOVER_LAYOUT, type DiscoverSectionId } from './-discover.layout';
+
+/**
+ * A section is only on screen if it is in a ZONE list.
+ *
+ * DISCOVER_LAYOUT gives a section its order and its empty policy, and it is
+ * natural to assume that is what puts it on the page. It is not. The page
+ * renders through renderZoneSections([...]) calls with hardcoded ids, so a
+ * section can be fully registered — in the union, in the layout, with a render
+ * case and a hasContent branch — and still never appear anywhere.
+ *
+ * That is exactly what happened to the Deezer editorial shelf: everything was
+ * wired except the zone list, and the row was simply absent from the page with
+ * nothing to explain it.
+ */
+
+const PAGE = readFileSync(
+  join(__dirname, '-ui', 'discover-page.tsx'),
+  'utf8',
+);
+
+/** Every id passed to a renderZoneSections([...]) call. */
+function zoneRenderedIds(): Set<string> {
+  const ids = new Set<string>();
+  const call = /renderZoneSections\(\s*\[([\s\S]*?)\]\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = call.exec(PAGE)) !== null) {
+    for (const id of match[1].matchAll(/'([a-z0-9-]+)'/g)) ids.add(id[1]);
+  }
+  return ids;
+}
+
+/** The ids the layout says belong on the page. */
+function layoutIds(): DiscoverSectionId[] {
+  return DISCOVER_LAYOUT.flatMap((e) => (e.kind === 'single' ? [e.id] : e.ids));
+}
+
+describe('every laid-out section is actually rendered by a zone', () => {
+  it('finds the zone lists at all', () => {
+    // a regex that matched nothing would make the check below vacuous
+    const rendered = zoneRenderedIds();
+    expect(rendered.size).toBeGreaterThan(10);
+    expect(rendered.has('listenbrainz')).toBe(true);
+  });
+
+  it('leaves no section registered but invisible', () => {
+    const rendered = zoneRenderedIds();
+    // 'adv-wave' is the dial, rendered inline rather than as a zone section
+    const orphans = layoutIds().filter((id) => id !== 'adv-wave' && !rendered.has(id));
+    expect(orphans, 'these sections are in DISCOVER_LAYOUT but no zone renders them').toEqual([]);
+  });
+
+  it('renders the Deezer editorial shelf', () => {
+    expect(zoneRenderedIds().has('deezer-editorial')).toBe(true);
+  });
+});

--- a/webui/src/routes/discover/-ui/artefact-parity.test.ts
+++ b/webui/src/routes/discover/-ui/artefact-parity.test.ts
@@ -140,8 +140,8 @@ const NEW_CLASSES: string[] = [
   // 3.3.0 zone regroup: the tools zone's grid modifier, styled in style.css
   'discovery-zone-section--map-tools',
   // NOTE: the Deezer editorial shelf adds no entry here on purpose. Its chips
-  // are styled in style.css, which makes them KNOWN rather than new, and the
-  // shelf itself reuses the page's own card classes.
+  // and its progress bar are styled in style.css, which makes them KNOWN
+  // rather than new, and the shelf reuses the page's own card classes.
 ];
 
 function componentFiles(): string[] {

--- a/webui/src/routes/discover/-ui/artefact-parity.test.ts
+++ b/webui/src/routes/discover/-ui/artefact-parity.test.ts
@@ -68,6 +68,9 @@ const KNOWN_IDS = new Set<string>([
  * component SOURCE and cannot tell a prop from an attribute.
  */
 const NEW_IDS = [
+  // Deezer's editors publish curated playlists and the public api serves them
+  // with no key. A shelf the vanilla never had, so its section anchor is new.
+  'deezer-editorial',
   'build-a-playlist',
   'lastfm-radio',
   'listenbrainz',
@@ -136,6 +139,9 @@ const DELETED_MARKUP_CLASSES = ['artweb-size-btn', 'watch-all-text'];
 const NEW_CLASSES: string[] = [
   // 3.3.0 zone regroup: the tools zone's grid modifier, styled in style.css
   'discovery-zone-section--map-tools',
+  // NOTE: the Deezer editorial shelf adds no entry here on purpose. Its chips
+  // are styled in style.css, which makes them KNOWN rather than new, and the
+  // shelf itself reuses the page's own card classes.
 ];
 
 function componentFiles(): string[] {

--- a/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
+++ b/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 import {
   type DeezerEditorialGenre,
+  type DeezerHandoffStage,
   type DeezerEditorialPlaylist,
   fetchDeezerEditorial,
   fetchDeezerEditorialGenres,
@@ -25,14 +26,35 @@ import { DiscoverSection } from './discover-section';
 /** Genre 0 is Deezer's everything chart, and the row the shelf opens on. */
 const DEFAULT_GENRE = 0;
 
+/** What the card says while it works. Silence is what made this feel broken. */
+function handoffLabel(stage?: DeezerHandoffStage | null): string {
+  if (!stage) return 'Starting…';
+  if (stage.phase === 'mirroring') return 'Adding to Sync…';
+  const { done, total } = stage;
+  if (done != null && total) return `Loading ${done} / ${total} tracks…`;
+  if (total) return `Loading ${total} tracks…`;
+  return 'Loading tracks…';
+}
+
+/** 0-100. The load owns the bar; mirroring is quick and finishes it. */
+function handoffPercent(stage?: DeezerHandoffStage | null): number {
+  if (!stage) return 0;
+  if (stage.phase === 'mirroring') return 100;
+  const { done, total } = stage;
+  if (done == null || !total) return 0;
+  return Math.min(100, Math.round((done / total) * 100));
+}
+
 function PlaylistCard({
   playlist,
   onOpen,
   busy,
+  stage,
 }: {
   playlist: DeezerEditorialPlaylist;
   onOpen: (p: DeezerEditorialPlaylist) => void;
   busy?: boolean;
+  stage?: DeezerHandoffStage | null;
 }) {
   const [failed, setFailed] = useState(false);
   const tracks = playlist.track_count;
@@ -60,8 +82,15 @@ function PlaylistCard({
       <div className="ya-card-info">
         <div className="ya-card-name">{playlist.title}</div>
         <div className="ya-card-sub">
-          {busy ? 'Adding to Sync…' : `${playlist.creator}${tracks ? ` · ${tracks} tracks` : ''}`}
+          {busy
+            ? handoffLabel(stage)
+            : `${playlist.creator}${tracks ? ` · ${tracks} tracks` : ''}`}
         </div>
+        {busy && (
+          <div className="dz-ed-progress" role="progressbar" aria-label="Adding to Sync">
+            <div className="dz-ed-progress-fill" style={{ width: `${handoffPercent(stage)}%` }} />
+          </div>
+        )}
       </div>
     </button>
   );
@@ -98,17 +127,18 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
   }, [genreId]);
 
   const [opening, setOpening] = useState<string | null>(null);
+  const [stage, setStage] = useState<DeezerHandoffStage | null>(null);
 
   const open = useCallback(
     async (playlist: DeezerEditorialPlaylist) => {
-      // a big editorial playlist takes a moment to load and mirror; without
-      // this the card looks like it ignored the click
       setOpening(playlist.id);
+      setStage({ phase: 'loading', total: playlist.track_count || undefined });
       try {
-        const error = await openDeezerPlaylistInSync(playlist);
+        const error = await openDeezerPlaylistInSync(playlist, setStage);
         if (error) onToast?.(error);
       } finally {
         setOpening(null);
+        setStage(null);
       }
     },
     [onToast],
@@ -156,6 +186,7 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
               playlist={p}
               onOpen={open}
               busy={opening === p.id}
+              stage={opening === p.id ? stage : null}
             />
           ))}
         </div>

--- a/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
+++ b/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
@@ -28,9 +28,11 @@ const DEFAULT_GENRE = 0;
 function PlaylistCard({
   playlist,
   onOpen,
+  busy,
 }: {
   playlist: DeezerEditorialPlaylist;
   onOpen: (p: DeezerEditorialPlaylist) => void;
+  busy?: boolean;
 }) {
   const [failed, setFailed] = useState(false);
   const tracks = playlist.track_count;
@@ -40,7 +42,8 @@ function PlaylistCard({
       className="ya-card discover-album-card"
       title={`${playlist.title} — ${playlist.creator}`}
       aria-label={`${playlist.title} by ${playlist.creator}, ${tracks} tracks`}
-      onClick={() => onOpen(playlist)}
+      onClick={() => void onOpen(playlist)}
+      aria-busy={busy || undefined}
     >
       <div className="ya-card-img">
         {!failed && playlist.image_url && (
@@ -57,8 +60,7 @@ function PlaylistCard({
       <div className="ya-card-info">
         <div className="ya-card-name">{playlist.title}</div>
         <div className="ya-card-sub">
-          {playlist.creator}
-          {tracks ? ` · ${tracks} tracks` : ''}
+          {busy ? 'Adding to Sync…' : `${playlist.creator}${tracks ? ` · ${tracks} tracks` : ''}`}
         </div>
       </div>
     </button>
@@ -95,10 +97,18 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
     };
   }, [genreId]);
 
+  const [opening, setOpening] = useState<string | null>(null);
+
   const open = useCallback(
-    (playlist: DeezerEditorialPlaylist) => {
-      if (!openDeezerPlaylistInSync(playlist)) {
-        onToast?.('Could not open the Sync page for that playlist');
+    async (playlist: DeezerEditorialPlaylist) => {
+      // a big editorial playlist takes a moment to load and mirror; without
+      // this the card looks like it ignored the click
+      setOpening(playlist.id);
+      try {
+        const error = await openDeezerPlaylistInSync(playlist);
+        if (error) onToast?.(error);
+      } finally {
+        setOpening(null);
       }
     },
     [onToast],
@@ -141,7 +151,12 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
       ) : (
         <div className="discover-grid">
           {playlists.map((p) => (
-            <PlaylistCard key={p.id} playlist={p} onOpen={open} />
+            <PlaylistCard
+              key={p.id}
+              playlist={p}
+              onOpen={open}
+              busy={opening === p.id}
+            />
           ))}
         </div>
       )}

--- a/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
+++ b/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
@@ -20,6 +20,7 @@ import {
   fetchDeezerEditorial,
   fetchDeezerEditorialGenres,
   openDeezerPlaylistInSync,
+  searchDeezerPlaylists,
 } from '../-discover.deezer-editorial';
 import { DiscoverSection } from './discover-section';
 
@@ -99,6 +100,8 @@ function PlaylistCard({
 export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) => void }) {
   const [genres, setGenres] = useState<DeezerEditorialGenre[]>([]);
   const [genreId, setGenreId] = useState<number>(DEFAULT_GENRE);
+  const [query, setQuery] = useState('');
+  const [searching, setSearching] = useState(false);
   const [playlists, setPlaylists] = useState<DeezerEditorialPlaylist[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -115,16 +118,27 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
   useEffect(() => {
     let live = true;
     setLoading(true);
-    void fetchDeezerEditorial(genreId).then((rows) => {
-      // a genre switched away from mid-flight must not overwrite the new one
-      if (!live) return;
-      setPlaylists(rows);
-      setLoading(false);
-    });
+    const trimmed = query.trim();
+    setSearching(trimmed.length > 0);
+    // debounced, so typing does not fire a request per keystroke at Deezer
+    const timer = window.setTimeout(
+      () => {
+        const request = trimmed ? searchDeezerPlaylists(trimmed) : fetchDeezerEditorial(genreId);
+        void request.then((rows) => {
+          // a genre or query switched away from mid-flight must not overwrite
+          // whatever replaced it
+          if (!live) return;
+          setPlaylists(rows);
+          setLoading(false);
+        });
+      },
+      trimmed ? 350 : 0,
+    );
     return () => {
       live = false;
+      window.clearTimeout(timer);
     };
-  }, [genreId]);
+  }, [genreId, query]);
 
   const [opening, setOpening] = useState<string | null>(null);
   const [stage, setStage] = useState<DeezerHandoffStage | null>(null);
@@ -152,31 +166,50 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
       count={playlists.length}
       loaded={!loading}
       actions={
-        genres.length > 0 ? (
+        <div className="dz-ed-controls">
+          <input
+            type="search"
+            className="dz-ed-search"
+            value={query}
+            placeholder="Search Deezer playlists…"
+            aria-label="Search Deezer playlists"
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          {genres.length > 0 ? (
           <div className="dz-ed-genres" role="tablist" aria-label="Deezer genres">
             {genres.map((g) => (
               <button
                 key={g.id}
                 type="button"
                 role="tab"
-                aria-selected={g.id === genreId}
-                className={`dz-ed-genre${g.id === genreId ? ' is-active' : ''}`}
-                onClick={() => setGenreId(g.id)}
+                aria-selected={!searching && g.id === genreId}
+                className={`dz-ed-genre${!searching && g.id === genreId ? ' is-active' : ''}`}
+                onClick={() => {
+                  // picking a genre leaves a search; they are two ways of
+                  // asking the same row a question, not two rows
+                  setQuery('');
+                  setGenreId(g.id);
+                }}
               >
                 {g.name}
               </button>
             ))}
-          </div>
-        ) : undefined
+            </div>
+          ) : null}
+        </div>
       }
     >
       {loading && playlists.length === 0 ? (
         <div className="discover-empty">
-          <p>Loading Deezer playlists…</p>
+          <p>{searching ? 'Searching Deezer…' : 'Loading Deezer playlists…'}</p>
         </div>
       ) : playlists.length === 0 ? (
         <div className="discover-empty">
-          <p>Could not reach Deezer just now.</p>
+          <p>
+            {searching
+              ? `No Deezer playlists match “${query.trim()}”.`
+              : 'Could not reach Deezer just now.'}
+          </p>
         </div>
       ) : (
         <div className="discover-grid">

--- a/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
+++ b/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
@@ -134,6 +134,10 @@ export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) 
         <div className="discover-empty">
           <p>Loading Deezer playlists…</p>
         </div>
+      ) : playlists.length === 0 ? (
+        <div className="discover-empty">
+          <p>Could not reach Deezer just now.</p>
+        </div>
       ) : (
         <div className="discover-grid">
           {playlists.map((p) => (

--- a/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
+++ b/webui/src/routes/discover/-ui/deezer-editorial-shelf.tsx
@@ -1,0 +1,146 @@
+/**
+ * Deezer's curated playlists, as a Discover shelf.
+ *
+ * Deliberately built out of the page's existing card markup (`ya-card` and its
+ * parts) rather than a new one: the art-forward card styling is scoped to
+ * `.discover-section`, so a shelf that uses the same classes looks like the
+ * rest of the page for free and cannot drift from it.
+ *
+ * Clicking a card does not start a second playlist pipeline. It hands the
+ * playlist to the Sync page exactly as pasting its link would — see
+ * openDeezerPlaylistInSync.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  type DeezerEditorialGenre,
+  type DeezerEditorialPlaylist,
+  fetchDeezerEditorial,
+  fetchDeezerEditorialGenres,
+  openDeezerPlaylistInSync,
+} from '../-discover.deezer-editorial';
+import { DiscoverSection } from './discover-section';
+
+/** Genre 0 is Deezer's everything chart, and the row the shelf opens on. */
+const DEFAULT_GENRE = 0;
+
+function PlaylistCard({
+  playlist,
+  onOpen,
+}: {
+  playlist: DeezerEditorialPlaylist;
+  onOpen: (p: DeezerEditorialPlaylist) => void;
+}) {
+  const [failed, setFailed] = useState(false);
+  const tracks = playlist.track_count;
+  return (
+    <button
+      type="button"
+      className="ya-card discover-album-card"
+      title={`${playlist.title} — ${playlist.creator}`}
+      aria-label={`${playlist.title} by ${playlist.creator}, ${tracks} tracks`}
+      onClick={() => onOpen(playlist)}
+    >
+      <div className="ya-card-img">
+        {!failed && playlist.image_url && (
+          <img
+            src={playlist.image_url}
+            alt=""
+            loading="lazy"
+            onError={() => setFailed(true)}
+          />
+        )}
+        {(failed || !playlist.image_url) && <div className="ya-card-placeholder">♫</div>}
+      </div>
+      <div className="ya-card-gradient" />
+      <div className="ya-card-info">
+        <div className="ya-card-name">{playlist.title}</div>
+        <div className="ya-card-sub">
+          {playlist.creator}
+          {tracks ? ` · ${tracks} tracks` : ''}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+export function DeezerEditorialShelf({ onToast }: { onToast?: (message: string) => void }) {
+  const [genres, setGenres] = useState<DeezerEditorialGenre[]>([]);
+  const [genreId, setGenreId] = useState<number>(DEFAULT_GENRE);
+  const [playlists, setPlaylists] = useState<DeezerEditorialPlaylist[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let live = true;
+    void fetchDeezerEditorialGenres().then((g) => {
+      if (live) setGenres(g);
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    void fetchDeezerEditorial(genreId).then((rows) => {
+      // a genre switched away from mid-flight must not overwrite the new one
+      if (!live) return;
+      setPlaylists(rows);
+      setLoading(false);
+    });
+    return () => {
+      live = false;
+    };
+  }, [genreId]);
+
+  const open = useCallback(
+    (playlist: DeezerEditorialPlaylist) => {
+      if (!openDeezerPlaylistInSync(playlist)) {
+        onToast?.('Could not open the Sync page for that playlist');
+      }
+    },
+    [onToast],
+  );
+
+  return (
+    <DiscoverSection
+      id="deezer-editorial"
+      title="From Deezer's editors"
+      subtitle="Curated playlists, straight from Deezer. Pick one to match it against your library."
+      count={playlists.length}
+      loaded={!loading}
+      actions={
+        genres.length > 0 ? (
+          <div className="dz-ed-genres" role="tablist" aria-label="Deezer genres">
+            {genres.map((g) => (
+              <button
+                key={g.id}
+                type="button"
+                role="tab"
+                aria-selected={g.id === genreId}
+                className={`dz-ed-genre${g.id === genreId ? ' is-active' : ''}`}
+                onClick={() => setGenreId(g.id)}
+              >
+                {g.name}
+              </button>
+            ))}
+          </div>
+        ) : undefined
+      }
+    >
+      {loading && playlists.length === 0 ? (
+        <div className="discover-empty">
+          <p>Loading Deezer playlists…</p>
+        </div>
+      ) : (
+        <div className="discover-grid">
+          {playlists.map((p) => (
+            <PlaylistCard key={p.id} playlist={p} onOpen={open} />
+          ))}
+        </div>
+      )}
+    </DiscoverSection>
+  );
+}

--- a/webui/src/routes/discover/-ui/discover-page.tsx
+++ b/webui/src/routes/discover/-ui/discover-page.tsx
@@ -1462,6 +1462,10 @@ export function DiscoverPage() {
               'cache-genre-explorer',
               'lastfm-radio',
               'listenbrainz',
+              // the page renders sections through these ZONE lists, not from
+              // DISCOVER_LAYOUT - registering a section in the layout alone
+              // gets it an order and a policy but never puts it on screen.
+              'deezer-editorial',
               'build-a-playlist',
             ])}
           </DiscoveryZone>

--- a/webui/src/routes/discover/-ui/discover-page.tsx
+++ b/webui/src/routes/discover/-ui/discover-page.tsx
@@ -1338,6 +1338,109 @@ export function DiscoverPage() {
               </button>
             </div>
           )}
+          {/* Quick Filter Navigation Rail (Spotify / Deezer style) */}
+          <nav className="dsc-quick-filter-bar" aria-label="Discover Categories">
+            <button
+              type="button"
+              className="dsc-filter-pill active"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-for-you')}
+            >
+              <span>✨ For You</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-for-you')}
+            >
+              <span>🎵 Daily Mixes</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('recommended-stations-section')}
+            >
+              <span>📻 Artist Radio</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-new-missing')}
+            >
+              <span>🔥 New Releases</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('deezer-editorial')}
+            >
+              <span>🎧 Deezer Curated</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-tools')}
+            >
+              <span>🪐 Explore & Lab</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-filter-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-library')}
+            >
+              <span>📦 Library Gaps</span>
+            </button>
+          </nav>
+
+          {/* Deezer Flow & Moods Bar */}
+          <div className="dsc-flow-bar" role="toolbar" aria-label="Music Moods">
+            <span className="dsc-flow-title">Flow Moods</span>
+            <button
+              type="button"
+              className="dsc-flow-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-for-you')}
+              title="Energizing high-tempo mixes"
+            >
+              <span className="dsc-flow-icon">⚡</span>
+              <span>Energizing</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-flow-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-for-you')}
+              title="Chill & ambient listening"
+            >
+              <span className="dsc-flow-icon">☕</span>
+              <span>Chill & Lo-Fi</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-flow-pill"
+              onClick={() => scrollToDiscoveryTarget('library-radio-section')}
+              title="Focus radio from your collection"
+            >
+              <span className="dsc-flow-icon">🎯</span>
+              <span>Focus</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-flow-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-library')}
+              title="Deep cuts and nocturnal sounds"
+            >
+              <span className="dsc-flow-icon">🌙</span>
+              <span>Deep Cuts</span>
+            </button>
+            <button
+              type="button"
+              className="dsc-flow-pill"
+              onClick={() => scrollToDiscoveryTarget('discover-zone-tools')}
+              title="Surprise discovery shuffle"
+            >
+              <span className="dsc-flow-icon">🎲</span>
+              <span>Discovery Roulette</span>
+            </button>
+          </div>
+
           <div className="discover-command-grid">
             <div className="discover-command-hero">
               <DiscoverHero

--- a/webui/src/routes/discover/-ui/discover-page.tsx
+++ b/webui/src/routes/discover/-ui/discover-page.tsx
@@ -60,6 +60,7 @@ import { useDownloadBar } from '../-discover.use-download-bar';
 import { useHero } from '../-discover.use-hero';
 import { useLastfmRadio } from '../-discover.use-lastfm-radio';
 import { useListenBrainz } from '../-discover.use-listenbrainz';
+import { DeezerEditorialShelf } from './deezer-editorial-shelf';
 import { defaultLazySource, useMixModal } from '../-discover.use-mix-modal';
 import { useDiscoverMixes } from '../-discover.use-mixes';
 import { useDiscoverPage } from '../-discover.use-page';
@@ -937,6 +938,7 @@ export function DiscoverPage() {
     (id: DiscoverSectionId): boolean => {
       if (id === 'lastfm-radio') return lastfm.configured === true;
       if (id === 'listenbrainz') return true; // renders its own load/error states
+      if (id === 'deezer-editorial') return true; // fetches and empties itself
       if (id === 'build-a-playlist') return true; // a control, like adv-wave
       if (id === 'your-mixes-section') return mixes.mixes.length > 0;
       if (id === 'year-mixes-section') return mixes.decadeMixes.length > 0;
@@ -1154,6 +1156,8 @@ export function DiscoverPage() {
             playingKey={playingMixKey}
           />
         );
+      case 'deezer-editorial':
+        return <DeezerEditorialShelf onToast={(m) => toast(m, 'error')} />;
       case 'build-a-playlist':
         return (
           <BuildPlaylistSection

--- a/webui/src/routes/discover/-ui/recommended-modal.tsx
+++ b/webui/src/routes/discover/-ui/recommended-modal.tsx
@@ -158,14 +158,32 @@ function ModalCard({
       <button
         type="button"
         className={
-          watching ? 'recommended-card-watchlist-btn watching' : 'recommended-card-watchlist-btn'
+          watching
+            ? 'recommended-card-watchlist-btn ya-watchlist-btn watching active'
+            : 'recommended-card-watchlist-btn ya-watchlist-btn'
         }
         data-artist-id={id}
         data-artist-name={name}
+        title={watching ? 'On watchlist' : 'Add to watchlist'}
+        aria-label={watching ? 'On watchlist' : 'Add to watchlist'}
         disabled={!clickable || watching}
-        onClick={() => onAddToWatchlist(id, name)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onAddToWatchlist(id, name);
+        }}
       >
-        {watching ? REC_WATCH_ON_LABEL : REC_WATCH_ADD_LABEL}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill={watching ? 'currentColor' : 'none'}
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <span className="sr-only">{watching ? REC_WATCH_ON_LABEL : REC_WATCH_ADD_LABEL}</span>
       </button>
       <a
         className="recommended-card-link"

--- a/webui/src/routes/discover/-ui/recommended-shelf.tsx
+++ b/webui/src/routes/discover/-ui/recommended-shelf.tsx
@@ -185,17 +185,33 @@ function RecommendedMiniCard({
         type="button"
         className={
           watching
-            ? 'recommended-card-watchlist-btn ya-card-reco-btn watching'
-            : 'recommended-card-watchlist-btn ya-card-reco-btn'
+            ? 'recommended-card-watchlist-btn ya-watchlist-btn ya-card-reco-btn watching active'
+            : 'recommended-card-watchlist-btn ya-watchlist-btn ya-card-reco-btn'
         }
         data-artist-id={card.artistId}
         data-artist-name={card.artistName}
+        title={watching ? 'On watchlist' : 'Add to watchlist'}
+        aria-label={watching ? 'On watchlist' : 'Add to watchlist'}
         // A card with neither an id nor a name cannot be watched — the request
         // would have nothing to identify.
         disabled={!clickable || watching}
-        onClick={() => onAddToWatchlist(card.watchId, card.artistName, card.watchSource)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onAddToWatchlist(card.watchId, card.artistName, card.watchSource);
+        }}
       >
-        {watching ? REC_WATCH_ON_LABEL : REC_WATCH_ADD_LABEL}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill={watching ? 'currentColor' : 'none'}
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+        <span className="sr-only">{watching ? REC_WATCH_ON_LABEL : REC_WATCH_ADD_LABEL}</span>
       </button>
     </div>
   );

--- a/webui/src/routes/import/-import.api.test.ts
+++ b/webui/src/routes/import/-import.api.test.ts
@@ -34,10 +34,8 @@ describe('import api', () => {
     await expect(rejectAutoImportResult(18)).rejects.toThrow(softFailureMessage);
   });
 
-  it('#772: import-process calls use a long timeout, not ky default 10s', async () => {
-    // Per-track import does heavy server-side enrichment (60-90s+); the default
-    // 10s timeout aborted it client-side -> progress bar stuck + "Failed" while
-    // files imported. These calls must pass an explicit long timeout.
+  it('#1245: import-process opts into background jobs with an idempotency key', async () => {
+    // The acceptance request is short; expensive work is polled by job ID.
     const ok = { json: async () => ({ success: true, processed: 1, total: 1, errors: [] }) };
     const spy = vi.spyOn(apiClient, 'post').mockReturnValue(ok as never);
 
@@ -46,9 +44,59 @@ describe('import api', () => {
 
     expect(spy).toHaveBeenCalledTimes(2);
     for (const call of spy.mock.calls) {
-      expect(call[1]).toMatchObject({ timeout: 300_000 });
+      expect(call[1]).toMatchObject({
+        timeout: 300_000,
+        headers: { Prefer: 'respond-async', 'Idempotency-Key': expect.any(String) },
+      });
     }
     spy.mockRestore();
+  });
+
+  it('polls the accepted job and returns the processing result without resubmitting', async () => {
+    vi.useFakeTimers();
+    const result = { success: true, processed: 1, total: 1, errors: [] };
+    const post = vi.spyOn(apiClient, 'post').mockReturnValue({
+      json: async () => ({ success: true, job_id: 'job-1245' }),
+    } as never);
+    const get = vi
+      .spyOn(apiClient, 'get')
+      .mockReturnValueOnce({ json: async () => ({ state: 'running' }) } as never)
+      .mockReturnValueOnce({
+        json: async () => ({ state: 'complete', status: 200, result }),
+      } as never);
+    try {
+      const pending = processImportSingleFile({ full_path: '/staging/song.flac' });
+      await vi.runAllTimersAsync();
+      await expect(pending).resolves.toEqual(result);
+      expect(post).toHaveBeenCalledTimes(1);
+      expect(get).toHaveBeenCalledTimes(2);
+      expect(get).toHaveBeenCalledWith('import/jobs/job-1245');
+    } finally {
+      post.mockRestore();
+      get.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves an import failure returned by the background worker', async () => {
+    vi.useFakeTimers();
+    const result = { success: false, error: 'Provider unavailable' };
+    const post = vi.spyOn(apiClient, 'post').mockReturnValue({
+      json: async () => ({ success: true, job_id: 'failed-job' }),
+    } as never);
+    const get = vi.spyOn(apiClient, 'get').mockReturnValue({
+      json: async () => ({ state: 'complete', status: 500, result }),
+    } as never);
+    try {
+      const pending = expect(processImportSingleFile({})).rejects.toThrow('Provider unavailable');
+      await vi.runAllTimersAsync();
+      await pending;
+      expect(post).toHaveBeenCalledTimes(1);
+    } finally {
+      post.mockRestore();
+      get.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it('#957: album-match call uses the long timeout, not ky default 10s', async () => {

--- a/webui/src/routes/import/-import.api.ts
+++ b/webui/src/routes/import/-import.api.ts
@@ -85,19 +85,55 @@ export async function matchImportAlbum(input: {
   );
 }
 
+type ImportJobResponse = {
+  job_id?: string;
+  state?: 'queued' | 'running' | 'complete';
+  result?: ImportProcessPayload;
+  status?: number;
+};
+
+async function runImportJob(path: string, json: unknown): Promise<ImportProcessPayload> {
+  // getRandomValues also works on plain HTTP LAN installs, where randomUUID
+  // is unavailable. Retain the old timeout for servers predating async imports.
+  const key = Array.from(crypto.getRandomValues(new Uint8Array(16)), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  const accepted = await readJson<ImportJobResponse & ImportProcessPayload>(
+    apiClient.post(path, {
+      json,
+      headers: { Prefer: 'respond-async', 'Idempotency-Key': key },
+      timeout: IMPORT_REQUEST_TIMEOUT_MS,
+    }),
+  );
+  // Supports an older server during an upgrade.
+  if (!accepted.job_id) return accepted;
+  let failures = 0;
+  for (;;) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    let job: ImportJobResponse;
+    try {
+      job = await readJson<ImportJobResponse>(apiClient.get(`import/jobs/${accepted.job_id}`));
+      failures = 0;
+    } catch (error) {
+      failures += 1;
+      if (failures >= 3 || (error instanceof Error && error.name === 'HTTPError')) throw error;
+      continue;
+    }
+    if (job.state === 'complete') {
+      if (!job.result) throw new Error('Import job returned no result');
+      if (!job.result.success || (job.status ?? 200) >= 400) {
+        throw new Error(job.result.error || 'Import processing failed');
+      }
+      return job.result;
+    }
+  }
+}
+
 export async function processImportAlbumTrack(input: {
   album: ImportAlbum;
   match: ImportAlbumMatch;
 }): Promise<ImportProcessPayload> {
-  return readJson<ImportProcessPayload>(
-    apiClient.post('import/album/process', {
-      json: {
-        album: input.album,
-        matches: [input.match],
-      },
-      timeout: IMPORT_REQUEST_TIMEOUT_MS,
-    }),
-  );
+  return runImportJob('import/album/process', { album: input.album, matches: [input.match] });
 }
 
 export async function searchImportTracks(query: string): Promise<ImportTrackSearchPayload> {
@@ -112,14 +148,7 @@ export async function searchImportTracks(query: string): Promise<ImportTrackSear
 }
 
 export async function processImportSingleFile(file: unknown): Promise<ImportProcessPayload> {
-  return readJson<ImportProcessPayload>(
-    apiClient.post('import/singles/process', {
-      json: {
-        files: [file],
-      },
-      timeout: IMPORT_REQUEST_TIMEOUT_MS,
-    }),
-  );
+  return runImportJob('import/singles/process', { files: [file] });
 }
 
 export async function fetchAutoImportStatus(): Promise<ImportAutoImportStatusPayload> {

--- a/webui/src/routes/label-detail/-ui/label-detail-page.test.tsx
+++ b/webui/src/routes/label-detail/-ui/label-detail-page.test.tsx
@@ -47,6 +47,7 @@ afterEach(() => {
   delete window.SoulSyncWebShellBridge;
   delete window._labelDetailReturnTo;
   delete window.SoulSyncWebRouter;
+  delete (window as { navigateToPage?: unknown }).navigateToPage;
   vi.unstubAllGlobals();
 });
 
@@ -191,10 +192,11 @@ describe('LabelDetailPage', () => {
     window._labelDetailReturnTo = 'watchlist';
     stubCatalog({ total: 0, releases: [] });
 
-    // The shell installs SoulSyncWebRouter at app start; under the test router
+    // navigateToPage, not the SoulSyncWebRouter bridge: the bridge moves the
+    // url and leaves the sidebar on the page you came FROM. Under the test
     // it is absent, so the page's optional call would silently no-op.
     const navigateToPage = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage } as unknown as Window['SoulSyncWebRouter'];
+    window.navigateToPage = navigateToPage;
 
     renderLabel();
     await screen.findByText('Record Label');
@@ -205,10 +207,11 @@ describe('LabelDetailPage', () => {
   it('falls back to search when nothing recorded an origin', async () => {
     stubCatalog({ total: 0, releases: [] });
 
-    // The shell installs SoulSyncWebRouter at app start; under the test router
+    // navigateToPage, not the SoulSyncWebRouter bridge: the bridge moves the
+    // url and leaves the sidebar on the page you came FROM. Under the test
     // it is absent, so the page's optional call would silently no-op.
     const navigateToPage = vi.fn();
-    window.SoulSyncWebRouter = { navigateToPage } as unknown as Window['SoulSyncWebRouter'];
+    window.navigateToPage = navigateToPage;
 
     renderLabel();
     await screen.findByText('Record Label');

--- a/webui/src/routes/label-detail/-ui/label-detail-page.tsx
+++ b/webui/src/routes/label-detail/-ui/label-detail-page.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import type { ShellPageId } from '@/platform/shell/route-manifest';
 
 import { useReactPageShell } from '@/platform/shell/route-controllers';
 
@@ -123,7 +122,9 @@ export function LabelDetailPage({ labelId, labelName }: { labelId: string; label
             // history.back() is unreliable through the SPA router, which is why
             // navigateToLabelDetail records where you came from.
             const returnTo = window._labelDetailReturnTo || 'search';
-            void window.SoulSyncWebRouter?.navigateToPage(returnTo as ShellPageId);
+            // the sidebar-aware entry; the raw bridge would leave the sidebar
+            // marking Label Detail after going back
+            void window.navigateToPage?.(returnTo);
           }}
         >
           ← Back

--- a/webui/src/routes/playlist-explorer/-explorer.discovery.test.tsx
+++ b/webui/src/routes/playlist-explorer/-explorer.discovery.test.tsx
@@ -26,6 +26,7 @@ afterEach(() => {
   delete window.discoverMirroredPlaylist;
   delete window.showToast;
   delete window.SoulSyncWebRouter;
+  delete (window as { navigateToPage?: unknown }).navigateToPage;
 });
 
 describe('the frame helpers', () => {
@@ -181,8 +182,10 @@ describe('useExplorerDiscovery', () => {
   });
 
   it('falls back to the Sync page when the discovery modal is absent', async () => {
+    // navigateToPage, not the SoulSyncWebRouter bridge: the bridge moves the
+    // url and leaves the sidebar marking Explorer after the hand-off to Sync
     const navigateToPage = vi.fn(async () => true);
-    window.SoulSyncWebRouter = { navigateToPage } as unknown as Window['SoulSyncWebRouter'];
+    window.navigateToPage = navigateToPage;
     window.showToast = vi.fn();
     const tab = document.createElement('button');
     tab.className = 'sync-tab-button';

--- a/webui/src/routes/playlist-explorer/-explorer.discovery.ts
+++ b/webui/src/routes/playlist-explorer/-explorer.discovery.ts
@@ -138,7 +138,8 @@ export function useExplorerDiscovery(onRefresh: () => void): ExplorerDiscovery {
           'This playlist needs more tracks discovered before exploring. Redirecting to Sync...',
           'info',
         );
-        void window.SoulSyncWebRouter?.navigateToPage('sync');
+        // the sidebar-aware entry; the raw bridge leaves Explorer highlighted
+        void window.navigateToPage?.('sync');
         setTimeout(() => {
           document.querySelector<HTMLElement>('.sync-tab-button[data-tab="mirrored"]')?.click();
         }, 200);

--- a/webui/src/routes/stats/-ui/lastfm-import-control.test.tsx
+++ b/webui/src/routes/stats/-ui/lastfm-import-control.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { expect, it, vi } from 'vitest';
+
+import { LastfmImportControl } from './stats-page';
+
+it('allows correcting a saved typo after a failed import and submits the corrected username', () => {
+  const run = vi.fn();
+  function Harness() {
+    const [username, setUsername] = useState('k');
+    return (
+      <LastfmImportControl
+        username={username}
+        onUsernameChange={setUsername}
+        onRun={() => run(username)}
+        running={false}
+        status={{ success: true, username: 'k', status: 'error', api_key_configured: true }}
+      />
+    );
+  }
+  render(<Harness />);
+  const input = screen.getByRole('textbox', { name: 'Last.fm username' });
+  fireEvent.change(input, { target: { value: '' } });
+  expect(input).toHaveValue('');
+  expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
+  fireEvent.change(input, { target: { value: 'c' } });
+  expect(screen.getByRole('textbox', { name: 'Last.fm username' })).toBe(input);
+  fireEvent.change(input, { target: { value: 'corrected' } });
+  fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+  expect(run).toHaveBeenCalledWith('corrected');
+});

--- a/webui/src/routes/stats/-ui/stats-page.tsx
+++ b/webui/src/routes/stats/-ui/stats-page.tsx
@@ -104,6 +104,7 @@ export function StatsPage() {
   const syncTimeoutRef = useRef<number | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [lastfmUsername, setLastfmUsername] = useState('');
+  const lastfmUsernameEdited = useRef(false);
   const [listeningDetailFilter, setListeningDetailFilter] =
     useState<StatsListeningEventsFilter | null>(null);
 
@@ -174,8 +175,8 @@ export function StatsPage() {
 
   useEffect(() => {
     const username = lastfmImportQuery.data?.username;
-    if (username && !lastfmUsername) setLastfmUsername(username);
-  }, [lastfmImportQuery.data?.username, lastfmUsername]);
+    if (!lastfmUsernameEdited.current) setLastfmUsername(username || '');
+  }, [lastfmImportQuery.data?.username]);
 
   useEffect(() => {
     const onProgress = () => {
@@ -285,7 +286,10 @@ export function StatsPage() {
               <LastfmImportControl
                 status={lastfmImportQuery.data}
                 username={lastfmUsername}
-                onUsernameChange={setLastfmUsername}
+                onUsernameChange={(value) => {
+                  lastfmUsernameEdited.current = true;
+                  setLastfmUsername(value);
+                }}
                 onRun={() => lastfmMutation.mutate()}
                 running={lastfmMutation.isPending}
               />
@@ -443,7 +447,7 @@ const PREVIOUS_PERIOD_LABEL: Partial<Record<StatsRange, string>> = {
   '12m': 'vs previous 12 months',
 };
 
-function LastfmImportControl({
+export function LastfmImportControl({
   onRun,
   onUsernameChange,
   running,
@@ -459,7 +463,7 @@ function LastfmImportControl({
   const active = !!status?.running;
   const pct = clampProgress(status?.progress);
   const canUseAuthenticatedUser = !!status?.authenticated_user_available;
-  const needsUsername = !username && !status?.username && !canUseAuthenticatedUser;
+  const needsUsername = !username.trim() && !canUseAuthenticatedUser;
   const disabled = running || active || !status?.api_key_configured || needsUsername;
   const subline = lastfmImportSubline(status);
 
@@ -485,15 +489,14 @@ function LastfmImportControl({
           }}
         />
       </div>
-      {needsUsername ? (
-        <input
-          className={styles.lastfmImportInput}
-          value={username}
-          onChange={(event) => onUsernameChange(event.target.value)}
-          placeholder="Last.fm username"
-          aria-label="Last.fm username"
-        />
-      ) : null}
+      <input
+        className={styles.lastfmImportInput}
+        value={username}
+        onChange={(event) => onUsernameChange(event.target.value)}
+        placeholder="Last.fm username"
+        aria-label="Last.fm username"
+        disabled={running || active}
+      />
       <button
         type="button"
         className={styles.lastfmImportRun}

--- a/webui/src/routes/sync/-sync.api.ts
+++ b/webui/src/routes/sync/-sync.api.ts
@@ -233,7 +233,17 @@ export async function fetchDeezerArlPlaylistTracks(
   return pollDeezerPlaylistLoad<AccountPlaylistTracks>(initial.job_id);
 }
 
-async function pollDeezerPlaylistLoad<T>(jobId: string): Promise<T> {
+/** What the load job reports while it runs: done, total and phase. */
+export interface DeezerLoadProgress {
+  done?: number;
+  total?: number;
+  phase?: string;
+}
+
+async function pollDeezerPlaylistLoad<T>(
+  jobId: string,
+  onProgress?: (progress: DeezerLoadProgress) => void,
+): Promise<T> {
   const deadline = Date.now() + 20 * 60 * 1000;
   while (Date.now() < deadline) {
     const statusResponse = await fetch(`/api/deezer/playlist-load/${jobId}`);
@@ -245,7 +255,11 @@ async function pollDeezerPlaylistLoad<T>(jobId: string): Promise<T> {
       status?: string;
       playlist?: T;
       error?: string;
+      progress?: DeezerLoadProgress;
     }>(statusResponse);
+    // the job has always reported done/total/phase and nothing read it, so a
+    // load that takes a minute looked identical to one that had died
+    if (onProgress && status.progress) onProgress(status.progress);
     if (status.status === 'complete' && status.playlist) return status.playlist;
     if (status.status === 'error') throw new Error(status.error || 'Deezer playlist load failed');
     await new Promise((resolve) => setTimeout(resolve, 1500));
@@ -367,7 +381,10 @@ export async function parseITunesLinkUrl(
  * the backend's error message on !ok — the vanilla's 2746-2749 throw, which
  * lands in the tab's catch toast.
  */
-export async function fetchDeezerLinkPlaylist(id: string): Promise<Record<string, unknown>> {
+export async function fetchDeezerLinkPlaylist(
+  id: string,
+  onProgress?: (progress: DeezerLoadProgress) => void,
+): Promise<Record<string, unknown>> {
   const response = await fetch(`/api/deezer/playlist/${id}?async=1`);
   if (!response.ok) {
     const error = await readJson<{ error?: string }>(response);
@@ -384,7 +401,7 @@ export async function fetchDeezerLinkPlaylist(id: string): Promise<Record<string
     return (initial.playlist ?? initial) as Record<string, unknown>;
   }
   if (!initial.job_id) throw new Error('Deezer playlist load did not return a job id');
-  return pollDeezerPlaylistLoad<Record<string, unknown>>(initial.job_id);
+  return pollDeezerPlaylistLoad<Record<string, unknown>>(initial.job_id, onProgress);
 }
 
 /** GET /api/youtube/playlists (loadYouTubePlaylistsFromBackend, sync-spotify.js 695). */

--- a/webui/src/routes/watchlist/-ui/watchlist-page.tsx
+++ b/webui/src/routes/watchlist/-ui/watchlist-page.tsx
@@ -167,9 +167,42 @@ export function WatchlistPage() {
     previousScanStatus.current = status;
   }, [scanStatus?.status, queryClient]);
 
+  type AttentionFilterKey = 'all' | 'fresh' | 'never' | 'stale' | 'custom';
+  const [attentionFilter, setAttentionFilter] = useState<AttentionFilterKey>('all');
+  const [isAddArtistOpen, setIsAddArtistOpen] = useState(false);
+  const [isInspectorOpen, setIsInspectorOpen] = useState(false);
+
+  const filteredByAttention = useMemo(() => {
+    if (attentionFilter === 'fresh') {
+      const freshNames = new Set(
+        recentReleases.map((r) => r.artist_name?.toLowerCase()).filter(Boolean),
+      );
+      return artists.filter((a) => freshNames.has(a.artist_name.toLowerCase()));
+    }
+    if (attentionFilter === 'never') {
+      return artists.filter((a) => !a.last_scan_timestamp);
+    }
+    if (attentionFilter === 'stale') {
+      return artists.filter((a) => (daysSince(a.last_scan_timestamp) ?? 999) >= 30);
+    }
+    if (attentionFilter === 'custom') {
+      return artists.filter(
+        (a) =>
+          !a.include_albums ||
+          !a.include_eps ||
+          !a.include_singles ||
+          a.include_live ||
+          a.include_remixes ||
+          a.include_acoustic ||
+          a.include_compilations,
+      );
+    }
+    return artists;
+  }, [artists, attentionFilter, recentReleases]);
+
   const visibleArtists = useMemo(
-    () => sortArtists(filterArtists(artists, search.q), search.sort),
-    [artists, search.q, search.sort],
+    () => sortArtists(filterArtists(filteredByAttention, search.q), search.sort),
+    [filteredByAttention, search.q, search.sort],
   );
   const [activeArtistId, setActiveArtistId] = useState<string | null>(null);
 
@@ -182,6 +215,15 @@ export function WatchlistPage() {
       return fallback ? primaryArtistId(fallback) : null;
     });
   }, [artists, visibleArtists]);
+
+  useEffect(() => {
+    if (!isInspectorOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsInspectorOpen(false);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isInspectorOpen]);
 
   const activeArtist = useMemo(
     () =>
@@ -478,6 +520,27 @@ export function WatchlistPage() {
 
         <button
           type="button"
+          className={`wl-chip wl-chip--slate${isAddArtistOpen ? ' wl-chip--active' : ''}`}
+          onClick={() => setIsAddArtistOpen((prev) => !prev)}
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          {isAddArtistOpen ? 'Close Search' : 'Add Artist'}
+        </button>
+
+        <button
+          type="button"
           className={`wl-chip wl-chip--slate${similarRunning ? ' btn-processing' : ''}`}
           disabled={similarRunning || startSimilar.isPending || isScanning}
           onClick={() => startSimilar.mutate()}
@@ -717,15 +780,21 @@ export function WatchlistPage() {
                 customRuleArtists={customRuleArtists}
                 recentCount={recentReleases.length}
                 globalOverrideActive={globalOverrideActive}
+                activeFilter={attentionFilter}
+                onSelectFilter={(next) =>
+                  setAttentionFilter((prev) => (prev === next ? 'all' : next))
+                }
               />
 
-              <WatchlistAddArtistSearch
-                profileId={profileId}
-                onAddArtist={(artistId, artistName, source) =>
-                  addArtist.mutate({ artistId, artistName, source })
-                }
-                adding={addArtist.isPending}
-              />
+              {isAddArtistOpen ? (
+                <WatchlistAddArtistSearch
+                  profileId={profileId}
+                  onAddArtist={(artistId, artistName, source) =>
+                    addArtist.mutate({ artistId, artistName, source })
+                  }
+                  adding={addArtist.isPending}
+                />
+              ) : null}
 
               <WatchlistRecentReleasesPanel
                 releases={recentReleases}
@@ -824,7 +893,10 @@ export function WatchlistPage() {
                             void navigate({ search: (prev) => ({ ...prev, configId: artistId }) })
                           }
                           onOpenDetail={() => {
-                            if (artistId) setActiveArtistId(artistId);
+                            if (artistId) {
+                              setActiveArtistId(artistId);
+                              setIsInspectorOpen(true);
+                            }
                           }}
                           onOpenFullDetail={() =>
                             artistId &&
@@ -838,21 +910,48 @@ export function WatchlistPage() {
                     })}
                   </div>
                 </div>
-                <WatchlistArtistInspector
-                  profileId={profileId}
-                  artist={activeArtist}
-                  globalOverrideActive={globalOverrideActive}
-                  onOpenConfig={(artistId) =>
-                    void navigate({ search: (prev) => ({ ...prev, configId: artistId }) })
-                  }
-                  onOpenDetail={(artistId) =>
-                    void navigate({ search: (prev) => ({ ...prev, detailId: artistId }) })
-                  }
-                  onRemove={(artistId) => {
-                    const name = activeArtist?.artist_name ?? 'this artist';
-                    void onRemoveOne(artistId, name);
-                  }}
-                />
+
+                {isInspectorOpen && activeArtist ? (
+                  <div
+                    className="watchlist-inspector-backdrop"
+                    onClick={() => setIsInspectorOpen(false)}
+                  >
+                    <div
+                      className="watchlist-inspector-drawer"
+                      onClick={(event) => event.stopPropagation()}
+                      role="dialog"
+                      aria-label={`Managing ${activeArtist.artist_name}`}
+                    >
+                      <div className="watchlist-inspector-header">
+                        <span className="watchlist-panel-kicker">Artist Inspector</span>
+                        <button
+                          type="button"
+                          className="watchlist-inspector-close-btn"
+                          aria-label="Close inspector"
+                          onClick={() => setIsInspectorOpen(false)}
+                        >
+                          ✕
+                        </button>
+                      </div>
+                      <WatchlistArtistInspector
+                        profileId={profileId}
+                        artist={activeArtist}
+                        globalOverrideActive={globalOverrideActive}
+                        onOpenConfig={(artistId) =>
+                          void navigate({ search: (prev) => ({ ...prev, configId: artistId }) })
+                        }
+                        onOpenDetail={(artistId) =>
+                          void navigate({ search: (prev) => ({ ...prev, detailId: artistId }) })
+                        }
+                        onRemove={(artistId) => {
+                          const name = activeArtist?.artist_name ?? 'this artist';
+                          void onRemoveOne(artistId, name);
+                          setIsInspectorOpen(false);
+                        }}
+                      />
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </>
           )}
@@ -1070,6 +1169,8 @@ function WatchlistAttentionStrip({
   customRuleArtists,
   recentCount,
   globalOverrideActive,
+  activeFilter = 'all',
+  onSelectFilter,
 }: {
   total: number;
   neverScanned: number;
@@ -1077,13 +1178,21 @@ function WatchlistAttentionStrip({
   customRuleArtists: number;
   recentCount: number;
   globalOverrideActive: boolean;
+  activeFilter?: 'all' | 'fresh' | 'never' | 'stale' | 'custom';
+  onSelectFilter?: (filter: 'all' | 'fresh' | 'never' | 'stale' | 'custom') => void;
 }) {
-  const items = [
-    { label: 'Watched artists', value: total, tone: 'neutral' },
-    { label: 'Fresh releases', value: recentCount, tone: 'green' },
-    { label: 'Never scanned', value: neverScanned, tone: neverScanned > 0 ? 'amber' : 'neutral' },
-    { label: 'Stale scans', value: staleArtists, tone: staleArtists > 0 ? 'amber' : 'neutral' },
+  const items: {
+    id: 'all' | 'fresh' | 'never' | 'stale' | 'custom';
+    label: string;
+    value: number;
+    tone: string;
+  }[] = [
+    { id: 'all', label: 'Watched artists', value: total, tone: 'neutral' },
+    { id: 'fresh', label: 'Fresh releases', value: recentCount, tone: 'green' },
+    { id: 'never', label: 'Never scanned', value: neverScanned, tone: neverScanned > 0 ? 'amber' : 'neutral' },
+    { id: 'stale', label: 'Stale scans', value: staleArtists, tone: staleArtists > 0 ? 'amber' : 'neutral' },
     {
+      id: 'custom',
       label: 'Custom rules',
       value: customRuleArtists,
       tone: customRuleArtists > 0 ? 'blue' : 'neutral',
@@ -1093,15 +1202,28 @@ function WatchlistAttentionStrip({
   return (
     <div className="watchlist-attention-strip">
       {items.map((item) => (
-        <div key={item.label} className={`watchlist-attention-card is-${item.tone}`}>
-          <span className="watchlist-attention-value">{item.value}</span>
+        <div
+          key={item.label}
+          className={`watchlist-attention-card is-${item.tone}${
+            activeFilter === item.id ? ' is-active' : ''
+          }`}
+          role="button"
+          tabIndex={0}
+          onClick={() => onSelectFilter?.(item.id)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              onSelectFilter?.(item.id);
+            }
+          }}
+        >
           <span className="watchlist-attention-label">{item.label}</span>
+          <span className="watchlist-attention-value">{item.value}</span>
         </div>
       ))}
       {globalOverrideActive ? (
         <div className="watchlist-attention-card is-amber watchlist-attention-card--wide">
-          <span className="watchlist-attention-value">ON</span>
           <span className="watchlist-attention-label">Global override active</span>
+          <span className="watchlist-attention-value">ON</span>
         </div>
       ) : null}
     </div>

--- a/webui/src/routes/watchlist/-watchlist.scan.test.ts
+++ b/webui/src/routes/watchlist/-watchlist.scan.test.ts
@@ -38,7 +38,12 @@ describe('scanProgressText / scanProgressPercent', () => {
   it('counts from one, not zero', () => {
     // current_artist_index is 0-based; the first artist reads "1 / 40".
     expect(scanProgressText({ current_artist_index: 0, total_artists: 40 })).toBe('1 / 40 artists');
-    expect(scanProgressPercent({ current_artist_index: 0, total_artists: 40 })).toBe(3);
+    // 12, not 3: the artist loop now occupies 10-100 because the source-matching
+    // phase that runs before it owns the first ten. Without that split the bar
+    // jumped BACKWARDS - matching finishing at 10%, then artist 1 restarting at
+    // 3% - which looks more broken than starting slightly high. A scan with
+    // nothing to match skips the phase entirely and simply opens at 10.
+    expect(scanProgressPercent({ current_artist_index: 0, total_artists: 40 })).toBe(12);
   });
 
   it('never exceeds the total', () => {
@@ -114,5 +119,56 @@ describe('scanCompletionMessage', () => {
     expect(scanCompletionMessage({})).toBe(
       'Scan completed: 0/0 artists scanned, no new tracks found',
     );
+  });
+});
+
+describe('the source-matching phase', () => {
+  // Every artist is looked up on every other metadata provider BEFORE the
+  // artist loop starts. For a few hundred artists that is the longest part of a
+  // scan, and nothing about the artist counter moves during it — so the page
+  // read "0 / 379 artists" the whole time and the scan looked hung (#1240).
+  const matching = (done: number, total = 379, source = 'deezer') => ({
+    current_phase: 'matching_sources',
+    matching_source: source,
+    matching_artists_done: done,
+    matching_artists_total: total,
+    current_artist_index: 0,
+    total_artists: 379,
+  });
+
+  it('counts the artists being matched, not the ones being scanned', () => {
+    expect(scanProgressText(matching(120))).toBe('Matching 120 / 379 artists to deezer');
+  });
+
+  it('does not fall back to the frozen artist counter', () => {
+    expect(scanProgressText(matching(120))).not.toContain('1 / 379 artists');
+  });
+
+  it('names the phase readably', () => {
+    expect(prettyScanPhase('matching_sources')).toBe('Matching artists to sources…');
+  });
+
+  it('drops the source when it is not known yet', () => {
+    expect(scanProgressText(matching(5, 379, ''))).toBe('Matching 5 / 379 artists');
+  });
+
+  it('moves the bar while matching', () => {
+    expect(scanProgressPercent(matching(0))).toBe(0);
+    expect(scanProgressPercent(matching(379))).toBe(10);
+  });
+
+  it('never sends the bar backwards when the artist loop starts', () => {
+    // matching finishes at 10; artist 1 of 379 must not restart below it
+    const matchingDone = scanProgressPercent(matching(379));
+    const firstArtist = scanProgressPercent({ current_artist_index: 0, total_artists: 379 });
+    expect(firstArtist).toBeGreaterThanOrEqual(matchingDone);
+  });
+
+  it('still reaches 100 on the last artist', () => {
+    expect(scanProgressPercent({ current_artist_index: 378, total_artists: 379 })).toBe(100);
+  });
+
+  it('leaves a normal scan frame alone', () => {
+    expect(scanProgressText({ current_artist_index: 2, total_artists: 40 })).toBe('3 / 40 artists');
   });
 });

--- a/webui/src/routes/watchlist/-watchlist.scan.ts
+++ b/webui/src/routes/watchlist/-watchlist.scan.ts
@@ -15,6 +15,15 @@ export interface WatchlistScanFrame extends WatchlistScanStatusResponse {
   current_phase?: string | null;
   current_artist_index?: number | null;
   total_artists?: number | null;
+  /** Source-matching phase: every artist is looked up on every other
+   *  metadata provider before the artist loop starts. For a few hundred
+   *  artists that is the longest part of a scan, and the artist counter has
+   *  not begun, so these are the only numbers that move during it (#1240). */
+  matching_source?: string | null;
+  matching_source_number?: number | null;
+  matching_source_total?: number | null;
+  matching_artists_done?: number | null;
+  matching_artists_total?: number | null;
   tracks_found_this_scan?: number | null;
   tracks_added_this_scan?: number | null;
   recent_wishlist_additions?: {
@@ -50,16 +59,48 @@ export function prettyScanPhase(phase: string | null | undefined): string {
     scanning_labels: 'Scanning record labels…',
     populating_discovery_pool: 'Populating discovery…',
     updating_listenbrainz: 'Updating ListenBrainz…',
+    matching_sources: 'Matching artists to sources…',
   };
   return map[phase] || phase.replace(/_/g, ' ');
 }
 
 /** Just the fields the progress helpers read, so callers (and tests) do not
  *  have to build a whole frame. */
-export type ScanProgressFields = Pick<WatchlistScanFrame, 'current_artist_index' | 'total_artists'>;
+export type ScanProgressFields = Pick<
+  WatchlistScanFrame,
+  | 'current_artist_index'
+  | 'total_artists'
+  | 'current_phase'
+  | 'matching_source'
+  | 'matching_artists_done'
+  | 'matching_artists_total'
+>;
+
+/** True while the scan is matching artists to sources, before the artist loop. */
+function isMatchingSources(frame: ScanProgressFields): boolean {
+  return frame.current_phase === 'matching_sources';
+}
+
+/** The matching phase owns the first tenth of the bar; artists own the rest.
+ *  Splitting it this way is what stops the bar jumping BACKWARDS when the
+ *  artist loop finally starts at index 1. */
+const MATCHING_BAND = 10;
 
 /** "3 / 40 artists", or '' when the total is not known yet. */
 export function scanProgressText(frame: ScanProgressFields): string {
+  // During source matching the artist counter has not started. Reporting it
+  // would read '0 / 379 artists' for the whole phase, which is exactly what
+  // made a working scan look like a hung one.
+  if (isMatchingSources(frame)) {
+    const matched = frame.matching_artists_total || 0;
+    if (matched) {
+      const done = Math.min(frame.matching_artists_done || 0, matched);
+      const source = frame.matching_source;
+      return source
+        ? `Matching ${done} / ${matched} artists to ${source}`
+        : `Matching ${done} / ${matched} artists`;
+    }
+  }
   const total = frame.total_artists || 0;
   if (!total) return '';
   const index = Math.min((frame.current_artist_index || 0) + 1, total);
@@ -68,10 +109,16 @@ export function scanProgressText(frame: ScanProgressFields): string {
 
 /** Progress bar width as a percentage. 0 when the total is unknown. */
 export function scanProgressPercent(frame: ScanProgressFields): number {
+  if (isMatchingSources(frame)) {
+    const matched = frame.matching_artists_total || 0;
+    if (!matched) return 0;
+    const done = Math.min(frame.matching_artists_done || 0, matched);
+    return Math.round((MATCHING_BAND * done) / matched);
+  }
   const total = frame.total_artists || 0;
   if (!total) return 0;
   const index = Math.min((frame.current_artist_index || 0) + 1, total);
-  return Math.round((100 * index) / total);
+  return MATCHING_BAND + Math.round(((100 - MATCHING_BAND) * index) / total);
 }
 
 /**

--- a/webui/src/routes/wishlist/-ui/wishlist-audiobooks.layout.test.ts
+++ b/webui/src/routes/wishlist/-ui/wishlist-audiobooks.layout.test.ts
@@ -1,0 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The audiobook wishlist is a wall of covers, like the video wishlist.
+ *
+ * It used to be a vertical list of rows with a 62px thumbnail on the left,
+ * which reads as a spreadsheet: the artwork was decoration and the text carried
+ * everything. The video wishlist does the opposite and is the model — a grid of
+ * posters, art dominant, title and meta underneath, the card itself almost
+ * invisible until pointed at (.vwsh-movie / .vwsh-movie-art, video-side.css).
+ *
+ * Read from the source because the failure mode is visual and structural: every
+ * control still present, every class still styled, and the geometry matching
+ * the page it is meant to resemble.
+ */
+
+const HERE = __dirname;
+const TSX = readFileSync(join(HERE, 'wishlist-audiobooks.tsx'), 'utf8');
+const CSS = readFileSync(join(HERE, 'wishlist-audiobooks.module.css'), 'utf8');
+const VIDEO_CSS = readFileSync(
+  join(HERE, '..', '..', '..', '..', 'static', 'video', 'video-side.css'),
+  'utf8',
+);
+
+function rule(name: string, source = CSS): string {
+  const match = new RegExp(`\\.${name}\\s*\\{([^}]*)\\}`).exec(source);
+  return match ? match[1] : '';
+}
+
+describe('the cards are a poster grid', () => {
+  it('renders a grid, not a stack of rows', () => {
+    expect(TSX).toContain('styles.grid');
+    expect(TSX).not.toContain('styles.rows');
+    expect(rule('grid')).toContain('grid-template-columns');
+  });
+
+  it('gives the cover its own square tile', () => {
+    // a 62px thumbnail was the whole complaint
+    const art = rule('art');
+    expect(art).toContain('aspect-ratio: 1');
+    expect(art).toContain('overflow: hidden');
+    expect(rule('cover')).toContain('object-fit: cover');
+  });
+
+  it('puts the text under the art rather than beside it', () => {
+    const card = rule('card');
+    expect(card).toContain('flex-direction: column');
+  });
+
+  it('matches the video wishlist geometry it is modelled on', () => {
+    // same auto-fill grid and the same hover lift, so the two pages read as
+    // one product rather than two
+    expect(rule('grid')).toContain('auto-fill');
+    expect(VIDEO_CSS).toContain('auto-fill');
+    expect(rule('card:hover .art', CSS) || CSS).toContain('translateY(-3px)');
+    expect(VIDEO_CSS).toContain('translateY(-3px)');
+  });
+});
+
+describe('nothing was lost in the rebuild', () => {
+  it('keeps every control the list had', () => {
+    for (const label of ['Find releases', 'Remove']) {
+      expect(TSX).toContain(label);
+    }
+    expect(TSX).toContain('changeNarratorMode');
+  });
+
+  it('still shows the status, now on the artwork', () => {
+    expect(TSX).toContain('STATUS_LABELS[item.status]');
+    expect(rule('badge')).toContain('position: absolute');
+  });
+
+  it('still shows the attempt trail and the last error', () => {
+    expect(TSX).toContain('attempt_count');
+    expect(TSX).toContain('last_error');
+  });
+
+  it('keeps the series line', () => {
+    expect(TSX).toContain('series_title');
+  });
+});
+
+describe('the controls stay usable', () => {
+  it('reveals the actions on hover and on keyboard focus', () => {
+    // focus-within matters: hover-only would hide them from the keyboard
+    expect(CSS).toContain('.card:focus-within .actions');
+  });
+
+  it('shows them outright where there is no hover', () => {
+    expect(CSS).toContain('@media (hover: none)');
+  });
+
+  it('gives the cover link a visible focus ring', () => {
+    expect(rule('coverLink:focus-visible', CSS) || CSS).toContain('outline');
+  });
+});
+
+describe('every class the markup uses is styled', () => {
+  it('has no unstyled class', () => {
+    const used = [...TSX.matchAll(/styles\.([A-Za-z]+)/g)].map((m) => m[1]);
+    const defined = new Set([...CSS.matchAll(/^\.([A-Za-z]+)/gm)].map((m) => m[1]));
+    const missing = [...new Set(used)].filter((name) => !defined.has(name));
+    expect(missing, 'these render unstyled').toEqual([]);
+  });
+});

--- a/webui/src/routes/wishlist/-ui/wishlist-audiobooks.module.css
+++ b/webui/src/routes/wishlist/-ui/wishlist-audiobooks.module.css
@@ -134,158 +134,6 @@
   opacity: 0.72;
 }
 
-/* ── Rows ───────────────────────────────────────────────────────────────── */
-
-.rows {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.row {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 12px 16px 12px 12px;
-  border-radius: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-top-color: rgba(255, 255, 255, 0.13);
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.06) 0%,
-    rgba(255, 255, 255, 0.025) 100%
-  );
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease,
-    box-shadow 0.18s ease;
-}
-
-.row:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-  transform: translateY(-2px);
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.4);
-}
-
-.coverLink {
-  flex-shrink: 0;
-  display: block;
-}
-
-.cover {
-  width: 62px;
-  height: 62px;
-  border-radius: 12px;
-  object-fit: cover;
-  display: block;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
-}
-
-.coverBlank {
-  background: linear-gradient(135deg, rgba(var(--accent-rgb), 0.28), rgba(255, 255, 255, 0.04));
-}
-
-.meta {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 0;
-  flex: 1;
-}
-
-.title {
-  font-size: 14.5px;
-  font-weight: 650;
-  letter-spacing: -0.01em;
-  color: #ffffff;
-  text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.title:hover {
-  color: rgba(var(--accent-rgb), 1);
-}
-
-.byline {
-  font-size: 12.5px;
-  color: rgba(255, 255, 255, 0.55);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.series {
-  font-size: 11.5px;
-  color: rgba(var(--accent-rgb), 0.85);
-}
-
-/* The waiting is the feature, so it says so out loud. */
-.trail {
-  margin-top: 3px;
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.34);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.status {
-  flex-shrink: 0;
-  padding: 5px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.05);
-  font-size: 11px;
-  font-weight: 620;
-  color: rgba(255, 255, 255, 0.7);
-  white-space: nowrap;
-}
-
-.statusActive {
-  border-color: rgba(var(--accent-rgb), 0.5);
-  background: rgba(var(--accent-rgb), 0.16);
-  color: #ffffff;
-}
-
-.statusDone {
-  border-color: rgba(80, 200, 130, 0.45);
-  background: rgba(80, 200, 130, 0.15);
-  color: #9ff0c2;
-}
-
-.rowActions {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.action {
-  padding: 7px 13px;
-  border-radius: 9px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(255, 255, 255, 0.05);
-  color: rgba(255, 255, 255, 0.75);
-  font-size: 12px;
-  font-weight: 560;
-  font-family: inherit;
-  cursor: pointer;
-  white-space: nowrap;
-  transition:
-    background 0.15s ease,
-    color 0.15s ease;
-}
-
-.action:hover {
-  background: rgba(255, 255, 255, 0.12);
-  color: #ffffff;
-}
-
 /* ── States ─────────────────────────────────────────────────────────────── */
 
 .skeleton {
@@ -327,6 +175,7 @@
 .empty p {
   margin: 0 auto 18px;
   max-width: 460px;
+  letter-spacing: -0.01em;
   font-size: 13.5px;
   line-height: 1.6;
   color: rgba(255, 255, 255, 0.55);
@@ -350,12 +199,232 @@
   background: rgba(255, 255, 255, 0.17);
 }
 
-@media (max-width: 860px) {
-  .row {
-    flex-wrap: wrap;
-  }
+/* ==========================================================================
+   The wishlist as a wall of covers, not a list of rows.
+   ==========================================================================
+   This was a vertical list with a 62px thumbnail on the left, which reads as a
+   spreadsheet: the artwork was decoration and the text carried everything.
 
-  .rowActions {
-    width: 100%;
+   The video wishlist does the opposite and is the model here — a grid of
+   posters, art dominant, title and meta underneath, the card itself almost
+   invisible until you point at it (.vwsh-movie / .vwsh-movie-art in
+   video-side.css). Same geometry, same hover, one difference: an audiobook
+   cover is SQUARE where a film poster is 2:3.
+   ========================================================================== */
+
+.grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  /* matches the video wishlist's movie grid */
+  grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+  gap: 26px 18px;
+}
+
+.card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.coverLink {
+  display: block;
+  border-radius: 12px;
+}
+
+.coverLink:focus-visible {
+  outline: 2px solid rgba(var(--accent-rgb), 0.9);
+  outline-offset: 3px;
+}
+
+.art {
+  position: relative;
+  /* square: an audiobook cover is not a film poster */
+  aspect-ratio: 1;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #16161d;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  transition:
+    border-color 0.18s ease,
+    transform 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.card:hover .art {
+  border-color: rgba(var(--accent-rgb), 0.48);
+  transform: translateY(-3px);
+  box-shadow:
+    0 14px 34px rgba(0, 0, 0, 0.34),
+    0 0 0 1px rgba(var(--accent-rgb), 0.12);
+}
+
+.cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.coverBlank {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 34px;
+  opacity: 0.4;
+}
+
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(0, 0, 0, 0.5), transparent 45%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.card:hover .scrim {
+  opacity: 1;
+}
+
+/* the state lives ON the art, so a wall of covers is still scannable */
+.badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: rgba(255, 255, 255, 0.86);
+  background: rgba(0, 0, 0, 0.62);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  white-space: nowrap;
+}
+
+.badgeActive {
+  background: rgba(var(--accent-rgb), 0.9);
+  border-color: transparent;
+  color: #0b0b0b;
+}
+
+.badgeDone {
+  background: rgba(34, 197, 94, 0.88);
+  border-color: transparent;
+  color: #05210f;
+}
+
+.badgeFailed {
+  background: rgba(239, 68, 68, 0.85);
+  border-color: transparent;
+  color: #fff;
+}
+
+.info {
+  padding: 10px 2px 0;
+  min-width: 0;
+}
+
+.title {
+  display: block;
+  letter-spacing: -0.01em;
+  font-size: 13.5px;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.title:hover {
+  color: var(--accent);
+}
+
+.byline,
+.series,
+.trail {
+  display: block;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.series {
+  color: rgba(255, 255, 255, 0.36);
+}
+
+.trail {
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 11px;
+}
+
+/* the actions do not sit on the artwork, and do not take a row of their own
+   until they are wanted — a wall of covers should read as covers */
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  opacity: 0;
+  transition: opacity 0.18s ease;
+}
+
+.card:hover .actions,
+.card:focus-within .actions {
+  opacity: 1;
+}
+
+/* touch has no hover, so there is nothing to reveal */
+@media (hover: none) {
+  .actions {
+    opacity: 1;
+  }
+}
+
+.action {
+  font-family: inherit;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 9px;
+  border-radius: 999px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.action:hover {
+  background: rgba(255, 255, 255, 0.09);
+  color: #fff;
+}
+
+.actionDanger:hover {
+  background: rgba(239, 68, 68, 0.85);
+  border-color: transparent;
+  color: #fff;
+}
+
+@media (max-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+    gap: 20px 14px;
   }
 }

--- a/webui/src/routes/wishlist/-ui/wishlist-audiobooks.tsx
+++ b/webui/src/routes/wishlist/-ui/wishlist-audiobooks.tsx
@@ -22,15 +22,17 @@ import styles from './wishlist-audiobooks.module.css';
 const FILTERS: { key: AudiobookWishlistStatus | 'all'; label: string }[] = [
   { key: 'all', label: 'All' },
   { key: 'wanted', label: 'Looking' },
-  { key: 'grabbed', label: 'Downloading' },
+  { key: 'grabbed', label: 'In progress' },
   { key: 'done', label: 'Got it' },
+  { key: 'cancelled', label: 'Cancelled' },
   { key: 'failed', label: 'Not found yet' },
 ];
 
 const STATUS_LABELS: Record<AudiobookWishlistStatus, string> = {
   wanted: 'Looking',
   searching: 'Searching now',
-  grabbed: 'Sent to downloads',
+  grabbed: 'Queued',
+  cancelled: 'Cancelled',
   done: 'In your library',
   failed: 'Not found yet',
 };
@@ -78,6 +80,8 @@ export function WishlistAudiobooks() {
 
   useEffect(() => {
     void load();
+    const timer = window.setInterval(() => void load(), 20000);
+    return () => window.clearInterval(timer);
   }, [load]);
 
   const shown = useMemo(
@@ -224,7 +228,17 @@ export function WishlistAudiobooks() {
                             : ''
                     }`}
                   >
-                    {STATUS_LABELS[item.status] ?? item.status}
+                    {item.status === 'grabbed'
+                      ? {
+                          downloading: 'Downloading',
+                          queued: 'Queued',
+                          paused: 'Paused',
+                          unavailable: 'Waiting for client',
+                          staged: 'Checking files',
+                          importing: 'Importing',
+                          cancelled: 'Cancelled',
+                        }[item.download_status || ''] || 'Waiting for client'
+                      : (STATUS_LABELS[item.status] ?? item.status)}
                   </span>
                 </div>
               </Link>

--- a/webui/src/routes/wishlist/-ui/wishlist-audiobooks.tsx
+++ b/webui/src/routes/wishlist/-ui/wishlist-audiobooks.tsx
@@ -195,64 +195,70 @@ export function WishlistAudiobooks() {
           </Link>
         </div>
       ) : (
-        <ul className={styles.rows}>
+        <ul className={styles.grid}>
           {shown.map((item) => (
-            <li className={styles.row} key={item.asin}>
+            <li className={styles.card} key={item.asin}>
               <Link
                 to="/audiobooks/$asin"
                 params={{ asin: item.asin }}
                 className={styles.coverLink}
+                aria-label={item.title}
               >
-                {item.cover_url ? (
-                  <img className={styles.cover} src={item.cover_url} alt="" loading="lazy" />
-                ) : (
-                  <span className={`${styles.cover} ${styles.coverBlank}`} aria-hidden="true" />
-                )}
+                <div className={styles.art}>
+                  {item.cover_url ? (
+                    <img className={styles.cover} src={item.cover_url} alt="" loading="lazy" />
+                  ) : (
+                    <span className={styles.coverBlank} aria-hidden="true">
+                      &#9835;
+                    </span>
+                  )}
+                  <span className={styles.scrim} aria-hidden="true" />
+                  <span
+                    className={`${styles.badge} ${
+                      item.status === 'done'
+                        ? styles.badgeDone
+                        : item.status === 'grabbed'
+                          ? styles.badgeActive
+                          : item.status === 'failed'
+                            ? styles.badgeFailed
+                            : ''
+                    }`}
+                  >
+                    {STATUS_LABELS[item.status] ?? item.status}
+                  </span>
+                </div>
               </Link>
 
-              <div className={styles.meta}>
+              <div className={styles.info}>
                 <Link to="/audiobooks/$asin" params={{ asin: item.asin }} className={styles.title}>
                   {item.title}
                 </Link>
-                <span className={styles.byline}>
-                  {item.authors.join(', ')}
-                  {item.narrators.length > 0 && ` · Narrated by ${item.narrators[0]}`}
-                </span>
+                <span className={styles.byline}>{item.authors.join(', ')}</span>
                 {item.series_title && (
                   <span className={styles.series}>
                     {item.series_sequence ? `Book ${item.series_sequence} of ` : ''}
                     {item.series_title}
                   </span>
                 )}
-                <span className={styles.trail}>
+                <span className={styles.trail} title={item.last_error || undefined}>
                   {item.attempt_count === 0
                     ? 'Not looked for yet'
-                    : `Looked ${item.attempt_count}× · last ${relativeTime(item.last_attempt_at)}`}
-                  {item.last_error ? ` · ${item.last_error}` : ''}
+                    : `Looked ${item.attempt_count}\u00d7 \u00b7 last ${relativeTime(item.last_attempt_at)}`}
+                  {item.last_error ? ` \u00b7 ${item.last_error}` : ''}
                 </span>
               </div>
 
-              <span
-                className={`${styles.status} ${
-                  item.status === 'done'
-                    ? styles.statusDone
-                    : item.status === 'grabbed'
-                      ? styles.statusActive
-                      : ''
-                }`}
-              >
-                {STATUS_LABELS[item.status] ?? item.status}
-              </span>
-
-              <div className={styles.rowActions}>
+              {/* the controls stay off the artwork and appear on hover, the way
+                  the video wishlist keeps its poster clean */}
+              <div className={styles.actions}>
                 {item.narrators.length > 0 && (
                   <button
                     type="button"
                     className={styles.action}
                     title={
                       item.narrator_mode === 'exact'
-                        ? `Only ${item.narrators[0]}'s reading will do — click to accept any narrator`
-                        : 'Any narrator will do — click to hold out for the one you picked'
+                        ? `Only ${item.narrators[0]}'s reading will do \u2014 click to accept any narrator`
+                        : 'Any narrator will do \u2014 click to hold out for the one you picked'
                     }
                     onClick={() =>
                       void changeNarratorMode(
@@ -261,7 +267,7 @@ export function WishlistAudiobooks() {
                       )
                     }
                   >
-                    {item.narrator_mode === 'exact' ? `${item.narrators[0]} only` : 'Any narrator'}
+                    {item.narrator_mode === 'exact' ? 'Narrator locked' : 'Any narrator'}
                   </button>
                 )}
                 <button
@@ -273,7 +279,7 @@ export function WishlistAudiobooks() {
                 </button>
                 <button
                   type="button"
-                  className={styles.action}
+                  className={`${styles.action} ${styles.actionDanger}`}
                   onClick={() => void remove(item.asin)}
                 >
                   Remove

--- a/webui/src/test/chat-connection.test.ts
+++ b/webui/src/test/chat-connection.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, it, vi } from 'vitest';
+
+import { extractFunction } from './vanilla-extract';
+const source = readFileSync(resolve(process.cwd(), 'static/chat.js'), 'utf8');
+it('turns a failed network request into a recoverable send result without retrying', async () => {
+  const fetcher = vi.fn().mockRejectedValue(new Error('offline'));
+  const post = new Function('fetch', `${extractFunction('postJSON', source)};return postJSON;`)(
+    fetcher,
+  );
+  const result = await post('/api/chat/conversations/peer', { message: 'draft' });
+  expect(result.ok).toBe(false);
+  expect(result.body.error).toContain('not confirmed');
+  expect(fetcher).toHaveBeenCalledOnce();
+});
+it('restores a failed draft without overwriting text typed while the request was pending', async () => {
+  const input = document.createElement('textarea');
+  input.value = 'original message';
+  const state = { canSend: true, view: 'pm', pmUser: 'peer' };
+  let finish!: (value: unknown) => void;
+  const pending = new Promise((resolve) => {
+    finish = resolve;
+  });
+  const post = vi.fn(() => pending);
+  const send = new Function(
+    'q',
+    'state',
+    'postJSON',
+    '_arcOn',
+    'showToast',
+    'renderComposer',
+    `${extractFunction('send', source)};return send;`,
+  )(
+    () => input,
+    state,
+    post,
+    () => false,
+    vi.fn(),
+    vi.fn(),
+  );
+  send();
+  expect(input.value).toBe('');
+  input.value = 'new words';
+  finish({ ok: false, body: { code: 'slskd_disconnected', error: 'Reconnect in slskd' } });
+  await pending;
+  await Promise.resolve();
+  expect(input.value).toBe('original message\nnew words');
+  expect(state.canSend).toBe(false);
+  expect(post).toHaveBeenCalledOnce();
+});

--- a/webui/src/test/settings-library-tabs.test.ts
+++ b/webui/src/test/settings-library-tabs.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+const source = readFileSync(resolve(process.cwd(), 'static/settings.js'), 'utf8');
+const block = source.slice(
+  source.indexOf('function switchLibraryMediaTab('),
+  source.indexOf('// Settings redesign'),
+);
+let tabs: {
+  switchLibraryMediaTab: (tab: Element) => void;
+  handleLibraryMediaTabKey: (event: KeyboardEvent & { currentTarget: Element }) => void;
+};
+beforeEach(() => {
+  const parsed = new DOMParser().parseFromString(html, 'text/html');
+  document.body.innerHTML = '<div id="settings-page"></div>';
+  for (const card of parsed.querySelectorAll('.stg-media-card'))
+    document.getElementById('settings-page')!.append(card.cloneNode(true));
+  tabs = new Function(
+    'document',
+    `${block};return {switchLibraryMediaTab,handleLibraryMediaTabKey}`,
+  )(document);
+});
+describe('Library settings media tabs', () => {
+  it('switches only its own card and preserves unsaved fields', () => {
+    const music = document.getElementById('transfer-path') as HTMLInputElement;
+    music.value = '/unsaved/music';
+    tabs.switchLibraryMediaTab(document.getElementById('folders-video-tab')!);
+    expect(document.getElementById('folders-music-panel')!.hidden).toBe(true);
+    expect(document.getElementById('folders-video-panel')!.hidden).toBe(false);
+    expect(document.getElementById('organization-music-panel')!.hidden).toBe(false);
+    tabs.switchLibraryMediaTab(document.getElementById('folders-music-tab')!);
+    expect(document.getElementById('transfer-path')).toBe(music);
+    expect(music.value).toBe('/unsaved/music');
+  });
+  it('supports arrow keys with a single active tab stop', () => {
+    const music = document.getElementById('organization-music-tab')!;
+    tabs.handleLibraryMediaTabKey({
+      key: 'ArrowRight',
+      currentTarget: music,
+      preventDefault() {},
+    } as KeyboardEvent & { currentTarget: Element });
+    const video = document.getElementById('organization-video-tab')!;
+    expect(document.activeElement).toBe(video);
+    expect(video.getAttribute('aria-selected')).toBe('true');
+    expect(music.tabIndex).toBe(-1);
+  });
+  it('keeps all four sets of controls in exactly one panel each', () => {
+    for (const [id, panel] of [
+      ['transfer-path', 'folders-music-panel'],
+      ['video-movies-path', 'folders-video-panel'],
+      ['template-album-path', 'organization-music-panel'],
+      ['vo-movie-template', 'organization-video-panel'],
+    ]) {
+      expect(document.querySelectorAll(`#${id}`).length).toBe(1);
+      expect(document.getElementById(id)!.closest('[role="tabpanel"]')!.id).toBe(panel);
+    }
+  });
+});

--- a/webui/src/test/settings-navigation.test.ts
+++ b/webui/src/test/settings-navigation.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, expect, it, vi } from 'vitest';
+const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+const source = readFileSync(resolve(process.cwd(), 'static/settings.js'), 'utf8');
+const block = source.slice(
+  source.indexOf('function switchSettingsTab('),
+  source.indexOf('window.filterSettings = filterSettings;'),
+);
+let nav: { switchSettingsTab: (tab: string) => void; filterSettings: (query: string) => void };
+beforeEach(() => {
+  const parsed = new DOMParser().parseFromString(html, 'text/html');
+  document.body.replaceChildren(parsed.getElementById('settings-page')!);
+  Element.prototype.scrollIntoView = vi.fn();
+  nav = new Function(
+    'document',
+    'window',
+    'autoTestSourcesOnce',
+    '_logViewerStop',
+    '_logViewerInit',
+    'switchLibraryMediaTab',
+    `${block}; return {switchSettingsTab, filterSettings};`,
+  )(document, window, vi.fn(), vi.fn(), vi.fn(), vi.fn());
+});
+it('uses one category bar instead of a second sidebar', () => {
+  expect(document.querySelectorAll('.stg-category-nav .stg-tabbar')).toHaveLength(1);
+  expect(document.querySelectorAll('.stg-category-nav .stg-tab')).toHaveLength(8);
+  expect(document.querySelector('.stg-nav-rail')).toBeNull();
+});
+it('search leaves mounted forms and their visibility unchanged until selecting a result', () => {
+  nav.switchSettingsTab('connections');
+  const input = document.getElementById('video-movies-path') as HTMLInputElement;
+  input.value = '/unsaved';
+  const section = input.closest('[data-stg]') as HTMLElement;
+  const display = section.style.display;
+  nav.filterSettings('Additional Movie Libraries');
+  expect(section.style.display).toBe(display);
+  expect(document.getElementById('video-movies-path')).toBe(input);
+  const shown = vi.fn();
+  document.addEventListener('soulsync:library-settings-shown', shown, { once: true });
+  (document.querySelector('#stg-search-results button') as HTMLButtonElement).click();
+  expect(shown).toHaveBeenCalledOnce();
+  expect(document.querySelector('.stg-tab[aria-current="page"]')?.getAttribute('data-tab')).toBe(
+    'library',
+  );
+  expect(input.value).toBe('/unsaved');
+});
+it('has an empty state and clearing search does not switch categories', () => {
+  nav.switchSettingsTab('library');
+  nav.filterSettings('no-such-setting-xyz');
+  expect(document.querySelector('#stg-search-results [role="status"]')?.textContent).toContain(
+    'No settings found',
+  );
+  nav.filterSettings('');
+  expect((document.getElementById('stg-search-results') as HTMLElement).hidden).toBe(true);
+  expect(document.querySelector('.stg-tab.active')?.getAttribute('data-tab')).toBe('library');
+});

--- a/webui/src/test/settings-video-library-load.test.ts
+++ b/webui/src/test/settings-video-library-load.test.ts
@@ -16,6 +16,8 @@ function setup() {
                 download_path: '/downloads',
                 movies_path: '/movies',
                 tv_path: '/tv',
+                movies_additional_paths: ['/movies2'],
+                tv_additional_paths: ['/tv2'],
                 youtube_path: '/youtube',
               },
         ),
@@ -61,4 +63,29 @@ describe('shared video Library initialization', () => {
     );
     expect((doc.getElementById('video-movies-path') as HTMLInputElement).value).toBe('/movies');
   });
+});
+
+it('loads, edits, adds and removes additional video library paths', async () => {
+  const { doc, fetcher, show } = setup();
+  show();
+  await waitFor(() =>
+    expect(doc.querySelector('#video-movies-additional-paths input')).not.toBeNull(),
+  );
+  const movie = doc.querySelector('#video-movies-additional-paths input') as HTMLInputElement;
+  await waitFor(() => expect(movie.disabled).toBe(false));
+  expect(movie.value).toBe('/movies2');
+  const tv = doc.querySelector('#video-tv-additional-paths input') as HTMLInputElement;
+  expect(tv.value).toBe('/tv2');
+  (doc.querySelector('[data-video-add-path="movies"]') as HTMLButtonElement).click();
+  const inputs = doc.querySelectorAll('#video-movies-additional-paths input');
+  expect(inputs.length).toBe(2);
+  (inputs[1] as HTMLInputElement).value = '/movies3';
+  inputs[1].dispatchEvent(new Event('change'));
+  const calls = fetcher.mock.calls as unknown as [string, RequestInit][];
+  let body = JSON.parse(calls.at(-1)![1].body as string);
+  expect(body.movies_additional_paths).toEqual(['/movies2', '/movies3']);
+  expect(body.tv_additional_paths).toEqual(['/tv2']);
+  (doc.querySelector('#video-movies-additional-paths button') as HTMLButtonElement).click();
+  body = JSON.parse(calls.at(-1)![1].body as string);
+  expect(body.movies_additional_paths).toEqual(['/movies3']);
 });

--- a/webui/src/test/settings-video-library-load.test.ts
+++ b/webui/src/test/settings-video-library-load.test.ts
@@ -1,0 +1,64 @@
+import { waitFor } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+const source = readFileSync(resolve(process.cwd(), 'static/video/video-settings.js'), 'utf8');
+const html = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
+function setup() {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const fetcher = vi.fn(
+    async (url: string) =>
+      new Response(
+        JSON.stringify(
+          url.includes('/organization')
+            ? { movie_template: '$title ($year)/$title', episode_template: '$series/$episodetitle' }
+            : {
+                download_path: '/downloads',
+                movies_path: '/movies',
+                tv_path: '/tv',
+                youtube_path: '/youtube',
+              },
+        ),
+      ),
+  );
+  new Function('document', 'window', 'fetch', source)(doc, {}, fetcher);
+  doc.dispatchEvent(new Event('DOMContentLoaded'));
+  return {
+    doc,
+    fetcher,
+    show: () => doc.dispatchEvent(new CustomEvent('soulsync:library-settings-shown')),
+  };
+}
+describe('shared video Library initialization', () => {
+  it('loads folders and organization on a fresh music-side Library visit', async () => {
+    const { doc, fetcher, show } = setup();
+    expect(fetcher).not.toHaveBeenCalled();
+    show();
+    show();
+    expect((doc.getElementById('video-movies-path') as HTMLInputElement).disabled).toBe(true);
+    await waitFor(() =>
+      expect((doc.getElementById('video-movies-path') as HTMLInputElement).disabled).toBe(false),
+    );
+    expect((doc.getElementById('video-movies-path') as HTMLInputElement).value).toBe('/movies');
+    expect((doc.getElementById('vo-movie-template') as HTMLInputElement).value).toBe(
+      '$title ($year)/$title',
+    );
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    (doc.getElementById('video-movies-path') as HTMLInputElement).value = '/unsaved';
+    show();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect((doc.getElementById('video-movies-path') as HTMLInputElement).value).toBe('/unsaved');
+  });
+  it('keeps blank controls disabled after a failed load and allows retry', async () => {
+    const { doc, fetcher, show } = setup();
+    fetcher.mockResolvedValueOnce(new Response('', { status: 503 }));
+    show();
+    await waitFor(() => expect(doc.querySelector('.stg-library-retry')).not.toBeNull());
+    expect((doc.getElementById('video-movies-path') as HTMLInputElement).disabled).toBe(true);
+    (doc.querySelector('.stg-library-retry') as HTMLButtonElement).click();
+    await waitFor(() =>
+      expect((doc.getElementById('video-movies-path') as HTMLInputElement).disabled).toBe(false),
+    );
+    expect((doc.getElementById('video-movies-path') as HTMLInputElement).value).toBe('/movies');
+  });
+});

--- a/webui/static/chat.js
+++ b/webui/static/chat.js
@@ -18,6 +18,7 @@
         rooms: [],               // joined rooms rail [{name, home}]
         canManage: false,        // admin: may join/leave rooms
         canSend: false,
+        connectionError: null,
         configured: null,        // null = unknown yet
         timer: null,
         lastStamp: null,         // newest message timestamp we've rendered
@@ -351,6 +352,8 @@
                 return r.json().catch(function () { return {}; }).then(function (body) {
                     return { ok: r.ok, status: r.status, body: body };
                 });
+            }).catch(function () {
+                return { ok: false, status: 0, body: { error: 'Could not reach SoulSync. Your message was not confirmed; check the conversation before trying again.' } };
             });
     }
 
@@ -3380,6 +3383,7 @@
         // last, because plain mode overrides the placeholder and hides the
         // rich controls this function just showed
         _syncModeBtn();
+        if (state.connectionError) input.placeholder = state.connectionError;
     }
 
     // ── composer toolbar (room only) ─────────────────────────────────────────
@@ -4753,12 +4757,16 @@
         if (state.view === 'room') {
             work = getJSON('/api/chat/room?room=' + encodeURIComponent(state.room || '')).then(function (res) {
                 if (!res.ok) {
+                    state.connectionError = res.body && res.body.error || 'Chat connection unavailable';
+                    state.canSend = false;
+                    renderComposer();
                     pollProblem(res.body && res.body.error
                         ? res.body.error
                         : 'Chat is unavailable right now.', state.renderedOk);
                     return;
                 }
                 pollRecovered();
+                state.connectionError = null;
                 state.canSend = !!res.body.can_send;
                 // auto-join OFF → the server no longer joins for us; show the
                 // join gate instead of the room (popwaffle9000's leave fix).
@@ -4780,11 +4788,15 @@
             work = getJSON('/api/chat/conversations/' + encodeURIComponent(state.pmUser))
                 .then(function (res) {
                     if (!res.ok) {
+                        state.connectionError = res.body && res.body.error || 'Chat connection unavailable';
+                        state.canSend = false;
+                        renderComposer();
                         pollProblem(res.body && res.body.error || 'Conversation unavailable.',
                             state.renderedOk);
                         return;
                     }
                     pollRecovered();
+                    state.connectionError = null;
                     state.canSend = !!res.body.can_send;
                     renderHead(); renderComposer();
                     renderMessages(res.body.messages);
@@ -5006,7 +5018,10 @@
                 if (typeof showToast === 'function') {
                     showToast(res.body && res.body.error || 'Message not sent', 'error');
                 }
-                input.value = text;     // give the words back
+                input.value = input.value ? text + '\n' + input.value : text; // preserve newer typing too
+                if (res.body && (res.body.code === 'slskd_disconnected' || res.body.code === 'slskd_unavailable')) {
+                    state.connectionError = res.body.error; state.canSend = false; renderComposer();
+                }
                 return;
             }
             // Optimistic echo: slskd takes a beat to include a just-sent message,
@@ -5917,6 +5932,7 @@
                 state.configured = !!(res.ok && res.body.configured);
                 state.homeRoom = (res.body && res.body.room) || 'SoulSync';
                 state.room = state.room || state.homeRoom;
+                state.connectionError = res.body && res.body.connected === false ? res.body.error || 'Soulseek is not connected' : null;
                 state.canSend = !!(res.body && res.body.can_send);
                 state.isAdmin = !!(res.body && res.body.is_admin);
                 state.selfName = String((res.body && res.body.username) || '');

--- a/webui/static/discover-premier.css
+++ b/webui/static/discover-premier.css
@@ -1,0 +1,1659 @@
+/* ==========================================================================
+   SoulSync Music Discover — Premier App Redesign (Deezer & Spotify Aesthetic)
+   Cinematic Hero Billboard, Deezer Flow Moods, Tactile Spotify Cards,
+   Ambient Lighting & Glassmorphic Surfaces
+   ========================================================================== */
+
+/* ── 1. Discover Canvas & Dynamic Ambient Environment ────────────────────── */
+.discover-container {
+    --dsc-bg-deep: #0a0d14;
+    --dsc-bg-card: rgba(22, 27, 38, 0.62);
+    --dsc-bg-card-hover: rgba(28, 34, 48, 0.85);
+    --dsc-border-glass: 1px solid rgba(255, 255, 255, 0.08);
+    --dsc-border-hover: 1px solid rgba(255, 255, 255, 0.16);
+    --dsc-text-primary: #ffffff;
+    --dsc-text-secondary: rgba(255, 255, 255, 0.7);
+    --dsc-text-muted: rgba(255, 255, 255, 0.45);
+    --dsc-accent-spotify: #1db954;
+    --dsc-accent-deezer: #a238ff;
+    --dsc-shadow-card: 0 12px 32px rgba(0, 0, 0, 0.45);
+    --dsc-shadow-glow: 0 16px 40px rgba(var(--accent-rgb, 29, 185, 84), 0.22);
+    
+    position: relative;
+    width: 100%;
+    max-width: 1480px;
+    margin: 0 auto;
+    padding: 16px 28px 96px;
+    box-sizing: border-box;
+    background: transparent;
+}
+
+/* Ambient dynamic background lighting */
+.discover-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 10%;
+    right: 10%;
+    height: 600px;
+    background: radial-gradient(ellipse at 50% 0%, rgba(var(--accent-rgb, 29, 185, 84), 0.18) 0%, rgba(162, 56, 255, 0.08) 45%, transparent 75%);
+    pointer-events: none;
+    z-index: 0;
+    filter: blur(60px);
+}
+
+/* ── 2. Top Quick-Filter Navigation Rail (Spotify / Deezer style) ─────────── */
+.dsc-quick-filter-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 0 20px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+    position: sticky;
+    top: 0;
+    z-index: 25;
+    background: linear-gradient(180deg, rgba(10, 13, 20, 0.95) 0%, rgba(10, 13, 20, 0.8) 75%, transparent 100%);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    margin-bottom: 8px;
+}
+
+.dsc-quick-filter-bar::-webkit-scrollbar {
+    display: none;
+}
+
+.dsc-filter-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 18px;
+    border-radius: 9999px;
+    font-size: 0.86rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--dsc-text-secondary);
+    background: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 180ms cubic-bezier(0.16, 1, 0.3, 1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    text-decoration: none;
+}
+
+.dsc-filter-pill:hover {
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.14);
+    border-color: rgba(255, 255, 255, 0.2);
+    transform: translateY(-1px);
+}
+
+.dsc-filter-pill.active,
+.dsc-filter-pill:active {
+    color: #000000;
+    background: #ffffff;
+    border-color: #ffffff;
+    box-shadow: 0 4px 16px rgba(255, 255, 255, 0.25);
+    font-weight: 700;
+}
+
+/* Deezer Flow & Moods Bar */
+.dsc-flow-bar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 0 16px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+}
+
+.dsc-flow-bar::-webkit-scrollbar {
+    display: none;
+}
+
+.dsc-flow-title {
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--dsc-text-muted);
+    margin-right: 4px;
+    white-space: nowrap;
+}
+
+.dsc-flow-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 14px;
+    border-radius: 9999px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    color: #ffffff;
+    background: rgba(162, 56, 255, 0.12);
+    border: 1px solid rgba(162, 56, 255, 0.25);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 180ms ease;
+}
+
+.dsc-flow-pill:hover {
+    background: rgba(162, 56, 255, 0.28);
+    border-color: rgba(162, 56, 255, 0.5);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(162, 56, 255, 0.35);
+}
+
+.dsc-flow-icon {
+    font-size: 14px;
+}
+
+/* ── 3. Cinematic Hero Billboard (Full-Width Immersion) ──────────────────── */
+.discover-command-grid {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 20px !important;
+    margin-bottom: 36px !important;
+    padding: 0 !important;
+}
+
+.discover-command-hero {
+    width: 100% !important;
+    flex: 1 1 100% !important;
+}
+
+.discover-hero {
+    position: relative !important;
+    width: 100% !important;
+    min-height: 430px !important;
+    height: auto !important;
+    border-radius: 24px !important;
+    overflow: hidden !important;
+    margin-bottom: 0 !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.15) !important;
+    background: #0d111a !important;
+}
+
+/* Full-bleed background image with right-side placement and cinematic grading */
+.discover-hero-background {
+    position: absolute !important;
+    inset: 0 !important;
+    width: 100% !important;
+    height: 100% !important;
+    background-size: cover !important;
+    background-position: 85% 25% !important;
+    transform: scale(1.02);
+    transition: transform 6s cubic-bezier(0.16, 1, 0.3, 1), filter 1s ease;
+    filter: saturate(1.15) contrast(1.05);
+}
+
+.discover-hero:hover .discover-hero-background {
+    transform: scale(1.05);
+}
+
+/* Scrim vignette — deep obsidian left shield guaranteeing 100% text legibility */
+.discover-hero-overlay {
+    position: absolute !important;
+    inset: 0 !important;
+    background:
+        linear-gradient(90deg, #0a0d14 0%, rgba(10, 13, 20, 0.98) 42%, rgba(10, 13, 20, 0.7) 65%, rgba(10, 13, 20, 0.15) 88%, transparent 100%),
+        linear-gradient(0deg, #0a0d14 0%, rgba(10, 13, 20, 0.8) 25%, transparent 65%),
+        linear-gradient(180deg, rgba(10, 13, 20, 0.45) 0%, transparent 35%) !important;
+    pointer-events: none;
+    z-index: 1;
+}
+
+/* Hide duplicate square image inside the hero */
+.discover-hero-image {
+    display: none !important;
+}
+
+/* Hero Content Area — Strictly Left-Aligned Flagship Layout */
+.discover-hero-content,
+.discover-command-hero .discover-hero-content {
+    position: relative !important;
+    z-index: 2 !important;
+    height: auto !important;
+    flex: 1 1 auto !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    align-items: flex-start !important;
+    text-align: left !important;
+    padding: 28px 60px 14px !important;
+    max-width: min(1120px, 78%) !important;
+    margin: 0 !important;
+    box-sizing: border-box !important;
+}
+
+.discover-hero-info,
+.discover-command-hero .discover-hero-info {
+    max-width: 100% !important;
+    width: 100% !important;
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    text-align: left !important;
+    margin: 0 !important;
+}
+
+/* Glowing Featured Eyebrow Badge */
+.discover-hero-label {
+    display: inline-flex !important;
+    align-items: center !important;
+    align-self: flex-start !important;
+    text-align: left !important;
+    gap: 6px !important;
+    font-size: 0.72rem !important;
+    font-weight: 800 !important;
+    letter-spacing: 0.12em !important;
+    text-transform: uppercase !important;
+    color: #ffffff !important;
+    background: linear-gradient(135deg, var(--accent-color, #1db954), #059669) !important;
+    padding: 5px 12px !important;
+    border-radius: 9999px !important;
+    box-shadow: 0 2px 10px rgba(var(--accent-rgb, 29, 185, 84), 0.4) !important;
+    margin: 0 0 12px 0 !important;
+    text-shadow: none !important;
+}
+
+/* Massive Spotify/Deezer Title */
+.discover-hero-title,
+.discover-command-hero .discover-hero-title {
+    font-size: clamp(30px, 3.8vw, 54px) !important;
+    font-weight: 850 !important;
+    letter-spacing: -0.03em !important;
+    line-height: 1.08 !important;
+    color: #ffffff !important;
+    text-align: left !important;
+    align-self: flex-start !important;
+    max-width: 100% !important;
+    margin: 0 0 10px 0 !important;
+    text-shadow: 0 4px 24px rgba(0, 0, 0, 0.7) !important;
+}
+
+/* Subtitle & Recommendation Reason */
+.discover-hero-subtitle,
+.discover-command-hero .discover-hero-subtitle {
+    font-size: 1.02rem !important;
+    line-height: 1.45 !important;
+    color: rgba(255, 255, 255, 0.85) !important;
+    max-width: 850px !important;
+    text-align: left !important;
+    align-self: flex-start !important;
+    margin: 0 0 14px 0 !important;
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.6) !important;
+}
+
+/* Meta Pills: Popularity, Owned Status, Genres */
+.discover-hero-meta,
+.discover-command-hero .discover-hero-meta {
+    width: 100% !important;
+    text-align: left !important;
+    margin: 0 0 20px 0 !important;
+}
+
+.discover-hero-meta-content {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    gap: 8px !important;
+    margin: 0 !important;
+    text-align: left !important;
+}
+
+.hero-meta-item {
+    background: rgba(255, 255, 255, 0.1) !important;
+    backdrop-filter: blur(12px) !important;
+    -webkit-backdrop-filter: blur(12px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: 9999px !important;
+    padding: 5px 12px !important;
+    font-size: 0.8rem !important;
+    font-weight: 600 !important;
+    color: #ffffff !important;
+}
+
+.hero-meta-item.hero-popularity {
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 5px !important;
+    background: rgba(245, 158, 11, 0.2) !important;
+    border-color: rgba(245, 158, 11, 0.4) !important;
+    color: #fbbf24 !important;
+}
+
+.genre-tag {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    border-radius: 9999px !important;
+    padding: 3px 10px !important;
+    font-size: 0.76rem !important;
+    color: rgba(255, 255, 255, 0.9) !important;
+}
+
+/* Primary Action Buttons */
+.discover-hero-actions,
+.discover-command-hero .discover-hero-actions {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    gap: 14px !important;
+    flex-wrap: wrap !important;
+    width: 100% !important;
+    margin: 0 !important;
+}
+
+.discover-hero-actions .discover-hero-button,
+.discover-hero-actions .watchlist-toggle-btn {
+    width: auto !important;
+    max-width: fit-content !important;
+    flex: 0 0 auto !important;
+    margin: 0 !important;
+}
+
+/* Spotify-style Primary Pill / Play Button */
+.discover-hero-button.primary {
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 8px !important;
+    background: var(--accent-color, #1db954) !important;
+    color: #05130a !important;
+    font-size: 0.92rem !important;
+    font-weight: 700 !important;
+    letter-spacing: -0.01em !important;
+    padding: 11px 24px !important;
+    border-radius: 9999px !important;
+    border: none !important;
+    cursor: pointer !important;
+    box-shadow: 0 8px 24px rgba(var(--accent-rgb, 29, 185, 84), 0.45) !important;
+    transition: all 180ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.discover-hero-button.primary:hover {
+    transform: scale(1.04) translateY(-1px) !important;
+    box-shadow: 0 12px 32px rgba(var(--accent-rgb, 29, 185, 84), 0.6) !important;
+    background: #22c55e !important;
+    color: #000000 !important;
+}
+
+.discover-hero-button.primary:active {
+    transform: scale(0.98) !important;
+}
+
+/* Secondary Discography Pill */
+.discover-hero-button.secondary {
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 8px !important;
+    background: rgba(255, 255, 255, 0.12) !important;
+    backdrop-filter: blur(12px) !important;
+    -webkit-backdrop-filter: blur(12px) !important;
+    color: #ffffff !important;
+    font-size: 0.9rem !important;
+    font-weight: 600 !important;
+    padding: 11px 22px !important;
+    border-radius: 9999px !important;
+    border: 1px solid rgba(255, 255, 255, 0.18) !important;
+    cursor: pointer !important;
+    transition: all 180ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.discover-hero-button.secondary:hover {
+    background: rgba(255, 255, 255, 0.22) !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+    transform: translateY(-1px) !important;
+}
+
+/* Hero Controls: Pill Indicators & Actions */
+.discover-hero-controls {
+    position: relative !important;
+    z-index: 3 !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    padding: 12px 56px 20px !important;
+    box-sizing: border-box !important;
+}
+
+.discover-hero-indicators {
+    display: flex !important;
+    align-items: center !important;
+    gap: 7px !important;
+    background: rgba(0, 0, 0, 0.45) !important;
+    backdrop-filter: blur(12px) !important;
+    -webkit-backdrop-filter: blur(12px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    padding: 6px 14px !important;
+    border-radius: 9999px !important;
+}
+
+.hero-indicator {
+    background: transparent !important;
+    border: none !important;
+    padding: 4px 2px !important;
+    cursor: pointer !important;
+    display: inline-flex !important;
+    align-items: center !important;
+}
+
+.hero-indicator-dot {
+    width: 6px !important;
+    height: 6px !important;
+    border-radius: 9999px !important;
+    background: rgba(255, 255, 255, 0.35) !important;
+    transition: all 240ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.hero-indicator.active .hero-indicator-dot {
+    width: 22px !important;
+    background: var(--accent-color, #1db954) !important;
+    box-shadow: 0 0 12px var(--accent-color, #1db954) !important;
+}
+
+.hero-indicator:hover .hero-indicator-dot {
+    background: rgba(255, 255, 255, 0.65) !important;
+}
+
+.discover-hero-bottom-actions {
+    display: flex !important;
+    align-items: center !important;
+    gap: 10px !important;
+}
+
+.discover-hero-bottom-actions button {
+    background: rgba(0, 0, 0, 0.45) !important;
+    backdrop-filter: blur(12px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    color: rgba(255, 255, 255, 0.85) !important;
+    border-radius: 9999px !important;
+    padding: 7px 16px !important;
+    font-size: 0.8rem !important;
+    font-weight: 600 !important;
+    cursor: pointer !important;
+    transition: all 160ms ease !important;
+}
+
+.discover-hero-bottom-actions button:hover {
+    background: rgba(255, 255, 255, 0.18) !important;
+    color: #ffffff !important;
+    border-color: rgba(255, 255, 255, 0.25) !important;
+}
+
+/* Prev/Next Hero Arrow Chevrons */
+.discover-hero-nav {
+    position: absolute !important;
+    top: 50% !important;
+    transform: translateY(-50%) !important;
+    width: 44px !important;
+    height: 44px !important;
+    border-radius: 50% !important;
+    background: rgba(10, 13, 20, 0.65) !important;
+    backdrop-filter: blur(12px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    color: #ffffff !important;
+    font-size: 24px !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    cursor: pointer !important;
+    z-index: 5 !important;
+    opacity: 0 !important;
+    transition: all 180ms ease !important;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4) !important;
+}
+
+.discover-hero:hover .discover-hero-nav {
+    opacity: 1 !important;
+}
+
+.discover-hero-nav-prev { left: 16px !important; }
+.discover-hero-nav-next { right: 16px !important; }
+
+.discover-hero-nav:hover {
+    background: rgba(255, 255, 255, 0.25) !important;
+    transform: translateY(-50%) scale(1.08) !important;
+}
+
+/* ── 4. Re-imagined Quick Signals Bar (Replacing the clunky sidebar) ──────── */
+.discover-command-panel {
+    display: grid !important;
+    grid-template-columns: minmax(280px, 340px) 1fr !important;
+    gap: 16px !important;
+    background: rgba(16, 20, 29, 0.7) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-radius: 20px !important;
+    padding: 16px 20px !important;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35) !important;
+}
+
+.discover-command-panel__head {
+    display: none !important;
+}
+
+.discover-next-move {
+    min-height: auto !important;
+    background: linear-gradient(135deg, rgba(var(--accent-rgb, 29, 185, 84), 0.22), rgba(16, 20, 29, 0.85)) !important;
+    border: 1px solid rgba(var(--accent-rgb, 29, 185, 84), 0.3) !important;
+    border-radius: 14px !important;
+    padding: 14px 18px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    gap: 4px !important;
+}
+
+.discover-next-move:hover {
+    border-color: var(--accent-color, #1db954) !important;
+    box-shadow: 0 6px 24px rgba(var(--accent-rgb, 29, 185, 84), 0.25) !important;
+}
+
+.discover-action-grid {
+    display: grid !important;
+    grid-template-columns: repeat(4, 1fr) !important;
+    gap: 10px !important;
+}
+
+.discover-action-card {
+    background: rgba(255, 255, 255, 0.04) !important;
+    border: 1px solid rgba(255, 255, 255, 0.07) !important;
+    border-radius: 13px !important;
+    padding: 12px 14px !important;
+    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.discover-action-card:hover {
+    background: rgba(255, 255, 255, 0.08) !important;
+    border-color: rgba(255, 255, 255, 0.16) !important;
+    transform: translateY(-2px) !important;
+}
+
+.discover-command-tools {
+    display: none !important;
+}
+
+/* ── 5. Discovery Zones: Clean Section Containers ────────────────────────── */
+.discovery-zone {
+    margin-bottom: 44px !important;
+    padding: 0 !important;
+    background: transparent !important;
+    border: none !important;
+}
+
+.discovery-zone-head {
+    display: flex !important;
+    align-items: flex-end !important;
+    justify-content: space-between !important;
+    margin-bottom: 20px !important;
+    padding: 0 4px 10px !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06) !important;
+}
+
+.discovery-zone-kicker {
+    font-size: 0.72rem !important;
+    font-weight: 700 !important;
+    letter-spacing: 0.12em !important;
+    text-transform: uppercase !important;
+    color: var(--accent-color, #1db954) !important;
+    margin-bottom: 4px !important;
+}
+
+.discovery-zone-head h2 {
+    font-size: 1.65rem !important;
+    font-weight: 800 !important;
+    letter-spacing: -0.025em !important;
+    color: #ffffff !important;
+    margin: 0 !important;
+}
+
+.discovery-zone-head p {
+    font-size: 0.88rem !important;
+    color: var(--dsc-text-secondary) !important;
+    margin-top: 4px !important;
+}
+
+.discovery-zone-metric {
+    font-size: 0.78rem !important;
+    font-weight: 700 !important;
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    border-radius: 9999px !important;
+    padding: 4px 12px !important;
+    color: var(--dsc-text-secondary) !important;
+}
+
+/* ── 6. Spotify-Style Tactile Music Cards ────────────────────────────────── */
+/* Grids & Horizontal Rails */
+.discover-mixes-grid,
+.discover-carousel,
+.discover-grid {
+    display: flex !important;
+    flex-direction: row !important;
+    gap: 18px !important;
+    overflow-x: auto !important;
+    padding: 6px 2px 18px !important;
+    scroll-snap-type: x mandatory !important;
+    scrollbar-width: thin !important;
+    scrollbar-color: rgba(255, 255, 255, 0.15) transparent !important;
+}
+
+.discover-mixes-grid::-webkit-scrollbar,
+.discover-carousel::-webkit-scrollbar,
+.discover-grid::-webkit-scrollbar {
+    height: 6px;
+}
+
+.discover-mixes-grid::-webkit-scrollbar-thumb,
+.discover-carousel::-webkit-scrollbar-thumb,
+.discover-grid::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 3px;
+}
+
+/* Multi-row library grid exception for Your Albums */
+[id="your-albums-section"] .discover-grid {
+    display: grid !important;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)) !important;
+    gap: 18px !important;
+    overflow-x: visible !important;
+    scroll-snap-type: none !important;
+}
+
+[id="your-albums-section"] .discover-grid > .ya-card {
+    flex: none !important;
+    width: 100% !important;
+    max-width: none !important;
+}
+
+/* Mix Cards */
+.discover-mix-card {
+    flex: 0 0 190px !important;
+    width: 190px !important;
+    max-width: 190px !important;
+    scroll-snap-align: start !important;
+    background: rgba(22, 27, 38, 0.6) !important;
+    border: 1px solid rgba(255, 255, 255, 0.06) !important;
+    border-radius: 16px !important;
+    padding: 14px !important;
+    box-sizing: border-box !important;
+    transition: all 220ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+    position: relative !important;
+    cursor: pointer !important;
+}
+
+.discover-mix-card:hover {
+    background: rgba(30, 36, 50, 0.9) !important;
+    border-color: rgba(255, 255, 255, 0.15) !important;
+    transform: translateY(-6px) !important;
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.5) !important;
+}
+
+/* Mix Cover Container */
+.mix-card-cover {
+    width: 100% !important;
+    aspect-ratio: 1 !important;
+    border-radius: 12px !important;
+    overflow: hidden !important;
+    position: relative !important;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4) !important;
+}
+
+/* Floating Circular Spotify Play Button */
+.mix-card-play {
+    position: absolute !important;
+    bottom: 10px !important;
+    right: 10px !important;
+    width: 44px !important;
+    height: 44px !important;
+    border-radius: 50% !important;
+    background: var(--accent-color, #1db954) !important;
+    color: #000000 !important;
+    border: none !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    font-size: 16px !important;
+    font-weight: bold !important;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.5) !important;
+    cursor: pointer !important;
+    z-index: 5 !important;
+    opacity: 0 !important;
+    transform: translateY(8px) scale(0.9) !important;
+    transition: all 200ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.discover-mix-card:hover .mix-card-play {
+    opacity: 1 !important;
+    transform: translateY(0) scale(1) !important;
+}
+
+.mix-card-play:hover {
+    transform: translateY(-2px) scale(1.08) !important;
+    box-shadow: 0 10px 24px rgba(var(--accent-rgb, 29, 185, 84), 0.55) !important;
+    background: #22c55e !important;
+}
+
+.mix-card-play:active {
+    transform: translateY(0) scale(0.96) !important;
+}
+
+/* Mix Title & Meta */
+.mix-card-name {
+    font-size: 0.94rem !important;
+    font-weight: 700 !important;
+    color: #ffffff !important;
+    margin-top: 12px !important;
+    line-height: 1.3 !important;
+}
+
+.mix-card-meta {
+    font-size: 0.78rem !important;
+    color: var(--dsc-text-muted) !important;
+    margin-top: 4px !important;
+}
+
+/* ── Base Music Cards (.ya-card) ─────────────────────────────────────────── */
+.discover-grid > .ya-card,
+.discover-carousel > .ya-card,
+.ya-card.discover-album-card,
+.ya-card.recommended-artist-card {
+    flex: 0 0 180px !important;
+    width: 180px !important;
+    max-width: 180px !important;
+    scroll-snap-align: start !important;
+    border-radius: 16px !important;
+    overflow: hidden !important;
+    background: rgba(22, 27, 38, 0.6) !important;
+    border: 1px solid rgba(255, 255, 255, 0.06) !important;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35) !important;
+    transition: all 220ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+    box-sizing: border-box !important;
+}
+
+.discover-grid > .ya-card:hover,
+.discover-carousel > .ya-card:hover,
+.ya-card.discover-album-card:hover,
+.ya-card.recommended-artist-card:hover {
+    transform: translateY(-6px) !important;
+    background: rgba(30, 36, 50, 0.9) !important;
+    border-color: rgba(255, 255, 255, 0.16) !important;
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.55) !important;
+}
+
+/* Album Cards & Deezer Picks (Square Artwork & Tactile Spotify/Deezer Shape) */
+.ya-card.discover-album-card {
+    padding: 12px 12px 14px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-start !important;
+    text-align: left !important;
+    cursor: pointer !important;
+}
+
+.ya-card.discover-album-card .ya-card-img {
+    position: relative !important;
+    inset: auto !important;
+    width: 100% !important;
+    aspect-ratio: 1 !important;
+    border-radius: 12px !important;
+    overflow: hidden !important;
+    margin-bottom: 10px !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4) !important;
+}
+
+.ya-card.discover-album-card .ya-card-gradient {
+    display: none !important;
+}
+
+.ya-card.discover-album-card .ya-card-info {
+    position: static !important;
+    padding: 0 !important;
+    width: 100% !important;
+    text-align: left !important;
+}
+
+.ya-card.discover-album-card .ya-card-name {
+    font-size: 0.92rem !important;
+    font-weight: 700 !important;
+    color: #ffffff !important;
+    line-height: 1.3 !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    margin-bottom: 4px !important;
+}
+
+.ya-card.discover-album-card .ya-card-sub {
+    font-size: 0.78rem !important;
+    color: rgba(255, 255, 255, 0.65) !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    line-height: 1.35 !important;
+}
+
+.ya-card-img img {
+    transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.ya-card:hover .ya-card-img img {
+    transform: scale(1.04) !important;
+}
+
+.ya-card-name {
+    font-size: 0.9rem !important;
+    font-weight: 700 !important;
+}
+
+.ya-card-sub {
+    font-size: 0.78rem !important;
+    color: rgba(255, 255, 255, 0.75) !important;
+}
+
+/* Recommended Artist Cards & Your Artists (Spotify Artist Avatar Aesthetic) */
+.ya-card.recommended-artist-card,
+[id="your-artists-carousel"] .ya-card {
+    padding: 14px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: space-between !important;
+    cursor: pointer !important;
+}
+
+.ya-card.recommended-artist-card .recommended-card-image,
+.ya-card.recommended-artist-card .ya-card-img,
+[id="your-artists-carousel"] .ya-card .ya-card-img {
+    width: 100% !important;
+    aspect-ratio: 1 !important;
+    border-radius: 50% !important;
+    overflow: hidden !important;
+    margin: 0 auto 12px !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.45) !important;
+    border: 2px solid rgba(255, 255, 255, 0.08) !important;
+    position: relative !important;
+}
+
+.ya-card.recommended-artist-card .recommended-card-image img,
+.ya-card.recommended-artist-card .ya-card-img img,
+[id="your-artists-carousel"] .ya-card .ya-card-img img {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: cover !important;
+    transition: transform 300ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.ya-card.recommended-artist-card:hover .recommended-card-image img,
+.ya-card.recommended-artist-card:hover .ya-card-img img,
+[id="your-artists-carousel"] .ya-card:hover .ya-card-img img {
+    transform: scale(1.06) !important;
+}
+
+.recommended-card-image-fallback {
+    width: 100% !important;
+    height: 100% !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    font-size: 38px !important;
+    background: rgba(255, 255, 255, 0.04) !important;
+}
+
+.ya-card.recommended-artist-card .ya-card-info,
+[id="your-artists-carousel"] .ya-card .ya-card-info {
+    text-align: center !important;
+    padding: 0 !important;
+    width: 100% !important;
+}
+
+.ya-card.recommended-artist-card .ya-card-name,
+[id="your-artists-carousel"] .ya-card .ya-card-name {
+    font-size: 0.92rem !important;
+    font-weight: 700 !important;
+    color: #ffffff !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    margin-bottom: 4px !important;
+}
+
+.ya-card.recommended-artist-card .ya-card-sub,
+[id="your-artists-carousel"] .ya-card .ya-card-sub {
+    font-size: 0.76rem !important;
+    color: var(--dsc-text-muted) !important;
+    white-space: nowrap !important;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    margin-bottom: 6px !important;
+}
+
+.ya-card.recommended-artist-card .ya-card-why {
+    display: flex !important;
+    justify-content: center !important;
+    flex-wrap: wrap !important;
+    gap: 4px !important;
+    margin-bottom: 6px !important;
+}
+
+.ya-why-chip {
+    font-size: 0.68rem !important;
+    padding: 2px 7px !important;
+    border-radius: 9999px !important;
+    background: rgba(255, 255, 255, 0.08) !important;
+    color: rgba(255, 255, 255, 0.8) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    font-weight: 500 !important;
+}
+
+/* Eye Symbol Watchlist Button (Top-Right on Artist Cards — matches Your Artists) */
+.ya-watchlist-btn,
+.recommended-artist-card .recommended-card-watchlist-btn,
+.recommended-card-watchlist-btn {
+    position: absolute !important;
+    top: 8px !important;
+    right: 8px !important;
+    bottom: auto !important;
+    left: auto !important;
+    z-index: 4 !important;
+    width: 28px !important;
+    height: 28px !important;
+    min-width: 28px !important;
+    max-width: 28px !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border-radius: 8px !important;
+    background: rgba(0, 0, 0, 0.55) !important;
+    backdrop-filter: blur(8px) !important;
+    -webkit-backdrop-filter: blur(8px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    color: rgba(255, 255, 255, 0.65) !important;
+    cursor: pointer !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    opacity: 0 !important;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35) !important;
+    transition: opacity 180ms cubic-bezier(0.16, 1, 0.3, 1),
+                transform 180ms cubic-bezier(0.16, 1, 0.3, 1),
+                background 180ms ease,
+                border-color 180ms ease,
+                color 180ms ease !important;
+}
+
+.ya-card:hover .ya-watchlist-btn,
+.ya-card:hover .recommended-card-watchlist-btn,
+.recommended-artist-card:hover .recommended-card-watchlist-btn,
+.recommended-artist-card:focus-within .recommended-card-watchlist-btn,
+.ya-watchlist-btn.active,
+.ya-watchlist-btn.watching,
+.recommended-card-watchlist-btn.watching,
+.recommended-card-watchlist-btn.active {
+    opacity: 1 !important;
+}
+
+.ya-watchlist-btn:hover:not(:disabled),
+.recommended-card-watchlist-btn:hover:not(:disabled) {
+    background: rgba(0, 0, 0, 0.8) !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+    color: #ffffff !important;
+    transform: scale(1.1) !important;
+}
+
+.ya-watchlist-btn.active,
+.ya-watchlist-btn.watching,
+.recommended-card-watchlist-btn.watching,
+.recommended-card-watchlist-btn.active {
+    opacity: 1 !important;
+    color: var(--accent, #1db954) !important;
+    border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.4) !important;
+    background: rgba(var(--accent-rgb, 29, 185, 84), 0.18) !important;
+    box-shadow: 0 0 12px rgba(var(--accent-rgb, 29, 185, 84), 0.3) !important;
+}
+
+.recommended-card-watchlist-btn .sr-only,
+.recommended-card-watchlist-btn span {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+@media (hover: none), (max-width: 768px) {
+    .ya-watchlist-btn,
+    .recommended-artist-card .recommended-card-watchlist-btn {
+        opacity: 0.92 !important;
+        transform: none !important;
+    }
+}
+
+/* ── 7. Stations Row & Live Avatars ──────────────────────────────────────── */
+.stations-row-wrap {
+    margin: 16px 0 28px !important;
+}
+
+.station-card {
+    border-radius: 18px !important;
+    background: rgba(22, 27, 38, 0.6) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    padding: 20px 16px !important;
+    transition: all 220ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.station-card:hover {
+    transform: translateY(-5px) !important;
+    border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.35) !important;
+    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.5) !important;
+}
+
+.station-avatar {
+    border-radius: 50% !important;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4) !important;
+    border: 2px solid rgba(255, 255, 255, 0.1) !important;
+}
+
+.station-card:hover .station-avatar {
+    border-color: var(--accent-color, #1db954) !important;
+    transform: scale(1.04) !important;
+}
+
+.station-play-btn {
+    border-radius: 9999px !important;
+    font-weight: 700 !important;
+    background: var(--accent-color, #1db954) !important;
+    color: #000000 !important;
+}
+
+/* ── 8. Taste Dial (Adventurousness Wave) ─────────────────────────────────── */
+.adv-wave {
+    position: relative !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 14px !important;
+    background: linear-gradient(135deg, rgba(20, 26, 38, 0.75) 0%, rgba(12, 16, 24, 0.85) 100%) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.09) !important;
+    border-radius: 20px !important;
+    padding: 24px 28px 22px !important;
+    margin: 20px 0 36px !important;
+    box-shadow: 0 12px 36px rgba(0, 0, 0, 0.4) !important;
+    overflow: hidden !important;
+}
+
+.adv-wave-head {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    width: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+.adv-wave-label {
+    font-size: 0.82rem !important;
+    font-weight: 800 !important;
+    text-transform: uppercase !important;
+    letter-spacing: 0.12em !important;
+    color: rgba(255, 255, 255, 0.65) !important;
+    margin: 0 !important;
+}
+
+.adv-wave-state {
+    font-size: 0.84rem !important;
+    font-weight: 700 !important;
+    padding: 4px 14px !important;
+    border-radius: 9999px !important;
+    background: rgba(255, 255, 255, 0.08) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2) !important;
+    line-height: 1.3 !important;
+    margin: 0 !important;
+}
+
+.adv-wave-track {
+    position: relative !important;
+    height: 104px !important;
+    border-radius: 14px !important;
+    overflow: hidden !important;
+    background: rgba(10, 13, 20, 0.85) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    box-shadow: inset 0 2px 10px rgba(0, 0, 0, 0.6) !important;
+    margin: 0 !important;
+}
+
+.adv-wave-ends {
+    display: flex !important;
+    justify-content: space-between !important;
+    font-size: 0.78rem !important;
+    font-weight: 500 !important;
+    color: rgba(255, 255, 255, 0.45) !important;
+    padding: 0 2px !important;
+    margin: 0 !important;
+}
+
+.adv-wave-help {
+    font-size: 0.82rem !important;
+    line-height: 1.5 !important;
+    color: rgba(255, 255, 255, 0.55) !important;
+    margin: 0 !important;
+}
+
+/* ── 9. Deezer Editorial Curated Shelf ────────────────────────────────────── */
+[id="deezer-editorial"] {
+    position: relative !important;
+    border-radius: 20px !important;
+    padding: 24px 28px !important;
+    background: linear-gradient(135deg, rgba(162, 56, 255, 0.07) 0%, rgba(18, 22, 32, 0.7) 100%) !important;
+    border: 1px solid rgba(162, 56, 255, 0.22) !important;
+    box-shadow: 0 16px 44px rgba(0, 0, 0, 0.4) !important;
+    margin-bottom: 40px !important;
+}
+
+[id="deezer-editorial"] .discovery-zone-title {
+    background: linear-gradient(135deg, #ffffff 40%, #c084fc 100%) !important;
+    -webkit-background-clip: text !important;
+    -webkit-text-fill-color: transparent !important;
+}
+
+.dz-ed-controls {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 12px !important;
+    margin-bottom: 16px !important;
+}
+
+.dz-ed-search {
+    width: 100% !important;
+    max-width: 380px !important;
+    background: rgba(255, 255, 255, 0.07) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: 9999px !important;
+    padding: 10px 18px !important;
+    font-size: 0.86rem !important;
+    color: #ffffff !important;
+    outline: none !important;
+    transition: all 180ms ease !important;
+}
+
+.dz-ed-search:focus {
+    background: rgba(255, 255, 255, 0.12) !important;
+    border-color: rgba(162, 56, 255, 0.6) !important;
+    box-shadow: 0 0 16px rgba(162, 56, 255, 0.25) !important;
+}
+
+.dz-ed-genres {
+    display: flex !important;
+    align-items: center !important;
+    gap: 8px !important;
+    overflow-x: auto !important;
+    scrollbar-width: none !important;
+    padding: 2px 0 6px !important;
+}
+
+.dz-ed-genres::-webkit-scrollbar {
+    display: none !important;
+}
+
+.dz-ed-genre {
+    display: inline-flex !important;
+    align-items: center !important;
+    padding: 6px 14px !important;
+    border-radius: 9999px !important;
+    font-size: 0.8rem !important;
+    font-weight: 600 !important;
+    color: rgba(255, 255, 255, 0.7) !important;
+    background: rgba(255, 255, 255, 0.06) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    cursor: pointer !important;
+    white-space: nowrap !important;
+    transition: all 160ms ease !important;
+}
+
+.dz-ed-genre:hover {
+    color: #ffffff !important;
+    background: rgba(255, 255, 255, 0.12) !important;
+}
+
+.dz-ed-genre.active {
+    color: #ffffff !important;
+    background: linear-gradient(135deg, #a238ff, #7928ca) !important;
+    border-color: #a238ff !important;
+    box-shadow: 0 4px 14px rgba(162, 56, 255, 0.4) !important;
+}
+
+.dz-ed-progress {
+    width: 100% !important;
+    height: 4px !important;
+    border-radius: 9999px !important;
+    background: rgba(255, 255, 255, 0.1) !important;
+    overflow: hidden !important;
+    margin-top: 6px !important;
+}
+
+.dz-ed-progress-fill {
+    height: 100% !important;
+    background: linear-gradient(90deg, #a238ff, #06b6d4) !important;
+    border-radius: 9999px !important;
+    transition: width 200ms ease !important;
+}
+
+/* Hero Help & Blacklist frosted glass buttons */
+.tool-help-button.discover-page-help-button,
+.discover-blacklist-btn {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    width: 38px !important;
+    height: 38px !important;
+    border-radius: 50% !important;
+    background: rgba(0, 0, 0, 0.45) !important;
+    backdrop-filter: blur(12px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.14) !important;
+    color: rgba(255, 255, 255, 0.8) !important;
+    cursor: pointer !important;
+    transition: all 180ms ease !important;
+}
+
+.tool-help-button.discover-page-help-button:hover,
+.discover-blacklist-btn:hover {
+    background: rgba(255, 255, 255, 0.2) !important;
+    color: #ffffff !important;
+    border-color: rgba(255, 255, 255, 0.3) !important;
+    transform: scale(1.06) !important;
+}
+
+/* ── 10. Premier Artist Map & Artist Web Hubs (Explore & Build) ──────────── */
+.discover-hub-row--tools {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    gap: 22px !important;
+    align-items: stretch !important;
+    margin: 0 0 28px !important;
+    padding: 0 !important;
+}
+
+@media (max-width: 1100px) {
+    .discover-hub-row--tools {
+        grid-template-columns: 1fr !important;
+        gap: 20px !important;
+    }
+}
+
+.discover-hub-row--tools .artmap-hub {
+    position: relative !important;
+    border-radius: 22px !important;
+    overflow: hidden !important;
+    background: linear-gradient(145deg, rgba(17, 23, 37, 0.75) 0%, rgba(10, 14, 24, 0.88) 100%) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    box-shadow: 0 16px 44px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.08) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    transition: transform 0.28s cubic-bezier(0.16, 1, 0.3, 1),
+                border-color 0.28s ease,
+                box-shadow 0.28s ease !important;
+    min-height: auto !important;
+    display: flex !important;
+    flex-direction: column !important;
+}
+
+.discover-hub-row--tools .artmap-hub:hover {
+    border-color: rgba(255, 255, 255, 0.14) !important;
+    box-shadow: 0 22px 54px rgba(0, 0, 0, 0.52), inset 0 1px 0 rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Background atmosphere with subtle glowing color clouds */
+.discover-hub-row--tools .artmap-hub-bg {
+    position: absolute !important;
+    inset: 0 !important;
+    z-index: 0 !important;
+    background: radial-gradient(circle at 18% 18%, rgba(162, 56, 255, 0.14) 0%, transparent 55%),
+                radial-gradient(circle at 82% 82%, rgba(59, 130, 246, 0.08) 0%, transparent 50%),
+                linear-gradient(145deg, #0f1422 0%, #090c14 100%) !important;
+    opacity: 0.95 !important;
+}
+
+/* Give the second card (Artist Web) an electric blue / indigo glow accent */
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-bg {
+    background: radial-gradient(circle at 18% 18%, rgba(56, 189, 248, 0.14) 0%, transparent 55%),
+                radial-gradient(circle at 82% 82%, rgba(162, 56, 255, 0.1) 0%, transparent 50%),
+                linear-gradient(145deg, #0b1526 0%, #080c14 100%) !important;
+}
+
+.discover-hub-row--tools .artmap-hub-bg::after {
+    display: none !important;
+}
+
+.discover-hub-row--tools .artmap-hub-bg::before {
+    opacity: 0.18 !important;
+}
+
+/* Hub Content & Header */
+.discover-hub-row--tools .artmap-hub-content {
+    position: relative !important;
+    z-index: 2 !important;
+    padding: 24px 26px 28px !important;
+    display: flex !important;
+    flex-direction: column !important;
+    flex: 1 1 auto !important;
+}
+
+.discover-hub-row--tools .artmap-hub-header {
+    display: flex !important;
+    align-items: center !important;
+    gap: 15px !important;
+    margin-bottom: 20px !important;
+}
+
+.discover-hub-row--tools .artmap-hub-icon {
+    width: 32px !important;
+    height: 32px !important;
+    color: #c084fc !important;
+    filter: drop-shadow(0 2px 10px rgba(192, 132, 252, 0.4)) !important;
+    flex-shrink: 0 !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-icon {
+    color: #38bdf8 !important;
+    filter: drop-shadow(0 2px 10px rgba(56, 189, 248, 0.4)) !important;
+}
+
+.discover-hub-row--tools .artmap-hub-title {
+    font-size: 1.3rem !important;
+    font-weight: 800 !important;
+    letter-spacing: -0.02em !important;
+    color: #ffffff !important;
+    margin: 0 !important;
+    line-height: 1.2 !important;
+}
+
+.discover-hub-row--tools .artmap-hub-subtitle {
+    font-size: 0.86rem !important;
+    color: rgba(255, 255, 255, 0.6) !important;
+    margin: 4px 0 0 !important;
+    line-height: 1.35 !important;
+}
+
+/* Grid of 3 action cards */
+.discover-hub-row--tools .artmap-hub-cards {
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    gap: 12px !important;
+    align-items: stretch !important;
+    flex: 1 1 auto !important;
+}
+
+/* Each action card button — redesigned from cramped row to generous structured card */
+.discover-hub-row--tools .artmap-hub-card {
+    display: grid !important;
+    grid-template-areas:
+        "icon arrow"
+        "text text" !important;
+    grid-template-columns: 1fr auto !important;
+    grid-template-rows: auto 1fr !important;
+    row-gap: 14px !important;
+    column-gap: 10px !important;
+    align-items: start !important;
+    text-align: left !important;
+    padding: 18px 16px 18px !important;
+    border-radius: 16px !important;
+    background: rgba(255, 255, 255, 0.035) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.22) !important;
+    backdrop-filter: blur(14px) !important;
+    -webkit-backdrop-filter: blur(14px) !important;
+    cursor: pointer !important;
+    position: relative !important;
+    overflow: hidden !important;
+    min-height: 148px !important;
+    box-sizing: border-box !important;
+    transition: transform 0.22s cubic-bezier(0.16, 1, 0.3, 1),
+                background 0.22s ease,
+                border-color 0.22s ease,
+                box-shadow 0.22s ease !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card::before {
+    content: '' !important;
+    position: absolute !important;
+    inset: 0 !important;
+    background: radial-gradient(circle at 50% 0%, rgba(162, 56, 255, 0.16) 0%, transparent 72%) !important;
+    opacity: 0 !important;
+    transition: opacity 0.22s ease !important;
+    pointer-events: none !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-card::before {
+    background: radial-gradient(circle at 50% 0%, rgba(56, 189, 248, 0.16) 0%, transparent 72%) !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:hover {
+    transform: translateY(-3px) !important;
+    background: rgba(255, 255, 255, 0.075) !important;
+    border-color: rgba(162, 56, 255, 0.4) !important;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38), 0 0 24px rgba(162, 56, 255, 0.16) !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-card:hover {
+    border-color: rgba(56, 189, 248, 0.42) !important;
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.38), 0 0 24px rgba(56, 189, 248, 0.16) !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:hover::before {
+    opacity: 1 !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:active {
+    transform: translateY(-1px) scale(0.99) !important;
+}
+
+/* Icon Squircle */
+.discover-hub-row--tools .artmap-hub-card-icon {
+    grid-area: icon !important;
+    justify-self: start !important;
+    width: 42px !important;
+    height: 42px !important;
+    border-radius: 12px !important;
+    background: rgba(162, 56, 255, 0.12) !important;
+    border: 1px solid rgba(162, 56, 255, 0.24) !important;
+    color: #d8b4fe !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    flex-shrink: 0 !important;
+    transition: all 0.22s ease !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-card-icon {
+    background: rgba(56, 189, 248, 0.12) !important;
+    border-color: rgba(56, 189, 248, 0.24) !important;
+    color: #7dd3fc !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card-icon svg {
+    width: 22px !important;
+    height: 22px !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:hover .artmap-hub-card-icon {
+    background: rgba(162, 56, 255, 0.24) !important;
+    border-color: rgba(162, 56, 255, 0.48) !important;
+    color: #ffffff !important;
+    transform: scale(1.06) !important;
+    box-shadow: 0 4px 14px rgba(162, 56, 255, 0.35) !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-card:hover .artmap-hub-card-icon {
+    background: rgba(56, 189, 248, 0.24) !important;
+    border-color: rgba(56, 189, 248, 0.48) !important;
+    color: #ffffff !important;
+    box-shadow: 0 4px 14px rgba(56, 189, 248, 0.35) !important;
+}
+
+/* Arrow indicator on top-right */
+.discover-hub-row--tools .artmap-hub-card-arrow {
+    grid-area: arrow !important;
+    justify-self: end !important;
+    align-self: center !important;
+    width: 18px !important;
+    height: 18px !important;
+    color: rgba(255, 255, 255, 0.28) !important;
+    transition: all 0.22s ease !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:hover .artmap-hub-card-arrow {
+    color: #c084fc !important;
+    transform: translateX(3px) !important;
+}
+
+.discover-hub-row--tools .artmap-hub:nth-child(2) .artmap-hub-card:hover .artmap-hub-card-arrow {
+    color: #38bdf8 !important;
+}
+
+/* Text block spanning full width below icon */
+.discover-hub-row--tools .artmap-hub-card-text {
+    grid-area: text !important;
+    width: 100% !important;
+    min-width: 0 !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card-text h3 {
+    font-size: 1.02rem !important;
+    font-weight: 700 !important;
+    letter-spacing: -0.01em !important;
+    color: #ffffff !important;
+    margin: 0 0 6px !important;
+    line-height: 1.25 !important;
+    transition: color 0.2s ease !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card-text p {
+    font-size: 0.81rem !important;
+    line-height: 1.44 !important;
+    color: rgba(255, 255, 255, 0.65) !important;
+    margin: 0 !important;
+    word-break: normal !important;
+    overflow-wrap: break-word !important;
+    transition: color 0.2s ease !important;
+}
+
+.discover-hub-row--tools .artmap-hub-card:hover .artmap-hub-card-text p {
+    color: rgba(255, 255, 255, 0.85) !important;
+}
+
+/* ── 11. Responsive Mobile Adjustments (< 768px) ─────────────────────────── */
+@media (max-width: 768px) {
+    .discover-container {
+        padding: 12px 14px 72px !important;
+    }
+
+    .discover-hero {
+        height: 290px !important;
+        border-radius: 18px !important;
+    }
+
+    .discover-hero-content {
+        padding: 20px 20px 14px !important;
+    }
+
+    .discover-hero-title {
+        font-size: 26px !important;
+        margin-bottom: 6px !important;
+    }
+
+    .discover-hero-subtitle {
+        font-size: 0.85rem !important;
+        margin-bottom: 10px !important;
+    }
+
+    .discover-hero-button.primary {
+        padding: 10px 20px !important;
+        font-size: 0.84rem !important;
+    }
+
+    .discover-hero-button.secondary {
+        padding: 9px 16px !important;
+        font-size: 0.82rem !important;
+    }
+
+    .discover-hero-controls {
+        padding: 6px 20px 14px !important;
+    }
+
+    /* On mobile, collapse the command analytics panel to prioritize music discovery shelves */
+    .discover-command-panel {
+        display: none !important;
+    }
+
+    .discover-mix-card {
+        flex: 0 0 152px !important;
+        width: 152px !important;
+        padding: 10px !important;
+        border-radius: 14px !important;
+    }
+
+    /* On mobile touch devices, keep Play button accessible */
+    .mix-card-play {
+        opacity: 0.92 !important;
+        transform: none !important;
+        width: 38px !important;
+        height: 38px !important;
+        font-size: 13px !important;
+    }
+
+    .discover-grid > .ya-card,
+    .discover-carousel > .ya-card,
+    .ya-card.discover-album-card,
+    .ya-card.recommended-artist-card,
+    [id="your-artists-carousel"] .ya-card {
+        flex: 0 0 148px !important;
+        width: 148px !important;
+        max-width: 148px !important;
+        padding: 10px !important;
+        border-radius: 14px !important;
+    }
+
+    [id="deezer-editorial"] {
+        padding: 18px 16px !important;
+    }
+
+    .dz-ed-search {
+        max-width: 100% !important;
+    }
+
+    .discover-hub-row--tools {
+        grid-template-columns: 1fr !important;
+        gap: 16px !important;
+    }
+
+    .discover-hub-row--tools .artmap-hub-cards {
+        grid-template-columns: 1fr !important;
+        gap: 10px !important;
+    }
+
+    .discover-hub-row--tools .artmap-hub-card {
+        grid-template-areas: "icon text arrow" !important;
+        grid-template-columns: auto 1fr auto !important;
+        grid-template-rows: auto !important;
+        column-gap: 14px !important;
+        row-gap: 0 !important;
+        align-items: center !important;
+        min-height: auto !important;
+        padding: 14px 16px !important;
+    }
+}

--- a/webui/static/helper.js
+++ b/webui/static/helper.js
@@ -3467,27 +3467,20 @@ function closeHelperSearch() {
 // projects that span multiple commits before shipping. Strip the flag at
 // release time and add a real `date:` line at the top of the version block.
 const WHATS_NEW = {
-    // Convention: keep only the CURRENT release here, plus a single brief
-    // "Earlier versions" summary entry. Don't accumulate old per-version blocks.
-    '3.4.0': [
-        { date: 'September 2026 \u00b7 3.4.0' },
-        { title: 'Podcasts', desc: 'a whole new section. search itunes, or paste an rss url straight into the search bar and it works out that is what you did. custom, patreon and private feeds all work.', page: 'podcasts' },
-        { title: 'Bring your subscriptions with you', desc: 'OPML 2.0 import and export, with a live checklist preview before anything subscribes.', page: 'podcasts' },
-        { title: 'Podcasts download themselves', desc: 'the watchlist grabs new episodes with retention settings, so a daily show does not eat your disk. library path and organization templates are yours to set, and there is an mp4 option for media servers that only really do video.', page: 'podcasts' },
-        { title: 'Audiobooks', desc: 'audible catalogue, browse, detail, author and narrator pages. acquisition through prowlarr, the shared torrent and usenet clients, and soulseek.', page: 'audiobooks' },
-        { title: 'Narrator search', desc: 'search by narrator, which is the one question nothing else can answer. plus series in reading order, genre charts and sample audio.', page: 'audiobooks' },
-        { title: 'Audiobooks are a real side, not a demo', desc: 'quality profile, blocklist, library scan, recycle bin and author watchlist. a failed download blocks the release it came from, so the wishlist stops grabbing the same broken posting forever.', page: 'audiobooks' },
-        { title: 'Every download source on one tab', desc: 'the torrent client, the usenet client and prowlarr came over from Downloads, and yt-dlp came over from Advanced, three tabs from the youtube source it exists to serve. the download chain replaced the source dropdown.', page: 'settings' },
-        { title: 'Connections is tiles now', desc: '22 services were nested accordions in two API Configuration groups. each tile says whether it is configured without being opened.', page: 'settings' },
-        { title: 'Library and Quality are merged', desc: 'the Quality tab had two cards both called Quality, the music profile and the video ladder. they could never appear on screen together, so nobody had noticed.', page: 'settings' },
-        { title: 'Settings works by keyboard', desc: 'all 31 section toggles are reachable without a mouse, on one type scale, with one grammar per row.', page: 'settings' },
-        { title: 'YouTube says what is actually wrong', desc: 'the probe behind the Test button was hardcoded to return true, so the dot was green no matter what. it reports the real reason now, and names the browsers that cannot work.', page: 'settings' },
-        { title: 'Reverse proxy url base paths', desc: 'soulsync can live at /soulsync behind a proxy instead of needing its own hostname.' },
-        { title: 'Profiles cover podcasts and audiobooks', desc: 'both can be granted or denied per profile, and wishlists and followed authors belong to the person who made them. the download permission reads from the session, so a caller can no longer vote on its own permissions by omitting a header.' },
-        { title: 'Discovery opens again', desc: 'it crashed on open with a wrong-shaped response read during render. the test mocked a contract the server has never had, so it was green the whole time.', page: 'discover' },
-        { title: 'Reorganize survives a restart', desc: 'the bulk queue lived only in memory, so a worker recycle took every queued album with it while the job still logged complete. outstanding work is stored now.' },
-        { title: 'Stations and Because You Listen To', desc: 'shelves repeated the same album under near-identical headings, and a station gave you one click with nothing to inspect, download or sync.', page: 'discover' },
-        { title: 'Earlier versions', desc: '3.3.3 took chat beyond your install and made release parsing read the actual audio. 3.3.2 gave the video side search receipts and rebuilt the downloads page. 3.3.1 made daily mixes and stations real.' },
+    // Keep the current release and one brief Earlier versions summary.
+    '3.4.1': [
+        { date: 'September 2026 \u00b7 3.4.1' },
+        {"title": "Less waiting on downloads and imports", "desc": "lyrics requests have real network timeouts, manual imports run as background jobs, and file recovery no longer holds up download status updates.", "page": "downloads"},
+        {"title": "More responsive browsing", "desc": "repeated artwork registration is cached, metadata searches have bounded waits and worker capacity, and offline Plex connections are cached instead of retried on every poll."},
+        {"title": "Discover, Watchlist and Settings refreshed", "desc": "new layouts, clearer controls and responsive forms, with shared music and video folder and organization settings.", "page": "settings"},
+        {"title": "Deezer editorial playlists", "desc": "browse editorial playlists across all 28 genres, search playlists, and see what happens as a playlist is handed off to sync.", "page": "discover"},
+        {"title": "Existing audiobook libraries", "desc": "scan books already on disk, browse the rebuilt library, and review catalogue edition matches using metadata and download provenance.", "page": "audiobooks"},
+        {"title": "Audiobook download reliability", "desc": "live progress follows the download client, cancellation persists, Soulseek transfers are matched correctly, and wishlist rows move on from sent to downloads.", "page": "audiobooks"},
+        {"title": "Watchlist progress and cancellation", "desc": "source matching appears on the page and automation card, and a long artist can be cancelled while matching.", "page": "watchlist"},
+        {"title": "Connection and import fixes", "desc": "correct a Last.fm username, import SoundCloud downloads, preserve the selected Deezer track, and keep unsent chat drafts when Soulseek is disconnected."},
+        {"title": "Podcast protections", "desc": "podcast fetches are guarded and watchlist automation respects profile ownership.", "page": "podcasts"},
+        {"title": "Video libraries across drives", "desc": "configure additional video library paths and load shared Library settings from either media side.", "page": "settings"},
+        {"title": "Earlier versions", "desc": "3.4.0 introduced podcasts and audiobooks, reorganized settings, and added reverse proxy base paths. 3.3.3 expanded chat and improved release parsing."},
     ],
 };
 
@@ -3518,7 +3511,23 @@ const WHATS_NEW = {
 //                  usage_note?: 'optional hint shown at the bottom' }
 const VERSION_MODAL_SECTIONS = [
     {
-        title: "3.4.0: podcasts and audiobooks, and a settings page you can read",
+    "title": "3.4.1: less waiting, clearer pages and stronger audiobook libraries",
+    "description": "This update addresses slow processing and navigation, refreshes Discover, Watchlist and Settings, and improves existing audiobook libraries and download tracking.",
+    "features": [
+        "Less waiting on downloads and imports: lyrics requests have real network timeouts, manual imports run as background jobs, and file recovery no longer holds up download status updates.",
+        "More responsive browsing: repeated artwork registration is cached, metadata searches have bounded waits and worker capacity, and offline Plex connections are cached instead of retried on every poll.",
+        "Discover, Watchlist and Settings refreshed: new layouts, clearer controls and responsive forms, with shared music and video folder and organization settings.",
+        "Deezer editorial playlists: browse editorial playlists across all 28 genres, search playlists, and see what happens as a playlist is handed off to sync.",
+        "Existing audiobook libraries: scan books already on disk, browse the rebuilt library, and review catalogue edition matches using metadata and download provenance.",
+        "Audiobook download reliability: live progress follows the download client, cancellation persists, Soulseek transfers are matched correctly, and wishlist rows move on from sent to downloads.",
+        "Watchlist progress and cancellation: source matching appears on the page and automation card, and a long artist can be cancelled while matching.",
+        "Connection and import fixes: correct a Last.fm username, import SoundCloud downloads, preserve the selected Deezer track, and keep unsent chat drafts when Soulseek is disconnected.",
+        "Podcast protections: podcast fetches are guarded and watchlist automation respects profile ownership.",
+        "Video libraries across drives: configure additional video library paths and load shared Library settings from either media side."
+    ]
+},
+    {
+        title: "Earlier in 3.4.0: podcasts and audiobooks, and a settings page you can read",
         description: "two new sides to the app. podcasts with itunes search, rss and OPML, and audiobooks built on audible's catalogue with their own database and source chain. the settings page was rebuilt around tiles, and ten reported bugs are fixed.",
         features: [
             "podcasts, a whole new section: itunes search or paste an rss url straight into the search bar, with custom, patreon and private feeds supported. browse, show detail with the full episode tracklist, and a player",

--- a/webui/static/settings-premier.css
+++ b/webui/static/settings-premier.css
@@ -1,630 +1,164 @@
-/* ==========================================================================
-   SoulSync Settings Redesign — Premier App Aesthetic (Apple / Meta / Google)
-   Master-Detail Architecture, Grouped Inset Cards, and Refined Form Controls
-   ========================================================================== */
-
-/* ── 1. Page Shell & Master-Detail Two-Pane Layout ────────────────────────── */
+/* Settings: one category bar within the application's existing navigation. */
 #settings-page {
-    --stg-radius-card: 18px;
-    --stg-radius-control: 10px;
-    --stg-bg-card: rgba(22, 27, 38, 0.65);
-    --stg-bg-card-hover: rgba(28, 34, 48, 0.75);
-    --stg-border-card: 1px solid rgba(255, 255, 255, 0.08);
-    --stg-border-divider: 1px solid rgba(255, 255, 255, 0.05);
-    --stg-shadow-card: 0 8px 32px rgba(0, 0, 0, 0.35);
-    --stg-text-primary: #f8fafc;
-    --stg-text-secondary: rgba(255, 255, 255, 0.55);
-    --stg-text-muted: rgba(255, 255, 255, 0.38);
+    --stg-text-primary: #f3f4f7;
+    --stg-text-secondary: #a9b0bf;
+    --stg-surface: rgba(22, 27, 38, .72);
+    --stg-line: rgba(255, 255, 255, .09);
 }
-
-#settings-page .page-shell {
-    max-width: 100% !important;
-    padding: 0 !important;
-    background: transparent !important;
-}
-
-/* Hide the old top-header compact bar */
-#settings-page .settings-header-compact {
-    display: none !important;
-}
-
-/* Master-Detail Flex Container */
+#settings-page .settings-header-compact { display: none; }
+#settings-page .page-shell { max-width: 100%; padding: 0; }
 #settings-page .settings-content {
-    display: flex !important;
-    flex-direction: row !important;
-    align-items: flex-start !important;
-    gap: 28px !important;
-    max-width: 1420px !important;
-    margin: 0 auto !important;
-    padding: 24px 28px 80px !important;
-    box-sizing: border-box !important;
-    width: 100% !important;
-}
-
-/* ── 2. Master Navigation Rail (Left Sidebar) ────────────────────────────── */
-#settings-page .stg-nav-rail {
-    width: 260px;
-    min-width: 260px;
-    position: sticky;
-    top: 20px;
-    z-index: 20;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    background: rgba(16, 20, 29, 0.82);
-    backdrop-filter: blur(24px);
-    -webkit-backdrop-filter: blur(24px);
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    border-radius: 20px;
-    padding: 16px 10px;
-    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
-
-/* Settings Search / Quick Filter Input */
-.stg-nav-search-wrap {
-    position: relative;
-    padding: 0 4px 10px;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    margin-bottom: 6px;
-}
-
-.stg-nav-search-wrap input {
+    display: block !important;
     width: 100%;
+    max-width: 1240px !important;
+    margin: 0 auto;
+    padding: 24px 32px 72px !important;
     box-sizing: border-box;
-    background: rgba(0, 0, 0, 0.35);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
-    padding: 8px 12px 8px 32px;
-    font-size: 0.84rem;
-    color: #f1f5f9;
-    outline: none;
-    transition: all 160ms ease;
-    font-family: inherit;
 }
-
-.stg-nav-search-wrap input:focus {
-    border-color: var(--accent-color, #1db954);
-    box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 29, 185, 84), 0.25);
-    background: rgba(0, 0, 0, 0.5);
+#settings-page .stg-category-nav { min-width: 0; margin-bottom: 28px; }
+#settings-page .stg-navigation-heading {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 24px; margin-bottom: 22px;
 }
-
-.stg-nav-search-wrap .stg-search-icon {
-    position: absolute;
-    left: 14px;
-    top: 50%;
-    transform: translateY(-50%) translateY(-5px);
-    width: 14px;
-    height: 14px;
-    fill: rgba(255, 255, 255, 0.4);
-    pointer-events: none;
+#settings-page .stg-eyebrow { font-size: 10px; letter-spacing: .12em; color: var(--stg-text-secondary); font-weight: 650; }
+#settings-page .stg-navigation-heading h2 { margin: 5px 0 0; font-size: 28px; letter-spacing: -.035em; line-height: 1.2; }
+#settings-page .stg-nav-search-wrap { position: relative; width: min(340px, 45%); }
+#settings-page .stg-nav-search-wrap input {
+    width: 100%; padding: 11px 14px 11px 38px !important; border-radius: 10px;
+    border: 1px solid var(--stg-line); background: rgba(0,0,0,.16); color: var(--stg-text-primary); box-sizing: border-box;
 }
-
-/* Section Header in Navigation Rail */
-.stg-nav-section-title {
-    font-size: 0.68rem;
-    font-weight: 700;
-    letter-spacing: 0.09em;
-    text-transform: uppercase;
-    color: var(--stg-text-muted);
-    padding: 10px 12px 4px;
-    user-select: none;
-}
-
-/* Navigation Items (.stg-tab) in Rail */
+#settings-page .stg-search-icon { position: absolute; left: 13px; top: 50%; transform: translateY(-50%); width: 15px; height: 15px; fill: var(--stg-text-secondary); pointer-events: none; }
 #settings-page .stg-tabbar {
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 3px !important;
-    background: transparent !important;
-    box-shadow: none !important;
-    border-radius: 0 !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    width: 100% !important;
+    display: flex !important; flex-direction: row !important; flex-wrap: nowrap !important; gap: 4px !important;
+    width: 100%; overflow-x: auto; background: transparent !important;
+    border: 0; border-bottom: 1px solid var(--stg-line); border-radius: 0 !important;
+    padding: 0 !important; margin: 0 !important; box-shadow: none !important;
+    scrollbar-width: thin;
 }
-
 #settings-page .stg-tab {
-    display: flex !important;
-    align-items: center !important;
-    gap: 12px !important;
-    width: 100% !important;
-    padding: 9px 12px !important;
-    border-radius: 12px !important;
-    font-size: 0.88rem !important;
-    font-weight: 500 !important;
-    color: var(--stg-text-secondary) !important;
-    background: transparent !important;
-    border: none !important;
-    cursor: pointer !important;
-    text-align: left !important;
-    box-sizing: border-box !important;
-    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
-    position: relative !important;
+    display: inline-flex !important; align-items: center; justify-content: center;
+    gap: 7px; flex: 0 0 auto; width: auto !important;
+    padding: 13px 12px !important; border: 0 !important; border-bottom: 2px solid transparent !important;
+    border-radius: 0 !important; background: transparent !important; color: var(--stg-text-secondary) !important;
+    font-size: 13px !important; font-weight: 550; white-space: nowrap; cursor: pointer;
+    box-shadow: none !important; transition: color 120ms, border-color 120ms;
 }
-
-#settings-page .stg-tab:hover {
-    background: rgba(255, 255, 255, 0.05) !important;
-    color: var(--stg-text-primary) !important;
-    transform: translateX(2px);
-}
-
-#settings-page .stg-tab.active {
-    background: rgba(var(--accent-rgb, 29, 185, 84), 0.14) !important;
-    color: #ffffff !important;
-    font-weight: 600 !important;
-    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb, 29, 185, 84), 0.3) !important;
-}
-
-#settings-page .stg-tab.active::before {
-    content: "";
-    position: absolute;
-    left: 2px;
-    top: 8px;
-    bottom: 8px;
-    width: 3.5px;
-    border-radius: 3px;
-    background: var(--accent-color, #1db954);
-    box-shadow: 0 0 8px var(--accent-color, #1db954);
-}
-
-/* Squircle Category Badges (Apple System Settings style) */
-.stg-tab-badge {
-    width: 28px;
-    height: 28px;
-    border-radius: 8px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-    transition: transform 180ms ease;
-}
-
-#settings-page .stg-tab:hover .stg-tab-badge {
-    transform: scale(1.08);
-}
-
-.stg-tab-badge svg {
-    width: 16px;
-    height: 16px;
-    fill: #ffffff;
-}
-
-/* Distinct gradients for each squircle badge */
-.badge-connections { background: linear-gradient(135deg, #0ea5e9, #2563eb); }
-.badge-downloads   { background: linear-gradient(135deg, #10b981, #059669); }
-.badge-sources     { background: linear-gradient(135deg, #8b5cf6, #6366f1); }
-.badge-quality     { background: linear-gradient(135deg, #f59e0b, #d97706); }
-.badge-library     { background: linear-gradient(135deg, #a855f7, #7c3aed); }
-.badge-appearance  { background: linear-gradient(135deg, #ec4899, #e11d48); }
-.badge-advanced    { background: linear-gradient(135deg, #64748b, #475569); }
-.badge-logs        { background: linear-gradient(135deg, #14b8a6, #0f766e); }
-
-.stg-tab-label {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* ── 3. Detail Workspace (Right Content Canvas) ──────────────────────────── */
-#settings-page .stg-detail-pane {
-    flex: 1;
-    min-width: 0;
-    max-width: 1040px;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-/* Sticky Action Header Bar */
+#settings-page .stg-tab:hover { color: var(--stg-text-primary) !important; }
+#settings-page .stg-tab.active { color: var(--stg-text-primary) !important; border-bottom-color: var(--accent-color, #1db954) !important; }
+#settings-page .stg-tab-badge { display: inline-flex; width: 16px; height: 16px; background: none; box-shadow: none; }
+#settings-page .stg-tab-badge svg { width: 16px; height: 16px; fill: currentColor; opacity: .75; }
+#settings-page .stg-tab.active .stg-tab-badge { color: var(--accent-color, #1db954); }
+#settings-page .stg-detail-pane { width: 100%; min-width: 0; }
 #settings-page .settings-nav-row {
-    display: flex !important;
-    align-items: center !important;
-    justify-content: space-between !important;
-    background: rgba(16, 20, 29, 0.82) !important;
-    backdrop-filter: blur(20px) !important;
-    -webkit-backdrop-filter: blur(20px) !important;
-    border: 1px solid rgba(255, 255, 255, 0.08) !important;
-    border-radius: 16px !important;
-    padding: 12px 20px !important;
-    margin-bottom: 20px !important;
-    position: sticky !important;
-    top: 20px !important;
-    z-index: 15 !important;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35) !important;
+    display: flex !important; flex-direction: row !important; align-items: center; justify-content: space-between;
+    gap: 24px; margin-bottom: 24px; padding: 0 !important;
+    background: transparent !important; border: 0 !important; box-shadow: none !important;
+    position: static !important;
 }
-
-.stg-active-section-title {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.stg-active-title-text {
-    font-size: 1.15rem;
-    font-weight: 700;
-    letter-spacing: -0.015em;
-    color: var(--stg-text-primary);
-}
-
-.stg-active-sub-text {
-    font-size: 0.78rem;
-    color: var(--stg-text-secondary);
-}
-
-/* Save Settings Button — Premier Style */
+#settings-page .stg-active-section-title { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+#settings-page .stg-active-title-text { font-size: 20px; font-weight: 650; letter-spacing: -.02em; }
+#settings-page .stg-active-sub-text { color: var(--stg-text-secondary); font-size: 13px; line-height: 1.5; }
 #settings-page .save-button {
-    background: linear-gradient(135deg, var(--accent-color, #1db954), color-mix(in srgb, var(--accent-color, #1db954) 80%, black)) !important;
-    color: #ffffff !important;
-    font-weight: 600 !important;
-    font-size: 0.88rem !important;
-    padding: 9px 22px !important;
-    border-radius: 11px !important;
-    border: none !important;
-    cursor: pointer !important;
-    box-shadow: 0 4px 14px rgba(var(--accent-rgb, 29, 185, 84), 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.2) !important;
-    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
-    letter-spacing: -0.005em !important;
-    display: inline-flex !important;
-    align-items: center !important;
-    gap: 8px !important;
+    display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    border: 1px solid rgba(var(--accent-rgb,29,185,84),.35); border-radius: 9px;
+    background: var(--accent-color,#1db954); color: #07190e; padding: 11px 18px;
+    font-size: 13px; font-weight: 700; white-space: nowrap; cursor: pointer; box-shadow: none;
 }
-
-#settings-page .save-button:hover {
-    transform: translateY(-1px) !important;
-    box-shadow: 0 6px 20px rgba(var(--accent-rgb, 29, 185, 84), 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.25) !important;
-}
-
-#settings-page .save-button:active {
-    transform: translateY(0) scale(0.98) !important;
-}
-
-#settings-page .save-button.is-saved {
-    background: linear-gradient(135deg, #10b981, #059669) !important;
-    box-shadow: 0 4px 16px rgba(16, 185, 129, 0.4) !important;
-}
-
-/* ── 4. Grouped Inset Cards (Apple / Meta style) ─────────────────────────── */
+#settings-page .save-button:disabled { opacity: .5; cursor: wait; }
 #settings-page .settings-columns {
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 20px !important;
-    margin-bottom: 0 !important;
+    display: flex !important; flex-direction: column !important; gap: 18px !important;
+    width: 100%; max-width: none !important; margin: 0; padding: 0;
 }
-
 #settings-page .settings-left-column,
 #settings-page .settings-right-column,
-#settings-page .settings-third-column {
-    min-width: 0 !important;
-    width: 100% !important;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-/* Ensure inline display: none is strictly respected when tabs switch, overriding video-side.css */
-#settings-page .settings-left-column[style*="display: none"],
-#settings-page .settings-left-column[style*="display:none"],
-#settings-page .settings-right-column[style*="display: none"],
-#settings-page .settings-right-column[style*="display:none"],
-#settings-page .settings-third-column[style*="display: none"],
-#settings-page .settings-third-column[style*="display:none"],
-#settings-page .settings-group[style*="display: none"],
-#settings-page .settings-group[style*="display:none"],
-#settings-page .settings-group[data-svc-side][style*="display: none"],
-#settings-page .settings-group[data-svc-side][style*="display:none"],
+#settings-page .settings-third-column { min-width: 0; width: 100%; display: flex; flex-direction: column; gap: 18px; }
 #settings-page [data-stg][style*="display: none"],
-#settings-page [data-stg][style*="display:none"] {
-    display: none !important;
+#settings-page [data-stg][style*="display:none"],
+#settings-page .settings-left-column[style*="display: none"],
+#settings-page .settings-right-column[style*="display: none"],
+#settings-page .settings-third-column[style*="display: none"] { display: none !important; }
+#settings-page .settings-group,
+#settings-page .stg-media-card {
+    background: var(--stg-surface) !important; border: 1px solid var(--stg-line) !important;
+    border-radius: 14px !important; padding: 22px 24px !important; margin-bottom: 0 !important;
+    box-shadow: none !important; backdrop-filter: none !important;
 }
-
-#settings-page .settings-group {
-    background: var(--stg-bg-card) !important;
-    border: var(--stg-border-card) !important;
-    backdrop-filter: blur(20px) !important;
-    -webkit-backdrop-filter: blur(20px) !important;
-    border-radius: var(--stg-radius-card) !important;
-    box-shadow: var(--stg-shadow-card) !important;
-    padding: 20px 24px !important;
-    margin-bottom: 0 !important;
-    transition: border-color 200ms ease;
-    overflow: visible;
-}
-
-#settings-page .settings-group:hover {
-    border-color: rgba(255, 255, 255, 0.12) !important;
-}
-
-/* Card Header */
-#settings-page .settings-group > h3 {
-    font-size: 1.05rem !important;
-    font-weight: 600 !important;
-    letter-spacing: -0.01em !important;
-    color: var(--stg-text-primary) !important;
-    margin: 0 0 16px !important;
-    padding-bottom: 12px !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.07) !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: space-between !important;
-}
-
-/* Section Header (Collapsible sections in Library / Advanced) */
+#settings-page .settings-group > h3 { font-size: 16px; font-weight: 650; margin: 0 0 18px; padding-bottom: 14px; border-bottom: 1px solid var(--stg-line); }
 #settings-page .settings-section-header {
-    background: rgba(255, 255, 255, 0.035) !important;
-    border: 1px solid rgba(255, 255, 255, 0.07) !important;
-    border-radius: 14px !important;
-    padding: 14px 18px !important;
-    margin-bottom: 10px !important;
-    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15) !important;
+    border: 1px solid var(--stg-line); border-radius: 12px; padding: 16px 18px;
+    background: var(--stg-surface); margin-bottom: 0; box-shadow: none;
 }
-
-#settings-page .settings-section-header:hover {
-    background: rgba(255, 255, 255, 0.065) !important;
-    border-color: rgba(255, 255, 255, 0.12) !important;
-    transform: translateY(-1px);
-}
-
-#settings-page .settings-section-body {
-    background: rgba(14, 18, 26, 0.5) !important;
-    border: 1px solid rgba(255, 255, 255, 0.06) !important;
-    border-radius: 14px !important;
-    padding: 16px 20px !important;
-    margin-bottom: 16px !important;
-}
-
-/* ── 5. Form Group Rows (Apple Inset Row Grammar) ────────────────────────── */
-#settings-page .form-group {
-    display: flex !important;
-    justify-content: space-between !important;
-    align-items: center !important;
-    padding: 12px 4px !important;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
-    margin-bottom: 0 !important;
-    min-height: 48px;
-    box-sizing: border-box;
-    gap: 16px;
-}
-
-#settings-page .form-group:last-child {
-    border-bottom: none !important;
-}
-
-#settings-page .form-group > label {
-    font-size: 0.92rem !important;
-    font-weight: 500 !important;
-    color: var(--stg-text-primary) !important;
-    margin-bottom: 0 !important;
-    flex: 1 !important;
-    line-height: 1.4 !important;
-}
-
-/* Subtitles / Helper Text */
+#settings-page .settings-section-header:hover { border-color: rgba(var(--accent-rgb,29,185,84),.35); }
+#settings-page .settings-section-body { border-radius: 12px; padding: 18px 22px; }
+/* Keep complex fields stacked: labels, paths, help, repeatable rows and buttons
+   are not interchangeable cells in a single flex row. */
+#settings-page .form-group { min-width: 0; margin-bottom: 20px; }
+#settings-page .form-group:last-child { margin-bottom: 0; }
+#settings-page .form-group > label { font-size: 13px; font-weight: 600; line-height: 1.5; margin-bottom: 8px; }
 #settings-page .setting-help-text,
 #settings-page .form-group-help,
-#settings-page .settings-subtext {
-    font-size: 0.8rem !important;
-    color: var(--stg-text-secondary) !important;
-    line-height: 1.45 !important;
-    margin-top: 3px !important;
+#settings-page .settings-subtext { font-size: 12px; line-height: 1.6; color: var(--stg-text-secondary); margin-top: 7px; }
+#settings-page input[type="text"], #settings-page input[type="password"],
+#settings-page input[type="number"], #settings-page select, #settings-page textarea {
+    box-sizing: border-box; max-width: 100%; border-radius: 8px;
+    border: 1px solid rgba(255,255,255,.14); background-color: rgba(0,0,0,.18);
+    color: var(--stg-text-primary); padding: 10px 12px; font: inherit; font-size: 13px;
 }
-
-/* ── 6. Form Controls: Inputs, Selects, and Switches ────────────────────── */
-#settings-page input[type="text"],
-#settings-page input[type="password"],
-#settings-page input[type="number"],
-#settings-page select,
-#settings-page textarea {
-    background: rgba(10, 14, 22, 0.75) !important;
-    border: 1px solid rgba(255, 255, 255, 0.12) !important;
-    border-radius: var(--stg-radius-control) !important;
-    padding: 8px 14px !important;
-    color: #ffffff !important;
-    font-size: 0.88rem !important;
-    font-family: inherit !important;
-    outline: none !important;
-    box-sizing: border-box !important;
-    transition: all 160ms ease !important;
-    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35) !important;
+#settings-page input[type="checkbox"] { accent-color: var(--accent-color,#1db954); }
+#settings-page button:focus-visible, #settings-page input:focus-visible,
+#settings-page select:focus-visible, #settings-page textarea:focus-visible {
+    outline: 2px solid var(--accent-color,#1db954) !important; outline-offset: 3px;
 }
-
-#settings-page select {
-    appearance: none !important;
-    -webkit-appearance: none !important;
-    padding-right: 32px !important;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E") !important;
-    background-repeat: no-repeat !important;
-    background-position: right 10px center !important;
-    cursor: pointer !important;
+#settings-page .svc-tile-row { display: grid !important; grid-template-columns: repeat(auto-fill,minmax(120px,1fr)); gap: 10px; }
+#settings-page .svc-tile { border-radius: 12px; box-shadow: none; }
+#settings-page .stg-search-results { margin-bottom: 18px; padding: 8px; border: 1px solid var(--stg-line); border-radius: 12px; background: var(--stg-surface); }
+#settings-page .stg-search-results[hidden] { display: none; }
+#settings-page .stg-search-results button { display: block; width: 100%; text-align: left; padding: 12px; border: 0; border-radius: 7px; background: transparent; color: var(--stg-text-primary); cursor: pointer; font: inherit; font-size: 13px; }
+#settings-page .stg-search-results button:hover { background: rgba(255,255,255,.06); }
+#settings-page .stg-search-results p { padding: 8px 12px; margin: 0; color: var(--stg-text-secondary); font-size: 13px; }
+#settings-page .stg-search-target { outline: 2px solid rgba(var(--accent-rgb,29,185,84),.55); outline-offset: 5px; scroll-margin-top: 30px; }
+@media (max-width: 900px) {
+    #settings-page .settings-content { padding: 20px 18px 60px !important; }
+    #settings-page .stg-tab { padding: 12px 10px !important; }
+    #settings-page .stg-tab-badge { display: none; }
 }
-
-#settings-page input[type="text"]:focus,
-#settings-page input[type="password"]:focus,
-#settings-page input[type="number"]:focus,
-#settings-page select:focus,
-#settings-page textarea:focus {
-    border-color: var(--accent-color, #1db954) !important;
-    box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 29, 185, 84), 0.25), inset 0 1px 2px rgba(0, 0, 0, 0.3) !important;
-    background: rgba(14, 19, 29, 0.9) !important;
+@media (max-width: 560px) {
+    #settings-page .settings-content { padding: 16px 12px 48px !important; }
+    #settings-page .stg-navigation-heading { align-items: stretch; flex-direction: column; gap: 16px; margin-bottom: 12px; }
+    #settings-page .stg-nav-search-wrap { width: 100%; }
+    #settings-page .stg-navigation-heading h2 { font-size: 25px; }
+    #settings-page .settings-nav-row { align-items: flex-start; gap: 12px; }
+    #settings-page .save-button { padding: 10px 12px; font-size: 12px; }
+    #settings-page .save-button svg { display: none; }
+    #settings-page .stg-active-sub-text { font-size: 12px; }
+    #settings-page .settings-group, #settings-page .stg-media-card { padding: 16px !important; }
+    #settings-page .settings-section-hint { display: none; }
 }
+@media (prefers-reduced-motion: reduce) { #settings-page *, #settings-page *::before, #settings-page *::after { transition: none !important; animation: none !important; scroll-behavior: auto !important; } }
 
-/* Apple-style Pill Switches */
-#settings-page input[type="checkbox"] {
-    appearance: none !important;
-    -webkit-appearance: none !important;
-    width: 44px !important;
-    height: 24px !important;
-    border-radius: 9999px !important;
-    background: rgba(255, 255, 255, 0.18) !important;
-    position: relative !important;
-    cursor: pointer !important;
-    transition: background-color 200ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 200ms ease !important;
-    outline: none !important;
-    margin: 0 !important;
-    flex-shrink: 0 !important;
-    border: none !important;
+#settings-page .stg-cardgroup { margin: 12px 0 0; gap: 10px; }
+#settings-page .stg-cardgroup:first-child { margin-top: 0; }
+#settings-page .stg-cardgroup-label { color: var(--stg-text-secondary); }
+#settings-page .header-actions { flex: 0 0 auto; }
+
+#settings-page .stg-media-card .form-group {
+    display: block !important; padding: 12px 0 !important;
 }
-
-#settings-page input[type="checkbox"]:checked {
-    background-color: var(--accent-color, #1db954) !important;
-    box-shadow: 0 0 12px rgba(var(--accent-rgb, 29, 185, 84), 0.4) !important;
+#settings-page .stg-media-card .form-group > label { display: block; }
+#settings-page .stg-media-card .form-group > input:not([type="checkbox"]):not([type="radio"]),
+#settings-page .stg-media-card .form-group > select,
+#settings-page .stg-media-card .form-group > textarea {
+    display: block; width: 100% !important; max-width: 100% !important;
 }
+#settings-page .settings-nav-row { flex-wrap: nowrap !important; }
+#settings-page .settings-nav-row .header-actions { width: auto !important; margin: 0 !important; }
 
-#settings-page input[type="checkbox"]::after {
-    content: "" !important;
-    position: absolute !important;
-    top: 2px !important;
-    left: 2px !important;
-    width: 20px !important;
-    height: 20px !important;
-    border-radius: 50% !important;
-    background: #ffffff !important;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.35) !important;
-    transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1) !important;
-}
+/* Legacy media pages require 960px; forms should fit beside the app sidebar. */
+.main-container:has(#settings-page.active),
+.main-content:has(#settings-page.active) { min-width: 0 !important; }
 
-#settings-page input[type="checkbox"]:checked::after {
-    transform: translateX(20px) !important;
-}
-
-#settings-page input[type="checkbox"]:focus-visible {
-    outline: 2px solid var(--accent-color, #1db954) !important;
-    outline-offset: 2px !important;
-}
-
-/* Secondary Buttons */
-#settings-page .test-button,
-#settings-page .btn-secondary,
-#settings-page .stg-accordion-toggle {
-    background: rgba(255, 255, 255, 0.07) !important;
-    border: 1px solid rgba(255, 255, 255, 0.1) !important;
-    color: var(--stg-text-primary) !important;
-    border-radius: 9px !important;
-    padding: 6px 14px !important;
-    font-size: 0.82rem !important;
-    font-weight: 500 !important;
-    cursor: pointer !important;
-    transition: all 140ms ease !important;
-}
-
-#settings-page .test-button:hover,
-#settings-page .btn-secondary:hover,
-#settings-page .stg-accordion-toggle:hover {
-    background: rgba(255, 255, 255, 0.12) !important;
-    border-color: rgba(255, 255, 255, 0.18) !important;
-    transform: translateY(-1px);
-}
-
-/* ── 7. Connections & Sources Service Tiles Elevating ───────────────────── */
-#settings-page .svc-tile-row {
-    display: grid !important;
-    grid-template-columns: repeat(auto-fill, minmax(136px, 1fr)) !important;
-    gap: 14px !important;
-}
-
-#settings-page .svc-tile {
-    background: rgba(22, 27, 38, 0.7) !important;
-    border: 1px solid rgba(255, 255, 255, 0.08) !important;
-    border-radius: 16px !important;
-    padding: 18px 12px 14px !important;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25) !important;
-    transition: all 180ms cubic-bezier(0.16, 1, 0.3, 1) !important;
-}
-
-#settings-page .svc-tile:hover {
-    transform: translateY(-3px) !important;
-    background: rgba(28, 34, 48, 0.85) !important;
-    border-color: rgba(255, 255, 255, 0.16) !important;
-    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45) !important;
-}
-
-#settings-page .svc-tile.is-active {
-    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb, 29, 185, 84), 0.4), 0 4px 16px rgba(0, 0, 0, 0.25) !important;
-}
-
-/* ── 8. Media Tabs (Library Folders & Organization) ─────────────────────── */
-#settings-page .stg-media-card {
-    background: var(--stg-bg-card) !important;
-    border: var(--stg-border-card) !important;
-    border-radius: var(--stg-radius-card) !important;
-    box-shadow: var(--stg-shadow-card) !important;
-    padding: 22px 24px !important;
-}
-
-#settings-page .stg-media-switcher {
-    background: rgba(0, 0, 0, 0.35) !important;
-    border-radius: 11px !important;
-    padding: 4px !important;
-    border: 1px solid rgba(255, 255, 255, 0.06) !important;
-}
-
-#settings-page .stg-media-switcher button {
-    border-radius: 8px !important;
-    font-size: 0.84rem !important;
-    font-weight: 500 !important;
-    padding: 7px 18px !important;
-    transition: all 140ms ease !important;
-}
-
-#settings-page .stg-media-switcher button[aria-selected="true"] {
-    background: var(--accent-color, #1db954) !important;
-    color: #ffffff !important;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25) !important;
-}
-
-/* ── 9. Responsive Fluid Behavior (< 880px) ─────────────────────────────── */
-@media (max-width: 880px) {
-    #settings-page .settings-content {
-        flex-direction: column !important;
-        padding: 16px 14px 60px !important;
-        gap: 16px !important;
-    }
-
-    #settings-page .stg-nav-rail {
-        width: 100% !important;
-        min-width: 0 !important;
-        position: static !important;
-        padding: 10px !important;
-        border-radius: 14px !important;
-    }
-
-    .stg-nav-section-title {
-        display: none !important;
-    }
-
-    #settings-page .stg-tabbar {
-        flex-direction: row !important;
-        overflow-x: auto !important;
-        gap: 6px !important;
-        padding-bottom: 4px !important;
-        scrollbar-width: none !important;
-    }
-
-    #settings-page .stg-tabbar::-webkit-scrollbar {
-        display: none !important;
-    }
-
-    #settings-page .stg-tab {
-        width: auto !important;
-        padding: 8px 14px !important;
-        white-space: nowrap !important;
-    }
-
-    #settings-page .stg-tab.active::before {
-        display: none !important;
-    }
-
-    #settings-page .settings-nav-row {
-        position: static !important;
-        margin-bottom: 12px !important;
-        padding: 10px 14px !important;
-    }
-
-    #settings-page .settings-group,
-    #settings-page .stg-media-card {
-        padding: 16px 18px !important;
-    }
+/* Keep saving within reach while scrolling a long category. */
+#settings-page .settings-nav-row {
+    position: sticky !important; top: 0; z-index: 20;
+    background: rgb(15, 15, 15) !important; padding: 12px 0 !important;
 }

--- a/webui/static/settings-premier.css
+++ b/webui/static/settings-premier.css
@@ -1,0 +1,630 @@
+/* ==========================================================================
+   SoulSync Settings Redesign — Premier App Aesthetic (Apple / Meta / Google)
+   Master-Detail Architecture, Grouped Inset Cards, and Refined Form Controls
+   ========================================================================== */
+
+/* ── 1. Page Shell & Master-Detail Two-Pane Layout ────────────────────────── */
+#settings-page {
+    --stg-radius-card: 18px;
+    --stg-radius-control: 10px;
+    --stg-bg-card: rgba(22, 27, 38, 0.65);
+    --stg-bg-card-hover: rgba(28, 34, 48, 0.75);
+    --stg-border-card: 1px solid rgba(255, 255, 255, 0.08);
+    --stg-border-divider: 1px solid rgba(255, 255, 255, 0.05);
+    --stg-shadow-card: 0 8px 32px rgba(0, 0, 0, 0.35);
+    --stg-text-primary: #f8fafc;
+    --stg-text-secondary: rgba(255, 255, 255, 0.55);
+    --stg-text-muted: rgba(255, 255, 255, 0.38);
+}
+
+#settings-page .page-shell {
+    max-width: 100% !important;
+    padding: 0 !important;
+    background: transparent !important;
+}
+
+/* Hide the old top-header compact bar */
+#settings-page .settings-header-compact {
+    display: none !important;
+}
+
+/* Master-Detail Flex Container */
+#settings-page .settings-content {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: flex-start !important;
+    gap: 28px !important;
+    max-width: 1420px !important;
+    margin: 0 auto !important;
+    padding: 24px 28px 80px !important;
+    box-sizing: border-box !important;
+    width: 100% !important;
+}
+
+/* ── 2. Master Navigation Rail (Left Sidebar) ────────────────────────────── */
+#settings-page .stg-nav-rail {
+    width: 260px;
+    min-width: 260px;
+    position: sticky;
+    top: 20px;
+    z-index: 20;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    background: rgba(16, 20, 29, 0.82);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 20px;
+    padding: 16px 10px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* Settings Search / Quick Filter Input */
+.stg-nav-search-wrap {
+    position: relative;
+    padding: 0 4px 10px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    margin-bottom: 6px;
+}
+
+.stg-nav-search-wrap input {
+    width: 100%;
+    box-sizing: border-box;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    padding: 8px 12px 8px 32px;
+    font-size: 0.84rem;
+    color: #f1f5f9;
+    outline: none;
+    transition: all 160ms ease;
+    font-family: inherit;
+}
+
+.stg-nav-search-wrap input:focus {
+    border-color: var(--accent-color, #1db954);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 29, 185, 84), 0.25);
+    background: rgba(0, 0, 0, 0.5);
+}
+
+.stg-nav-search-wrap .stg-search-icon {
+    position: absolute;
+    left: 14px;
+    top: 50%;
+    transform: translateY(-50%) translateY(-5px);
+    width: 14px;
+    height: 14px;
+    fill: rgba(255, 255, 255, 0.4);
+    pointer-events: none;
+}
+
+/* Section Header in Navigation Rail */
+.stg-nav-section-title {
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--stg-text-muted);
+    padding: 10px 12px 4px;
+    user-select: none;
+}
+
+/* Navigation Items (.stg-tab) in Rail */
+#settings-page .stg-tabbar {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 3px !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    width: 100% !important;
+}
+
+#settings-page .stg-tab {
+    display: flex !important;
+    align-items: center !important;
+    gap: 12px !important;
+    width: 100% !important;
+    padding: 9px 12px !important;
+    border-radius: 12px !important;
+    font-size: 0.88rem !important;
+    font-weight: 500 !important;
+    color: var(--stg-text-secondary) !important;
+    background: transparent !important;
+    border: none !important;
+    cursor: pointer !important;
+    text-align: left !important;
+    box-sizing: border-box !important;
+    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+    position: relative !important;
+}
+
+#settings-page .stg-tab:hover {
+    background: rgba(255, 255, 255, 0.05) !important;
+    color: var(--stg-text-primary) !important;
+    transform: translateX(2px);
+}
+
+#settings-page .stg-tab.active {
+    background: rgba(var(--accent-rgb, 29, 185, 84), 0.14) !important;
+    color: #ffffff !important;
+    font-weight: 600 !important;
+    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb, 29, 185, 84), 0.3) !important;
+}
+
+#settings-page .stg-tab.active::before {
+    content: "";
+    position: absolute;
+    left: 2px;
+    top: 8px;
+    bottom: 8px;
+    width: 3.5px;
+    border-radius: 3px;
+    background: var(--accent-color, #1db954);
+    box-shadow: 0 0 8px var(--accent-color, #1db954);
+}
+
+/* Squircle Category Badges (Apple System Settings style) */
+.stg-tab-badge {
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    transition: transform 180ms ease;
+}
+
+#settings-page .stg-tab:hover .stg-tab-badge {
+    transform: scale(1.08);
+}
+
+.stg-tab-badge svg {
+    width: 16px;
+    height: 16px;
+    fill: #ffffff;
+}
+
+/* Distinct gradients for each squircle badge */
+.badge-connections { background: linear-gradient(135deg, #0ea5e9, #2563eb); }
+.badge-downloads   { background: linear-gradient(135deg, #10b981, #059669); }
+.badge-sources     { background: linear-gradient(135deg, #8b5cf6, #6366f1); }
+.badge-quality     { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.badge-library     { background: linear-gradient(135deg, #a855f7, #7c3aed); }
+.badge-appearance  { background: linear-gradient(135deg, #ec4899, #e11d48); }
+.badge-advanced    { background: linear-gradient(135deg, #64748b, #475569); }
+.badge-logs        { background: linear-gradient(135deg, #14b8a6, #0f766e); }
+
+.stg-tab-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* ── 3. Detail Workspace (Right Content Canvas) ──────────────────────────── */
+#settings-page .stg-detail-pane {
+    flex: 1;
+    min-width: 0;
+    max-width: 1040px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+/* Sticky Action Header Bar */
+#settings-page .settings-nav-row {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    background: rgba(16, 20, 29, 0.82) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-radius: 16px !important;
+    padding: 12px 20px !important;
+    margin-bottom: 20px !important;
+    position: sticky !important;
+    top: 20px !important;
+    z-index: 15 !important;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35) !important;
+}
+
+.stg-active-section-title {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.stg-active-title-text {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    color: var(--stg-text-primary);
+}
+
+.stg-active-sub-text {
+    font-size: 0.78rem;
+    color: var(--stg-text-secondary);
+}
+
+/* Save Settings Button — Premier Style */
+#settings-page .save-button {
+    background: linear-gradient(135deg, var(--accent-color, #1db954), color-mix(in srgb, var(--accent-color, #1db954) 80%, black)) !important;
+    color: #ffffff !important;
+    font-weight: 600 !important;
+    font-size: 0.88rem !important;
+    padding: 9px 22px !important;
+    border-radius: 11px !important;
+    border: none !important;
+    cursor: pointer !important;
+    box-shadow: 0 4px 14px rgba(var(--accent-rgb, 29, 185, 84), 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.2) !important;
+    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+    letter-spacing: -0.005em !important;
+    display: inline-flex !important;
+    align-items: center !important;
+    gap: 8px !important;
+}
+
+#settings-page .save-button:hover {
+    transform: translateY(-1px) !important;
+    box-shadow: 0 6px 20px rgba(var(--accent-rgb, 29, 185, 84), 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.25) !important;
+}
+
+#settings-page .save-button:active {
+    transform: translateY(0) scale(0.98) !important;
+}
+
+#settings-page .save-button.is-saved {
+    background: linear-gradient(135deg, #10b981, #059669) !important;
+    box-shadow: 0 4px 16px rgba(16, 185, 129, 0.4) !important;
+}
+
+/* ── 4. Grouped Inset Cards (Apple / Meta style) ─────────────────────────── */
+#settings-page .settings-columns {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 20px !important;
+    margin-bottom: 0 !important;
+}
+
+#settings-page .settings-left-column,
+#settings-page .settings-right-column,
+#settings-page .settings-third-column {
+    min-width: 0 !important;
+    width: 100% !important;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Ensure inline display: none is strictly respected when tabs switch, overriding video-side.css */
+#settings-page .settings-left-column[style*="display: none"],
+#settings-page .settings-left-column[style*="display:none"],
+#settings-page .settings-right-column[style*="display: none"],
+#settings-page .settings-right-column[style*="display:none"],
+#settings-page .settings-third-column[style*="display: none"],
+#settings-page .settings-third-column[style*="display:none"],
+#settings-page .settings-group[style*="display: none"],
+#settings-page .settings-group[style*="display:none"],
+#settings-page .settings-group[data-svc-side][style*="display: none"],
+#settings-page .settings-group[data-svc-side][style*="display:none"],
+#settings-page [data-stg][style*="display: none"],
+#settings-page [data-stg][style*="display:none"] {
+    display: none !important;
+}
+
+#settings-page .settings-group {
+    background: var(--stg-bg-card) !important;
+    border: var(--stg-border-card) !important;
+    backdrop-filter: blur(20px) !important;
+    -webkit-backdrop-filter: blur(20px) !important;
+    border-radius: var(--stg-radius-card) !important;
+    box-shadow: var(--stg-shadow-card) !important;
+    padding: 20px 24px !important;
+    margin-bottom: 0 !important;
+    transition: border-color 200ms ease;
+    overflow: visible;
+}
+
+#settings-page .settings-group:hover {
+    border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Card Header */
+#settings-page .settings-group > h3 {
+    font-size: 1.05rem !important;
+    font-weight: 600 !important;
+    letter-spacing: -0.01em !important;
+    color: var(--stg-text-primary) !important;
+    margin: 0 0 16px !important;
+    padding-bottom: 12px !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07) !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+}
+
+/* Section Header (Collapsible sections in Library / Advanced) */
+#settings-page .settings-section-header {
+    background: rgba(255, 255, 255, 0.035) !important;
+    border: 1px solid rgba(255, 255, 255, 0.07) !important;
+    border-radius: 14px !important;
+    padding: 14px 18px !important;
+    margin-bottom: 10px !important;
+    transition: all 160ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.15) !important;
+}
+
+#settings-page .settings-section-header:hover {
+    background: rgba(255, 255, 255, 0.065) !important;
+    border-color: rgba(255, 255, 255, 0.12) !important;
+    transform: translateY(-1px);
+}
+
+#settings-page .settings-section-body {
+    background: rgba(14, 18, 26, 0.5) !important;
+    border: 1px solid rgba(255, 255, 255, 0.06) !important;
+    border-radius: 14px !important;
+    padding: 16px 20px !important;
+    margin-bottom: 16px !important;
+}
+
+/* ── 5. Form Group Rows (Apple Inset Row Grammar) ────────────────────────── */
+#settings-page .form-group {
+    display: flex !important;
+    justify-content: space-between !important;
+    align-items: center !important;
+    padding: 12px 4px !important;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05) !important;
+    margin-bottom: 0 !important;
+    min-height: 48px;
+    box-sizing: border-box;
+    gap: 16px;
+}
+
+#settings-page .form-group:last-child {
+    border-bottom: none !important;
+}
+
+#settings-page .form-group > label {
+    font-size: 0.92rem !important;
+    font-weight: 500 !important;
+    color: var(--stg-text-primary) !important;
+    margin-bottom: 0 !important;
+    flex: 1 !important;
+    line-height: 1.4 !important;
+}
+
+/* Subtitles / Helper Text */
+#settings-page .setting-help-text,
+#settings-page .form-group-help,
+#settings-page .settings-subtext {
+    font-size: 0.8rem !important;
+    color: var(--stg-text-secondary) !important;
+    line-height: 1.45 !important;
+    margin-top: 3px !important;
+}
+
+/* ── 6. Form Controls: Inputs, Selects, and Switches ────────────────────── */
+#settings-page input[type="text"],
+#settings-page input[type="password"],
+#settings-page input[type="number"],
+#settings-page select,
+#settings-page textarea {
+    background: rgba(10, 14, 22, 0.75) !important;
+    border: 1px solid rgba(255, 255, 255, 0.12) !important;
+    border-radius: var(--stg-radius-control) !important;
+    padding: 8px 14px !important;
+    color: #ffffff !important;
+    font-size: 0.88rem !important;
+    font-family: inherit !important;
+    outline: none !important;
+    box-sizing: border-box !important;
+    transition: all 160ms ease !important;
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35) !important;
+}
+
+#settings-page select {
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    padding-right: 32px !important;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.6)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E") !important;
+    background-repeat: no-repeat !important;
+    background-position: right 10px center !important;
+    cursor: pointer !important;
+}
+
+#settings-page input[type="text"]:focus,
+#settings-page input[type="password"]:focus,
+#settings-page input[type="number"]:focus,
+#settings-page select:focus,
+#settings-page textarea:focus {
+    border-color: var(--accent-color, #1db954) !important;
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb, 29, 185, 84), 0.25), inset 0 1px 2px rgba(0, 0, 0, 0.3) !important;
+    background: rgba(14, 19, 29, 0.9) !important;
+}
+
+/* Apple-style Pill Switches */
+#settings-page input[type="checkbox"] {
+    appearance: none !important;
+    -webkit-appearance: none !important;
+    width: 44px !important;
+    height: 24px !important;
+    border-radius: 9999px !important;
+    background: rgba(255, 255, 255, 0.18) !important;
+    position: relative !important;
+    cursor: pointer !important;
+    transition: background-color 200ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 200ms ease !important;
+    outline: none !important;
+    margin: 0 !important;
+    flex-shrink: 0 !important;
+    border: none !important;
+}
+
+#settings-page input[type="checkbox"]:checked {
+    background-color: var(--accent-color, #1db954) !important;
+    box-shadow: 0 0 12px rgba(var(--accent-rgb, 29, 185, 84), 0.4) !important;
+}
+
+#settings-page input[type="checkbox"]::after {
+    content: "" !important;
+    position: absolute !important;
+    top: 2px !important;
+    left: 2px !important;
+    width: 20px !important;
+    height: 20px !important;
+    border-radius: 50% !important;
+    background: #ffffff !important;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.35) !important;
+    transition: transform 200ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+#settings-page input[type="checkbox"]:checked::after {
+    transform: translateX(20px) !important;
+}
+
+#settings-page input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent-color, #1db954) !important;
+    outline-offset: 2px !important;
+}
+
+/* Secondary Buttons */
+#settings-page .test-button,
+#settings-page .btn-secondary,
+#settings-page .stg-accordion-toggle {
+    background: rgba(255, 255, 255, 0.07) !important;
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
+    color: var(--stg-text-primary) !important;
+    border-radius: 9px !important;
+    padding: 6px 14px !important;
+    font-size: 0.82rem !important;
+    font-weight: 500 !important;
+    cursor: pointer !important;
+    transition: all 140ms ease !important;
+}
+
+#settings-page .test-button:hover,
+#settings-page .btn-secondary:hover,
+#settings-page .stg-accordion-toggle:hover {
+    background: rgba(255, 255, 255, 0.12) !important;
+    border-color: rgba(255, 255, 255, 0.18) !important;
+    transform: translateY(-1px);
+}
+
+/* ── 7. Connections & Sources Service Tiles Elevating ───────────────────── */
+#settings-page .svc-tile-row {
+    display: grid !important;
+    grid-template-columns: repeat(auto-fill, minmax(136px, 1fr)) !important;
+    gap: 14px !important;
+}
+
+#settings-page .svc-tile {
+    background: rgba(22, 27, 38, 0.7) !important;
+    border: 1px solid rgba(255, 255, 255, 0.08) !important;
+    border-radius: 16px !important;
+    padding: 18px 12px 14px !important;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25) !important;
+    transition: all 180ms cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+#settings-page .svc-tile:hover {
+    transform: translateY(-3px) !important;
+    background: rgba(28, 34, 48, 0.85) !important;
+    border-color: rgba(255, 255, 255, 0.16) !important;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45) !important;
+}
+
+#settings-page .svc-tile.is-active {
+    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb, 29, 185, 84), 0.4), 0 4px 16px rgba(0, 0, 0, 0.25) !important;
+}
+
+/* ── 8. Media Tabs (Library Folders & Organization) ─────────────────────── */
+#settings-page .stg-media-card {
+    background: var(--stg-bg-card) !important;
+    border: var(--stg-border-card) !important;
+    border-radius: var(--stg-radius-card) !important;
+    box-shadow: var(--stg-shadow-card) !important;
+    padding: 22px 24px !important;
+}
+
+#settings-page .stg-media-switcher {
+    background: rgba(0, 0, 0, 0.35) !important;
+    border-radius: 11px !important;
+    padding: 4px !important;
+    border: 1px solid rgba(255, 255, 255, 0.06) !important;
+}
+
+#settings-page .stg-media-switcher button {
+    border-radius: 8px !important;
+    font-size: 0.84rem !important;
+    font-weight: 500 !important;
+    padding: 7px 18px !important;
+    transition: all 140ms ease !important;
+}
+
+#settings-page .stg-media-switcher button[aria-selected="true"] {
+    background: var(--accent-color, #1db954) !important;
+    color: #ffffff !important;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25) !important;
+}
+
+/* ── 9. Responsive Fluid Behavior (< 880px) ─────────────────────────────── */
+@media (max-width: 880px) {
+    #settings-page .settings-content {
+        flex-direction: column !important;
+        padding: 16px 14px 60px !important;
+        gap: 16px !important;
+    }
+
+    #settings-page .stg-nav-rail {
+        width: 100% !important;
+        min-width: 0 !important;
+        position: static !important;
+        padding: 10px !important;
+        border-radius: 14px !important;
+    }
+
+    .stg-nav-section-title {
+        display: none !important;
+    }
+
+    #settings-page .stg-tabbar {
+        flex-direction: row !important;
+        overflow-x: auto !important;
+        gap: 6px !important;
+        padding-bottom: 4px !important;
+        scrollbar-width: none !important;
+    }
+
+    #settings-page .stg-tabbar::-webkit-scrollbar {
+        display: none !important;
+    }
+
+    #settings-page .stg-tab {
+        width: auto !important;
+        padding: 8px 14px !important;
+        white-space: nowrap !important;
+    }
+
+    #settings-page .stg-tab.active::before {
+        display: none !important;
+    }
+
+    #settings-page .settings-nav-row {
+        position: static !important;
+        margin-bottom: 12px !important;
+        padding: 10px 14px !important;
+    }
+
+    #settings-page .settings-group,
+    #settings-page .stg-media-card {
+        padding: 16px 18px !important;
+    }
+}

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1056,9 +1056,18 @@ function handleLibraryMediaTabKey(event) {
 
 // Settings redesign — tab switching + service accordions
 function switchSettingsTab(tab) {
+    const search = document.getElementById('stg-search-input');
+    const results = document.getElementById('stg-search-results');
+    if (search) search.value = '';
+    if (results) results.hidden = true;
     if (tab === 'library') document.dispatchEvent(new CustomEvent('soulsync:library-settings-shown'));
     // Update tab bar
-    document.querySelectorAll('.stg-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
+    document.querySelectorAll('#settings-page .stg-tab').forEach(t => {
+        const active = t.dataset.tab === tab;
+        t.classList.toggle('active', active);
+        if (active) t.setAttribute('aria-current', 'page');
+        else t.removeAttribute('aria-current');
+    });
     // Show/hide settings groups and section headers by data-stg attribute
     document.querySelectorAll('#settings-page [data-stg]').forEach(g => {
         g.style.display = g.dataset.stg === tab ? '' : 'none';
@@ -1122,9 +1131,9 @@ function switchSettingsTab(tab) {
     const titles = {
         connections: { title: 'Connections', sub: 'Accounts, media servers, and API keys SoulSync connects to' },
         sources: { title: 'Sources', sub: 'Configure and prioritize acquisition sources and indexers' },
-        downloads: { title: 'Downloads', sub: 'Download modes, folder destinations, and chain priorities' },
+        downloads: { title: 'Downloads', sub: 'Download sources, queue behavior, and transfer preferences' },
         quality: { title: 'Quality', sub: 'Audio and video formats, release profiles, and ladders' },
-        library: { title: 'Library', sub: 'Organization rules, tagging, filters, and collection preferences' },
+        library: { title: 'Library', sub: 'Folders, file organization, tagging, and collection preferences' },
         appearance: { title: 'Appearance', sub: 'Visual themes, accents, GPU animations, and interface controls' },
         advanced: { title: 'Advanced', sub: 'Database tools, cache management, networking, and system diagnostics' },
         logs: { title: 'Logs', sub: 'Live streaming logs and real-time operational diagnostics' }
@@ -1136,23 +1145,56 @@ function switchSettingsTab(tab) {
 }
 
 function filterSettings(query) {
+    const results = document.getElementById('stg-search-results');
+    if (!results) return;
     const q = (query || '').trim().toLowerCase();
-    if (!q) {
-        const activeTab = document.querySelector('#settings-page .stg-tab.active')?.dataset.tab || 'connections';
-        switchSettingsTab(activeTab);
-        return;
-    }
-    document.querySelectorAll('#settings-page [data-stg]').forEach(el => {
-        const text = (el.textContent || '').toLowerCase();
-        if (text.includes(q)) {
-            el.style.display = '';
-            if (el.classList.contains('settings-section-body')) el.style.display = 'block';
-        } else {
-            el.style.display = 'none';
-        }
+    results.replaceChildren();
+    results.hidden = !q;
+    if (!q) return;
+    // Search only labels/help, never saved values or credentials. Navigation
+    // initializes the chosen category instead of exposing hidden, unloaded forms.
+    const matches = [];
+    document.querySelectorAll('#settings-page .settings-group[data-stg], #settings-page .settings-section-body[data-stg]').forEach(section => {
+        if (!(section.textContent || '').toLowerCase().includes(q)) return;
+        if (matches.some(item => item.contains(section))) return;
+        matches.push(section);
     });
-    document.querySelectorAll('#settings-page .settings-left-column, #settings-page .settings-right-column, #settings-page .settings-third-column').forEach(col => {
-        col.style.display = '';
+    if (!matches.length) {
+        const empty = document.createElement('p');
+        empty.setAttribute('role', 'status');
+        empty.textContent = 'No settings found. Try a service name, folder, or feature.';
+        results.append(empty);
+    }
+    matches.slice(0, 10).forEach(section => {
+        const category = section.dataset.stg;
+        const tab = document.querySelector('#settings-page .stg-tab[data-tab="' + category + '"]');
+        const heading = section.querySelector('h3') || section.previousElementSibling?.querySelector('h3');
+        const title = heading?.textContent.trim() || category;
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = (tab?.textContent.trim() || category) + ' — ' + title;
+        button.addEventListener('click', () => {
+            switchSettingsTab(category);
+            if (section.classList.contains('settings-section-body')) {
+                section.classList.remove('collapsed');
+                section.style.display = '';
+                const header = section.previousElementSibling;
+                header?.classList.remove('collapsed');
+                header?.setAttribute('aria-expanded', 'true');
+            }
+            const matchingLabel = Array.from(section.querySelectorAll('label, h4')).find(label => label.textContent.toLowerCase().includes(q));
+            const mediaPanel = matchingLabel?.closest('[role="tabpanel"]');
+            if (mediaPanel) {
+                const mediaTab = document.querySelector('[aria-controls="' + mediaPanel.id + '"]');
+                if (mediaTab) switchLibraryMediaTab(mediaTab);
+            }
+            section.tabIndex = -1;
+            section.focus({ preventScroll: true });
+            section.scrollIntoView({ block: 'start', behavior: 'auto' });
+            section.classList.add('stg-search-target');
+            window.setTimeout(() => section.classList.remove('stg-search-target'), 2000);
+        });
+        results.append(button);
     });
 }
 window.filterSettings = filterSettings;

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -2802,6 +2802,8 @@ async function loadSettingsData() {
         if (_slfmKey) _slfmKey.value = settings.concerts?.setlistfm_api_key || '';
         document.getElementById('lastfm-api-key').value = settings.lastfm?.api_key || '';
         document.getElementById('lastfm-api-secret').value = settings.lastfm?.api_secret || '';
+        const _lfmUser = document.getElementById('lastfm-username');
+        if (_lfmUser) _lfmUser.value = settings.lastfm?.username || '';
         document.getElementById('lastfm-scrobble-enabled').checked = settings.lastfm?.scrobble_enabled === true;
         const lfmStatus = document.getElementById('lastfm-scrobble-status');
         if (lfmStatus) {
@@ -5935,6 +5937,10 @@ async function saveSettings(quiet = false) {
             setlistfm_api_key: _cfgStr('concerts-setlistfm-api-key', { trim: true })
         },
         lastfm: {
+            // _cfgStr rather than .value: this input is absent on the video
+            // side, and reading .value off a missing element is how a save
+            // wipes a stored setting.
+            username: _cfgStr('lastfm-username', { trim: true }),
             api_key: document.getElementById('lastfm-api-key').value,
             api_secret: document.getElementById('lastfm-api-secret').value,
             scrobble_enabled: document.getElementById('lastfm-scrobble-enabled').checked,

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1117,7 +1117,46 @@ function switchSettingsTab(tab) {
     if (tab === 'connections') {
         try { applyServiceStatusGradients(); } catch (e) { }
     }
+
+    // Update active section title & subtitle in the detail header
+    const titles = {
+        connections: { title: 'Connections', sub: 'Accounts, media servers, and API keys SoulSync connects to' },
+        sources: { title: 'Sources', sub: 'Configure and prioritize acquisition sources and indexers' },
+        downloads: { title: 'Downloads', sub: 'Download modes, folder destinations, and chain priorities' },
+        quality: { title: 'Quality', sub: 'Audio and video formats, release profiles, and ladders' },
+        library: { title: 'Library', sub: 'Organization rules, tagging, filters, and collection preferences' },
+        appearance: { title: 'Appearance', sub: 'Visual themes, accents, GPU animations, and interface controls' },
+        advanced: { title: 'Advanced', sub: 'Database tools, cache management, networking, and system diagnostics' },
+        logs: { title: 'Logs', sub: 'Live streaming logs and real-time operational diagnostics' }
+    };
+    const titleEl = document.getElementById('stg-active-title');
+    const subEl = document.getElementById('stg-active-sub');
+    if (titleEl && titles[tab]) titleEl.textContent = titles[tab].title;
+    if (subEl && titles[tab]) subEl.textContent = titles[tab].sub;
 }
+
+function filterSettings(query) {
+    const q = (query || '').trim().toLowerCase();
+    if (!q) {
+        const activeTab = document.querySelector('#settings-page .stg-tab.active')?.dataset.tab || 'connections';
+        switchSettingsTab(activeTab);
+        return;
+    }
+    document.querySelectorAll('#settings-page [data-stg]').forEach(el => {
+        const text = (el.textContent || '').toLowerCase();
+        if (text.includes(q)) {
+            el.style.display = '';
+            if (el.classList.contains('settings-section-body')) el.style.display = 'block';
+        } else {
+            el.style.display = 'none';
+        }
+    });
+    document.querySelectorAll('#settings-page .settings-left-column, #settings-page .settings-right-column, #settings-page .settings-third-column').forEach(col => {
+        col.style.display = '';
+    });
+}
+window.filterSettings = filterSettings;
+
 
 // ── Settings → Connections: per-service status gradient + verify wiring ──
 // Gradient shows green when the user has filled in credentials, yellow when empty.
@@ -1252,6 +1291,16 @@ async function _stgRefreshAfterSave() {
             .filter(Boolean);
         if (expandedServices.length > 0) {
             _stgVerifyServices(expandedServices, { force: true });
+        }
+        const btn = document.getElementById('save-settings');
+        if (btn) {
+            const origHTML = btn.innerHTML;
+            btn.classList.add('is-saved');
+            btn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/></svg><span>Saved</span>';
+            setTimeout(() => {
+                btn.classList.remove('is-saved');
+                btn.innerHTML = origHTML;
+            }, 2000);
         }
     } catch (e) {
         console.warn('[Settings Status] Post-save refresh failed:', e);

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -929,7 +929,10 @@ const LIBRARY_SUMMARIES = {
     'library-video-folders': () => {
         const set = ['video-movies-path', 'video-tv-path', 'video-youtube-path']
             .filter(id => (document.getElementById(id)?.value || '').trim()).length;
-        return set ? `${set} of 3 libraries set` : 'no libraries set yet';
+        const extra = [...document.querySelectorAll('[data-video-extra-kind] input')]
+            .filter(input => input.value.trim()).length;
+        const primary = set ? `${set} of 3 libraries set` : 'no primary libraries set';
+        return extra ? `${primary} · ${extra} additional` : (set ? primary : 'no libraries set yet');
     },
     'library-post-processing': () => {
         const on = (id) => document.getElementById(id)?.checked;

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1053,6 +1053,7 @@ function handleLibraryMediaTabKey(event) {
 
 // Settings redesign — tab switching + service accordions
 function switchSettingsTab(tab) {
+    if (tab === 'library') document.dispatchEvent(new CustomEvent('soulsync:library-settings-shown'));
     // Update tab bar
     document.querySelectorAll('.stg-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
     // Show/hide settings groups and section headers by data-stg attribute

--- a/webui/static/settings.js
+++ b/webui/static/settings.js
@@ -1028,6 +1028,29 @@ document.addEventListener('click', (e) => {
     });
 });
 
+// Media tabs keep both panels mounted, preserving unsaved values and listeners.
+function switchLibraryMediaTab(tab) {
+    const card = tab.closest('.stg-media-card');
+    if (!card) return;
+    card.querySelectorAll('[role="tab"]').forEach(button => {
+        const selected = button === tab;
+        button.setAttribute('aria-selected', String(selected));
+        button.tabIndex = selected ? 0 : -1;
+        const panel = document.getElementById(button.getAttribute('aria-controls'));
+        if (panel) panel.hidden = !selected;
+    });
+}
+function handleLibraryMediaTabKey(event) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+    const tabs = Array.from(event.currentTarget.closest('[role="tablist"]').querySelectorAll('[role="tab"]'));
+    const current = tabs.indexOf(event.currentTarget);
+    const index = event.key === 'Home' ? 0 : event.key === 'End' ? tabs.length - 1
+        : (current + (event.key === 'ArrowRight' ? 1 : -1) + tabs.length) % tabs.length;
+    event.preventDefault();
+    switchLibraryMediaTab(tabs[index]);
+    tabs[index].focus();
+}
+
 // Settings redesign — tab switching + service accordions
 function switchSettingsTab(tab) {
     // Update tab bar

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -85339,3 +85339,197 @@ body.src-modal-open { overflow: hidden; }
     margin: -2px 0 14px;
     max-width: 74ch;
 }
+
+/* ==========================================================================
+   DISCOVER — art-forward cards (the Deezer / Spotify idiom)
+   ==========================================================================
+   The shelves used a portrait tile with the title printed ON the artwork under
+   a black gradient. That reads as a poster: the art is a backdrop for text, and
+   every cover is cropped to 0.85 so nothing is ever shown as it was made.
+
+   Deezer and Spotify both do the opposite, and for the same reason — the art is
+   the product. A square cover at its own aspect, nothing written over it, and
+   the title sitting underneath in plain type. The card itself is invisible
+   until you point at it, so a shelf reads as a row of covers rather than a row
+   of boxes.
+
+   Scoped to .discover-section on purpose. `.ya-card` is shared with the
+   dashboard rails (see the dash-card--rail block), and those are a deliberately
+   different, smaller strip. Everything here stays on the Discover page.
+
+   No play button on the hover, even though both apps have one: these cards open
+   a modal, they do not start playback, and a play triangle would promise
+   something the click does not do.
+   ========================================================================== */
+
+.discover-section .ya-card,
+.discover-section .discover-grid .ya-card {
+    /* height comes from the art plus the caption now, not a fixed ratio */
+    aspect-ratio: auto;
+    height: auto;
+    width: 184px;
+
+    /* the box disappears; the artwork carries the card */
+    background: transparent;
+    border: 1px solid transparent;
+    box-shadow: none;
+    border-radius: 12px;
+    padding: 8px;
+
+    transition: background-color 0.22s ease, border-color 0.22s ease;
+}
+
+.discover-section .ya-card:hover,
+.discover-section .discover-grid .ya-card:hover {
+    /* a tint, not a jump. the lift fought the scroll on a horizontal shelf */
+    transform: none;
+    background: rgba(255, 255, 255, 0.055);
+    border-color: rgba(255, 255, 255, 0.05);
+    box-shadow: none;
+}
+
+/* the artwork: square, in flow, and the only rounded thing on the card */
+.discover-section .ya-card-img {
+    position: relative;
+    inset: auto;
+    aspect-ratio: 1;
+    width: 100%;
+    border-radius: 8px;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+
+.discover-section .ya-card-img img {
+    transition: transform 0.45s cubic-bezier(0.2, 0, 0.2, 1);
+}
+
+.discover-section .ya-card:hover .ya-card-img img {
+    transform: scale(1.045);
+}
+
+/* nothing is printed over the art any more, so the scrim has no job */
+.discover-section .ya-card-gradient {
+    display: none;
+}
+
+/* the caption drops below the cover */
+.discover-section .ya-card-info {
+    position: static;
+    padding: 12px 2px 2px;
+    z-index: auto;
+}
+
+.discover-section .ya-card-name {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+    letter-spacing: -0.01em;
+    color: #fff;
+    /* the shadow existed to lift text off artwork; there is no artwork under it */
+    text-shadow: none;
+}
+
+.discover-section .ya-card-sub {
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.4;
+    color: rgba(255, 255, 255, 0.55);
+    text-shadow: none;
+    margin-top: 3px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* badges sit on the art, so they move in by the card's new padding */
+.discover-section .ya-card-badges {
+    top: 16px;
+    left: 16px;
+}
+
+/* a grid cell should fill its column; only the shelf card is a fixed width */
+.discover-section .discover-grid .ya-card {
+    width: 100%;
+}
+
+/* the shelf gets room to breathe, the way both apps space a rail */
+.discover-section .discover-section-title {
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+.discover-section .discover-section-subtitle {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.45);
+}
+
+@media (max-width: 768px) {
+    .discover-section .ya-card {
+        width: 146px;
+        padding: 6px;
+    }
+    .discover-section .ya-card-name { font-size: 13px; }
+    .discover-section .ya-card-sub { font-size: 11px; }
+    .discover-section .ya-card-badges { top: 12px; left: 12px; }
+}
+
+/* the shelf itself: a touch wider and airier, matching the card sizing above.
+   172px was sized for a portrait tile with the title printed inside it; a
+   square cover with the caption underneath wants a little more room. */
+.discover-section .discover-grid {
+    grid-auto-columns: 184px;
+    gap: 20px;
+}
+
+@media (max-width: 768px) {
+    .discover-section .discover-grid {
+        grid-auto-columns: 146px;
+        gap: 14px;
+    }
+}
+
+/* ── Deezer editorial: the genre chips in the section header ── */
+.dz-ed-genres {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.dz-ed-genre {
+    appearance: none;
+    -webkit-appearance: none;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    background: rgba(255, 255, 255, 0.035);
+    color: rgba(255, 255, 255, 0.62);
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    padding: 6px 12px;
+    border-radius: 999px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.dz-ed-genre:hover {
+    background: rgba(255, 255, 255, 0.075);
+    color: #fff;
+}
+
+.dz-ed-genre.is-active {
+    background: var(--accent);
+    border-color: transparent;
+    /* the accent is a bright colour; dark text is what stays readable on it */
+    color: #0b0b0b;
+}
+
+.dz-ed-genre:focus-visible {
+    outline: 2px solid rgba(var(--accent-rgb), 0.9);
+    outline-offset: 2px;
+}
+
+/* a playlist cover is square art like any other card, so it inherits the
+   shelf card styling above and needs nothing of its own */

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -85627,12 +85627,12 @@ body.src-modal-open { overflow: hidden; }
 #settings-page .stg-media-context strong { font-size: 16px; font-weight: 600; color: #eee; }
 #settings-page .stg-media-summary { font-size: 12px; line-height: 1.5; color: rgba(255,255,255,.5); }
 #settings-page .stg-media-summary.is-live { color: rgba(var(--accent-rgb),.8); }
-#settings-page .stg-media-panel > .settings-group { margin-top: 0; }
 @media (max-width: 600px) {
     #settings-page .stg-media-card .stg-media-switcher { display: flex; }
     #settings-page .stg-media-switcher button { flex: 1; }
 }
 #settings-page .stg-media-panel > .settings-group {
+    margin-top: 0;
     background: transparent !important;
     border: 0 !important;
     border-radius: 0 !important;

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -85557,3 +85557,37 @@ body.src-modal-open { overflow: hidden; }
     opacity: 0.55;
     transition: opacity 0.25s ease;
 }
+
+/* the editorial shelf's header controls: a search box above the genre chips */
+.dz-ed-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-end;
+    max-width: 620px;
+}
+
+.dz-ed-search {
+    width: 100%;
+    max-width: 260px;
+    padding: 7px 12px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    background: rgba(255, 255, 255, 0.035);
+    color: #fff;
+    font-size: 12.5px;
+    outline: none;
+    transition: border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.dz-ed-search::placeholder { color: rgba(255, 255, 255, 0.35); }
+
+.dz-ed-search:focus {
+    border-color: rgba(var(--accent-rgb), 0.5);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+@media (max-width: 768px) {
+    .dz-ed-controls { align-items: stretch; }
+    .dz-ed-search { max-width: none; }
+}

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -85591,3 +85591,60 @@ body.src-modal-open { overflow: hidden; }
     .dz-ed-controls { align-items: stretch; }
     .dz-ed-search { max-width: none; }
 }
+
+/* Library: shared cards with persistent Music / Video panels. */
+#settings-page .stg-media-card .stg-media-switcher {
+    display: inline-flex;
+    gap: 4px;
+    padding: 4px;
+    margin: 4px 0 20px;
+    border: 1px solid rgba(255,255,255,.1);
+    border-radius: 12px;
+    background: rgba(0,0,0,.2);
+}
+#settings-page .stg-media-switcher button {
+    min-width: 100px;
+    padding: 9px 22px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    color: rgba(255,255,255,.6);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background .15s, color .15s;
+}
+#settings-page .stg-media-switcher button:hover { color: #fff; background: rgba(255,255,255,.06); }
+#settings-page .stg-media-switcher button[aria-selected="true"] {
+    background: rgba(var(--accent-rgb),.18);
+    color: var(--accent);
+    box-shadow: inset 0 0 0 1px rgba(var(--accent-rgb),.25);
+}
+#settings-page .stg-media-switcher button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+#settings-page .stg-media-panel[hidden] { display: none !important; }
+#settings-page .stg-media-context { display: flex; flex-direction: column; gap: 5px; margin-bottom: 20px; }
+#settings-page .stg-media-context strong { font-size: 16px; font-weight: 600; color: #eee; }
+#settings-page .stg-media-summary { font-size: 12px; line-height: 1.5; color: rgba(255,255,255,.5); }
+#settings-page .stg-media-summary.is-live { color: rgba(var(--accent-rgb),.8); }
+#settings-page .stg-media-panel > .settings-group { margin-top: 0; }
+@media (max-width: 600px) {
+    #settings-page .stg-media-card .stg-media-switcher { display: flex; }
+    #settings-page .stg-media-switcher button { flex: 1; }
+}
+#settings-page .stg-media-panel > .settings-group {
+    background: transparent !important;
+    border: 0 !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin: 0 0 22px !important;
+}
+#settings-page .stg-media-panel > .settings-group::before { display: none; }
+#settings-page .stg-media-panel > .settings-group > h3 {
+    padding: 12px 0;
+    border-left: 0;
+    border-bottom: 1px solid rgba(255,255,255,.08);
+    font-size: 13px;
+}
+#settings-page .stg-media-panel > .settings-group:last-child { margin-bottom: 0 !important; }

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -85533,3 +85533,27 @@ body.src-modal-open { overflow: hidden; }
 
 /* a playlist cover is square art like any other card, so it inherits the
    shelf card styling above and needs nothing of its own */
+
+/* the editorial card while it is loading a playlist into Sync. a 200-track
+   playlist takes the better part of a minute to fetch, and the job has always
+   reported done/total - the card just never showed it. */
+.dz-ed-progress {
+    margin-top: 8px;
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.1);
+    overflow: hidden;
+}
+
+.dz-ed-progress-fill {
+    height: 100%;
+    border-radius: 2px;
+    background: var(--accent);
+    transition: width 0.35s ease;
+}
+
+/* it is working, so the art should not look idle */
+.discover-section .ya-card[aria-busy='true'] .ya-card-img img {
+    opacity: 0.55;
+    transition: opacity 0.25s ease;
+}

--- a/webui/static/style.css
+++ b/webui/static/style.css
@@ -4344,16 +4344,25 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     line-height: 1;
 }
 
-/* Quality tab: the settings tiles stay exactly on the normal centered 920px
-   settings column. On wide screens only the profile panel protrudes into the
-   empty right margin, so the Quality tab lines up with the other tabs. */
+/* Quality tab: the profile panel sits INSIDE the settings column, as its right
+   hand column.
+
+   It used to hang outside instead - the layout was one side-panel wider than its
+   container, so the panel spilled into the empty margin beside a 920px settings
+   column. That was the right trade when the column was 920px and a 320px panel
+   would have left the tiles too narrow to read.
+
+   The column is --settings-max-width wide now, so the trade is gone: the tiles
+   keep about 1070px, which is wider than the whole column used to be. Hanging
+   outside had also started to LOOK wrong once the settings card grew a visible
+   border, because the panel was sitting past it with nothing behind it. */
 .qp-layout {
     --qp-side-width: 320px;
-    --qp-side-gap: 8px;
+    --qp-side-gap: 22px;
     display: flex;
     align-items: flex-start;
     gap: var(--qp-side-gap);
-    width: calc(100% + var(--qp-side-width) + var(--qp-side-gap));
+    width: 100%;
     overflow: visible;
 }
 
@@ -4862,7 +4871,12 @@ body.helper-mode-active #dashboard-activity-feed:hover {
     min-width: 132px;
 }
 
-@media (max-width: 1800px) {
+/* Stacked only when the column really is too narrow to split. The old
+   breakpoint was 1800px because the panel hung outside and needed the viewport
+   to be wider than the column PLUS the panel plus margins. Now it lives inside
+   the column, so it can stay beside the tiles until the two together get tight,
+   which is a good deal narrower. */
+@media (max-width: 1100px) {
     .qp-layout {
         flex-direction: column-reverse;
         width: 100%;

--- a/webui/static/video/video-settings.js
+++ b/webui/static/video/video-settings.js
@@ -376,6 +376,48 @@
         if (btn && !btn._vseedWired) { btn._vseedWired = true; btn.addEventListener('click', loadSeedIndexers); }
     }
 
+    function addVideoPathRow(host, value) {
+        var row = document.createElement('div');
+        row.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:8px';
+        var input = document.createElement('input');
+        input.type = 'text';
+        input.value = value || '';
+        input.placeholder = host.dataset.videoExtraKind === 'movies' ? '/media/movies2' : '/media/tv2';
+        input.setAttribute('aria-label', host.dataset.videoExtraKind === 'movies' ? 'Additional movie library path' : 'Additional TV library path');
+        input.style.cssText = 'flex:1;min-width:0';
+        input.addEventListener('change', function () { saveDownloads(true); });
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'test-button';
+        remove.textContent = 'Remove';
+        remove.setAttribute('aria-label', 'Remove library path');
+        remove.addEventListener('click', function () { row.remove(); saveDownloads(true); });
+        if (host.closest('[aria-busy="true"]')) {
+            [input, remove].forEach(function (control) {
+                control.setAttribute('data-library-disabled', 'false');
+                control.disabled = true;
+            });
+        }
+        row.appendChild(input);
+        row.appendChild(remove);
+        host.appendChild(row);
+        return input;
+    }
+
+    function loadVideoPaths(kind, paths) {
+        var host = document.getElementById('video-' + kind + '-additional-paths');
+        if (!host) return;
+        host.replaceChildren();
+        (Array.isArray(paths) ? paths : []).forEach(function (path) { addVideoPathRow(host, path); });
+        host.dataset.loaded = 'true';
+    }
+
+    function collectVideoPaths(kind) {
+        var host = document.getElementById('video-' + kind + '-additional-paths');
+        if (!host || host.dataset.loaded !== 'true') return undefined;
+        return Array.from(host.querySelectorAll('input')).map(function (input) { return input.value.trim(); }).filter(Boolean);
+    }
+
     function loadDownloads() {
         return fetch(DOWNLOADS_URL, { headers: { 'Accept': 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
@@ -385,6 +427,8 @@
                 setP('video-download-path', d.download_path);
                 setP('video-movies-path', d.movies_path);
                 setP('video-tv-path', d.tv_path);
+                loadVideoPaths('movies', d.movies_additional_paths);
+                loadVideoPaths('tv', d.tv_additional_paths);
                 setP('video-youtube-path', d.youtube_path);
                 _videoMode = d.download_mode || 'soulseek';
                 _videoHybrid = (d.hybrid_order && d.hybrid_order.length) ? d.hybrid_order : ['soulseek'];
@@ -414,6 +458,8 @@
                 download_path: val('video-download-path'),
                 movies_path: val('video-movies-path'),
                 tv_path: val('video-tv-path'),
+                movies_additional_paths: collectVideoPaths('movies'),
+                tv_additional_paths: collectVideoPaths('tv'),
                 youtube_path: val('video-youtube-path'),
                 // download_mode / hybrid_order are NOT sent from here any more.
                 // The shared download-chain widget owns them and writes them
@@ -778,6 +824,14 @@
     }
 
     function wireDownloads() {
+        document.querySelectorAll('[data-video-add-path]').forEach(function (button) {
+            if (button._vdWired) return;
+            button._vdWired = true;
+            button.addEventListener('click', function () {
+                var host = document.getElementById('video-' + button.dataset.videoAddPath + '-additional-paths');
+                if (host && host.dataset.loaded === 'true') addVideoPathRow(host, '').focus();
+            });
+        });
         var ms = document.getElementById('video-download-mode');
         if (ms && !ms._vdWired) {
             ms._vdWired = true;

--- a/webui/static/video/video-settings.js
+++ b/webui/static/video/video-settings.js
@@ -377,10 +377,10 @@
     }
 
     function loadDownloads() {
-        fetch(DOWNLOADS_URL, { headers: { 'Accept': 'application/json' } })
+        return fetch(DOWNLOADS_URL, { headers: { 'Accept': 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (d) {
-                if (!d) return;
+                if (!d) return false;
                 var setP = function (id, v) { var el = document.getElementById(id); if (el && v != null) el.value = v; };
                 setP('video-download-path', d.download_path);
                 setP('video-movies-path', d.movies_path);
@@ -401,8 +401,9 @@
                 wireSeedIndexers();
                 renderVideoHybrid();
                 updateVideoSourceUI();
+                return true;
             })
-            .catch(function () { /* ignore */ });
+            .catch(function () { return false; });
     }
 
     function saveDownloads(silent) {
@@ -1343,10 +1344,10 @@
         renderOrgPreview();
     }
     function loadOrganization() {
-        fetch(ORG_URL, { headers: { 'Accept': 'application/json' } })
+        return fetch(ORG_URL, { headers: { 'Accept': 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
-            .then(function (d) { if (d) { _videoOrg = d; fillOrg(); } })
-            .catch(function () { /* ignore */ });
+            .then(function (d) { if (!d) return false; _videoOrg = d; fillOrg(); return true; })
+            .catch(function () { return false; });
     }
     function collectOrg() {
         var val = function (id) { var el = document.getElementById(id); return el ? el.value : ''; };
@@ -1416,24 +1417,71 @@
         });
     }
 
+    // Both media sides share these Library panels. Load once per document,
+    // deduplicate requests, and never replace edits on a tab round-trip.
+    var _libraryLoaded = false;
+    var _libraryLoading = null;
+    function loadSharedLibrary() {
+        if (_libraryLoaded || _libraryLoading) return _libraryLoading;
+        var panels = ['folders-video-panel', 'organization-video-panel'].map(function (id) {
+            return document.getElementById(id);
+        }).filter(Boolean);
+        panels.forEach(function (panel) {
+            panel.setAttribute('aria-busy', 'true');
+            panel.querySelectorAll('input, select, textarea, button:not(.stg-library-retry)').forEach(function (input) {
+                if (!input.hasAttribute('data-library-disabled')) input.setAttribute('data-library-disabled', String(input.disabled));
+                input.disabled = true;
+            });
+            var status = panel.querySelector('.stg-library-load-status');
+            if (!status) {
+                status = document.createElement('p');
+                status.className = 'stg-library-load-status settings-hint';
+                status.setAttribute('role', 'status');
+                panel.prepend(status);
+            }
+            status.textContent = 'Loading saved video settings...';
+        });
+        wireDownloads();
+        wireOrganization();
+        _libraryLoading = Promise.all([loadDownloads(), loadOrganization()]).then(function (results) {
+            _libraryLoaded = results.every(Boolean);
+            panels.forEach(function (panel) {
+                panel.setAttribute('aria-busy', 'false');
+                var status = panel.querySelector('.stg-library-load-status');
+                if (_libraryLoaded) {
+                    panel.querySelectorAll('[data-library-disabled]').forEach(function (input) {
+                        input.disabled = input.getAttribute('data-library-disabled') === 'true';
+                        input.removeAttribute('data-library-disabled');
+                    });
+                    status.remove();
+                } else {
+                    status.textContent = 'Could not load saved video settings. ';
+                    var retry = document.createElement('button');
+                    retry.type = 'button'; retry.className = 'stg-library-retry'; retry.textContent = 'Retry';
+                    retry.addEventListener('click', loadSharedLibrary);
+                    status.append(retry);
+                }
+            });
+            if (typeof window.refreshLibrarySummaries === 'function') window.refreshLibrarySummaries();
+        }).finally(function () { _libraryLoading = null; });
+        return _libraryLoading;
+    }
+
     function onPageShown(e) {
         if (e && e.detail !== PAGE_ID) return;
         loadServer();
         loadConn();
         load();
         loadKeys();
-        loadDownloads();
+        loadSharedLibrary();
         loadImportLists();
         loadNotify();
-        wireDownloads();
         loadQuality();
         wireQuality();
         loadYtQuality();
         wireYtQuality();
         loadSlskd();
         wireSlskd();
-        loadOrganization();
-        wireOrganization();
     }
 
     function init() {
@@ -1516,6 +1564,7 @@
                 .catch(function () { toast('Some settings could not be saved', 'error'); });
         }, true);
         document.addEventListener('soulsync:video-page-shown', onPageShown);
+        document.addEventListener('soulsync:library-settings-shown', loadSharedLibrary);
     }
 
     if (document.readyState === 'loading') {

--- a/webui/static/watchlist-premier.css
+++ b/webui/static/watchlist-premier.css
@@ -1,0 +1,1183 @@
+/* ==========================================================================
+   SoulSync Watchlist Premier - Modern Media Hub Redesign
+   High-fidelity, glassmorphic layout matching Discover & Settings Premier.
+   ========================================================================== */
+
+.watchlist-page-container {
+  --wl-bg-radial: radial-gradient(circle at 18% -10%, rgba(var(--accent-rgb, 29, 185, 84), 0.12) 0%, transparent 45%),
+                  radial-gradient(circle at 85% 15%, rgba(64, 120, 255, 0.08) 0%, transparent 40%);
+  --wl-surface: rgba(20, 24, 33, 0.75);
+  --wl-surface-elevated: rgba(26, 32, 45, 0.92);
+  --wl-surface-subtle: rgba(255, 255, 255, 0.04);
+  --wl-surface-hover: rgba(255, 255, 255, 0.075);
+  --wl-line: rgba(255, 255, 255, 0.08);
+  --wl-line-highlight: rgba(255, 255, 255, 0.18);
+  --wl-text-primary: #f8f9fc;
+  --wl-text-secondary: #9ea6b5;
+  --wl-text-muted: #6b7280;
+  --wl-radius-lg: 16px;
+  --wl-radius-md: 12px;
+  --wl-radius-sm: 8px;
+  --wl-radius-full: 9999px;
+  --wl-shadow-card: 0 4px 20px -2px rgba(0, 0, 0, 0.4), 0 0 0 1px var(--wl-line);
+  --wl-shadow-hover: 0 12px 32px -4px rgba(0, 0, 0, 0.55), 0 0 0 1px var(--wl-line-highlight), 0 0 24px -6px rgba(var(--accent-rgb, 29, 185, 84), 0.22);
+  --wl-accent-glow: 0 0 18px rgba(var(--accent-rgb, 29, 185, 84), 0.35);
+
+  position: relative;
+  max-width: 1540px;
+  margin: 0 auto;
+  padding: 16px 28px 64px;
+  color: var(--wl-text-primary);
+  background-image: var(--wl-bg-radial);
+  background-attachment: fixed;
+  box-sizing: border-box;
+}
+
+/* --------------------------------------------------------------------------
+   Page Header
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--wl-line);
+}
+
+.watchlist-page-container .watchlist-page-header-left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.watchlist-page-container .watchlist-page-title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--wl-text-primary);
+}
+
+.watchlist-page-container .watchlist-page-title svg {
+  filter: drop-shadow(0 0 10px rgba(var(--accent-rgb, 29, 185, 84), 0.5));
+}
+
+.watchlist-page-container .watchlist-page-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.watchlist-page-container .wl-meta-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 14px;
+  border-radius: var(--wl-radius-full);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  color: var(--wl-text-secondary);
+  backdrop-filter: blur(8px);
+}
+
+.watchlist-page-container .wl-meta-chip--accent {
+  background: rgba(var(--accent-rgb, 29, 185, 84), 0.12);
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.3);
+  color: rgb(var(--accent-rgb, 29, 185, 84));
+  box-shadow: 0 0 12px rgba(var(--accent-rgb, 29, 185, 84), 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   Action Bar (Consolidated & Hierarchical)
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-page-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.watchlist-page-container .wl-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-radius: var(--wl-radius-full);
+  font-size: 13px;
+  font-weight: 650;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  text-decoration: none;
+  white-space: nowrap;
+  position: relative;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+
+.watchlist-page-container .wl-chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
+/* Primary CTA Button */
+.watchlist-page-container .wl-chip--cta {
+  background: linear-gradient(135deg, rgb(var(--accent-rgb, 29, 185, 84)) 0%, #12833b 100%);
+  color: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  box-shadow: 0 4px 14px rgba(var(--accent-rgb, 29, 185, 84), 0.35);
+}
+
+.watchlist-page-container .wl-chip--cta:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(var(--accent-rgb, 29, 185, 84), 0.5);
+  filter: brightness(1.05);
+}
+
+.watchlist-page-container .wl-chip--cta:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+/* Secondary Slate Glass Buttons */
+.watchlist-page-container .wl-chip--slate {
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  color: var(--wl-text-secondary);
+  backdrop-filter: blur(12px);
+}
+
+.watchlist-page-container .wl-chip--slate:hover:not(:disabled) {
+  background: var(--wl-surface-hover);
+  border-color: var(--wl-line-highlight);
+  color: var(--wl-text-primary);
+  transform: translateY(-1px);
+}
+
+.watchlist-page-container .wl-chip--slate.wl-chip--active {
+  background: rgba(var(--accent-rgb, 29, 185, 84), 0.15);
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.4);
+  color: #ffffff;
+}
+
+/* Red / Danger Action Buttons */
+.watchlist-page-container .wl-chip--red {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #f87171;
+  backdrop-filter: blur(8px);
+}
+
+.watchlist-page-container .wl-chip--red:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.22);
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #ffffff;
+  transform: translateY(-1px);
+}
+
+.watchlist-page-container .watchlist-global-settings-active {
+  background: rgba(245, 158, 11, 0.15) !important;
+  border-color: rgba(245, 158, 11, 0.4) !important;
+  color: #fbbf24 !important;
+  box-shadow: 0 0 14px rgba(245, 158, 11, 0.2);
+}
+
+/* --------------------------------------------------------------------------
+   Global Override & Last Scan Banners
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-global-override-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px;
+  margin-bottom: 20px;
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12), rgba(245, 158, 11, 0.04));
+  border: 1px solid rgba(245, 158, 11, 0.25);
+  border-radius: var(--wl-radius-md);
+  color: #fbbf24;
+  font-size: 13px;
+  font-weight: 550;
+  backdrop-filter: blur(10px);
+}
+
+.watchlist-page-container .watchlist-last-scan-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  margin-bottom: 18px;
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  color: var(--wl-text-secondary);
+  font-size: 13px;
+}
+
+.watchlist-page-container .watchlist-last-scan-strip svg {
+  color: rgb(var(--accent-rgb, 29, 185, 84));
+  flex-shrink: 0;
+}
+
+/* --------------------------------------------------------------------------
+   Attention Strip / Quick-Filter Rail
+   -------------------------------------------------------------------------- */
+/* --------------------------------------------------------------------------
+   Attention Strip / Quick-Filter Rail (Compact & Sleek)
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-attention-strip {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 8px !important;
+  margin-top: 10px !important;
+  margin-bottom: 14px !important;
+  padding: 0 !important;
+  grid-template-columns: none !important;
+}
+
+.watchlist-page-container .watchlist-attention-card {
+  display: inline-flex !important;
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 7px !important;
+  min-height: 0 !important;
+  height: 28px !important;
+  padding: 0 10px !important;
+  background: rgba(255, 255, 255, 0.04) !important;
+  border: 1px solid rgba(255, 255, 255, 0.08) !important;
+  border-radius: 9999px !important;
+  cursor: pointer !important;
+  user-select: none !important;
+  transition: all 0.18s cubic-bezier(0.16, 1, 0.3, 1) !important;
+  white-space: nowrap !important;
+  backdrop-filter: blur(12px) !important;
+  flex-shrink: 0 !important;
+}
+
+.watchlist-page-container .watchlist-attention-card:hover {
+  background: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.18) !important;
+  transform: translateY(-1px) !important;
+}
+
+.watchlist-page-container .watchlist-attention-card.is-active {
+  background: rgba(var(--accent-rgb, 147, 51, 234), 0.16) !important;
+  border-color: rgba(var(--accent-rgb, 147, 51, 234), 0.5) !important;
+  box-shadow: 0 0 12px rgba(var(--accent-rgb, 147, 51, 234), 0.22) !important;
+}
+
+.watchlist-page-container .watchlist-attention-label {
+  font-size: 11.5px !important;
+  font-weight: 550 !important;
+  text-transform: none !important;
+  letter-spacing: 0.01em !important;
+  color: var(--wl-text-secondary) !important;
+  line-height: 1 !important;
+}
+
+.watchlist-page-container .watchlist-attention-card.is-active .watchlist-attention-label {
+  color: #ffffff !important;
+  font-weight: 650 !important;
+}
+
+.watchlist-page-container .watchlist-attention-value {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  min-width: 18px !important;
+  height: 18px !important;
+  padding: 0 5px !important;
+  border-radius: 9px !important;
+  font-size: 11px !important;
+  font-weight: 750 !important;
+  line-height: 1 !important;
+  background: rgba(255, 255, 255, 0.07) !important;
+  color: var(--wl-text-muted) !important;
+}
+
+.watchlist-page-container .watchlist-attention-card.is-active .watchlist-attention-value {
+  background: rgba(var(--accent-rgb, 147, 51, 234), 0.35) !important;
+  color: #ffffff !important;
+}
+
+/* Tone accents */
+.watchlist-page-container .watchlist-attention-card.is-green .watchlist-attention-value {
+  background: rgba(34, 197, 94, 0.15) !important;
+  color: #4ade80 !important;
+}
+
+.watchlist-page-container .watchlist-attention-card.is-amber .watchlist-attention-value {
+  background: rgba(245, 158, 11, 0.15) !important;
+  color: #fbbf24 !important;
+}
+
+.watchlist-page-container .watchlist-attention-card.is-blue .watchlist-attention-value {
+  background: rgba(59, 130, 246, 0.15) !important;
+  color: #60a5fa !important;
+}
+
+.watchlist-page-container .watchlist-attention-card--wide {
+  grid-column: auto !important;
+}
+
+/* --------------------------------------------------------------------------
+   Add Artist Provider Search Panel
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-add-panel {
+  background: var(--wl-surface-elevated);
+  border: 1px solid var(--wl-line-highlight);
+  border-radius: var(--wl-radius-lg);
+  padding: 18px 22px;
+  margin-bottom: 22px;
+  box-shadow: var(--wl-shadow-card);
+  backdrop-filter: blur(16px);
+  animation: wlFadeIn 0.2s ease-out;
+}
+
+.watchlist-page-container .watchlist-add-copy {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.watchlist-page-container .watchlist-add-kicker {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgb(var(--accent-rgb, 29, 185, 84));
+}
+
+.watchlist-page-container .watchlist-add-copy span:last-child {
+  font-size: 13px;
+  color: var(--wl-text-secondary);
+}
+
+.watchlist-page-container .watchlist-add-form {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  position: relative;
+}
+
+.watchlist-page-container .watchlist-add-form .watchlist-sort-select {
+  flex-shrink: 0;
+  min-width: 170px;
+  height: 42px;
+  padding: 0 14px;
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  color: var(--wl-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.watchlist-page-container .watchlist-add-input {
+  flex: 1;
+  height: 42px;
+  padding: 0 16px;
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  color: #ffffff;
+  font-size: 14px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.watchlist-page-container .watchlist-add-input:focus {
+  outline: none;
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.5);
+  box-shadow: 0 0 16px rgba(var(--accent-rgb, 29, 185, 84), 0.15);
+}
+
+.watchlist-page-container .watchlist-add-status {
+  font-size: 12px;
+  font-weight: 550;
+  color: var(--wl-text-muted);
+  white-space: nowrap;
+}
+
+.watchlist-page-container .watchlist-add-clear {
+  position: absolute;
+  right: 12px;
+  background: transparent;
+  border: none;
+  color: var(--wl-text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+}
+
+.watchlist-page-container .watchlist-add-clear:hover {
+  color: #ffffff;
+}
+
+.watchlist-page-container .watchlist-add-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--wl-line);
+}
+
+.watchlist-page-container .watchlist-add-result {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 10px 14px;
+  border-radius: var(--wl-radius-md);
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.watchlist-page-container .watchlist-add-result:hover {
+  background: var(--wl-surface-hover);
+  border-color: var(--wl-line-highlight);
+}
+
+.watchlist-page-container .watchlist-add-result img,
+.watchlist-page-container .watchlist-add-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--wl-radius-md);
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.watchlist-page-container .watchlist-add-avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--accent-rgb, 29, 185, 84), 0.15);
+  color: rgb(var(--accent-rgb, 29, 185, 84));
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.watchlist-page-container .watchlist-add-result-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.watchlist-page-container .watchlist-add-result-main span {
+  font-size: 14px;
+  font-weight: 650;
+  color: #ffffff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watchlist-page-container .watchlist-add-result-main small {
+  font-size: 12px;
+  color: var(--wl-text-secondary);
+}
+
+.watchlist-page-container .watchlist-add-result-action {
+  padding: 7px 16px;
+  border-radius: var(--wl-radius-full);
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  color: var(--wl-text-primary);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.watchlist-page-container .watchlist-add-result-action:hover:not(:disabled) {
+  background: rgb(var(--accent-rgb, 29, 185, 84));
+  border-color: transparent;
+  color: #ffffff;
+}
+
+/* --------------------------------------------------------------------------
+   Recent Releases Strip
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-recent-panel {
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-lg);
+  padding: 16px 20px;
+  margin-bottom: 22px;
+  backdrop-filter: blur(12px);
+}
+
+.watchlist-page-container .watchlist-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.watchlist-page-container .watchlist-panel-kicker {
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--wl-text-muted);
+}
+
+.watchlist-page-container .watchlist-panel-head h3 {
+  margin: 2px 0 0;
+  font-size: 18px;
+  font-weight: 750;
+  letter-spacing: -0.02em;
+}
+
+.watchlist-page-container .watchlist-recent-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.watchlist-page-container .watchlist-release-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px;
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  position: relative;
+  overflow: hidden;
+  transition: all 0.15s ease;
+}
+
+.watchlist-page-container .watchlist-release-card:hover {
+  background: var(--wl-surface-hover);
+  border-color: var(--wl-line-highlight);
+  transform: translateY(-1px);
+}
+
+.watchlist-page-container .watchlist-release-card img,
+.watchlist-page-container .watchlist-release-fallback {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.watchlist-page-container .watchlist-release-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 20px;
+}
+
+.watchlist-page-container .watchlist-release-card div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.watchlist-page-container .watchlist-release-card span {
+  font-size: 13px;
+  font-weight: 650;
+  color: #ffffff;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watchlist-page-container .watchlist-release-card small {
+  font-size: 11px;
+  color: var(--wl-text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --------------------------------------------------------------------------
+   Toolbar (Unified Search & Sort)
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.watchlist-page-container .watchlist-search-container {
+  flex: 1;
+  position: relative;
+  display: flex;
+  align-items: center;
+  margin-bottom: 0 !important;
+}
+
+.watchlist-page-container .watchlist-search-input {
+  width: 100%;
+  height: 44px;
+  padding: 0 16px 0 42px !important;
+  background: var(--wl-surface) !important;
+  border: 1px solid var(--wl-line) !important;
+  border-radius: var(--wl-radius-md) !important;
+  color: var(--wl-text-primary) !important;
+  font-size: 14px !important;
+  font-weight: 500 !important;
+  transition: all 0.2s ease !important;
+  box-sizing: border-box;
+}
+
+.watchlist-page-container .watchlist-search-input:focus {
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.5) !important;
+  box-shadow: 0 0 18px rgba(var(--accent-rgb, 29, 185, 84), 0.15) !important;
+  background: var(--wl-surface-elevated) !important;
+}
+
+.watchlist-page-container .watchlist-search-icon {
+  position: absolute;
+  left: 14px;
+  pointer-events: none;
+}
+
+.watchlist-page-container .watchlist-sort-select {
+  height: 44px;
+  padding: 0 16px;
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  color: var(--wl-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.watchlist-page-container .watchlist-sort-select:focus {
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.5);
+  box-shadow: 0 0 14px rgba(var(--accent-rgb, 29, 185, 84), 0.15);
+}
+
+/* --------------------------------------------------------------------------
+   Batch Bar
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-batch-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 10px 18px;
+  margin-bottom: 16px;
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+  backdrop-filter: blur(10px);
+}
+
+.watchlist-page-container .watchlist-select-all-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--wl-text-secondary);
+}
+
+.watchlist-page-container .watchlist-select-all-label:hover {
+  color: var(--wl-text-primary);
+}
+
+.watchlist-page-container .watchlist-batch-count {
+  font-size: 12px;
+  font-weight: 700;
+  color: rgb(var(--accent-rgb, 29, 185, 84));
+}
+
+.watchlist-page-container .watchlist-batch-remove-btn {
+  padding: 6px 14px;
+  border-radius: var(--wl-radius-full);
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #f87171;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.watchlist-page-container .watchlist-batch-remove-btn:hover:not(:disabled) {
+  background: rgba(239, 68, 68, 0.28);
+  border-color: rgba(239, 68, 68, 0.5);
+  color: #ffffff;
+}
+
+/* --------------------------------------------------------------------------
+   Layout: Full-Width Responsive Artist Grid
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-command-layout {
+  display: block;
+  position: relative;
+  width: 100%;
+}
+
+.watchlist-page-container .watchlist-roster-panel {
+  padding: 0;
+  width: 100%;
+}
+
+.watchlist-page-container .watchlist-roster-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--wl-text-muted);
+}
+
+.watchlist-page-container .watchlist-artists-grid--rows {
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr)) !important;
+  gap: 14px !important;
+  padding: 0 !important;
+}
+
+/* --------------------------------------------------------------------------
+   Artist Cards - Premier Flex & Grid Architecture
+   -------------------------------------------------------------------------- */
+.watchlist-page-container .watchlist-artists-grid--rows .watchlist-artist-card {
+  display: grid !important;
+  grid-template-columns: 72px minmax(0, 1fr) auto !important;
+  grid-template-areas:
+    "art info menu"
+    "art stats stats"
+    "art tags tags" !important;
+  align-items: start !important;
+  gap: 6px 14px !important;
+  padding: 14px 16px !important;
+  background: var(--wl-surface) !important;
+  border: 1px solid var(--wl-line) !important;
+  border-radius: var(--wl-radius-md) !important;
+  box-shadow: var(--wl-shadow-card) !important;
+  backdrop-filter: blur(14px) !important;
+  transition: all 0.22s cubic-bezier(0.16, 1, 0.3, 1) !important;
+  cursor: pointer;
+  position: relative !important;
+  overflow: visible !important;
+  box-sizing: border-box;
+}
+
+.watchlist-page-container .watchlist-artists-grid--rows .watchlist-artist-card:hover {
+  background: var(--wl-surface-elevated) !important;
+  border-color: var(--wl-line-highlight) !important;
+  transform: translateY(-2px) !important;
+  box-shadow: var(--wl-shadow-hover) !important;
+}
+
+.watchlist-page-container .watchlist-artist-card--active {
+  background: linear-gradient(135deg, rgba(var(--accent-rgb, 29, 185, 84), 0.12), rgba(26, 32, 45, 0.95)) !important;
+  border-color: rgba(var(--accent-rgb, 29, 185, 84), 0.45) !important;
+  box-shadow: 0 0 20px rgba(var(--accent-rgb, 29, 185, 84), 0.2) !important;
+}
+
+/* Card Artwork */
+.watchlist-artists-grid--rows .watchlist-card-image {
+  grid-area: art !important;
+  width: 72px !important;
+  height: 72px !important;
+  min-width: 72px !important;
+  border-radius: 12px !important;
+  overflow: hidden !important;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4) !important;
+  background: rgba(0, 0, 0, 0.3) !important;
+  position: relative !important;
+  flex-shrink: 0;
+}
+
+.watchlist-artists-grid--rows .watchlist-card-image img {
+  width: 100% !important;
+  height: 100% !important;
+  object-fit: cover !important;
+  transition: transform 0.3s ease;
+}
+
+.watchlist-page-container .watchlist-artist-card:hover .watchlist-card-image img {
+  transform: scale(1.06);
+}
+
+.watchlist-card-image-fallback {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Checkbox (Subtle overlay top-left) */
+.watchlist-card-checkbox {
+  position: absolute !important;
+  top: 10px !important;
+  left: 10px !important;
+  z-index: 10 !important;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  cursor: pointer;
+}
+
+.watchlist-artist-card:hover .watchlist-card-checkbox,
+.watchlist-card-checkbox:has(input:checked) {
+  opacity: 1 !important;
+}
+
+/* Artist Title & Subtitle */
+.watchlist-artists-grid--rows .watchlist-card-info {
+  grid-area: info !important;
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 2px !important;
+  min-width: 0 !important;
+  width: 100% !important;
+  overflow: hidden !important;
+}
+
+.watchlist-artists-grid--rows .watchlist-card-name {
+  font-size: 16px !important;
+  font-weight: 750 !important;
+  color: #ffffff !important;
+  line-height: 1.25 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+  display: block !important;
+  width: 100% !important;
+  transition: color 0.15s ease;
+}
+
+.watchlist-artists-grid--rows .watchlist-card-name:hover {
+  color: rgb(var(--accent-rgb, 29, 185, 84)) !important;
+}
+
+.watchlist-card-meta {
+  font-size: 12px !important;
+  color: var(--wl-text-muted) !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+/* 3-Dot Action Menu Button */
+.watchlist-row-menu-trigger {
+  grid-area: menu !important;
+  justify-self: end !important;
+  width: 28px !important;
+  height: 28px !important;
+  border-radius: var(--wl-radius-sm) !important;
+  background: var(--wl-surface-subtle) !important;
+  border: 1px solid var(--wl-line) !important;
+  color: var(--wl-text-secondary) !important;
+  font-size: 13px !important;
+  font-weight: 800 !important;
+  cursor: pointer !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  transition: all 0.15s ease !important;
+}
+
+.watchlist-row-menu-trigger:hover,
+.watchlist-row-menu-trigger[aria-expanded="true"] {
+  background: var(--wl-surface-hover) !important;
+  border-color: var(--wl-line-highlight) !important;
+  color: #ffffff !important;
+}
+
+/* Release Stats */
+.watchlist-row-stats {
+  grid-area: stats !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  font-size: 12px !important;
+  color: var(--wl-text-secondary) !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+.watchlist-row-stats span:first-child {
+  font-weight: 600 !important;
+  color: #cbd5e1 !important;
+}
+
+.watchlist-row-stats span:last-child {
+  font-size: 11px !important;
+  color: var(--wl-text-muted) !important;
+}
+
+/* Tags & Provider Micro-Badges */
+.watchlist-row-tags {
+  grid-area: tags !important;
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 5px !important;
+  margin-top: 4px !important;
+  min-width: 0 !important;
+}
+
+.watchlist-card-sources,
+.watchlist-card-pills {
+  display: inline-flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  gap: 4px !important;
+  padding: 0 !important;
+}
+
+.watchlist-source-badge {
+  display: inline-flex !important;
+  align-items: center !important;
+  padding: 2px 7px !important;
+  border-radius: var(--wl-radius-full) !important;
+  font-size: 10px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.02em !important;
+  background: rgba(255, 255, 255, 0.06) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  color: var(--wl-text-secondary) !important;
+}
+
+.watchlist-source-spotify {
+  background: rgba(29, 185, 84, 0.14) !important;
+  border-color: rgba(29, 185, 84, 0.3) !important;
+  color: #26d462 !important;
+}
+
+.watchlist-source-deezer {
+  background: rgba(162, 56, 255, 0.14) !important;
+  border-color: rgba(162, 56, 255, 0.3) !important;
+  color: #c084fc !important;
+}
+
+.watchlist-source-itunes {
+  background: rgba(250, 45, 72, 0.14) !important;
+  border-color: rgba(250, 45, 72, 0.3) !important;
+  color: #fb7185 !important;
+}
+
+.watchlist-pill {
+  display: inline-flex !important;
+  align-items: center !important;
+  padding: 2px 7px !important;
+  border-radius: var(--wl-radius-full) !important;
+  font-size: 10px !important;
+  font-weight: 650 !important;
+  background: rgba(255, 255, 255, 0.05) !important;
+  border: 1px solid var(--wl-line) !important;
+  color: var(--wl-text-secondary) !important;
+}
+
+/* Health badges — clean and subtle at the end of tags */
+.watchlist-row-health {
+  display: none !important; /* Replaced by clean subtitle dot + tag indicators */
+}
+
+/* --------------------------------------------------------------------------
+   Slide-Over Artist Inspector Drawer
+   -------------------------------------------------------------------------- */
+.watchlist-inspector-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+  animation: wlFadeIn 0.2s ease-out;
+}
+
+.watchlist-inspector-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 440px;
+  max-width: 92vw;
+  background: var(--wl-surface-elevated);
+  border-left: 1px solid var(--wl-line-highlight);
+  box-shadow: -12px 0 40px rgba(0, 0, 0, 0.7);
+  z-index: 1001;
+  overflow-y: auto;
+  padding: 24px;
+  box-sizing: border-box;
+  animation: wlSlideIn 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+@keyframes wlFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes wlSlideIn {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+.watchlist-inspector-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.watchlist-inspector-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--wl-radius-full);
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  color: var(--wl-text-secondary);
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.watchlist-inspector-close-btn:hover {
+  background: var(--wl-surface-hover);
+  border-color: var(--wl-line-highlight);
+  color: #ffffff;
+}
+
+/* Inspector Hero */
+.watchlist-page-container .watchlist-inspector-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--wl-line);
+}
+
+.watchlist-page-container .watchlist-inspector-hero img,
+.watchlist-page-container .watchlist-inspector-hero .watchlist-card-image-fallback {
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  border-radius: var(--wl-radius-md);
+  object-fit: cover;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+.watchlist-page-container .watchlist-inspector-hero h3 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.watchlist-page-container .watchlist-inspector-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.watchlist-page-container .watchlist-inspector-actions .wl-chip {
+  flex: 1;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+.watchlist-page-container .watchlist-inspector-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  background: var(--wl-surface-subtle);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-md);
+}
+
+.watchlist-page-container .watchlist-inspector-section h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+/* Empty State */
+.watchlist-page-container .watchlist-page-empty {
+  padding: 80px 24px;
+  text-align: center;
+  background: var(--wl-surface);
+  border: 1px solid var(--wl-line);
+  border-radius: var(--wl-radius-lg);
+  backdrop-filter: blur(12px);
+  margin-top: 16px;
+}
+
+.watchlist-page-container .watchlist-page-empty h3 {
+  font-size: 22px;
+  font-weight: 800;
+  margin: 16px 0 8px;
+  color: #ffffff;
+}
+
+.watchlist-page-container .watchlist-page-empty p {
+  font-size: 14px;
+  color: var(--wl-text-secondary);
+  max-width: 440px;
+  margin: 0 auto 24px;
+  line-height: 1.6;
+}
+
+/* --------------------------------------------------------------------------
+   Responsive Breakpoints
+   -------------------------------------------------------------------------- */
+@media (max-width: 768px) {
+  .watchlist-page-container {
+    padding: 12px 14px 48px;
+  }
+
+  .watchlist-page-container .watchlist-page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .watchlist-page-container .watchlist-artists-grid--rows {
+    grid-template-columns: 1fr !important;
+  }
+
+  .watchlist-page-container .watchlist-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .watchlist-inspector-drawer {
+    width: 100vw;
+  }
+}

--- a/webui/static/watchlist-premier.css
+++ b/webui/static/watchlist-premier.css
@@ -1154,12 +1154,213 @@
   line-height: 1.6;
 }
 
+/* Inner inspector reset from style.css legacy mobile fixed positioning */
+.watchlist-inspector-drawer .watchlist-inspector {
+  position: static !important;
+  max-height: none !important;
+  padding: 0 !important;
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  z-index: auto !important;
+  overflow: visible !important;
+}
+
+.watchlist-inspector-drawer .watchlist-inspector::before {
+  display: none !important;
+}
+
+/* --------------------------------------------------------------------------
+   Watchlist Artist Full Detail Modal (Premier Mobile & Desktop)
+   -------------------------------------------------------------------------- */
+.watchlist-artist-detail-overlay {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  background: #0d1017 !important;
+  z-index: 10060 !important; /* Above hamburger button (9999) and float buttons */
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch !important;
+  transform: translateX(100%);
+  transition: transform 0.28s cubic-bezier(0.16, 1, 0.3, 1) !important;
+}
+
+.watchlist-artist-detail-overlay.visible {
+  transform: translateX(0) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-banner {
+  position: relative !important;
+  width: 100% !important;
+  max-height: 240px !important;
+  overflow: hidden !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-banner img {
+  width: 100% !important;
+  height: 240px !important;
+  object-fit: cover !important;
+  display: block !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-banner-fade {
+  position: absolute !important;
+  bottom: 0 !important;
+  left: 0 !important;
+  right: 0 !important;
+  height: 100px !important;
+  background: linear-gradient(to bottom, transparent, #0d1017) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-content {
+  position: relative !important;
+  z-index: 2 !important;
+  padding: 24px 20px calc(48px + env(safe-area-inset-bottom, 24px)) !important;
+  max-width: 680px !important;
+  margin: 0 auto !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-back {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 8px !important;
+  padding: 9px 18px !important;
+  background: rgba(255, 255, 255, 0.08) !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  border-radius: var(--wl-radius-full) !important;
+  color: #ffffff !important;
+  font-size: 13px !important;
+  font-weight: 650 !important;
+  cursor: pointer !important;
+  margin-bottom: 20px !important;
+  backdrop-filter: blur(16px) !important;
+  transition: all 0.2s ease !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-back:hover {
+  background: rgba(255, 255, 255, 0.14) !important;
+  transform: translateX(-2px) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-hero {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  text-align: center !important;
+  gap: 16px !important;
+  margin-bottom: 28px !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-hero img {
+  width: 120px !important;
+  height: 120px !important;
+  border-radius: 50% !important;
+  border: 3px solid rgba(var(--accent-rgb, 147, 51, 234), 0.5) !important;
+  box-shadow: 0 0 30px rgba(var(--accent-rgb, 147, 51, 234), 0.35) !important;
+  object-fit: cover !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-hero-name {
+  font-size: 26px !important;
+  font-weight: 850 !important;
+  letter-spacing: -0.02em !important;
+  color: #ffffff !important;
+  margin: 0 !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-hero-stats {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 16px !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-hero-genres {
+  display: flex !important;
+  flex-wrap: wrap !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 6px !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-genre-tag {
+  display: inline-flex !important;
+  padding: 4px 10px !important;
+  background: rgba(255, 255, 255, 0.06) !important;
+  border: 1px solid rgba(255, 255, 255, 0.1) !important;
+  border-radius: var(--wl-radius-full) !important;
+  font-size: 11.5px !important;
+  font-weight: 600 !important;
+  color: var(--wl-text-secondary) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-actions {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 10px !important;
+  margin: 24px 0 32px !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-discography-btn,
+.watchlist-artist-detail-overlay .watchlist-detail-settings-btn,
+.watchlist-artist-detail-overlay .watchlist-detail-remove-btn {
+  width: 100% !important;
+  min-height: 46px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  border-radius: 12px !important;
+  font-size: 14px !important;
+  font-weight: 700 !important;
+  cursor: pointer !important;
+  transition: all 0.2s ease !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-discography-btn {
+  background: linear-gradient(135deg, rgba(var(--accent-rgb, 147, 51, 234), 0.9), rgba(var(--accent-rgb, 147, 51, 234), 0.7)) !important;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  box-shadow: 0 4px 20px rgba(var(--accent-rgb, 147, 51, 234), 0.35) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-settings-btn {
+  background: rgba(255, 255, 255, 0.06) !important;
+  color: #ffffff !important;
+  border: 1px solid rgba(255, 255, 255, 0.12) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-remove-btn {
+  background: rgba(239, 68, 68, 0.12) !important;
+  color: #fca5a5 !important;
+  border: 1px solid rgba(239, 68, 68, 0.3) !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-section {
+  background: var(--wl-surface) !important;
+  border: 1px solid var(--wl-line) !important;
+  border-radius: 16px !important;
+  padding: 16px !important;
+  margin-bottom: 16px !important;
+}
+
+.watchlist-artist-detail-overlay .watchlist-detail-section-title {
+  font-size: 12px !important;
+  font-weight: 750 !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.05em !important;
+  color: var(--wl-text-muted) !important;
+  margin-bottom: 10px !important;
+}
+
 /* --------------------------------------------------------------------------
    Responsive Breakpoints
    -------------------------------------------------------------------------- */
 @media (max-width: 768px) {
   .watchlist-page-container {
-    padding: 12px 14px 48px;
+    padding: 12px 14px calc(48px + env(safe-area-inset-bottom, 24px)) !important;
   }
 
   .watchlist-page-container .watchlist-page-header {
@@ -1168,16 +1369,169 @@
     gap: 12px;
   }
 
+  .watchlist-page-container .watchlist-page-header-left {
+    width: 100%;
+    padding-left: 54px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .watchlist-page-container .watchlist-page-actions {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    flex-wrap: nowrap !important;
+    overflow-x: auto !important;
+    scrollbar-width: none !important;
+    -webkit-overflow-scrolling: touch !important;
+    gap: 8px !important;
+    padding-bottom: 6px !important;
+    width: 100% !important;
+  }
+
+  .watchlist-page-container .watchlist-page-actions::-webkit-scrollbar {
+    display: none;
+  }
+
+  .watchlist-page-container .watchlist-page-actions .wl-chip {
+    padding: 7px 13px !important;
+    font-size: 12.5px !important;
+    flex-shrink: 0 !important;
+  }
+
+  .watchlist-page-container .watchlist-attention-strip {
+    flex-wrap: nowrap !important;
+    overflow-x: auto !important;
+    padding-bottom: 6px !important;
+    scrollbar-width: none !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  .watchlist-page-container .watchlist-attention-strip::-webkit-scrollbar {
+    display: none;
+  }
+
   .watchlist-page-container .watchlist-artists-grid--rows {
     grid-template-columns: 1fr !important;
+    gap: 10px !important;
+  }
+
+  .watchlist-page-container .watchlist-artist-card {
+    padding: 10px 12px !important;
+    grid-template-columns: 60px minmax(0, 1fr) auto !important;
+    gap: 12px !important;
+  }
+
+  .watchlist-page-container .watchlist-card-image,
+  .watchlist-page-container .watchlist-card-image img,
+  .watchlist-page-container .watchlist-card-image .watchlist-card-image-fallback {
+    width: 60px !important;
+    height: 60px !important;
+    border-radius: 10px !important;
+  }
+
+  .watchlist-page-container .watchlist-card-name {
+    font-size: 15px !important;
   }
 
   .watchlist-page-container .watchlist-toolbar {
     flex-direction: column;
     align-items: stretch;
+    gap: 8px;
+  }
+
+  .watchlist-page-container .watchlist-sort-select {
+    width: 100%;
+  }
+
+  /* Slide-Over Drawer on Mobile -> Bottom Sheet */
+  .watchlist-inspector-backdrop {
+    z-index: 10050 !important;
+    background: rgba(0, 0, 0, 0.75) !important;
+    backdrop-filter: blur(16px) !important;
   }
 
   .watchlist-inspector-drawer {
-    width: 100vw;
+    position: fixed !important;
+    top: auto !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    max-height: 85vh !important;
+    background: #141722 !important;
+    border-radius: 24px 24px 0 0 !important;
+    border-left: none !important;
+    border-top: 1px solid rgba(255, 255, 255, 0.15) !important;
+    box-shadow: 0 -12px 48px rgba(0, 0, 0, 0.85) !important;
+    z-index: 10051 !important;
+    padding: 16px 18px calc(24px + env(safe-area-inset-bottom, 20px)) !important;
+    animation: wlSlideUpMobile 0.28s cubic-bezier(0.16, 1, 0.3, 1) !important;
+    display: flex !important;
+    flex-direction: column !important;
+    gap: 16px !important;
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch !important;
+  }
+
+  .watchlist-inspector-drawer::before {
+    content: '' !important;
+    display: block !important;
+    width: 44px !important;
+    height: 4px !important;
+    border-radius: 2px !important;
+    background: rgba(255, 255, 255, 0.25) !important;
+    margin: 0 auto 4px !important;
+    flex-shrink: 0 !important;
+  }
+
+  .watchlist-inspector-header {
+    margin-bottom: 4px !important;
+  }
+
+  .watchlist-page-container .watchlist-inspector-actions {
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    gap: 8px !important;
+  }
+
+  .watchlist-page-container .watchlist-inspector-actions .wl-chip {
+    width: 100% !important;
+    justify-content: center !important;
+    padding: 9px 8px !important;
+    font-size: 13px !important;
   }
 }
+
+@keyframes wlSlideUpMobile {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+
+/* --------------------------------------------------------------------------
+   Suppress floating action buttons & mobile hamburger during modals/drawers
+   -------------------------------------------------------------------------- */
+body:has(.watchlist-artist-detail-overlay.visible) .hamburger-btn,
+body:has(.watchlist-artist-detail-overlay.visible) #gsearch-bar,
+body:has(.watchlist-artist-detail-overlay.visible) #gsearch-aura,
+body:has(.watchlist-artist-detail-overlay.visible) #notif-bell-btn,
+body:has(.watchlist-artist-detail-overlay.visible) #helper-float-btn,
+body:has(.watchlist-artist-detail-overlay.visible) .activity-float-btn,
+body:has(.watchlist-inspector-backdrop) #gsearch-bar,
+body:has(.watchlist-inspector-backdrop) #gsearch-aura,
+body:has(.watchlist-inspector-backdrop) #notif-bell-btn,
+body:has(.watchlist-inspector-backdrop) #helper-float-btn,
+body:has(.watchlist-inspector-backdrop) .activity-float-btn,
+body:has(#watchlist-artist-config-modal-overlay) #gsearch-bar,
+body:has(#watchlist-artist-config-modal-overlay) #gsearch-aura,
+body:has(#watchlist-artist-config-modal-overlay) #notif-bell-btn,
+body:has(#watchlist-artist-config-modal-overlay) #helper-float-btn,
+body:has(#watchlist-artist-config-modal-overlay) .activity-float-btn {
+  display: none !important;
+}
+


### PR DESCRIPTION
# SoulSync 3.4.1: `dev` → `main`

This release addresses long waits during download processing, manual imports and navigation, refreshes Discover, Watchlist and Settings, and improves audiobook library scanning and download tracking. Scope: commits since the `3.4.0` tag.

## Performance and reliability — #1245

- LRClib requests now have transport timeouts, so a stalled lyrics service cannot leave a request waiting indefinitely.
- Manual imports use background jobs with progress polling and retry-safe submission. Existing synchronous callers remain supported.
- Download file recovery runs outside the shared status lock with bounded work. Cancellation and newer download attempts are preserved during recovery and failed submission.
- Repeated image URL registration is cached; dashboard rails use cached thumbnails and invalidate stale full-size responses.
- Multi-source metadata searches return completed results within a deadline and use bounded shared worker capacity. Already-running provider calls can finish in the background without creating a new pool for every request.
- Offline Plex connections are cached. Interactive video checks use short network timeouts while bulk operations retain longer reads. Credential changes invalidate cached connections, and scan checks refresh library state.
- Database-update watchdogs receive an initial progress timestamp.

These changes address specific blocking paths; they do not promise a fixed end-to-end processing time for every external service or installation.

## Discover, Watchlist and Settings

- Refreshed layouts, artwork, responsive spacing and controls across all three pages.
- Deezer editorial playlists, all 28 genres, playlist search and visible sync handoff progress. Public browse requests no longer send an unnecessary access token.
- Watchlist source matching reports progress on the page and automation card, and cancellation works during a long artist match (#1240).
- Shared Folders and Organization cards retain music and video controls. Video Library settings load from either media side, with refined navigation, responsive forms and safe search.
- Cross-page navigation keeps the sidebar selection in sync.

## Audiobooks

- Index existing libraries and browse them in the rebuilt library view; the wishlist uses cover cards.
- Match catalogue editions using file metadata and download provenance, with review controls for uncertain matches.
- Report live client progress and status while keeping audiobook jobs outside music timeout handling.
- Persist cancellation, match Soulseek filename references to peer transfers, reuse the Soulseek client, and move wishlist rows beyond “sent to downloads” as jobs finish.

## Other fixes

- SoundCloud downloads are found and passed on for import and tagging (#1239).
- Last.fm usernames can be corrected without stale import state (#1241).
- Deezer import keeps the track ID used for the download instead of searching for a replacement.
- Chat requires an active Soulseek login, guards send actions and preserves unsent drafts. Connection detection probes both slskd server endpoints.
- Podcast fetches are guarded against unsafe destinations, and watchlist automation respects profile ownership.
- Additional video library paths support libraries spread across drives.

## Validation

- Performance review: 284 backend tests passed, followed by 74 focused tests after the final correction; 18 frontend import tests passed.
- Audiobook inventory lint correction: 69 library tests passed.
- Updated regression contracts: 205 affected tests and 109 audiobook state/monitor tests passed. Repository-wide lint and diff checks passed.
- The supplied full CI run had six failures and 18,487 passes. All six failing cases are covered by the corrected targeted runs; the full suite has not been rerun locally.
